### PR TITLE
BOOKKEEPER-908: BKLedgerExistException creation is missing

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
@@ -92,6 +92,8 @@ public abstract class BKException extends Exception {
             return new BKReplicationException();
         case Code.ClientClosedException:
             return new BKClientClosedException();
+        case Code.LedgerExistException:
+            return new BKLedgerExistException();
         case Code.IllegalOpException:
             return new BKIllegalOpException();
         case Code.AddEntryQuorumTimeoutException:


### PR DESCRIPTION
Add missing case statement for Code.LedgerExistException
in the crearte() function of BKException class

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>