### PR TITLE
BOOKKEEPER-891: Read entries failure should trigger callback only once

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -373,6 +373,11 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
     }
 
     private void submitCallback(int code) {
+        if (cb == null) {
+            // Callback had already been triggered before
+            return;
+        }
+
         long latencyNanos = MathUtils.elapsedNanos(requestTimeNanos);
         if (code != BKException.Code.OK) {
             long firstUnread = LedgerHandle.INVALID_ENTRY_ID;
@@ -390,6 +395,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
         }
         cancelSpeculativeTask(true);
         cb.readComplete(code, lh, PendingReadOp.this, PendingReadOp.this.ctx);
+        cb = null;
     }
 
     @Override


### PR DESCRIPTION
When reading multiple entries with `LedgerHandle.asyncReadEntries()`, in case there is a read error, the callback is currently being invoked for each of the requested entries.
Since a single "success" callback is expected, we should also have a single "failure" callback invocation.