### PR TITLE
BOOKKEEPER-883: Test timeout in bookkeeper-benchmark

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManager.java
@@ -88,6 +88,11 @@ class FlatLedgerManager extends AbstractZkLedgerManager {
     }
 
     @Override
+    protected boolean isSpecialZnode(String znode) {
+        return znode.startsWith(ZkLedgerIdGenerator.LEDGER_ID_GEN_PREFIX) || super.isSpecialZnode(znode);
+    }
+
+    @Override
     public LedgerRangeIterator getLedgerRanges() {
         return new LedgerRangeIterator() {
             // single iterator, can visit only one time

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerIdGenerator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerIdGenerator.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 public class ZkLedgerIdGenerator implements LedgerIdGenerator {
     static final Logger LOG = LoggerFactory.getLogger(ZkLedgerIdGenerator.class);
 
+    static final String LEDGER_ID_GEN_PREFIX = "ID-";
+
     final ZooKeeper zk;
     final String ledgerIdGenPath;
     final String ledgerPrefix;
@@ -55,7 +57,7 @@ public class ZkLedgerIdGenerator implements LedgerIdGenerator {
         } else {
             this.ledgerIdGenPath = ledgersPath + "/" + idGenZnodeName;
         }
-        this.ledgerPrefix = this.ledgerIdGenPath + "/ID-";
+        this.ledgerPrefix = this.ledgerIdGenPath + "/" + LEDGER_ID_GEN_PREFIX;
     }
 
     @Override


### PR DESCRIPTION
Problem:

The BenchReadThroughputLatency is tight with FlatLedgerManager. so lots of assumptions are made based on how the znodes are changed when ledgers are created. There was a change introduced LedgerIdGenerator, which broke the assumptions that made by BenchReadThroughputLatency.

Fix:

- Use a hashset to cache processed ledgers on reacting on children changes
- Remove unpredictable test on next ledger
- Fix an error logging on FlatLedgerManager processing ledgers