### PR TITLE
BOOKKEEPER-870: Change the default value for bookie settings.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -150,7 +150,7 @@ public class ServerConfiguration extends AbstractConfiguration {
      * @return entry logger size limitation
      */
     public long getEntryLogSizeLimit() {
-        return this.getLong(ENTRY_LOG_SIZE_LIMIT, 2 * 1024 * 1024 * 1024L);
+        return this.getLong(ENTRY_LOG_SIZE_LIMIT, 1 * 1024 * 1024 * 1024L);
     }
 
     /**
@@ -186,12 +186,15 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get Garbage collection wait time
+     * Get Garbage collection wait time. Default value is 10 minutes.
+     * The guideline is not to set a too low value for this, if using zookeeper based
+     * ledger manager. And it would be nice to align with the average lifecyle time of
+     * ledgers in the system.
      *
      * @return gc wait time
      */
     public long getGcWaitTime() {
-        return this.getLong(GC_WAIT_TIME, 1000);
+        return this.getLong(GC_WAIT_TIME, 600000);
     }
 
     /**
@@ -207,12 +210,14 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get flush interval
+     * Get flush interval. Default value is 10 second. It isn't useful to decrease
+     * this value, since ledger storage only checkpoints when an entry logger file
+     * is rolled.
      *
      * @return flush interval
      */
     public int getFlushInterval() {
-        return this.getInt(FLUSH_INTERVAL, 100);
+        return this.getInt(FLUSH_INTERVAL, 10000);
     }
 
     /**
@@ -237,12 +242,12 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get open file limit
+     * Get open file limit. Default value is 20000.
      *
      * @return max number of files to open
      */
     public int getOpenFileLimit() {
-        return this.getInt(OPEN_FILE_LIMIT, 900);
+        return this.getInt(OPEN_FILE_LIMIT, 20000);
     }
 
     /**
@@ -1090,12 +1095,12 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Maximum latency to impose on a journal write to achieve grouping
+     * Maximum latency to impose on a journal write to achieve grouping. Default is 2ms.
      *
      * @return max wait for grouping
      */
     public long getJournalMaxGroupWaitMSec() {
-        return getLong(JOURNAL_MAX_GROUP_WAIT_MSEC, 200);
+        return getLong(JOURNAL_MAX_GROUP_WAIT_MSEC, 2);
     }
 
     /**
@@ -1164,12 +1169,12 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get whether read-only mode is enabled. The default is false.
+     * Get whether read-only mode is enabled. The default is true.
      *
      * @return boolean
      */
     public boolean isReadOnlyModeEnabled() {
-        return getBoolean(READ_ONLY_MODE_ENABLED, false);
+        return getBoolean(READ_ONLY_MODE_ENABLED, true);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
@@ -79,6 +79,7 @@ public class TestSyncThread {
     public void testSyncThreadLongShutdown() throws Exception {
         int flushInterval = 100;
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setFlushInterval(flushInterval);
         CheckpointSource checkpointSource = new DummyCheckpointSource();
         LedgerDirsListener listener = new DummyLedgerDirsListener();
 
@@ -154,6 +155,7 @@ public class TestSyncThread {
     public void testSyncThreadSuspension() throws Exception {
         int flushInterval = 100;
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setFlushInterval(flushInterval);
         CheckpointSource checkpointSource = new DummyCheckpointSource();
         LedgerDirsListener listener = new DummyLedgerDirsListener();
 
@@ -198,6 +200,7 @@ public class TestSyncThread {
     public void testSyncThreadShutdownOnError() throws Exception {
         int flushInterval = 100;
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setFlushInterval(flushInterval);
         CheckpointSource checkpointSource = new DummyCheckpointSource();
         final CountDownLatch fatalLatch = new CountDownLatch(1);
         LedgerDirsListener listener = new DummyLedgerDirsListener() {
@@ -229,6 +232,7 @@ public class TestSyncThread {
     public void testSyncThreadDisksFull() throws Exception {
         int flushInterval = 100;
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setFlushInterval(flushInterval);
         CheckpointSource checkpointSource = new DummyCheckpointSource();
         final CountDownLatch diskFullLatch = new CountDownLatch(1);
         LedgerDirsListener listener = new DummyLedgerDirsListener() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
@@ -29,6 +29,7 @@ public class TestBKConfiguration {
         // enable journal format version
         confReturn.setJournalFormatVersionToWrite(5);
         confReturn.setAllowLoopback(true);
+        confReturn.setGcWaitTime(1000);
         return confReturn;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -178,6 +178,10 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
      */
     @Test(timeout = 60000)
     public void testBookieShutdownIfReadOnlyModeNotEnabled() throws Exception {
+        killBookie(1);
+        baseConf.setReadOnlyModeEnabled(false);
+        startNewBookie();
+
         File[] ledgerDirs = bsConfs.get(1).getLedgerDirs();
         assertEquals("Only one ledger dir should be present", 1,
                 ledgerDirs.length);


### PR DESCRIPTION
- ENTRY_LOG_SIZE_LIMIT to 1GB
- increase GC_WAIT_TIME to 10 minutes, since 1 second isn't good for a real production environment
- FLUSH_INTERVAL to 10 second. lowering this value won't help since the actual checkpoint only happened on entry log file rolling
- OPEN_FILE_LIMIT to 20000.
- JOURNAL_MAX_GROUP_WAIT_MSEC to 2 ms. make the default value for low latency
- READ_ONLY_MODE_ENABLED to true. enable readonly mode by default.
