### PR TITLE
BOOKKEEPER-924  Handle Spurious wakeups

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -540,7 +540,6 @@ public class BookKeeper implements AutoCloseable {
                                      DigestType digestType, byte passwd[])
             throws InterruptedException, BKException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
         /*
          * Calls asynchronous version
          */
@@ -550,7 +549,7 @@ public class BookKeeper implements AutoCloseable {
         /*
          * Wait
          */
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK) {
             LOG.error("Error while creating ledger : {}", counter.getrc());
             throw BKException.create(counter.getrc());
@@ -582,7 +581,6 @@ public class BookKeeper implements AutoCloseable {
                                         DigestType digestType, byte passwd[])
             throws InterruptedException, BKException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
         /*
          * Calls asynchronous version
          */
@@ -592,7 +590,7 @@ public class BookKeeper implements AutoCloseable {
         /*
          * Wait
          */
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK) {
             LOG.error("Error while creating ledger : {}", counter.getrc());
             throw BKException.create(counter.getrc());
@@ -755,7 +753,6 @@ public class BookKeeper implements AutoCloseable {
     public LedgerHandle openLedger(long lId, DigestType digestType, byte passwd[])
             throws BKException, InterruptedException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
 
         /*
          * Calls async open ledger
@@ -765,7 +762,7 @@ public class BookKeeper implements AutoCloseable {
         /*
          * Wait
          */
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK)
             throw BKException.create(counter.getrc());
 
@@ -790,7 +787,6 @@ public class BookKeeper implements AutoCloseable {
     public LedgerHandle openLedgerNoRecovery(long lId, DigestType digestType, byte passwd[])
             throws BKException, InterruptedException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
 
         /*
          * Calls async open ledger
@@ -801,7 +797,7 @@ public class BookKeeper implements AutoCloseable {
         /*
          * Wait
          */
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK)
             throw BKException.create(counter.getrc());
 
@@ -844,11 +840,10 @@ public class BookKeeper implements AutoCloseable {
      */
     public void deleteLedger(long lId) throws InterruptedException, BKException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
         // Call asynchronous version
         asyncDeleteLedger(lId, new SyncDeleteCallback(), counter);
         // Wait
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK) {
             LOG.error("Error deleting ledger " + lId + " : " + counter.getrc());
             throw BKException.create(counter.getrc());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -254,12 +254,11 @@ public class BookKeeperAdmin {
     public LedgerHandle openLedger(final long lId) throws InterruptedException,
             BKException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
         new LedgerOpenOp(bkc, lId, new SyncOpenCallback(), counter).initiate();
         /*
          * Wait
          */
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK) {
             throw BKException.create(counter.getrc());
         }
@@ -297,13 +296,12 @@ public class BookKeeperAdmin {
     public LedgerHandle openLedgerNoRecovery(final long lId)
             throws InterruptedException, BKException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
         new LedgerOpenOp(bkc, lId, new SyncOpenCallback(), counter)
                 .initiateWithoutRecovery();
         /*
          * Wait
          */
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK) {
             throw BKException.create(counter.getrc());
         }
@@ -378,11 +376,10 @@ public class BookKeeperAdmin {
             if (lastEntryId == -1 || nextEntryId <= lastEntryId) {
                 try {
                     SyncCounter counter = new SyncCounter();
-                    counter.inc();
 
                     handle.asyncReadEntriesInternal(nextEntryId, nextEntryId, new LedgerHandle.SyncReadCallback(),
                             counter);
-                    counter.block(0);
+                    counter.block();
                     if (counter.getrc() != BKException.Code.OK) {
                         throw BKException.create(counter.getrc());
                     }
@@ -857,9 +854,8 @@ public class BookKeeperAdmin {
         SingleFragmentCallback cb = new SingleFragmentCallback(resultCallBack,
                 lh, ledgerFragment.getFirstEntryId(), ledgerFragment
                         .getAddress(), targetBookieAddress);
-        syncCounter.inc();
         asyncRecoverLedgerFragment(lh, ledgerFragment, cb, targetBookieAddress);
-        syncCounter.block(0);
+        syncCounter.block();
         if (syncCounter.getrc() != BKException.Code.OK) {
             throw BKException.create(bkc.getReturnRc(syncCounter.getrc()));
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -230,11 +230,10 @@ public class LedgerHandle implements AutoCloseable {
     public void close()
             throws InterruptedException, BKException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
 
         asyncClose(new SyncCloseCallback(), counter);
 
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK) {
             throw BKException.create(counter.getrc());
         }
@@ -425,11 +424,10 @@ public class LedgerHandle implements AutoCloseable {
     public Enumeration<LedgerEntry> readEntries(long firstEntry, long lastEntry)
             throws InterruptedException, BKException {
         SyncCounter counter = new SyncCounter();
-        counter.inc();
 
         asyncReadEntries(firstEntry, lastEntry, new SyncReadCallback(), counter);
 
-        counter.block(0);
+        counter.block();
         if (counter.getrc() != BKException.Code.OK) {
             throw BKException.create(counter.getrc());
         }
@@ -514,11 +512,10 @@ public class LedgerHandle implements AutoCloseable {
         LOG.debug("Adding entry {}", data);
 
         SyncCounter counter = new SyncCounter();
-        counter.inc();
 
         SyncAddCallback callback = new SyncAddCallback();
         asyncAddEntry(data, offset, length, callback, counter);
-        counter.block(0);
+        counter.block();
 
         if (counter.getrc() != BKException.Code.OK) {
             throw BKException.create(counter.getrc());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -91,12 +91,11 @@ public class LedgerHandleAdv extends LedgerHandle {
         LOG.debug("Adding entry {}", data);
 
         SyncCounter counter = new SyncCounter();
-        counter.inc();
 
         SyncAddCallback callback = new SyncAddCallback();
         asyncAddEntry(entryId, data, offset, length, callback, counter);
 
-        counter.block(0);
+        counter.block();
 
         if (counter.getrc() != BKException.Code.OK) {
             throw BKException.create(counter.getrc());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCounter.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCounter.java
@@ -22,6 +22,7 @@
 package org.apache.bookkeeper.client;
 
 import java.util.Enumeration;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Implements objects to help with the synchronization of asynchronous calls
@@ -31,32 +32,16 @@ import java.util.Enumeration;
 class SyncCounter {
     int i;
     int rc;
-    int total;
     Enumeration<LedgerEntry> seq = null;
     LedgerHandle lh = null;
+    private CountDownLatch latch = new CountDownLatch(1);
 
-    synchronized void inc() {
-        i++;
-        total++;
+    void dec() {
+        latch.countDown();
     }
 
-    synchronized void dec() {
-        i--;
-        notifyAll();
-    }
-
-    synchronized void block(int limit) throws InterruptedException {
-        while (i > limit) {
-            int prev = i;
-            wait();
-            if (i == prev) {
-                break;
-            }
-        }
-    }
-
-    synchronized int total() {
-        return total;
+    void block() throws InterruptedException {
+        latch.await();
     }
 
     void setrc(int rc) {


### PR DESCRIPTION
SyncCounter doesn't handle Spurious wakeups.
Make use of CountDownLatch latch instead of native counter

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>