### PR TITLE
BOOKKEEPER-937 Upgrade protobuf to 2.6

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -200,6 +200,10 @@
               <minimizeJar>true</minimizeJar>
               <relocations>
                 <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>bk-shade.com.google.proto_${protobuf.version}</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>bk-shade.com.google</shadedPattern>
                 </relocation>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperProtocol.java
@@ -8,20 +8,46 @@ public final class BookkeeperProtocol {
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
   }
+  /**
+   * Protobuf enum {@code ProtocolVersion}
+   *
+   * <pre>
+   **
+   * Protocol Versions.
+   * </pre>
+   */
   public enum ProtocolVersion
       implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>VERSION_ONE = 1;</code>
+     */
     VERSION_ONE(0, 1),
+    /**
+     * <code>VERSION_TWO = 2;</code>
+     */
     VERSION_TWO(1, 2),
+    /**
+     * <code>VERSION_THREE = 3;</code>
+     */
     VERSION_THREE(2, 3),
     ;
-    
+
+    /**
+     * <code>VERSION_ONE = 1;</code>
+     */
     public static final int VERSION_ONE_VALUE = 1;
+    /**
+     * <code>VERSION_TWO = 2;</code>
+     */
     public static final int VERSION_TWO_VALUE = 2;
+    /**
+     * <code>VERSION_THREE = 3;</code>
+     */
     public static final int VERSION_THREE_VALUE = 3;
-    
-    
+
+
     public final int getNumber() { return value; }
-    
+
     public static ProtocolVersion valueOf(int value) {
       switch (value) {
         case 1: return VERSION_ONE;
@@ -30,7 +56,7 @@ public final class BookkeeperProtocol {
         default: return null;
       }
     }
-    
+
     public static com.google.protobuf.Internal.EnumLiteMap<ProtocolVersion>
         internalGetValueMap() {
       return internalValueMap;
@@ -42,7 +68,7 @@ public final class BookkeeperProtocol {
               return ProtocolVersion.valueOf(number);
             }
           };
-    
+
     public final com.google.protobuf.Descriptors.EnumValueDescriptor
         getValueDescriptor() {
       return getDescriptor().getValues().get(index);
@@ -55,11 +81,9 @@ public final class BookkeeperProtocol {
         getDescriptor() {
       return org.apache.bookkeeper.proto.BookkeeperProtocol.getDescriptor().getEnumTypes().get(0);
     }
-    
-    private static final ProtocolVersion[] VALUES = {
-      VERSION_ONE, VERSION_TWO, VERSION_THREE, 
-    };
-    
+
+    private static final ProtocolVersion[] VALUES = values();
+
     public static ProtocolVersion valueOf(
         com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
       if (desc.getType() != getDescriptor()) {
@@ -68,44 +92,122 @@ public final class BookkeeperProtocol {
       }
       return VALUES[desc.getIndex()];
     }
-    
+
     private final int index;
     private final int value;
-    
+
     private ProtocolVersion(int index, int value) {
       this.index = index;
       this.value = value;
     }
-    
+
     // @@protoc_insertion_point(enum_scope:ProtocolVersion)
   }
-  
+
+  /**
+   * Protobuf enum {@code StatusCode}
+   *
+   * <pre>
+   **
+   * Status codes.
+   * </pre>
+   */
   public enum StatusCode
       implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>EOK = 0;</code>
+     */
     EOK(0, 0),
+    /**
+     * <code>ENOLEDGER = 402;</code>
+     *
+     * <pre>
+     * Server side Errors 4xx
+     * </pre>
+     */
     ENOLEDGER(1, 402),
+    /**
+     * <code>ENOENTRY = 403;</code>
+     */
     ENOENTRY(2, 403),
+    /**
+     * <code>EBADREQ = 404;</code>
+     */
     EBADREQ(3, 404),
+    /**
+     * <code>EIO = 501;</code>
+     *
+     * <pre>
+     * IO/access errors 5xx
+     * </pre>
+     */
     EIO(4, 501),
+    /**
+     * <code>EUA = 502;</code>
+     */
     EUA(5, 502),
+    /**
+     * <code>EBADVERSION = 503;</code>
+     */
     EBADVERSION(6, 503),
+    /**
+     * <code>EFENCED = 504;</code>
+     */
     EFENCED(7, 504),
+    /**
+     * <code>EREADONLY = 505;</code>
+     */
     EREADONLY(8, 505),
     ;
-    
+
+    /**
+     * <code>EOK = 0;</code>
+     */
     public static final int EOK_VALUE = 0;
+    /**
+     * <code>ENOLEDGER = 402;</code>
+     *
+     * <pre>
+     * Server side Errors 4xx
+     * </pre>
+     */
     public static final int ENOLEDGER_VALUE = 402;
+    /**
+     * <code>ENOENTRY = 403;</code>
+     */
     public static final int ENOENTRY_VALUE = 403;
+    /**
+     * <code>EBADREQ = 404;</code>
+     */
     public static final int EBADREQ_VALUE = 404;
+    /**
+     * <code>EIO = 501;</code>
+     *
+     * <pre>
+     * IO/access errors 5xx
+     * </pre>
+     */
     public static final int EIO_VALUE = 501;
+    /**
+     * <code>EUA = 502;</code>
+     */
     public static final int EUA_VALUE = 502;
+    /**
+     * <code>EBADVERSION = 503;</code>
+     */
     public static final int EBADVERSION_VALUE = 503;
+    /**
+     * <code>EFENCED = 504;</code>
+     */
     public static final int EFENCED_VALUE = 504;
+    /**
+     * <code>EREADONLY = 505;</code>
+     */
     public static final int EREADONLY_VALUE = 505;
-    
-    
+
+
     public final int getNumber() { return value; }
-    
+
     public static StatusCode valueOf(int value) {
       switch (value) {
         case 0: return EOK;
@@ -120,7 +222,7 @@ public final class BookkeeperProtocol {
         default: return null;
       }
     }
-    
+
     public static com.google.protobuf.Internal.EnumLiteMap<StatusCode>
         internalGetValueMap() {
       return internalValueMap;
@@ -132,7 +234,7 @@ public final class BookkeeperProtocol {
               return StatusCode.valueOf(number);
             }
           };
-    
+
     public final com.google.protobuf.Descriptors.EnumValueDescriptor
         getValueDescriptor() {
       return getDescriptor().getValues().get(index);
@@ -145,11 +247,9 @@ public final class BookkeeperProtocol {
         getDescriptor() {
       return org.apache.bookkeeper.proto.BookkeeperProtocol.getDescriptor().getEnumTypes().get(1);
     }
-    
-    private static final StatusCode[] VALUES = {
-      EOK, ENOLEDGER, ENOENTRY, EBADREQ, EIO, EUA, EBADVERSION, EFENCED, EREADONLY, 
-    };
-    
+
+    private static final StatusCode[] VALUES = values();
+
     public static StatusCode valueOf(
         com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
       if (desc.getType() != getDescriptor()) {
@@ -158,36 +258,82 @@ public final class BookkeeperProtocol {
       }
       return VALUES[desc.getIndex()];
     }
-    
+
     private final int index;
     private final int value;
-    
+
     private StatusCode(int index, int value) {
       this.index = index;
       this.value = value;
     }
-    
+
     // @@protoc_insertion_point(enum_scope:StatusCode)
   }
-  
+
+  /**
+   * Protobuf enum {@code OperationType}
+   *
+   * <pre>
+   **
+   * Supported operations by this protocol.
+   * </pre>
+   */
   public enum OperationType
       implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>READ_ENTRY = 1;</code>
+     */
     READ_ENTRY(0, 1),
+    /**
+     * <code>ADD_ENTRY = 2;</code>
+     */
     ADD_ENTRY(1, 2),
+    /**
+     * <code>RANGE_READ_ENTRY = 3;</code>
+     *
+     * <pre>
+     * Not supported yet.
+     * </pre>
+     */
     RANGE_READ_ENTRY(2, 3),
+    /**
+     * <code>RANGE_ADD_ENTRY = 4;</code>
+     */
     RANGE_ADD_ENTRY(3, 4),
+    /**
+     * <code>AUTH = 5;</code>
+     */
     AUTH(4, 5),
     ;
-    
+
+    /**
+     * <code>READ_ENTRY = 1;</code>
+     */
     public static final int READ_ENTRY_VALUE = 1;
+    /**
+     * <code>ADD_ENTRY = 2;</code>
+     */
     public static final int ADD_ENTRY_VALUE = 2;
+    /**
+     * <code>RANGE_READ_ENTRY = 3;</code>
+     *
+     * <pre>
+     * Not supported yet.
+     * </pre>
+     */
     public static final int RANGE_READ_ENTRY_VALUE = 3;
+    /**
+     * <code>RANGE_ADD_ENTRY = 4;</code>
+     */
     public static final int RANGE_ADD_ENTRY_VALUE = 4;
+    /**
+     * <code>AUTH = 5;</code>
+     */
     public static final int AUTH_VALUE = 5;
-    
-    
+
+
     public final int getNumber() { return value; }
-    
+
     public static OperationType valueOf(int value) {
       switch (value) {
         case 1: return READ_ENTRY;
@@ -198,7 +344,7 @@ public final class BookkeeperProtocol {
         default: return null;
       }
     }
-    
+
     public static com.google.protobuf.Internal.EnumLiteMap<OperationType>
         internalGetValueMap() {
       return internalValueMap;
@@ -210,7 +356,7 @@ public final class BookkeeperProtocol {
               return OperationType.valueOf(number);
             }
           };
-    
+
     public final com.google.protobuf.Descriptors.EnumValueDescriptor
         getValueDescriptor() {
       return getDescriptor().getValues().get(index);
@@ -223,11 +369,9 @@ public final class BookkeeperProtocol {
         getDescriptor() {
       return org.apache.bookkeeper.proto.BookkeeperProtocol.getDescriptor().getEnumTypes().get(2);
     }
-    
-    private static final OperationType[] VALUES = {
-      READ_ENTRY, ADD_ENTRY, RANGE_READ_ENTRY, RANGE_ADD_ENTRY, AUTH, 
-    };
-    
+
+    private static final OperationType[] VALUES = values();
+
     public static OperationType valueOf(
         com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
       if (desc.getType() != getDescriptor()) {
@@ -236,396 +380,103 @@ public final class BookkeeperProtocol {
       }
       return VALUES[desc.getIndex()];
     }
-    
+
     private final int index;
     private final int value;
-    
+
     private OperationType(int index, int value) {
       this.index = index;
       this.value = value;
     }
-    
+
     // @@protoc_insertion_point(enum_scope:OperationType)
   }
-  
-  public interface BKPacketHeaderOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // required .ProtocolVersion version = 1;
+
+  public interface BKPacketHeaderOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:BKPacketHeader)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required .ProtocolVersion version = 1;</code>
+     */
     boolean hasVersion();
+    /**
+     * <code>required .ProtocolVersion version = 1;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion getVersion();
-    
-    // required .OperationType operation = 2;
+
+    /**
+     * <code>required .OperationType operation = 2;</code>
+     */
     boolean hasOperation();
+    /**
+     * <code>required .OperationType operation = 2;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType getOperation();
-    
-    // required uint64 txnId = 3;
+
+    /**
+     * <code>required uint64 txnId = 3;</code>
+     */
     boolean hasTxnId();
+    /**
+     * <code>required uint64 txnId = 3;</code>
+     */
     long getTxnId();
   }
+  /**
+   * Protobuf type {@code BKPacketHeader}
+   *
+   * <pre>
+   **
+   * Packet header for all requests.
+   * </pre>
+   */
   public static final class BKPacketHeader extends
-      com.google.protobuf.GeneratedMessage
-      implements BKPacketHeaderOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:BKPacketHeader)
+      BKPacketHeaderOrBuilder {
     // Use BKPacketHeader.newBuilder() to construct.
-    private BKPacketHeader(Builder builder) {
+    private BKPacketHeader(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private BKPacketHeader(boolean noInit) {}
-    
+    private BKPacketHeader(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final BKPacketHeader defaultInstance;
     public static BKPacketHeader getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public BKPacketHeader getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_descriptor;
-    }
-    
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_fieldAccessorTable;
-    }
-    
-    private int bitField0_;
-    // required .ProtocolVersion version = 1;
-    public static final int VERSION_FIELD_NUMBER = 1;
-    private org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion version_;
-    public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
-    }
-    public org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion getVersion() {
-      return version_;
-    }
-    
-    // required .OperationType operation = 2;
-    public static final int OPERATION_FIELD_NUMBER = 2;
-    private org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType operation_;
-    public boolean hasOperation() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
-    }
-    public org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType getOperation() {
-      return operation_;
-    }
-    
-    // required uint64 txnId = 3;
-    public static final int TXNID_FIELD_NUMBER = 3;
-    private long txnId_;
-    public boolean hasTxnId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    public long getTxnId() {
-      return txnId_;
-    }
-    
-    private void initFields() {
-      version_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion.VERSION_ONE;
-      operation_ = org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType.READ_ENTRY;
-      txnId_ = 0L;
-    }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
-      if (!hasVersion()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasOperation()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasTxnId()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
-    }
-    
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(1, version_.getNumber());
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeEnum(2, operation_.getNumber());
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeUInt64(3, txnId_);
-      }
-      getUnknownFields().writeTo(output);
-    }
-    
-    private int memoizedSerializedSize = -1;
-    public int getSerializedSize() {
-      int size = memoizedSerializedSize;
-      if (size != -1) return size;
-    
-      size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, version_.getNumber());
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(2, operation_.getNumber());
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(3, txnId_);
-      }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
-      return size;
-    }
-    
-    private static final long serialVersionUID = 0L;
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
     }
-    
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
+    private BKPacketHeader(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
-    }
-    
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-    public Builder toBuilder() { return newBuilder(this); }
-    
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_descriptor;
-      }
-      
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_fieldAccessorTable;
-      }
-      
-      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-      
-      private Builder(BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-      
-      public Builder clear() {
-        super.clear();
-        version_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion.VERSION_ONE;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        operation_ = org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType.READ_ENTRY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        txnId_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        return this;
-      }
-      
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-      
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDescriptor();
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader getDefaultInstanceForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader build() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-      
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader buildPartial() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader result = new org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.operation_ = operation_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.txnId_ = txnId_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-      
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader) {
-          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-      
-      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader other) {
-        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance()) return this;
-        if (other.hasVersion()) {
-          setVersion(other.getVersion());
-        }
-        if (other.hasOperation()) {
-          setOperation(other.getOperation());
-        }
-        if (other.hasTxnId()) {
-          setTxnId(other.getTxnId());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-      
-      public final boolean isInitialized() {
-        if (!hasVersion()) {
-          
-          return false;
-        }
-        if (!hasOperation()) {
-          
-          return false;
-        }
-        if (!hasTxnId()) {
-          
-          return false;
-        }
-        return true;
-      }
-      
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
           int tag = input.readTag();
           switch (tag) {
             case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
+              done = true;
+              break;
             default: {
               if (!parseUnknownField(input, unknownFields,
                                      extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
+                done = true;
               }
               break;
             }
@@ -658,18 +509,397 @@ public final class BookkeeperProtocol {
             }
           }
         }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
       }
-      
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.class, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<BKPacketHeader> PARSER =
+        new com.google.protobuf.AbstractParser<BKPacketHeader>() {
+      public BKPacketHeader parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new BKPacketHeader(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<BKPacketHeader> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int VERSION_FIELD_NUMBER = 1;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion version_;
+    /**
+     * <code>required .ProtocolVersion version = 1;</code>
+     */
+    public boolean hasVersion() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required .ProtocolVersion version = 1;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion getVersion() {
+      return version_;
+    }
+
+    public static final int OPERATION_FIELD_NUMBER = 2;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType operation_;
+    /**
+     * <code>required .OperationType operation = 2;</code>
+     */
+    public boolean hasOperation() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required .OperationType operation = 2;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType getOperation() {
+      return operation_;
+    }
+
+    public static final int TXNID_FIELD_NUMBER = 3;
+    private long txnId_;
+    /**
+     * <code>required uint64 txnId = 3;</code>
+     */
+    public boolean hasTxnId() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>required uint64 txnId = 3;</code>
+     */
+    public long getTxnId() {
+      return txnId_;
+    }
+
+    private void initFields() {
+      version_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion.VERSION_ONE;
+      operation_ = org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType.READ_ENTRY;
+      txnId_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasVersion()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasOperation()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasTxnId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeEnum(1, version_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeEnum(2, operation_.getNumber());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeUInt64(3, txnId_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(1, version_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(2, operation_.getNumber());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(3, txnId_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code BKPacketHeader}
+     *
+     * <pre>
+     **
+     * Packet header for all requests.
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:BKPacketHeader)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.class, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        version_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion.VERSION_ONE;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        operation_ = org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType.READ_ENTRY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        txnId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_BKPacketHeader_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader result = new org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.version_ = version_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.operation_ = operation_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.txnId_ = txnId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance()) return this;
+        if (other.hasVersion()) {
+          setVersion(other.getVersion());
+        }
+        if (other.hasOperation()) {
+          setOperation(other.getOperation());
+        }
+        if (other.hasTxnId()) {
+          setTxnId(other.getTxnId());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasVersion()) {
+          
+          return false;
+        }
+        if (!hasOperation()) {
+          
+          return false;
+        }
+        if (!hasTxnId()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
       private int bitField0_;
-      
-      // required .ProtocolVersion version = 1;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion version_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion.VERSION_ONE;
+      /**
+       * <code>required .ProtocolVersion version = 1;</code>
+       */
       public boolean hasVersion() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
+      /**
+       * <code>required .ProtocolVersion version = 1;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion getVersion() {
         return version_;
       }
+      /**
+       * <code>required .ProtocolVersion version = 1;</code>
+       */
       public Builder setVersion(org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion value) {
         if (value == null) {
           throw new NullPointerException();
@@ -679,21 +909,32 @@ public final class BookkeeperProtocol {
         onChanged();
         return this;
       }
+      /**
+       * <code>required .ProtocolVersion version = 1;</code>
+       */
       public Builder clearVersion() {
         bitField0_ = (bitField0_ & ~0x00000001);
         version_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion.VERSION_ONE;
         onChanged();
         return this;
       }
-      
-      // required .OperationType operation = 2;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType operation_ = org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType.READ_ENTRY;
+      /**
+       * <code>required .OperationType operation = 2;</code>
+       */
       public boolean hasOperation() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
+      /**
+       * <code>required .OperationType operation = 2;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType getOperation() {
         return operation_;
       }
+      /**
+       * <code>required .OperationType operation = 2;</code>
+       */
       public Builder setOperation(org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType value) {
         if (value == null) {
           throw new NullPointerException();
@@ -703,149 +944,367 @@ public final class BookkeeperProtocol {
         onChanged();
         return this;
       }
+      /**
+       * <code>required .OperationType operation = 2;</code>
+       */
       public Builder clearOperation() {
         bitField0_ = (bitField0_ & ~0x00000002);
         operation_ = org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType.READ_ENTRY;
         onChanged();
         return this;
       }
-      
-      // required uint64 txnId = 3;
+
       private long txnId_ ;
+      /**
+       * <code>required uint64 txnId = 3;</code>
+       */
       public boolean hasTxnId() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
+      /**
+       * <code>required uint64 txnId = 3;</code>
+       */
       public long getTxnId() {
         return txnId_;
       }
+      /**
+       * <code>required uint64 txnId = 3;</code>
+       */
       public Builder setTxnId(long value) {
         bitField0_ |= 0x00000004;
         txnId_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required uint64 txnId = 3;</code>
+       */
       public Builder clearTxnId() {
         bitField0_ = (bitField0_ & ~0x00000004);
         txnId_ = 0L;
         onChanged();
         return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:BKPacketHeader)
     }
-    
+
     static {
       defaultInstance = new BKPacketHeader(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:BKPacketHeader)
   }
-  
-  public interface RequestOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // required .BKPacketHeader header = 1;
+
+  public interface RequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:Request)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     boolean hasHeader();
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader getHeader();
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder getHeaderOrBuilder();
-    
-    // optional .ReadRequest readRequest = 100;
+
+    /**
+     * <code>optional .ReadRequest readRequest = 100;</code>
+     *
+     * <pre>
+     * Requests
+     * </pre>
+     */
     boolean hasReadRequest();
+    /**
+     * <code>optional .ReadRequest readRequest = 100;</code>
+     *
+     * <pre>
+     * Requests
+     * </pre>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest getReadRequest();
+    /**
+     * <code>optional .ReadRequest readRequest = 100;</code>
+     *
+     * <pre>
+     * Requests
+     * </pre>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequestOrBuilder getReadRequestOrBuilder();
-    
-    // optional .AddRequest addRequest = 101;
+
+    /**
+     * <code>optional .AddRequest addRequest = 101;</code>
+     */
     boolean hasAddRequest();
+    /**
+     * <code>optional .AddRequest addRequest = 101;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest getAddRequest();
+    /**
+     * <code>optional .AddRequest addRequest = 101;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequestOrBuilder getAddRequestOrBuilder();
-    
-    // optional .AuthMessage authRequest = 102;
+
+    /**
+     * <code>optional .AuthMessage authRequest = 102;</code>
+     */
     boolean hasAuthRequest();
+    /**
+     * <code>optional .AuthMessage authRequest = 102;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage getAuthRequest();
+    /**
+     * <code>optional .AuthMessage authRequest = 102;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder getAuthRequestOrBuilder();
   }
+  /**
+   * Protobuf type {@code Request}
+   */
   public static final class Request extends
-      com.google.protobuf.GeneratedMessage
-      implements RequestOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:Request)
+      RequestOrBuilder {
     // Use Request.newBuilder() to construct.
-    private Request(Builder builder) {
+    private Request(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private Request(boolean noInit) {}
-    
+    private Request(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final Request defaultInstance;
     public static Request getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public Request getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Request(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                subBuilder = header_.toBuilder();
+              }
+              header_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(header_);
+                header_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
+            case 802: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                subBuilder = readRequest_.toBuilder();
+              }
+              readRequest_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(readRequest_);
+                readRequest_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000002;
+              break;
+            }
+            case 810: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+                subBuilder = addRequest_.toBuilder();
+              }
+              addRequest_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(addRequest_);
+                addRequest_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000004;
+              break;
+            }
+            case 818: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+                subBuilder = authRequest_.toBuilder();
+              }
+              authRequest_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(authRequest_);
+                authRequest_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000008;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Request_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Request_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Request_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.Request.class, org.apache.bookkeeper.proto.BookkeeperProtocol.Request.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<Request> PARSER =
+        new com.google.protobuf.AbstractParser<Request>() {
+      public Request parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Request(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Request> getParserForType() {
+      return PARSER;
+    }
+
     private int bitField0_;
-    // required .BKPacketHeader header = 1;
     public static final int HEADER_FIELD_NUMBER = 1;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader header_;
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     public boolean hasHeader() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader getHeader() {
       return header_;
     }
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder getHeaderOrBuilder() {
       return header_;
     }
-    
-    // optional .ReadRequest readRequest = 100;
+
     public static final int READREQUEST_FIELD_NUMBER = 100;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest readRequest_;
+    /**
+     * <code>optional .ReadRequest readRequest = 100;</code>
+     *
+     * <pre>
+     * Requests
+     * </pre>
+     */
     public boolean hasReadRequest() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
+    /**
+     * <code>optional .ReadRequest readRequest = 100;</code>
+     *
+     * <pre>
+     * Requests
+     * </pre>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest getReadRequest() {
       return readRequest_;
     }
+    /**
+     * <code>optional .ReadRequest readRequest = 100;</code>
+     *
+     * <pre>
+     * Requests
+     * </pre>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequestOrBuilder getReadRequestOrBuilder() {
       return readRequest_;
     }
-    
-    // optional .AddRequest addRequest = 101;
+
     public static final int ADDREQUEST_FIELD_NUMBER = 101;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest addRequest_;
+    /**
+     * <code>optional .AddRequest addRequest = 101;</code>
+     */
     public boolean hasAddRequest() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
+    /**
+     * <code>optional .AddRequest addRequest = 101;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest getAddRequest() {
       return addRequest_;
     }
+    /**
+     * <code>optional .AddRequest addRequest = 101;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequestOrBuilder getAddRequestOrBuilder() {
       return addRequest_;
     }
-    
-    // optional .AuthMessage authRequest = 102;
+
     public static final int AUTHREQUEST_FIELD_NUMBER = 102;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage authRequest_;
+    /**
+     * <code>optional .AuthMessage authRequest = 102;</code>
+     */
     public boolean hasAuthRequest() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
+    /**
+     * <code>optional .AuthMessage authRequest = 102;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage getAuthRequest() {
       return authRequest_;
     }
+    /**
+     * <code>optional .AuthMessage authRequest = 102;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder getAuthRequestOrBuilder() {
       return authRequest_;
     }
-    
+
     private void initFields() {
       header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
       readRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance();
@@ -855,8 +1314,9 @@ public final class BookkeeperProtocol {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       if (!hasHeader()) {
         memoizedIsInitialized = 0;
         return false;
@@ -886,7 +1346,7 @@ public final class BookkeeperProtocol {
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -904,12 +1364,12 @@ public final class BookkeeperProtocol {
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -931,113 +1391,106 @@ public final class BookkeeperProtocol {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Request parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.Request prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code Request}
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.BookkeeperProtocol.RequestOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:Request)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.RequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Request_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Request_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Request_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.Request.class, org.apache.bookkeeper.proto.BookkeeperProtocol.Request.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.Request.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -1052,7 +1505,7 @@ public final class BookkeeperProtocol {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         if (headerBuilder_ == null) {
@@ -1081,20 +1534,20 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.Request.getDescriptor();
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Request_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.Request getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.BookkeeperProtocol.Request.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.Request build() {
         org.apache.bookkeeper.proto.BookkeeperProtocol.Request result = buildPartial();
         if (!result.isInitialized()) {
@@ -1102,17 +1555,7 @@ public final class BookkeeperProtocol {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.Request buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.Request result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.Request buildPartial() {
         org.apache.bookkeeper.proto.BookkeeperProtocol.Request result = new org.apache.bookkeeper.proto.BookkeeperProtocol.Request(this);
         int from_bitField0_ = bitField0_;
@@ -1153,7 +1596,7 @@ public final class BookkeeperProtocol {
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.Request) {
           return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.Request)other);
@@ -1162,7 +1605,7 @@ public final class BookkeeperProtocol {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.Request other) {
         if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.Request.getDefaultInstance()) return this;
         if (other.hasHeader()) {
@@ -1180,7 +1623,7 @@ public final class BookkeeperProtocol {
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         if (!hasHeader()) {
           
@@ -1210,79 +1653,38 @@ public final class BookkeeperProtocol {
         }
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 10: {
-              org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder subBuilder = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.newBuilder();
-              if (hasHeader()) {
-                subBuilder.mergeFrom(getHeader());
-              }
-              input.readMessage(subBuilder, extensionRegistry);
-              setHeader(subBuilder.buildPartial());
-              break;
-            }
-            case 802: {
-              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder subBuilder = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.newBuilder();
-              if (hasReadRequest()) {
-                subBuilder.mergeFrom(getReadRequest());
-              }
-              input.readMessage(subBuilder, extensionRegistry);
-              setReadRequest(subBuilder.buildPartial());
-              break;
-            }
-            case 810: {
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder subBuilder = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.newBuilder();
-              if (hasAddRequest()) {
-                subBuilder.mergeFrom(getAddRequest());
-              }
-              input.readMessage(subBuilder, extensionRegistry);
-              setAddRequest(subBuilder.buildPartial());
-              break;
-            }
-            case 818: {
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder subBuilder = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.newBuilder();
-              if (hasAuthRequest()) {
-                subBuilder.mergeFrom(getAuthRequest());
-              }
-              input.readMessage(subBuilder, extensionRegistry);
-              setAuthRequest(subBuilder.buildPartial());
-              break;
-            }
+        org.apache.bookkeeper.proto.BookkeeperProtocol.Request parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.Request) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // required .BKPacketHeader header = 1;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder> headerBuilder_;
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public boolean hasHeader() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader getHeader() {
         if (headerBuilder_ == null) {
           return header_;
@@ -1290,6 +1692,9 @@ public final class BookkeeperProtocol {
           return headerBuilder_.getMessage();
         }
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public Builder setHeader(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader value) {
         if (headerBuilder_ == null) {
           if (value == null) {
@@ -1303,6 +1708,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000001;
         return this;
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public Builder setHeader(
           org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder builderForValue) {
         if (headerBuilder_ == null) {
@@ -1314,6 +1722,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000001;
         return this;
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public Builder mergeHeader(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader value) {
         if (headerBuilder_ == null) {
           if (((bitField0_ & 0x00000001) == 0x00000001) &&
@@ -1330,6 +1741,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000001;
         return this;
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public Builder clearHeader() {
         if (headerBuilder_ == null) {
           header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
@@ -1340,11 +1754,17 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder getHeaderBuilder() {
         bitField0_ |= 0x00000001;
         onChanged();
         return getHeaderFieldBuilder().getBuilder();
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder getHeaderOrBuilder() {
         if (headerBuilder_ != null) {
           return headerBuilder_.getMessageOrBuilder();
@@ -1352,27 +1772,43 @@ public final class BookkeeperProtocol {
           return header_;
         }
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder> 
           getHeaderFieldBuilder() {
         if (headerBuilder_ == null) {
           headerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder>(
-                  header_,
+                  getHeader(),
                   getParentForChildren(),
                   isClean());
           header_ = null;
         }
         return headerBuilder_;
       }
-      
-      // optional .ReadRequest readRequest = 100;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest readRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequestOrBuilder> readRequestBuilder_;
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       public boolean hasReadRequest() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest getReadRequest() {
         if (readRequestBuilder_ == null) {
           return readRequest_;
@@ -1380,6 +1816,13 @@ public final class BookkeeperProtocol {
           return readRequestBuilder_.getMessage();
         }
       }
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       public Builder setReadRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest value) {
         if (readRequestBuilder_ == null) {
           if (value == null) {
@@ -1393,6 +1836,13 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000002;
         return this;
       }
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       public Builder setReadRequest(
           org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder builderForValue) {
         if (readRequestBuilder_ == null) {
@@ -1404,6 +1854,13 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000002;
         return this;
       }
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       public Builder mergeReadRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest value) {
         if (readRequestBuilder_ == null) {
           if (((bitField0_ & 0x00000002) == 0x00000002) &&
@@ -1420,6 +1877,13 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000002;
         return this;
       }
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       public Builder clearReadRequest() {
         if (readRequestBuilder_ == null) {
           readRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance();
@@ -1430,11 +1894,25 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder getReadRequestBuilder() {
         bitField0_ |= 0x00000002;
         onChanged();
         return getReadRequestFieldBuilder().getBuilder();
       }
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequestOrBuilder getReadRequestOrBuilder() {
         if (readRequestBuilder_ != null) {
           return readRequestBuilder_.getMessageOrBuilder();
@@ -1442,27 +1920,39 @@ public final class BookkeeperProtocol {
           return readRequest_;
         }
       }
+      /**
+       * <code>optional .ReadRequest readRequest = 100;</code>
+       *
+       * <pre>
+       * Requests
+       * </pre>
+       */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequestOrBuilder> 
           getReadRequestFieldBuilder() {
         if (readRequestBuilder_ == null) {
           readRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequestOrBuilder>(
-                  readRequest_,
+                  getReadRequest(),
                   getParentForChildren(),
                   isClean());
           readRequest_ = null;
         }
         return readRequestBuilder_;
       }
-      
-      // optional .AddRequest addRequest = 101;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest addRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequestOrBuilder> addRequestBuilder_;
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       public boolean hasAddRequest() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest getAddRequest() {
         if (addRequestBuilder_ == null) {
           return addRequest_;
@@ -1470,6 +1960,9 @@ public final class BookkeeperProtocol {
           return addRequestBuilder_.getMessage();
         }
       }
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       public Builder setAddRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest value) {
         if (addRequestBuilder_ == null) {
           if (value == null) {
@@ -1483,6 +1976,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000004;
         return this;
       }
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       public Builder setAddRequest(
           org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder builderForValue) {
         if (addRequestBuilder_ == null) {
@@ -1494,6 +1990,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000004;
         return this;
       }
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       public Builder mergeAddRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest value) {
         if (addRequestBuilder_ == null) {
           if (((bitField0_ & 0x00000004) == 0x00000004) &&
@@ -1510,6 +2009,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000004;
         return this;
       }
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       public Builder clearAddRequest() {
         if (addRequestBuilder_ == null) {
           addRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDefaultInstance();
@@ -1520,11 +2022,17 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder getAddRequestBuilder() {
         bitField0_ |= 0x00000004;
         onChanged();
         return getAddRequestFieldBuilder().getBuilder();
       }
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequestOrBuilder getAddRequestOrBuilder() {
         if (addRequestBuilder_ != null) {
           return addRequestBuilder_.getMessageOrBuilder();
@@ -1532,27 +2040,35 @@ public final class BookkeeperProtocol {
           return addRequest_;
         }
       }
+      /**
+       * <code>optional .AddRequest addRequest = 101;</code>
+       */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequestOrBuilder> 
           getAddRequestFieldBuilder() {
         if (addRequestBuilder_ == null) {
           addRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequestOrBuilder>(
-                  addRequest_,
+                  getAddRequest(),
                   getParentForChildren(),
                   isClean());
           addRequest_ = null;
         }
         return addRequestBuilder_;
       }
-      
-      // optional .AuthMessage authRequest = 102;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage authRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder> authRequestBuilder_;
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       public boolean hasAuthRequest() {
         return ((bitField0_ & 0x00000008) == 0x00000008);
       }
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage getAuthRequest() {
         if (authRequestBuilder_ == null) {
           return authRequest_;
@@ -1560,6 +2076,9 @@ public final class BookkeeperProtocol {
           return authRequestBuilder_.getMessage();
         }
       }
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       public Builder setAuthRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage value) {
         if (authRequestBuilder_ == null) {
           if (value == null) {
@@ -1573,6 +2092,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000008;
         return this;
       }
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       public Builder setAuthRequest(
           org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder builderForValue) {
         if (authRequestBuilder_ == null) {
@@ -1584,6 +2106,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000008;
         return this;
       }
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       public Builder mergeAuthRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage value) {
         if (authRequestBuilder_ == null) {
           if (((bitField0_ & 0x00000008) == 0x00000008) &&
@@ -1600,6 +2125,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000008;
         return this;
       }
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       public Builder clearAuthRequest() {
         if (authRequestBuilder_ == null) {
           authRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
@@ -1610,11 +2138,17 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder getAuthRequestBuilder() {
         bitField0_ |= 0x00000008;
         onChanged();
         return getAuthRequestFieldBuilder().getBuilder();
       }
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder getAuthRequestOrBuilder() {
         if (authRequestBuilder_ != null) {
           return authRequestBuilder_.getMessageOrBuilder();
@@ -1622,498 +2156,139 @@ public final class BookkeeperProtocol {
           return authRequest_;
         }
       }
+      /**
+       * <code>optional .AuthMessage authRequest = 102;</code>
+       */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder> 
           getAuthRequestFieldBuilder() {
         if (authRequestBuilder_ == null) {
           authRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder>(
-                  authRequest_,
+                  getAuthRequest(),
                   getParentForChildren(),
                   isClean());
           authRequest_ = null;
         }
         return authRequestBuilder_;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:Request)
     }
-    
+
     static {
       defaultInstance = new Request(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:Request)
   }
-  
-  public interface ReadRequestOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // optional .ReadRequest.Flag flag = 100;
+
+  public interface ReadRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:ReadRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .ReadRequest.Flag flag = 100;</code>
+     */
     boolean hasFlag();
+    /**
+     * <code>optional .ReadRequest.Flag flag = 100;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag getFlag();
-    
-    // required int64 ledgerId = 1;
+
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
     boolean hasLedgerId();
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
     long getLedgerId();
-    
-    // required int64 entryId = 2;
+
+    /**
+     * <code>required int64 entryId = 2;</code>
+     *
+     * <pre>
+     * entryId will be -1 for reading the LAST_ADD_CONFIRMED entry.
+     * </pre>
+     */
     boolean hasEntryId();
+    /**
+     * <code>required int64 entryId = 2;</code>
+     *
+     * <pre>
+     * entryId will be -1 for reading the LAST_ADD_CONFIRMED entry.
+     * </pre>
+     */
     long getEntryId();
-    
-    // optional bytes masterKey = 3;
+
+    /**
+     * <code>optional bytes masterKey = 3;</code>
+     *
+     * <pre>
+     * Used while fencing a ledger.
+     * </pre>
+     */
     boolean hasMasterKey();
+    /**
+     * <code>optional bytes masterKey = 3;</code>
+     *
+     * <pre>
+     * Used while fencing a ledger.
+     * </pre>
+     */
     com.google.protobuf.ByteString getMasterKey();
   }
+  /**
+   * Protobuf type {@code ReadRequest}
+   */
   public static final class ReadRequest extends
-      com.google.protobuf.GeneratedMessage
-      implements ReadRequestOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:ReadRequest)
+      ReadRequestOrBuilder {
     // Use ReadRequest.newBuilder() to construct.
-    private ReadRequest(Builder builder) {
+    private ReadRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private ReadRequest(boolean noInit) {}
-    
+    private ReadRequest(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final ReadRequest defaultInstance;
     public static ReadRequest getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public ReadRequest getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_descriptor;
-    }
-    
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_fieldAccessorTable;
-    }
-    
-    public enum Flag
-        implements com.google.protobuf.ProtocolMessageEnum {
-      FENCE_LEDGER(0, 1),
-      ;
-      
-      public static final int FENCE_LEDGER_VALUE = 1;
-      
-      
-      public final int getNumber() { return value; }
-      
-      public static Flag valueOf(int value) {
-        switch (value) {
-          case 1: return FENCE_LEDGER;
-          default: return null;
-        }
-      }
-      
-      public static com.google.protobuf.Internal.EnumLiteMap<Flag>
-          internalGetValueMap() {
-        return internalValueMap;
-      }
-      private static com.google.protobuf.Internal.EnumLiteMap<Flag>
-          internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<Flag>() {
-              public Flag findValueByNumber(int number) {
-                return Flag.valueOf(number);
-              }
-            };
-      
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDescriptor().getEnumTypes().get(0);
-      }
-      
-      private static final Flag[] VALUES = {
-        FENCE_LEDGER, 
-      };
-      
-      public static Flag valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-      
-      private final int index;
-      private final int value;
-      
-      private Flag(int index, int value) {
-        this.index = index;
-        this.value = value;
-      }
-      
-      // @@protoc_insertion_point(enum_scope:ReadRequest.Flag)
-    }
-    
-    private int bitField0_;
-    // optional .ReadRequest.Flag flag = 100;
-    public static final int FLAG_FIELD_NUMBER = 100;
-    private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag flag_;
-    public boolean hasFlag() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
-    }
-    public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag getFlag() {
-      return flag_;
-    }
-    
-    // required int64 ledgerId = 1;
-    public static final int LEDGERID_FIELD_NUMBER = 1;
-    private long ledgerId_;
-    public boolean hasLedgerId() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
-    }
-    public long getLedgerId() {
-      return ledgerId_;
-    }
-    
-    // required int64 entryId = 2;
-    public static final int ENTRYID_FIELD_NUMBER = 2;
-    private long entryId_;
-    public boolean hasEntryId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    public long getEntryId() {
-      return entryId_;
-    }
-    
-    // optional bytes masterKey = 3;
-    public static final int MASTERKEY_FIELD_NUMBER = 3;
-    private com.google.protobuf.ByteString masterKey_;
-    public boolean hasMasterKey() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
-    }
-    public com.google.protobuf.ByteString getMasterKey() {
-      return masterKey_;
-    }
-    
-    private void initFields() {
-      flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag.FENCE_LEDGER;
-      ledgerId_ = 0L;
-      entryId_ = 0L;
-      masterKey_ = com.google.protobuf.ByteString.EMPTY;
-    }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
-      if (!hasLedgerId()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasEntryId()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
-    }
-    
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeInt64(1, ledgerId_);
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeInt64(2, entryId_);
-      }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeBytes(3, masterKey_);
-      }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(100, flag_.getNumber());
-      }
-      getUnknownFields().writeTo(output);
-    }
-    
-    private int memoizedSerializedSize = -1;
-    public int getSerializedSize() {
-      int size = memoizedSerializedSize;
-      if (size != -1) return size;
-    
-      size = 0;
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(1, ledgerId_);
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(2, entryId_);
-      }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(3, masterKey_);
-      }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(100, flag_.getNumber());
-      }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
-      return size;
-    }
-    
-    private static final long serialVersionUID = 0L;
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
     }
-    
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
+    private ReadRequest(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
-    }
-    
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-    public Builder toBuilder() { return newBuilder(this); }
-    
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequestOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_descriptor;
-      }
-      
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_fieldAccessorTable;
-      }
-      
-      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-      
-      private Builder(BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-      
-      public Builder clear() {
-        super.clear();
-        flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag.FENCE_LEDGER;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        ledgerId_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        entryId_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        masterKey_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        return this;
-      }
-      
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-      
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDescriptor();
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest getDefaultInstanceForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance();
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest build() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-      
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest buildPartial() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest result = new org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.flag_ = flag_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.ledgerId_ = ledgerId_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.entryId_ = entryId_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.masterKey_ = masterKey_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-      
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest) {
-          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-      
-      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest other) {
-        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance()) return this;
-        if (other.hasFlag()) {
-          setFlag(other.getFlag());
-        }
-        if (other.hasLedgerId()) {
-          setLedgerId(other.getLedgerId());
-        }
-        if (other.hasEntryId()) {
-          setEntryId(other.getEntryId());
-        }
-        if (other.hasMasterKey()) {
-          setMasterKey(other.getMasterKey());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-      
-      public final boolean isInitialized() {
-        if (!hasLedgerId()) {
-          
-          return false;
-        }
-        if (!hasEntryId()) {
-          
-          return false;
-        }
-        return true;
-      }
-      
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
           int tag = input.readTag();
           switch (tag) {
             case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
+              done = true;
+              break;
             default: {
               if (!parseUnknownField(input, unknownFields,
                                      extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
+                done = true;
               }
               break;
             }
@@ -2145,179 +2320,69 @@ public final class BookkeeperProtocol {
             }
           }
         }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
       }
-      
-      private int bitField0_;
-      
-      // optional .ReadRequest.Flag flag = 100;
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag.FENCE_LEDGER;
-      public boolean hasFlag() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
-      }
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag getFlag() {
-        return flag_;
-      }
-      public Builder setFlag(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
-        flag_ = value;
-        onChanged();
-        return this;
-      }
-      public Builder clearFlag() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag.FENCE_LEDGER;
-        onChanged();
-        return this;
-      }
-      
-      // required int64 ledgerId = 1;
-      private long ledgerId_ ;
-      public boolean hasLedgerId() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
-      }
-      public long getLedgerId() {
-        return ledgerId_;
-      }
-      public Builder setLedgerId(long value) {
-        bitField0_ |= 0x00000002;
-        ledgerId_ = value;
-        onChanged();
-        return this;
-      }
-      public Builder clearLedgerId() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        ledgerId_ = 0L;
-        onChanged();
-        return this;
-      }
-      
-      // required int64 entryId = 2;
-      private long entryId_ ;
-      public boolean hasEntryId() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
-      }
-      public long getEntryId() {
-        return entryId_;
-      }
-      public Builder setEntryId(long value) {
-        bitField0_ |= 0x00000004;
-        entryId_ = value;
-        onChanged();
-        return this;
-      }
-      public Builder clearEntryId() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        entryId_ = 0L;
-        onChanged();
-        return this;
-      }
-      
-      // optional bytes masterKey = 3;
-      private com.google.protobuf.ByteString masterKey_ = com.google.protobuf.ByteString.EMPTY;
-      public boolean hasMasterKey() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
-      }
-      public com.google.protobuf.ByteString getMasterKey() {
-        return masterKey_;
-      }
-      public Builder setMasterKey(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
-        masterKey_ = value;
-        onChanged();
-        return this;
-      }
-      public Builder clearMasterKey() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        masterKey_ = getDefaultInstance().getMasterKey();
-        onChanged();
-        return this;
-      }
-      
-      // @@protoc_insertion_point(builder_scope:ReadRequest)
     }
-    
-    static {
-      defaultInstance = new ReadRequest(true);
-      defaultInstance.initFields();
-    }
-    
-    // @@protoc_insertion_point(class_scope:ReadRequest)
-  }
-  
-  public interface AddRequestOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // optional .AddRequest.Flag flag = 100;
-    boolean hasFlag();
-    org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag getFlag();
-    
-    // required int64 ledgerId = 1;
-    boolean hasLedgerId();
-    long getLedgerId();
-    
-    // required int64 entryId = 2;
-    boolean hasEntryId();
-    long getEntryId();
-    
-    // required bytes masterKey = 3;
-    boolean hasMasterKey();
-    com.google.protobuf.ByteString getMasterKey();
-    
-    // required bytes body = 4;
-    boolean hasBody();
-    com.google.protobuf.ByteString getBody();
-  }
-  public static final class AddRequest extends
-      com.google.protobuf.GeneratedMessage
-      implements AddRequestOrBuilder {
-    // Use AddRequest.newBuilder() to construct.
-    private AddRequest(Builder builder) {
-      super(builder);
-    }
-    private AddRequest(boolean noInit) {}
-    
-    private static final AddRequest defaultInstance;
-    public static AddRequest getDefaultInstance() {
-      return defaultInstance;
-    }
-    
-    public AddRequest getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-    
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_descriptor;
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<ReadRequest> PARSER =
+        new com.google.protobuf.AbstractParser<ReadRequest>() {
+      public ReadRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ReadRequest(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ReadRequest> getParserForType() {
+      return PARSER;
+    }
+
+    /**
+     * Protobuf enum {@code ReadRequest.Flag}
+     */
     public enum Flag
         implements com.google.protobuf.ProtocolMessageEnum {
-      RECOVERY_ADD(0, 1),
+      /**
+       * <code>FENCE_LEDGER = 1;</code>
+       */
+      FENCE_LEDGER(0, 1),
       ;
-      
-      public static final int RECOVERY_ADD_VALUE = 1;
-      
-      
+
+      /**
+       * <code>FENCE_LEDGER = 1;</code>
+       */
+      public static final int FENCE_LEDGER_VALUE = 1;
+
+
       public final int getNumber() { return value; }
-      
+
       public static Flag valueOf(int value) {
         switch (value) {
-          case 1: return RECOVERY_ADD;
+          case 1: return FENCE_LEDGER;
           default: return null;
         }
       }
-      
+
       public static com.google.protobuf.Internal.EnumLiteMap<Flag>
           internalGetValueMap() {
         return internalValueMap;
@@ -2329,7 +2394,7 @@ public final class BookkeeperProtocol {
                 return Flag.valueOf(number);
               }
             };
-      
+
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         return getDescriptor().getValues().get(index);
@@ -2340,13 +2405,11 @@ public final class BookkeeperProtocol {
       }
       public static final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptor() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDescriptor().getEnumTypes().get(0);
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDescriptor().getEnumTypes().get(0);
       }
-      
-      private static final Flag[] VALUES = {
-        RECOVERY_ADD, 
-      };
-      
+
+      private static final Flag[] VALUES = values();
+
       public static Flag valueOf(
           com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
         if (desc.getType() != getDescriptor()) {
@@ -2355,81 +2418,107 @@ public final class BookkeeperProtocol {
         }
         return VALUES[desc.getIndex()];
       }
-      
+
       private final int index;
       private final int value;
-      
+
       private Flag(int index, int value) {
         this.index = index;
         this.value = value;
       }
-      
-      // @@protoc_insertion_point(enum_scope:AddRequest.Flag)
+
+      // @@protoc_insertion_point(enum_scope:ReadRequest.Flag)
     }
-    
+
     private int bitField0_;
-    // optional .AddRequest.Flag flag = 100;
     public static final int FLAG_FIELD_NUMBER = 100;
-    private org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag flag_;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag flag_;
+    /**
+     * <code>optional .ReadRequest.Flag flag = 100;</code>
+     */
     public boolean hasFlag() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
-    public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag getFlag() {
+    /**
+     * <code>optional .ReadRequest.Flag flag = 100;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag getFlag() {
       return flag_;
     }
-    
-    // required int64 ledgerId = 1;
+
     public static final int LEDGERID_FIELD_NUMBER = 1;
     private long ledgerId_;
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
     public boolean hasLedgerId() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
     public long getLedgerId() {
       return ledgerId_;
     }
-    
-    // required int64 entryId = 2;
+
     public static final int ENTRYID_FIELD_NUMBER = 2;
     private long entryId_;
+    /**
+     * <code>required int64 entryId = 2;</code>
+     *
+     * <pre>
+     * entryId will be -1 for reading the LAST_ADD_CONFIRMED entry.
+     * </pre>
+     */
     public boolean hasEntryId() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
+    /**
+     * <code>required int64 entryId = 2;</code>
+     *
+     * <pre>
+     * entryId will be -1 for reading the LAST_ADD_CONFIRMED entry.
+     * </pre>
+     */
     public long getEntryId() {
       return entryId_;
     }
-    
-    // required bytes masterKey = 3;
+
     public static final int MASTERKEY_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString masterKey_;
+    /**
+     * <code>optional bytes masterKey = 3;</code>
+     *
+     * <pre>
+     * Used while fencing a ledger.
+     * </pre>
+     */
     public boolean hasMasterKey() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
+    /**
+     * <code>optional bytes masterKey = 3;</code>
+     *
+     * <pre>
+     * Used while fencing a ledger.
+     * </pre>
+     */
     public com.google.protobuf.ByteString getMasterKey() {
       return masterKey_;
     }
-    
-    // required bytes body = 4;
-    public static final int BODY_FIELD_NUMBER = 4;
-    private com.google.protobuf.ByteString body_;
-    public boolean hasBody() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
-    }
-    public com.google.protobuf.ByteString getBody() {
-      return body_;
-    }
-    
+
     private void initFields() {
-      flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag.RECOVERY_ADD;
+      flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag.FENCE_LEDGER;
       ledgerId_ = 0L;
       entryId_ = 0L;
       masterKey_ = com.google.protobuf.ByteString.EMPTY;
-      body_ = com.google.protobuf.ByteString.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       if (!hasLedgerId()) {
         memoizedIsInitialized = 0;
         return false;
@@ -2438,18 +2527,10 @@ public final class BookkeeperProtocol {
         memoizedIsInitialized = 0;
         return false;
       }
-      if (!hasMasterKey()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasBody()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -2462,20 +2543,17 @@ public final class BookkeeperProtocol {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeBytes(3, masterKey_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeBytes(4, body_);
-      }
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeEnum(100, flag_.getNumber());
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -2489,10 +2567,6 @@ public final class BookkeeperProtocol {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, masterKey_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(4, body_);
-      }
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(100, flag_.getNumber());
@@ -2501,113 +2575,106 @@ public final class BookkeeperProtocol {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(byte[] data)
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(java.io.InputStream input)
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseDelimitedFrom(java.io.InputStream input)
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseDelimitedFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest prototype) {
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code ReadRequest}
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequestOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:ReadRequest)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_descriptor;
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder.class);
       }
-      
-      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.newBuilder()
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -2618,10 +2685,10 @@ public final class BookkeeperProtocol {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
-        flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag.RECOVERY_ADD;
+        flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag.FENCE_LEDGER;
         bitField0_ = (bitField0_ & ~0x00000001);
         ledgerId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -2629,44 +2696,32 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000004);
         masterKey_ = com.google.protobuf.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000008);
-        body_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDescriptor();
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadRequest_descriptor;
       }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest getDefaultInstanceForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDefaultInstance();
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance();
       }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest build() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest result = buildPartial();
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest buildPartial() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest result = new org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest(this);
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest result = new org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2685,26 +2740,22 @@ public final class BookkeeperProtocol {
           to_bitField0_ |= 0x00000008;
         }
         result.masterKey_ = masterKey_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.body_ = body_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest) {
-          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest)other);
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
-      
-      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest other) {
-        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDefaultInstance()) return this;
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance()) return this;
         if (other.hasFlag()) {
           setFlag(other.getFlag());
         }
@@ -2717,13 +2768,10 @@ public final class BookkeeperProtocol {
         if (other.hasMasterKey()) {
           setMasterKey(other.getMasterKey());
         }
-        if (other.hasBody()) {
-          setBody(other.getBody());
-        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         if (!hasLedgerId()) {
           
@@ -2733,37 +2781,303 @@ public final class BookkeeperProtocol {
           
           return false;
         }
-        if (!hasMasterKey()) {
-          
-          return false;
-        }
-        if (!hasBody()) {
-          
-          return false;
-        }
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag.FENCE_LEDGER;
+      /**
+       * <code>optional .ReadRequest.Flag flag = 100;</code>
+       */
+      public boolean hasFlag() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional .ReadRequest.Flag flag = 100;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag getFlag() {
+        return flag_;
+      }
+      /**
+       * <code>optional .ReadRequest.Flag flag = 100;</code>
+       */
+      public Builder setFlag(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
+        flag_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .ReadRequest.Flag flag = 100;</code>
+       */
+      public Builder clearFlag() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Flag.FENCE_LEDGER;
+        onChanged();
+        return this;
+      }
+
+      private long ledgerId_ ;
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public boolean hasLedgerId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public long getLedgerId() {
+        return ledgerId_;
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public Builder setLedgerId(long value) {
+        bitField0_ |= 0x00000002;
+        ledgerId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public Builder clearLedgerId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        ledgerId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long entryId_ ;
+      /**
+       * <code>required int64 entryId = 2;</code>
+       *
+       * <pre>
+       * entryId will be -1 for reading the LAST_ADD_CONFIRMED entry.
+       * </pre>
+       */
+      public boolean hasEntryId() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>required int64 entryId = 2;</code>
+       *
+       * <pre>
+       * entryId will be -1 for reading the LAST_ADD_CONFIRMED entry.
+       * </pre>
+       */
+      public long getEntryId() {
+        return entryId_;
+      }
+      /**
+       * <code>required int64 entryId = 2;</code>
+       *
+       * <pre>
+       * entryId will be -1 for reading the LAST_ADD_CONFIRMED entry.
+       * </pre>
+       */
+      public Builder setEntryId(long value) {
+        bitField0_ |= 0x00000004;
+        entryId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 entryId = 2;</code>
+       *
+       * <pre>
+       * entryId will be -1 for reading the LAST_ADD_CONFIRMED entry.
+       * </pre>
+       */
+      public Builder clearEntryId() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        entryId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString masterKey_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes masterKey = 3;</code>
+       *
+       * <pre>
+       * Used while fencing a ledger.
+       * </pre>
+       */
+      public boolean hasMasterKey() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional bytes masterKey = 3;</code>
+       *
+       * <pre>
+       * Used while fencing a ledger.
+       * </pre>
+       */
+      public com.google.protobuf.ByteString getMasterKey() {
+        return masterKey_;
+      }
+      /**
+       * <code>optional bytes masterKey = 3;</code>
+       *
+       * <pre>
+       * Used while fencing a ledger.
+       * </pre>
+       */
+      public Builder setMasterKey(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        masterKey_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes masterKey = 3;</code>
+       *
+       * <pre>
+       * Used while fencing a ledger.
+       * </pre>
+       */
+      public Builder clearMasterKey() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        masterKey_ = getDefaultInstance().getMasterKey();
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:ReadRequest)
+    }
+
+    static {
+      defaultInstance = new ReadRequest(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:ReadRequest)
+  }
+
+  public interface AddRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:AddRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .AddRequest.Flag flag = 100;</code>
+     */
+    boolean hasFlag();
+    /**
+     * <code>optional .AddRequest.Flag flag = 100;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag getFlag();
+
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    boolean hasLedgerId();
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    long getLedgerId();
+
+    /**
+     * <code>required int64 entryId = 2;</code>
+     */
+    boolean hasEntryId();
+    /**
+     * <code>required int64 entryId = 2;</code>
+     */
+    long getEntryId();
+
+    /**
+     * <code>required bytes masterKey = 3;</code>
+     */
+    boolean hasMasterKey();
+    /**
+     * <code>required bytes masterKey = 3;</code>
+     */
+    com.google.protobuf.ByteString getMasterKey();
+
+    /**
+     * <code>required bytes body = 4;</code>
+     */
+    boolean hasBody();
+    /**
+     * <code>required bytes body = 4;</code>
+     */
+    com.google.protobuf.ByteString getBody();
+  }
+  /**
+   * Protobuf type {@code AddRequest}
+   */
+  public static final class AddRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:AddRequest)
+      AddRequestOrBuilder {
+    // Use AddRequest.newBuilder() to construct.
+    private AddRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private AddRequest(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final AddRequest defaultInstance;
+    public static AddRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public AddRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AddRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
           int tag = input.readTag();
           switch (tag) {
             case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
+              done = true;
+              break;
             default: {
               if (!parseUnknownField(input, unknownFields,
                                      extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
+                done = true;
               }
               break;
             }
@@ -2800,18 +3114,537 @@ public final class BookkeeperProtocol {
             }
           }
         }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
       }
-      
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<AddRequest> PARSER =
+        new com.google.protobuf.AbstractParser<AddRequest>() {
+      public AddRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AddRequest(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AddRequest> getParserForType() {
+      return PARSER;
+    }
+
+    /**
+     * Protobuf enum {@code AddRequest.Flag}
+     */
+    public enum Flag
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>RECOVERY_ADD = 1;</code>
+       */
+      RECOVERY_ADD(0, 1),
+      ;
+
+      /**
+       * <code>RECOVERY_ADD = 1;</code>
+       */
+      public static final int RECOVERY_ADD_VALUE = 1;
+
+
+      public final int getNumber() { return value; }
+
+      public static Flag valueOf(int value) {
+        switch (value) {
+          case 1: return RECOVERY_ADD;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<Flag>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static com.google.protobuf.Internal.EnumLiteMap<Flag>
+          internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<Flag>() {
+              public Flag findValueByNumber(int number) {
+                return Flag.valueOf(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(index);
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final Flag[] VALUES = values();
+
+      public static Flag valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int index;
+      private final int value;
+
+      private Flag(int index, int value) {
+        this.index = index;
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:AddRequest.Flag)
+    }
+
+    private int bitField0_;
+    public static final int FLAG_FIELD_NUMBER = 100;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag flag_;
+    /**
+     * <code>optional .AddRequest.Flag flag = 100;</code>
+     */
+    public boolean hasFlag() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional .AddRequest.Flag flag = 100;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag getFlag() {
+      return flag_;
+    }
+
+    public static final int LEDGERID_FIELD_NUMBER = 1;
+    private long ledgerId_;
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    public boolean hasLedgerId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    public long getLedgerId() {
+      return ledgerId_;
+    }
+
+    public static final int ENTRYID_FIELD_NUMBER = 2;
+    private long entryId_;
+    /**
+     * <code>required int64 entryId = 2;</code>
+     */
+    public boolean hasEntryId() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>required int64 entryId = 2;</code>
+     */
+    public long getEntryId() {
+      return entryId_;
+    }
+
+    public static final int MASTERKEY_FIELD_NUMBER = 3;
+    private com.google.protobuf.ByteString masterKey_;
+    /**
+     * <code>required bytes masterKey = 3;</code>
+     */
+    public boolean hasMasterKey() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>required bytes masterKey = 3;</code>
+     */
+    public com.google.protobuf.ByteString getMasterKey() {
+      return masterKey_;
+    }
+
+    public static final int BODY_FIELD_NUMBER = 4;
+    private com.google.protobuf.ByteString body_;
+    /**
+     * <code>required bytes body = 4;</code>
+     */
+    public boolean hasBody() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>required bytes body = 4;</code>
+     */
+    public com.google.protobuf.ByteString getBody() {
+      return body_;
+    }
+
+    private void initFields() {
+      flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag.RECOVERY_ADD;
+      ledgerId_ = 0L;
+      entryId_ = 0L;
+      masterKey_ = com.google.protobuf.ByteString.EMPTY;
+      body_ = com.google.protobuf.ByteString.EMPTY;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasLedgerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasEntryId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasMasterKey()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasBody()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(1, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt64(2, entryId_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBytes(3, masterKey_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeBytes(4, body_);
+      }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeEnum(100, flag_.getNumber());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, entryId_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(3, masterKey_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(4, body_);
+      }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(100, flag_.getNumber());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code AddRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:AddRequest)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag.RECOVERY_ADD;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        ledgerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        entryId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        masterKey_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        body_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000010);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddRequest_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest result = new org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.flag_ = flag_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.ledgerId_ = ledgerId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.entryId_ = entryId_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.masterKey_ = masterKey_;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.body_ = body_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDefaultInstance()) return this;
+        if (other.hasFlag()) {
+          setFlag(other.getFlag());
+        }
+        if (other.hasLedgerId()) {
+          setLedgerId(other.getLedgerId());
+        }
+        if (other.hasEntryId()) {
+          setEntryId(other.getEntryId());
+        }
+        if (other.hasMasterKey()) {
+          setMasterKey(other.getMasterKey());
+        }
+        if (other.hasBody()) {
+          setBody(other.getBody());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasLedgerId()) {
+          
+          return false;
+        }
+        if (!hasEntryId()) {
+          
+          return false;
+        }
+        if (!hasMasterKey()) {
+          
+          return false;
+        }
+        if (!hasBody()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
       private int bitField0_;
-      
-      // optional .AddRequest.Flag flag = 100;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag.RECOVERY_ADD;
+      /**
+       * <code>optional .AddRequest.Flag flag = 100;</code>
+       */
       public boolean hasFlag() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
+      /**
+       * <code>optional .AddRequest.Flag flag = 100;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag getFlag() {
         return flag_;
       }
+      /**
+       * <code>optional .AddRequest.Flag flag = 100;</code>
+       */
       public Builder setFlag(org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag value) {
         if (value == null) {
           throw new NullPointerException();
@@ -2821,63 +3654,96 @@ public final class BookkeeperProtocol {
         onChanged();
         return this;
       }
+      /**
+       * <code>optional .AddRequest.Flag flag = 100;</code>
+       */
       public Builder clearFlag() {
         bitField0_ = (bitField0_ & ~0x00000001);
         flag_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Flag.RECOVERY_ADD;
         onChanged();
         return this;
       }
-      
-      // required int64 ledgerId = 1;
+
       private long ledgerId_ ;
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
       public boolean hasLedgerId() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
       public long getLedgerId() {
         return ledgerId_;
       }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
       public Builder setLedgerId(long value) {
         bitField0_ |= 0x00000002;
         ledgerId_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
       public Builder clearLedgerId() {
         bitField0_ = (bitField0_ & ~0x00000002);
         ledgerId_ = 0L;
         onChanged();
         return this;
       }
-      
-      // required int64 entryId = 2;
+
       private long entryId_ ;
+      /**
+       * <code>required int64 entryId = 2;</code>
+       */
       public boolean hasEntryId() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
+      /**
+       * <code>required int64 entryId = 2;</code>
+       */
       public long getEntryId() {
         return entryId_;
       }
+      /**
+       * <code>required int64 entryId = 2;</code>
+       */
       public Builder setEntryId(long value) {
         bitField0_ |= 0x00000004;
         entryId_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required int64 entryId = 2;</code>
+       */
       public Builder clearEntryId() {
         bitField0_ = (bitField0_ & ~0x00000004);
         entryId_ = 0L;
         onChanged();
         return this;
       }
-      
-      // required bytes masterKey = 3;
+
       private com.google.protobuf.ByteString masterKey_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>required bytes masterKey = 3;</code>
+       */
       public boolean hasMasterKey() {
         return ((bitField0_ & 0x00000008) == 0x00000008);
       }
+      /**
+       * <code>required bytes masterKey = 3;</code>
+       */
       public com.google.protobuf.ByteString getMasterKey() {
         return masterKey_;
       }
+      /**
+       * <code>required bytes masterKey = 3;</code>
+       */
       public Builder setMasterKey(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -2887,21 +3753,32 @@ public final class BookkeeperProtocol {
         onChanged();
         return this;
       }
+      /**
+       * <code>required bytes masterKey = 3;</code>
+       */
       public Builder clearMasterKey() {
         bitField0_ = (bitField0_ & ~0x00000008);
         masterKey_ = getDefaultInstance().getMasterKey();
         onChanged();
         return this;
       }
-      
-      // required bytes body = 4;
+
       private com.google.protobuf.ByteString body_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>required bytes body = 4;</code>
+       */
       public boolean hasBody() {
         return ((bitField0_ & 0x00000010) == 0x00000010);
       }
+      /**
+       * <code>required bytes body = 4;</code>
+       */
       public com.google.protobuf.ByteString getBody() {
         return body_;
       }
+      /**
+       * <code>required bytes body = 4;</code>
+       */
       public Builder setBody(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -2911,142 +3788,390 @@ public final class BookkeeperProtocol {
         onChanged();
         return this;
       }
+      /**
+       * <code>required bytes body = 4;</code>
+       */
       public Builder clearBody() {
         bitField0_ = (bitField0_ & ~0x00000010);
         body_ = getDefaultInstance().getBody();
         onChanged();
         return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:AddRequest)
     }
-    
+
     static {
       defaultInstance = new AddRequest(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:AddRequest)
   }
-  
-  public interface ResponseOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // required .BKPacketHeader header = 1;
+
+  public interface ResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:Response)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     boolean hasHeader();
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader getHeader();
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder getHeaderOrBuilder();
-    
-    // required .StatusCode status = 2;
+
+    /**
+     * <code>required .StatusCode status = 2;</code>
+     *
+     * <pre>
+     * EOK if the underlying request succeeded. Each individual response
+     * has a more meaningful status. EBADREQ if we have an unsupported request.
+     * </pre>
+     */
     boolean hasStatus();
+    /**
+     * <code>required .StatusCode status = 2;</code>
+     *
+     * <pre>
+     * EOK if the underlying request succeeded. Each individual response
+     * has a more meaningful status. EBADREQ if we have an unsupported request.
+     * </pre>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus();
-    
-    // optional .ReadResponse readResponse = 100;
+
+    /**
+     * <code>optional .ReadResponse readResponse = 100;</code>
+     *
+     * <pre>
+     * Response
+     * </pre>
+     */
     boolean hasReadResponse();
+    /**
+     * <code>optional .ReadResponse readResponse = 100;</code>
+     *
+     * <pre>
+     * Response
+     * </pre>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse getReadResponse();
+    /**
+     * <code>optional .ReadResponse readResponse = 100;</code>
+     *
+     * <pre>
+     * Response
+     * </pre>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponseOrBuilder getReadResponseOrBuilder();
-    
-    // optional .AddResponse addResponse = 101;
+
+    /**
+     * <code>optional .AddResponse addResponse = 101;</code>
+     */
     boolean hasAddResponse();
+    /**
+     * <code>optional .AddResponse addResponse = 101;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse getAddResponse();
+    /**
+     * <code>optional .AddResponse addResponse = 101;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponseOrBuilder getAddResponseOrBuilder();
-    
-    // optional .AuthMessage authResponse = 102;
+
+    /**
+     * <code>optional .AuthMessage authResponse = 102;</code>
+     */
     boolean hasAuthResponse();
+    /**
+     * <code>optional .AuthMessage authResponse = 102;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage getAuthResponse();
+    /**
+     * <code>optional .AuthMessage authResponse = 102;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder getAuthResponseOrBuilder();
   }
+  /**
+   * Protobuf type {@code Response}
+   */
   public static final class Response extends
-      com.google.protobuf.GeneratedMessage
-      implements ResponseOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:Response)
+      ResponseOrBuilder {
     // Use Response.newBuilder() to construct.
-    private Response(Builder builder) {
+    private Response(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private Response(boolean noInit) {}
-    
+    private Response(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final Response defaultInstance;
     public static Response getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public Response getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Response(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                subBuilder = header_.toBuilder();
+              }
+              header_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(header_);
+                header_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
+            case 16: {
+              int rawValue = input.readEnum();
+              org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(2, rawValue);
+              } else {
+                bitField0_ |= 0x00000002;
+                status_ = value;
+              }
+              break;
+            }
+            case 802: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+                subBuilder = readResponse_.toBuilder();
+              }
+              readResponse_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(readResponse_);
+                readResponse_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000004;
+              break;
+            }
+            case 810: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+                subBuilder = addResponse_.toBuilder();
+              }
+              addResponse_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(addResponse_);
+                addResponse_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000008;
+              break;
+            }
+            case 818: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000010) == 0x00000010)) {
+                subBuilder = authResponse_.toBuilder();
+              }
+              authResponse_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(authResponse_);
+                authResponse_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000010;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Response_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Response_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Response_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.Response.class, org.apache.bookkeeper.proto.BookkeeperProtocol.Response.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<Response> PARSER =
+        new com.google.protobuf.AbstractParser<Response>() {
+      public Response parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Response(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Response> getParserForType() {
+      return PARSER;
+    }
+
     private int bitField0_;
-    // required .BKPacketHeader header = 1;
     public static final int HEADER_FIELD_NUMBER = 1;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader header_;
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     public boolean hasHeader() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader getHeader() {
       return header_;
     }
+    /**
+     * <code>required .BKPacketHeader header = 1;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder getHeaderOrBuilder() {
       return header_;
     }
-    
-    // required .StatusCode status = 2;
+
     public static final int STATUS_FIELD_NUMBER = 2;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_;
+    /**
+     * <code>required .StatusCode status = 2;</code>
+     *
+     * <pre>
+     * EOK if the underlying request succeeded. Each individual response
+     * has a more meaningful status. EBADREQ if we have an unsupported request.
+     * </pre>
+     */
     public boolean hasStatus() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
+    /**
+     * <code>required .StatusCode status = 2;</code>
+     *
+     * <pre>
+     * EOK if the underlying request succeeded. Each individual response
+     * has a more meaningful status. EBADREQ if we have an unsupported request.
+     * </pre>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
       return status_;
     }
-    
-    // optional .ReadResponse readResponse = 100;
+
     public static final int READRESPONSE_FIELD_NUMBER = 100;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse readResponse_;
+    /**
+     * <code>optional .ReadResponse readResponse = 100;</code>
+     *
+     * <pre>
+     * Response
+     * </pre>
+     */
     public boolean hasReadResponse() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
+    /**
+     * <code>optional .ReadResponse readResponse = 100;</code>
+     *
+     * <pre>
+     * Response
+     * </pre>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse getReadResponse() {
       return readResponse_;
     }
+    /**
+     * <code>optional .ReadResponse readResponse = 100;</code>
+     *
+     * <pre>
+     * Response
+     * </pre>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponseOrBuilder getReadResponseOrBuilder() {
       return readResponse_;
     }
-    
-    // optional .AddResponse addResponse = 101;
+
     public static final int ADDRESPONSE_FIELD_NUMBER = 101;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse addResponse_;
+    /**
+     * <code>optional .AddResponse addResponse = 101;</code>
+     */
     public boolean hasAddResponse() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
+    /**
+     * <code>optional .AddResponse addResponse = 101;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse getAddResponse() {
       return addResponse_;
     }
+    /**
+     * <code>optional .AddResponse addResponse = 101;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponseOrBuilder getAddResponseOrBuilder() {
       return addResponse_;
     }
-    
-    // optional .AuthMessage authResponse = 102;
+
     public static final int AUTHRESPONSE_FIELD_NUMBER = 102;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage authResponse_;
+    /**
+     * <code>optional .AuthMessage authResponse = 102;</code>
+     */
     public boolean hasAuthResponse() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
+    /**
+     * <code>optional .AuthMessage authResponse = 102;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage getAuthResponse() {
       return authResponse_;
     }
+    /**
+     * <code>optional .AuthMessage authResponse = 102;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder getAuthResponseOrBuilder() {
       return authResponse_;
     }
-    
+
     private void initFields() {
       header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
       status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
@@ -3057,8 +4182,9 @@ public final class BookkeeperProtocol {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       if (!hasHeader()) {
         memoizedIsInitialized = 0;
         return false;
@@ -3092,7 +4218,7 @@ public final class BookkeeperProtocol {
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -3113,12 +4239,12 @@ public final class BookkeeperProtocol {
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -3144,113 +4270,106 @@ public final class BookkeeperProtocol {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.Response parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.Response prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code Response}
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.BookkeeperProtocol.ResponseOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:Response)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Response_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Response_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.Response.class, org.apache.bookkeeper.proto.BookkeeperProtocol.Response.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.Response.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -3265,7 +4384,7 @@ public final class BookkeeperProtocol {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         if (headerBuilder_ == null) {
@@ -3296,20 +4415,20 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.Response.getDescriptor();
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_Response_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.Response getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.BookkeeperProtocol.Response.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.Response build() {
         org.apache.bookkeeper.proto.BookkeeperProtocol.Response result = buildPartial();
         if (!result.isInitialized()) {
@@ -3317,17 +4436,7 @@ public final class BookkeeperProtocol {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.Response buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.Response result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.Response buildPartial() {
         org.apache.bookkeeper.proto.BookkeeperProtocol.Response result = new org.apache.bookkeeper.proto.BookkeeperProtocol.Response(this);
         int from_bitField0_ = bitField0_;
@@ -3372,7 +4481,7 @@ public final class BookkeeperProtocol {
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.Response) {
           return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.Response)other);
@@ -3381,7 +4490,7 @@ public final class BookkeeperProtocol {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.Response other) {
         if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.Response.getDefaultInstance()) return this;
         if (other.hasHeader()) {
@@ -3402,7 +4511,7 @@ public final class BookkeeperProtocol {
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         if (!hasHeader()) {
           
@@ -3436,90 +4545,38 @@ public final class BookkeeperProtocol {
         }
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 10: {
-              org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder subBuilder = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.newBuilder();
-              if (hasHeader()) {
-                subBuilder.mergeFrom(getHeader());
-              }
-              input.readMessage(subBuilder, extensionRegistry);
-              setHeader(subBuilder.buildPartial());
-              break;
-            }
-            case 16: {
-              int rawValue = input.readEnum();
-              org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(2, rawValue);
-              } else {
-                bitField0_ |= 0x00000002;
-                status_ = value;
-              }
-              break;
-            }
-            case 802: {
-              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder subBuilder = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.newBuilder();
-              if (hasReadResponse()) {
-                subBuilder.mergeFrom(getReadResponse());
-              }
-              input.readMessage(subBuilder, extensionRegistry);
-              setReadResponse(subBuilder.buildPartial());
-              break;
-            }
-            case 810: {
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder subBuilder = org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.newBuilder();
-              if (hasAddResponse()) {
-                subBuilder.mergeFrom(getAddResponse());
-              }
-              input.readMessage(subBuilder, extensionRegistry);
-              setAddResponse(subBuilder.buildPartial());
-              break;
-            }
-            case 818: {
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder subBuilder = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.newBuilder();
-              if (hasAuthResponse()) {
-                subBuilder.mergeFrom(getAuthResponse());
-              }
-              input.readMessage(subBuilder, extensionRegistry);
-              setAuthResponse(subBuilder.buildPartial());
-              break;
-            }
+        org.apache.bookkeeper.proto.BookkeeperProtocol.Response parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.Response) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // required .BKPacketHeader header = 1;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder> headerBuilder_;
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public boolean hasHeader() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader getHeader() {
         if (headerBuilder_ == null) {
           return header_;
@@ -3527,6 +4584,9 @@ public final class BookkeeperProtocol {
           return headerBuilder_.getMessage();
         }
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public Builder setHeader(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader value) {
         if (headerBuilder_ == null) {
           if (value == null) {
@@ -3540,6 +4600,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000001;
         return this;
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public Builder setHeader(
           org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder builderForValue) {
         if (headerBuilder_ == null) {
@@ -3551,6 +4614,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000001;
         return this;
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public Builder mergeHeader(org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader value) {
         if (headerBuilder_ == null) {
           if (((bitField0_ & 0x00000001) == 0x00000001) &&
@@ -3567,6 +4633,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000001;
         return this;
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public Builder clearHeader() {
         if (headerBuilder_ == null) {
           header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
@@ -3577,11 +4646,17 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder getHeaderBuilder() {
         bitField0_ |= 0x00000001;
         onChanged();
         return getHeaderFieldBuilder().getBuilder();
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder getHeaderOrBuilder() {
         if (headerBuilder_ != null) {
           return headerBuilder_.getMessageOrBuilder();
@@ -3589,28 +4664,54 @@ public final class BookkeeperProtocol {
           return header_;
         }
       }
+      /**
+       * <code>required .BKPacketHeader header = 1;</code>
+       */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder> 
           getHeaderFieldBuilder() {
         if (headerBuilder_ == null) {
           headerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeaderOrBuilder>(
-                  header_,
+                  getHeader(),
                   getParentForChildren(),
                   isClean());
           header_ = null;
         }
         return headerBuilder_;
       }
-      
-      // required .StatusCode status = 2;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      /**
+       * <code>required .StatusCode status = 2;</code>
+       *
+       * <pre>
+       * EOK if the underlying request succeeded. Each individual response
+       * has a more meaningful status. EBADREQ if we have an unsupported request.
+       * </pre>
+       */
       public boolean hasStatus() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
+      /**
+       * <code>required .StatusCode status = 2;</code>
+       *
+       * <pre>
+       * EOK if the underlying request succeeded. Each individual response
+       * has a more meaningful status. EBADREQ if we have an unsupported request.
+       * </pre>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
         return status_;
       }
+      /**
+       * <code>required .StatusCode status = 2;</code>
+       *
+       * <pre>
+       * EOK if the underlying request succeeded. Each individual response
+       * has a more meaningful status. EBADREQ if we have an unsupported request.
+       * </pre>
+       */
       public Builder setStatus(org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value) {
         if (value == null) {
           throw new NullPointerException();
@@ -3620,20 +4721,41 @@ public final class BookkeeperProtocol {
         onChanged();
         return this;
       }
+      /**
+       * <code>required .StatusCode status = 2;</code>
+       *
+       * <pre>
+       * EOK if the underlying request succeeded. Each individual response
+       * has a more meaningful status. EBADREQ if we have an unsupported request.
+       * </pre>
+       */
       public Builder clearStatus() {
         bitField0_ = (bitField0_ & ~0x00000002);
         status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
         onChanged();
         return this;
       }
-      
-      // optional .ReadResponse readResponse = 100;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse readResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponseOrBuilder> readResponseBuilder_;
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       public boolean hasReadResponse() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse getReadResponse() {
         if (readResponseBuilder_ == null) {
           return readResponse_;
@@ -3641,6 +4763,13 @@ public final class BookkeeperProtocol {
           return readResponseBuilder_.getMessage();
         }
       }
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       public Builder setReadResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse value) {
         if (readResponseBuilder_ == null) {
           if (value == null) {
@@ -3654,6 +4783,13 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000004;
         return this;
       }
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       public Builder setReadResponse(
           org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder builderForValue) {
         if (readResponseBuilder_ == null) {
@@ -3665,6 +4801,13 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000004;
         return this;
       }
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       public Builder mergeReadResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse value) {
         if (readResponseBuilder_ == null) {
           if (((bitField0_ & 0x00000004) == 0x00000004) &&
@@ -3681,6 +4824,13 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000004;
         return this;
       }
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       public Builder clearReadResponse() {
         if (readResponseBuilder_ == null) {
           readResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.getDefaultInstance();
@@ -3691,11 +4841,25 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder getReadResponseBuilder() {
         bitField0_ |= 0x00000004;
         onChanged();
         return getReadResponseFieldBuilder().getBuilder();
       }
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponseOrBuilder getReadResponseOrBuilder() {
         if (readResponseBuilder_ != null) {
           return readResponseBuilder_.getMessageOrBuilder();
@@ -3703,27 +4867,39 @@ public final class BookkeeperProtocol {
           return readResponse_;
         }
       }
+      /**
+       * <code>optional .ReadResponse readResponse = 100;</code>
+       *
+       * <pre>
+       * Response
+       * </pre>
+       */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponseOrBuilder> 
           getReadResponseFieldBuilder() {
         if (readResponseBuilder_ == null) {
           readResponseBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponseOrBuilder>(
-                  readResponse_,
+                  getReadResponse(),
                   getParentForChildren(),
                   isClean());
           readResponse_ = null;
         }
         return readResponseBuilder_;
       }
-      
-      // optional .AddResponse addResponse = 101;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse addResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponseOrBuilder> addResponseBuilder_;
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       public boolean hasAddResponse() {
         return ((bitField0_ & 0x00000008) == 0x00000008);
       }
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse getAddResponse() {
         if (addResponseBuilder_ == null) {
           return addResponse_;
@@ -3731,6 +4907,9 @@ public final class BookkeeperProtocol {
           return addResponseBuilder_.getMessage();
         }
       }
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       public Builder setAddResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse value) {
         if (addResponseBuilder_ == null) {
           if (value == null) {
@@ -3744,6 +4923,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000008;
         return this;
       }
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       public Builder setAddResponse(
           org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder builderForValue) {
         if (addResponseBuilder_ == null) {
@@ -3755,6 +4937,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000008;
         return this;
       }
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       public Builder mergeAddResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse value) {
         if (addResponseBuilder_ == null) {
           if (((bitField0_ & 0x00000008) == 0x00000008) &&
@@ -3771,6 +4956,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000008;
         return this;
       }
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       public Builder clearAddResponse() {
         if (addResponseBuilder_ == null) {
           addResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.getDefaultInstance();
@@ -3781,11 +4969,17 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder getAddResponseBuilder() {
         bitField0_ |= 0x00000008;
         onChanged();
         return getAddResponseFieldBuilder().getBuilder();
       }
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponseOrBuilder getAddResponseOrBuilder() {
         if (addResponseBuilder_ != null) {
           return addResponseBuilder_.getMessageOrBuilder();
@@ -3793,27 +4987,35 @@ public final class BookkeeperProtocol {
           return addResponse_;
         }
       }
+      /**
+       * <code>optional .AddResponse addResponse = 101;</code>
+       */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponseOrBuilder> 
           getAddResponseFieldBuilder() {
         if (addResponseBuilder_ == null) {
           addResponseBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponseOrBuilder>(
-                  addResponse_,
+                  getAddResponse(),
                   getParentForChildren(),
                   isClean());
           addResponse_ = null;
         }
         return addResponseBuilder_;
       }
-      
-      // optional .AuthMessage authResponse = 102;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage authResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder> authResponseBuilder_;
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       public boolean hasAuthResponse() {
         return ((bitField0_ & 0x00000010) == 0x00000010);
       }
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage getAuthResponse() {
         if (authResponseBuilder_ == null) {
           return authResponse_;
@@ -3821,6 +5023,9 @@ public final class BookkeeperProtocol {
           return authResponseBuilder_.getMessage();
         }
       }
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       public Builder setAuthResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage value) {
         if (authResponseBuilder_ == null) {
           if (value == null) {
@@ -3834,6 +5039,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000010;
         return this;
       }
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       public Builder setAuthResponse(
           org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder builderForValue) {
         if (authResponseBuilder_ == null) {
@@ -3845,6 +5053,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000010;
         return this;
       }
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       public Builder mergeAuthResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage value) {
         if (authResponseBuilder_ == null) {
           if (((bitField0_ & 0x00000010) == 0x00000010) &&
@@ -3861,6 +5072,9 @@ public final class BookkeeperProtocol {
         bitField0_ |= 0x00000010;
         return this;
       }
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       public Builder clearAuthResponse() {
         if (authResponseBuilder_ == null) {
           authResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
@@ -3871,11 +5085,17 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder getAuthResponseBuilder() {
         bitField0_ |= 0x00000010;
         onChanged();
         return getAuthResponseFieldBuilder().getBuilder();
       }
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder getAuthResponseOrBuilder() {
         if (authResponseBuilder_ != null) {
           return authResponseBuilder_.getMessageOrBuilder();
@@ -3883,440 +5103,123 @@ public final class BookkeeperProtocol {
           return authResponse_;
         }
       }
+      /**
+       * <code>optional .AuthMessage authResponse = 102;</code>
+       */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder> 
           getAuthResponseFieldBuilder() {
         if (authResponseBuilder_ == null) {
           authResponseBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder>(
-                  authResponse_,
+                  getAuthResponse(),
                   getParentForChildren(),
                   isClean());
           authResponse_ = null;
         }
         return authResponseBuilder_;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:Response)
     }
-    
+
     static {
       defaultInstance = new Response(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:Response)
   }
-  
-  public interface ReadResponseOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // required .StatusCode status = 1;
+
+  public interface ReadResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:ReadResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
     boolean hasStatus();
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
     org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus();
-    
-    // required int64 ledgerId = 2;
+
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
     boolean hasLedgerId();
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
     long getLedgerId();
-    
-    // required int64 entryId = 3;
+
+    /**
+     * <code>required int64 entryId = 3;</code>
+     */
     boolean hasEntryId();
+    /**
+     * <code>required int64 entryId = 3;</code>
+     */
     long getEntryId();
-    
-    // optional bytes body = 4;
+
+    /**
+     * <code>optional bytes body = 4;</code>
+     */
     boolean hasBody();
+    /**
+     * <code>optional bytes body = 4;</code>
+     */
     com.google.protobuf.ByteString getBody();
   }
+  /**
+   * Protobuf type {@code ReadResponse}
+   */
   public static final class ReadResponse extends
-      com.google.protobuf.GeneratedMessage
-      implements ReadResponseOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:ReadResponse)
+      ReadResponseOrBuilder {
     // Use ReadResponse.newBuilder() to construct.
-    private ReadResponse(Builder builder) {
+    private ReadResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private ReadResponse(boolean noInit) {}
-    
+    private ReadResponse(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final ReadResponse defaultInstance;
     public static ReadResponse getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public ReadResponse getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_descriptor;
-    }
-    
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_fieldAccessorTable;
-    }
-    
-    private int bitField0_;
-    // required .StatusCode status = 1;
-    public static final int STATUS_FIELD_NUMBER = 1;
-    private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_;
-    public boolean hasStatus() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
-    }
-    public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
-      return status_;
-    }
-    
-    // required int64 ledgerId = 2;
-    public static final int LEDGERID_FIELD_NUMBER = 2;
-    private long ledgerId_;
-    public boolean hasLedgerId() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
-    }
-    public long getLedgerId() {
-      return ledgerId_;
-    }
-    
-    // required int64 entryId = 3;
-    public static final int ENTRYID_FIELD_NUMBER = 3;
-    private long entryId_;
-    public boolean hasEntryId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    public long getEntryId() {
-      return entryId_;
-    }
-    
-    // optional bytes body = 4;
-    public static final int BODY_FIELD_NUMBER = 4;
-    private com.google.protobuf.ByteString body_;
-    public boolean hasBody() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
-    }
-    public com.google.protobuf.ByteString getBody() {
-      return body_;
-    }
-    
-    private void initFields() {
-      status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
-      ledgerId_ = 0L;
-      entryId_ = 0L;
-      body_ = com.google.protobuf.ByteString.EMPTY;
-    }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
-      if (!hasStatus()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasLedgerId()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasEntryId()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      memoizedIsInitialized = 1;
-      return true;
-    }
-    
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(1, status_.getNumber());
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeInt64(2, ledgerId_);
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeInt64(3, entryId_);
-      }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeBytes(4, body_);
-      }
-      getUnknownFields().writeTo(output);
-    }
-    
-    private int memoizedSerializedSize = -1;
-    public int getSerializedSize() {
-      int size = memoizedSerializedSize;
-      if (size != -1) return size;
-    
-      size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, status_.getNumber());
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(2, ledgerId_);
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(3, entryId_);
-      }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(4, body_);
-      }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
-      return size;
-    }
-    
-    private static final long serialVersionUID = 0L;
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
     }
-    
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
-    }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
+    private ReadResponse(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
-    }
-    
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-    public Builder toBuilder() { return newBuilder(this); }
-    
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponseOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_descriptor;
-      }
-      
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_fieldAccessorTable;
-      }
-      
-      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-      
-      private Builder(BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-      
-      public Builder clear() {
-        super.clear();
-        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        ledgerId_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        entryId_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        body_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        return this;
-      }
-      
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-      
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.getDescriptor();
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse getDefaultInstanceForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.getDefaultInstance();
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse build() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-      
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse buildPartial() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse result = new org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.status_ = status_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.ledgerId_ = ledgerId_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.entryId_ = entryId_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.body_ = body_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-      
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse) {
-          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-      
-      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse other) {
-        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.getDefaultInstance()) return this;
-        if (other.hasStatus()) {
-          setStatus(other.getStatus());
-        }
-        if (other.hasLedgerId()) {
-          setLedgerId(other.getLedgerId());
-        }
-        if (other.hasEntryId()) {
-          setEntryId(other.getEntryId());
-        }
-        if (other.hasBody()) {
-          setBody(other.getBody());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-      
-      public final boolean isInitialized() {
-        if (!hasStatus()) {
-          
-          return false;
-        }
-        if (!hasLedgerId()) {
-          
-          return false;
-        }
-        if (!hasEntryId()) {
-          
-          return false;
-        }
-        return true;
-      }
-      
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
           int tag = input.readTag();
           switch (tag) {
             case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
+              done = true;
+              break;
             default: {
               if (!parseUnknownField(input, unknownFields,
                                      extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
+                done = true;
               }
               break;
             }
@@ -4348,195 +5251,116 @@ public final class BookkeeperProtocol {
             }
           }
         }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
       }
-      
-      private int bitField0_;
-      
-      // required .StatusCode status = 1;
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
-      public boolean hasStatus() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
-      }
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
-        return status_;
-      }
-      public Builder setStatus(org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
-        status_ = value;
-        onChanged();
-        return this;
-      }
-      public Builder clearStatus() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
-        onChanged();
-        return this;
-      }
-      
-      // required int64 ledgerId = 2;
-      private long ledgerId_ ;
-      public boolean hasLedgerId() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
-      }
-      public long getLedgerId() {
-        return ledgerId_;
-      }
-      public Builder setLedgerId(long value) {
-        bitField0_ |= 0x00000002;
-        ledgerId_ = value;
-        onChanged();
-        return this;
-      }
-      public Builder clearLedgerId() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        ledgerId_ = 0L;
-        onChanged();
-        return this;
-      }
-      
-      // required int64 entryId = 3;
-      private long entryId_ ;
-      public boolean hasEntryId() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
-      }
-      public long getEntryId() {
-        return entryId_;
-      }
-      public Builder setEntryId(long value) {
-        bitField0_ |= 0x00000004;
-        entryId_ = value;
-        onChanged();
-        return this;
-      }
-      public Builder clearEntryId() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        entryId_ = 0L;
-        onChanged();
-        return this;
-      }
-      
-      // optional bytes body = 4;
-      private com.google.protobuf.ByteString body_ = com.google.protobuf.ByteString.EMPTY;
-      public boolean hasBody() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
-      }
-      public com.google.protobuf.ByteString getBody() {
-        return body_;
-      }
-      public Builder setBody(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
-        body_ = value;
-        onChanged();
-        return this;
-      }
-      public Builder clearBody() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        body_ = getDefaultInstance().getBody();
-        onChanged();
-        return this;
-      }
-      
-      // @@protoc_insertion_point(builder_scope:ReadResponse)
     }
-    
-    static {
-      defaultInstance = new ReadResponse(true);
-      defaultInstance.initFields();
-    }
-    
-    // @@protoc_insertion_point(class_scope:ReadResponse)
-  }
-  
-  public interface AddResponseOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // required .StatusCode status = 1;
-    boolean hasStatus();
-    org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus();
-    
-    // required int64 ledgerId = 2;
-    boolean hasLedgerId();
-    long getLedgerId();
-    
-    // required int64 entryId = 3;
-    boolean hasEntryId();
-    long getEntryId();
-  }
-  public static final class AddResponse extends
-      com.google.protobuf.GeneratedMessage
-      implements AddResponseOrBuilder {
-    // Use AddResponse.newBuilder() to construct.
-    private AddResponse(Builder builder) {
-      super(builder);
-    }
-    private AddResponse(boolean noInit) {}
-    
-    private static final AddResponse defaultInstance;
-    public static AddResponse getDefaultInstance() {
-      return defaultInstance;
-    }
-    
-    public AddResponse getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-    
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_descriptor;
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<ReadResponse> PARSER =
+        new com.google.protobuf.AbstractParser<ReadResponse>() {
+      public ReadResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ReadResponse(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ReadResponse> getParserForType() {
+      return PARSER;
+    }
+
     private int bitField0_;
-    // required .StatusCode status = 1;
     public static final int STATUS_FIELD_NUMBER = 1;
     private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_;
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
     public boolean hasStatus() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
     public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
       return status_;
     }
-    
-    // required int64 ledgerId = 2;
+
     public static final int LEDGERID_FIELD_NUMBER = 2;
     private long ledgerId_;
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
     public boolean hasLedgerId() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
     public long getLedgerId() {
       return ledgerId_;
     }
-    
-    // required int64 entryId = 3;
+
     public static final int ENTRYID_FIELD_NUMBER = 3;
     private long entryId_;
+    /**
+     * <code>required int64 entryId = 3;</code>
+     */
     public boolean hasEntryId() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
+    /**
+     * <code>required int64 entryId = 3;</code>
+     */
     public long getEntryId() {
       return entryId_;
     }
-    
+
+    public static final int BODY_FIELD_NUMBER = 4;
+    private com.google.protobuf.ByteString body_;
+    /**
+     * <code>optional bytes body = 4;</code>
+     */
+    public boolean hasBody() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional bytes body = 4;</code>
+     */
+    public com.google.protobuf.ByteString getBody() {
+      return body_;
+    }
+
     private void initFields() {
       status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
       ledgerId_ = 0L;
       entryId_ = 0L;
+      body_ = com.google.protobuf.ByteString.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       if (!hasStatus()) {
         memoizedIsInitialized = 0;
         return false;
@@ -4552,7 +5376,7 @@ public final class BookkeeperProtocol {
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -4565,14 +5389,17 @@ public final class BookkeeperProtocol {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeInt64(3, entryId_);
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBytes(4, body_);
+      }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -4586,117 +5413,114 @@ public final class BookkeeperProtocol {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(3, entryId_);
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(4, body_);
+      }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(byte[] data)
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(java.io.InputStream input)
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseDelimitedFrom(java.io.InputStream input)
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseDelimitedFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
-    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse prototype) {
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code ReadResponse}
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponseOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:ReadResponse)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_descriptor;
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder.class);
       }
-      
-      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.newBuilder()
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -4707,7 +5531,7 @@ public final class BookkeeperProtocol {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
@@ -4716,42 +5540,34 @@ public final class BookkeeperProtocol {
         bitField0_ = (bitField0_ & ~0x00000002);
         entryId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000004);
+        body_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.getDescriptor();
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadResponse_descriptor;
       }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse getDefaultInstanceForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.getDefaultInstance();
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.getDefaultInstance();
       }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse build() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse result = buildPartial();
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
-      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse buildPartial() {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse result = new org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse(this);
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse result = new org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4766,22 +5582,26 @@ public final class BookkeeperProtocol {
           to_bitField0_ |= 0x00000004;
         }
         result.entryId_ = entryId_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.body_ = body_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse) {
-          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse)other);
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
-      
-      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse other) {
-        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.getDefaultInstance()) return this;
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.getDefaultInstance()) return this;
         if (other.hasStatus()) {
           setStatus(other.getStatus());
         }
@@ -4791,10 +5611,13 @@ public final class BookkeeperProtocol {
         if (other.hasEntryId()) {
           setEntryId(other.getEntryId());
         }
+        if (other.hasBody()) {
+          setBody(other.getBody());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         if (!hasStatus()) {
           
@@ -4810,27 +5633,251 @@ public final class BookkeeperProtocol {
         }
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public boolean hasStatus() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
+        return status_;
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public Builder setStatus(org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
+        status_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public Builder clearStatus() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+        onChanged();
+        return this;
+      }
+
+      private long ledgerId_ ;
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public boolean hasLedgerId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public long getLedgerId() {
+        return ledgerId_;
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public Builder setLedgerId(long value) {
+        bitField0_ |= 0x00000002;
+        ledgerId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public Builder clearLedgerId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        ledgerId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long entryId_ ;
+      /**
+       * <code>required int64 entryId = 3;</code>
+       */
+      public boolean hasEntryId() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>required int64 entryId = 3;</code>
+       */
+      public long getEntryId() {
+        return entryId_;
+      }
+      /**
+       * <code>required int64 entryId = 3;</code>
+       */
+      public Builder setEntryId(long value) {
+        bitField0_ |= 0x00000004;
+        entryId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 entryId = 3;</code>
+       */
+      public Builder clearEntryId() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        entryId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString body_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes body = 4;</code>
+       */
+      public boolean hasBody() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional bytes body = 4;</code>
+       */
+      public com.google.protobuf.ByteString getBody() {
+        return body_;
+      }
+      /**
+       * <code>optional bytes body = 4;</code>
+       */
+      public Builder setBody(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        body_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes body = 4;</code>
+       */
+      public Builder clearBody() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        body_ = getDefaultInstance().getBody();
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:ReadResponse)
+    }
+
+    static {
+      defaultInstance = new ReadResponse(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:ReadResponse)
+  }
+
+  public interface AddResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:AddResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    boolean hasStatus();
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus();
+
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    boolean hasLedgerId();
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    long getLedgerId();
+
+    /**
+     * <code>required int64 entryId = 3;</code>
+     */
+    boolean hasEntryId();
+    /**
+     * <code>required int64 entryId = 3;</code>
+     */
+    long getEntryId();
+  }
+  /**
+   * Protobuf type {@code AddResponse}
+   */
+  public static final class AddResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:AddResponse)
+      AddResponseOrBuilder {
+    // Use AddResponse.newBuilder() to construct.
+    private AddResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private AddResponse(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final AddResponse defaultInstance;
+    public static AddResponse getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public AddResponse getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AddResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
           int tag = input.readTag();
           switch (tag) {
             case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
+              done = true;
+              break;
             default: {
               if (!parseUnknownField(input, unknownFields,
                                      extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
+                done = true;
               }
               break;
             }
@@ -4857,18 +5904,392 @@ public final class BookkeeperProtocol {
             }
           }
         }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
       }
-      
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<AddResponse> PARSER =
+        new com.google.protobuf.AbstractParser<AddResponse>() {
+      public AddResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AddResponse(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AddResponse> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int STATUS_FIELD_NUMBER = 1;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_;
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    public boolean hasStatus() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
+      return status_;
+    }
+
+    public static final int LEDGERID_FIELD_NUMBER = 2;
+    private long ledgerId_;
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    public boolean hasLedgerId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    public long getLedgerId() {
+      return ledgerId_;
+    }
+
+    public static final int ENTRYID_FIELD_NUMBER = 3;
+    private long entryId_;
+    /**
+     * <code>required int64 entryId = 3;</code>
+     */
+    public boolean hasEntryId() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>required int64 entryId = 3;</code>
+     */
+    public long getEntryId() {
+      return entryId_;
+    }
+
+    private void initFields() {
+      status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      ledgerId_ = 0L;
+      entryId_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasStatus()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasLedgerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasEntryId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeEnum(1, status_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(2, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt64(3, entryId_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(1, status_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(3, entryId_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code AddResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:AddResponse)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        ledgerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        entryId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AddResponse_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse result = new org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.status_ = status_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.ledgerId_ = ledgerId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.entryId_ = entryId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.getDefaultInstance()) return this;
+        if (other.hasStatus()) {
+          setStatus(other.getStatus());
+        }
+        if (other.hasLedgerId()) {
+          setLedgerId(other.getLedgerId());
+        }
+        if (other.hasEntryId()) {
+          setEntryId(other.getEntryId());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasStatus()) {
+          
+          return false;
+        }
+        if (!hasLedgerId()) {
+          
+          return false;
+        }
+        if (!hasEntryId()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
       private int bitField0_;
-      
-      // required .StatusCode status = 1;
+
       private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
       public boolean hasStatus() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
       public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
         return status_;
       }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
       public Builder setStatus(org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value) {
         if (value == null) {
           throw new NullPointerException();
@@ -4878,143 +6299,266 @@ public final class BookkeeperProtocol {
         onChanged();
         return this;
       }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
       public Builder clearStatus() {
         bitField0_ = (bitField0_ & ~0x00000001);
         status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
         onChanged();
         return this;
       }
-      
-      // required int64 ledgerId = 2;
+
       private long ledgerId_ ;
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
       public boolean hasLedgerId() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
       public long getLedgerId() {
         return ledgerId_;
       }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
       public Builder setLedgerId(long value) {
         bitField0_ |= 0x00000002;
         ledgerId_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
       public Builder clearLedgerId() {
         bitField0_ = (bitField0_ & ~0x00000002);
         ledgerId_ = 0L;
         onChanged();
         return this;
       }
-      
-      // required int64 entryId = 3;
+
       private long entryId_ ;
+      /**
+       * <code>required int64 entryId = 3;</code>
+       */
       public boolean hasEntryId() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
+      /**
+       * <code>required int64 entryId = 3;</code>
+       */
       public long getEntryId() {
         return entryId_;
       }
+      /**
+       * <code>required int64 entryId = 3;</code>
+       */
       public Builder setEntryId(long value) {
         bitField0_ |= 0x00000004;
         entryId_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required int64 entryId = 3;</code>
+       */
       public Builder clearEntryId() {
         bitField0_ = (bitField0_ & ~0x00000004);
         entryId_ = 0L;
         onChanged();
         return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:AddResponse)
     }
-    
+
     static {
       defaultInstance = new AddResponse(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:AddResponse)
   }
-  
+
   public interface AuthMessageOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:AuthMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<AuthMessage> {
-    
-    // required string authPluginName = 1;
+
+    /**
+     * <code>required string authPluginName = 1;</code>
+     */
     boolean hasAuthPluginName();
-    String getAuthPluginName();
+    /**
+     * <code>required string authPluginName = 1;</code>
+     */
+    java.lang.String getAuthPluginName();
+    /**
+     * <code>required string authPluginName = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getAuthPluginNameBytes();
   }
+  /**
+   * Protobuf type {@code AuthMessage}
+   *
+   * <pre>
+   **
+   * Extendible message which auth mechanisms
+   * can use to carry their payload.
+   * </pre>
+   */
   public static final class AuthMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        AuthMessage> implements AuthMessageOrBuilder {
+        AuthMessage> implements
+      // @@protoc_insertion_point(message_implements:AuthMessage)
+      AuthMessageOrBuilder {
     // Use AuthMessage.newBuilder() to construct.
-    private AuthMessage(Builder builder) {
+    private AuthMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, ?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private AuthMessage(boolean noInit) {}
-    
+    private AuthMessage(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final AuthMessage defaultInstance;
     public static AuthMessage getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public AuthMessage getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AuthMessage(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              authPluginName_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AuthMessage_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AuthMessage_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AuthMessage_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.class, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<AuthMessage> PARSER =
+        new com.google.protobuf.AbstractParser<AuthMessage>() {
+      public AuthMessage parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AuthMessage(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AuthMessage> getParserForType() {
+      return PARSER;
+    }
+
     private int bitField0_;
-    // required string authPluginName = 1;
     public static final int AUTHPLUGINNAME_FIELD_NUMBER = 1;
     private java.lang.Object authPluginName_;
+    /**
+     * <code>required string authPluginName = 1;</code>
+     */
     public boolean hasAuthPluginName() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
-    public String getAuthPluginName() {
+    /**
+     * <code>required string authPluginName = 1;</code>
+     */
+    public java.lang.String getAuthPluginName() {
       java.lang.Object ref = authPluginName_;
-      if (ref instanceof String) {
-        return (String) ref;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
-        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
           authPluginName_ = s;
         }
         return s;
       }
     }
-    private com.google.protobuf.ByteString getAuthPluginNameBytes() {
+    /**
+     * <code>required string authPluginName = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getAuthPluginNameBytes() {
       java.lang.Object ref = authPluginName_;
-      if (ref instanceof String) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         authPluginName_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
-    
+
     private void initFields() {
       authPluginName_ = "";
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       if (!hasAuthPluginName()) {
         memoizedIsInitialized = 0;
         return false;
@@ -5026,7 +6570,7 @@ public final class BookkeeperProtocol {
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -5039,12 +6583,12 @@ public final class BookkeeperProtocol {
       extensionWriter.writeUntil(536870912, output);
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -5055,113 +6599,113 @@ public final class BookkeeperProtocol {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code AuthMessage}
+     *
+     * <pre>
+     **
+     * Extendible message which auth mechanisms
+     * can use to carry their payload.
+     * </pre>
+     */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, Builder> implements org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder {
+          org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage, Builder> implements
+        // @@protoc_insertion_point(builder_implements:AuthMessage)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AuthMessage_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AuthMessage_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AuthMessage_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.class, org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -5172,27 +6716,27 @@ public final class BookkeeperProtocol {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         authPluginName_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDescriptor();
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_AuthMessage_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage build() {
         org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage result = buildPartial();
         if (!result.isInitialized()) {
@@ -5200,17 +6744,7 @@ public final class BookkeeperProtocol {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage buildPartial() {
         org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage result = new org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage(this);
         int from_bitField0_ = bitField0_;
@@ -5223,7 +6757,7 @@ public final class BookkeeperProtocol {
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage) {
           return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage)other);
@@ -5232,17 +6766,19 @@ public final class BookkeeperProtocol {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage other) {
         if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance()) return this;
         if (other.hasAuthPluginName()) {
-          setAuthPluginName(other.getAuthPluginName());
+          bitField0_ |= 0x00000001;
+          authPluginName_ = other.authPluginName_;
+          onChanged();
         }
         this.mergeExtensionFields(other);
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         if (!hasAuthPluginName()) {
           
@@ -5254,57 +6790,71 @@ public final class BookkeeperProtocol {
         }
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              authPluginName_ = input.readBytes();
-              break;
-            }
+        org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // required string authPluginName = 1;
+
       private java.lang.Object authPluginName_ = "";
+      /**
+       * <code>required string authPluginName = 1;</code>
+       */
       public boolean hasAuthPluginName() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
-      public String getAuthPluginName() {
+      /**
+       * <code>required string authPluginName = 1;</code>
+       */
+      public java.lang.String getAuthPluginName() {
         java.lang.Object ref = authPluginName_;
-        if (!(ref instanceof String)) {
-          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-          authPluginName_ = s;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            authPluginName_ = s;
+          }
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
-      public Builder setAuthPluginName(String value) {
+      /**
+       * <code>required string authPluginName = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getAuthPluginNameBytes() {
+        java.lang.Object ref = authPluginName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          authPluginName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string authPluginName = 1;</code>
+       */
+      public Builder setAuthPluginName(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -5313,70 +6863,81 @@ public final class BookkeeperProtocol {
         onChanged();
         return this;
       }
+      /**
+       * <code>required string authPluginName = 1;</code>
+       */
       public Builder clearAuthPluginName() {
         bitField0_ = (bitField0_ & ~0x00000001);
         authPluginName_ = getDefaultInstance().getAuthPluginName();
         onChanged();
         return this;
       }
-      void setAuthPluginName(com.google.protobuf.ByteString value) {
-        bitField0_ |= 0x00000001;
+      /**
+       * <code>required string authPluginName = 1;</code>
+       */
+      public Builder setAuthPluginNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         authPluginName_ = value;
         onChanged();
+        return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:AuthMessage)
     }
-    
+
     static {
       defaultInstance = new AuthMessage(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:AuthMessage)
   }
-  
-  private static com.google.protobuf.Descriptors.Descriptor
+
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_BKPacketHeader_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_BKPacketHeader_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_Request_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Request_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_ReadRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ReadRequest_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_AddRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_AddRequest_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_Response_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Response_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_ReadResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ReadResponse_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_AddResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_AddResponse_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_AuthMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_AuthMessage_fieldAccessorTable;
-  
+
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
@@ -5420,82 +6981,66 @@ public final class BookkeeperProtocol {
       "\033org.apache.bookkeeper.protoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-        public com.google.protobuf.ExtensionRegistry assignDescriptors(
-            com.google.protobuf.Descriptors.FileDescriptor root) {
-          descriptor = root;
-          internal_static_BKPacketHeader_descriptor =
-            getDescriptor().getMessageTypes().get(0);
-          internal_static_BKPacketHeader_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_BKPacketHeader_descriptor,
-              new java.lang.String[] { "Version", "Operation", "TxnId", },
-              org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.class,
-              org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.Builder.class);
-          internal_static_Request_descriptor =
-            getDescriptor().getMessageTypes().get(1);
-          internal_static_Request_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_Request_descriptor,
-              new java.lang.String[] { "Header", "ReadRequest", "AddRequest", "AuthRequest", },
-              org.apache.bookkeeper.proto.BookkeeperProtocol.Request.class,
-              org.apache.bookkeeper.proto.BookkeeperProtocol.Request.Builder.class);
-          internal_static_ReadRequest_descriptor =
-            getDescriptor().getMessageTypes().get(2);
-          internal_static_ReadRequest_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_ReadRequest_descriptor,
-              new java.lang.String[] { "Flag", "LedgerId", "EntryId", "MasterKey", },
-              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.class,
-              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.Builder.class);
-          internal_static_AddRequest_descriptor =
-            getDescriptor().getMessageTypes().get(3);
-          internal_static_AddRequest_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_AddRequest_descriptor,
-              new java.lang.String[] { "Flag", "LedgerId", "EntryId", "MasterKey", "Body", },
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.class,
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.Builder.class);
-          internal_static_Response_descriptor =
-            getDescriptor().getMessageTypes().get(4);
-          internal_static_Response_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_Response_descriptor,
-              new java.lang.String[] { "Header", "Status", "ReadResponse", "AddResponse", "AuthResponse", },
-              org.apache.bookkeeper.proto.BookkeeperProtocol.Response.class,
-              org.apache.bookkeeper.proto.BookkeeperProtocol.Response.Builder.class);
-          internal_static_ReadResponse_descriptor =
-            getDescriptor().getMessageTypes().get(5);
-          internal_static_ReadResponse_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_ReadResponse_descriptor,
-              new java.lang.String[] { "Status", "LedgerId", "EntryId", "Body", },
-              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.class,
-              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.Builder.class);
-          internal_static_AddResponse_descriptor =
-            getDescriptor().getMessageTypes().get(6);
-          internal_static_AddResponse_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_AddResponse_descriptor,
-              new java.lang.String[] { "Status", "LedgerId", "EntryId", },
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.class,
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.Builder.class);
-          internal_static_AuthMessage_descriptor =
-            getDescriptor().getMessageTypes().get(7);
-          internal_static_AuthMessage_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_AuthMessage_descriptor,
-              new java.lang.String[] { "AuthPluginName", },
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.class,
-              org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.Builder.class);
-          return null;
-        }
-      };
+        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+          public com.google.protobuf.ExtensionRegistry assignDescriptors(
+              com.google.protobuf.Descriptors.FileDescriptor root) {
+            descriptor = root;
+            return null;
+          }
+        };
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
+    internal_static_BKPacketHeader_descriptor =
+      getDescriptor().getMessageTypes().get(0);
+    internal_static_BKPacketHeader_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_BKPacketHeader_descriptor,
+        new java.lang.String[] { "Version", "Operation", "TxnId", });
+    internal_static_Request_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_Request_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_Request_descriptor,
+        new java.lang.String[] { "Header", "ReadRequest", "AddRequest", "AuthRequest", });
+    internal_static_ReadRequest_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_ReadRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_ReadRequest_descriptor,
+        new java.lang.String[] { "Flag", "LedgerId", "EntryId", "MasterKey", });
+    internal_static_AddRequest_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_AddRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_AddRequest_descriptor,
+        new java.lang.String[] { "Flag", "LedgerId", "EntryId", "MasterKey", "Body", });
+    internal_static_Response_descriptor =
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_Response_descriptor,
+        new java.lang.String[] { "Header", "Status", "ReadResponse", "AddResponse", "AuthResponse", });
+    internal_static_ReadResponse_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_ReadResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_ReadResponse_descriptor,
+        new java.lang.String[] { "Status", "LedgerId", "EntryId", "Body", });
+    internal_static_AddResponse_descriptor =
+      getDescriptor().getMessageTypes().get(6);
+    internal_static_AddResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_AddResponse_descriptor,
+        new java.lang.String[] { "Status", "LedgerId", "EntryId", });
+    internal_static_AuthMessage_descriptor =
+      getDescriptor().getMessageTypes().get(7);
+    internal_static_AuthMessage_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_AuthMessage_descriptor,
+        new java.lang.String[] { "AuthPluginName", });
   }
-  
+
   // @@protoc_insertion_point(outer_class_scope)
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/DataFormats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/DataFormats.java
@@ -8,107 +8,349 @@ public final class DataFormats {
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
   }
-  public interface LedgerMetadataFormatOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // required int32 quorumSize = 1;
+  public interface LedgerMetadataFormatOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:LedgerMetadataFormat)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required int32 quorumSize = 1;</code>
+     */
     boolean hasQuorumSize();
+    /**
+     * <code>required int32 quorumSize = 1;</code>
+     */
     int getQuorumSize();
-    
-    // required int32 ensembleSize = 2;
+
+    /**
+     * <code>required int32 ensembleSize = 2;</code>
+     */
     boolean hasEnsembleSize();
+    /**
+     * <code>required int32 ensembleSize = 2;</code>
+     */
     int getEnsembleSize();
-    
-    // required int64 length = 3;
+
+    /**
+     * <code>required int64 length = 3;</code>
+     */
     boolean hasLength();
+    /**
+     * <code>required int64 length = 3;</code>
+     */
     long getLength();
-    
-    // optional int64 lastEntryId = 4;
+
+    /**
+     * <code>optional int64 lastEntryId = 4;</code>
+     */
     boolean hasLastEntryId();
+    /**
+     * <code>optional int64 lastEntryId = 4;</code>
+     */
     long getLastEntryId();
-    
-    // required .LedgerMetadataFormat.State state = 5 [default = OPEN];
+
+    /**
+     * <code>required .LedgerMetadataFormat.State state = 5 [default = OPEN];</code>
+     */
     boolean hasState();
+    /**
+     * <code>required .LedgerMetadataFormat.State state = 5 [default = OPEN];</code>
+     */
     org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State getState();
-    
-    // repeated .LedgerMetadataFormat.Segment segment = 6;
+
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment> 
         getSegmentList();
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment getSegment(int index);
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     int getSegmentCount();
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     java.util.List<? extends org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder> 
         getSegmentOrBuilderList();
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder getSegmentOrBuilder(
         int index);
-    
-    // optional .LedgerMetadataFormat.DigestType digestType = 7;
+
+    /**
+     * <code>optional .LedgerMetadataFormat.DigestType digestType = 7;</code>
+     */
     boolean hasDigestType();
+    /**
+     * <code>optional .LedgerMetadataFormat.DigestType digestType = 7;</code>
+     */
     org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType getDigestType();
-    
-    // optional bytes password = 8;
+
+    /**
+     * <code>optional bytes password = 8;</code>
+     */
     boolean hasPassword();
+    /**
+     * <code>optional bytes password = 8;</code>
+     */
     com.google.protobuf.ByteString getPassword();
-    
-    // optional int32 ackQuorumSize = 9;
+
+    /**
+     * <code>optional int32 ackQuorumSize = 9;</code>
+     */
     boolean hasAckQuorumSize();
+    /**
+     * <code>optional int32 ackQuorumSize = 9;</code>
+     */
     int getAckQuorumSize();
-    
-    // optional int64 ctime = 10;
+
+    /**
+     * <code>optional int64 ctime = 10;</code>
+     */
     boolean hasCtime();
+    /**
+     * <code>optional int64 ctime = 10;</code>
+     */
     long getCtime();
-    
-    // repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;
+
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry> 
         getCustomMetadataList();
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry getCustomMetadata(int index);
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     int getCustomMetadataCount();
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     java.util.List<? extends org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder> 
         getCustomMetadataOrBuilderList();
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder getCustomMetadataOrBuilder(
         int index);
   }
+  /**
+   * Protobuf type {@code LedgerMetadataFormat}
+   *
+   * <pre>
+   **
+   * Metadata format for storing ledger information
+   * </pre>
+   */
   public static final class LedgerMetadataFormat extends
-      com.google.protobuf.GeneratedMessage
-      implements LedgerMetadataFormatOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:LedgerMetadataFormat)
+      LedgerMetadataFormatOrBuilder {
     // Use LedgerMetadataFormat.newBuilder() to construct.
-    private LedgerMetadataFormat(Builder builder) {
+    private LedgerMetadataFormat(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private LedgerMetadataFormat(boolean noInit) {}
-    
+    private LedgerMetadataFormat(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final LedgerMetadataFormat defaultInstance;
     public static LedgerMetadataFormat getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public LedgerMetadataFormat getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private LedgerMetadataFormat(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              quorumSize_ = input.readInt32();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              ensembleSize_ = input.readInt32();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              length_ = input.readInt64();
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              lastEntryId_ = input.readInt64();
+              break;
+            }
+            case 40: {
+              int rawValue = input.readEnum();
+              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State value = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(5, rawValue);
+              } else {
+                bitField0_ |= 0x00000010;
+                state_ = value;
+              }
+              break;
+            }
+            case 50: {
+              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+                segment_ = new java.util.ArrayList<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment>();
+                mutable_bitField0_ |= 0x00000020;
+              }
+              segment_.add(input.readMessage(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.PARSER, extensionRegistry));
+              break;
+            }
+            case 56: {
+              int rawValue = input.readEnum();
+              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType value = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(7, rawValue);
+              } else {
+                bitField0_ |= 0x00000020;
+                digestType_ = value;
+              }
+              break;
+            }
+            case 66: {
+              bitField0_ |= 0x00000040;
+              password_ = input.readBytes();
+              break;
+            }
+            case 72: {
+              bitField0_ |= 0x00000080;
+              ackQuorumSize_ = input.readInt32();
+              break;
+            }
+            case 80: {
+              bitField0_ |= 0x00000100;
+              ctime_ = input.readInt64();
+              break;
+            }
+            case 90: {
+              if (!((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
+                customMetadata_ = new java.util.ArrayList<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry>();
+                mutable_bitField0_ |= 0x00000400;
+              }
+              customMetadata_.add(input.readMessage(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+          segment_ = java.util.Collections.unmodifiableList(segment_);
+        }
+        if (((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
+          customMetadata_ = java.util.Collections.unmodifiableList(customMetadata_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.class, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<LedgerMetadataFormat> PARSER =
+        new com.google.protobuf.AbstractParser<LedgerMetadataFormat>() {
+      public LedgerMetadataFormat parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new LedgerMetadataFormat(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<LedgerMetadataFormat> getParserForType() {
+      return PARSER;
+    }
+
+    /**
+     * Protobuf enum {@code LedgerMetadataFormat.State}
+     */
     public enum State
         implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>OPEN = 1;</code>
+       */
       OPEN(0, 1),
+      /**
+       * <code>IN_RECOVERY = 2;</code>
+       */
       IN_RECOVERY(1, 2),
+      /**
+       * <code>CLOSED = 3;</code>
+       */
       CLOSED(2, 3),
       ;
-      
+
+      /**
+       * <code>OPEN = 1;</code>
+       */
       public static final int OPEN_VALUE = 1;
+      /**
+       * <code>IN_RECOVERY = 2;</code>
+       */
       public static final int IN_RECOVERY_VALUE = 2;
+      /**
+       * <code>CLOSED = 3;</code>
+       */
       public static final int CLOSED_VALUE = 3;
-      
-      
+
+
       public final int getNumber() { return value; }
-      
+
       public static State valueOf(int value) {
         switch (value) {
           case 1: return OPEN;
@@ -117,7 +359,7 @@ public final class DataFormats {
           default: return null;
         }
       }
-      
+
       public static com.google.protobuf.Internal.EnumLiteMap<State>
           internalGetValueMap() {
         return internalValueMap;
@@ -129,7 +371,7 @@ public final class DataFormats {
                 return State.valueOf(number);
               }
             };
-      
+
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         return getDescriptor().getValues().get(index);
@@ -142,11 +384,9 @@ public final class DataFormats {
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.getDescriptor().getEnumTypes().get(0);
       }
-      
-      private static final State[] VALUES = {
-        OPEN, IN_RECOVERY, CLOSED, 
-      };
-      
+
+      private static final State[] VALUES = values();
+
       public static State valueOf(
           com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
         if (desc.getType() != getDescriptor()) {
@@ -155,30 +395,45 @@ public final class DataFormats {
         }
         return VALUES[desc.getIndex()];
       }
-      
+
       private final int index;
       private final int value;
-      
+
       private State(int index, int value) {
         this.index = index;
         this.value = value;
       }
-      
+
       // @@protoc_insertion_point(enum_scope:LedgerMetadataFormat.State)
     }
-    
+
+    /**
+     * Protobuf enum {@code LedgerMetadataFormat.DigestType}
+     */
     public enum DigestType
         implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>CRC32 = 1;</code>
+       */
       CRC32(0, 1),
+      /**
+       * <code>HMAC = 2;</code>
+       */
       HMAC(1, 2),
       ;
-      
+
+      /**
+       * <code>CRC32 = 1;</code>
+       */
       public static final int CRC32_VALUE = 1;
+      /**
+       * <code>HMAC = 2;</code>
+       */
       public static final int HMAC_VALUE = 2;
-      
-      
+
+
       public final int getNumber() { return value; }
-      
+
       public static DigestType valueOf(int value) {
         switch (value) {
           case 1: return CRC32;
@@ -186,7 +441,7 @@ public final class DataFormats {
           default: return null;
         }
       }
-      
+
       public static com.google.protobuf.Internal.EnumLiteMap<DigestType>
           internalGetValueMap() {
         return internalValueMap;
@@ -198,7 +453,7 @@ public final class DataFormats {
                 return DigestType.valueOf(number);
               }
             };
-      
+
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         return getDescriptor().getValues().get(index);
@@ -211,11 +466,9 @@ public final class DataFormats {
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.getDescriptor().getEnumTypes().get(1);
       }
-      
-      private static final DigestType[] VALUES = {
-        CRC32, HMAC, 
-      };
-      
+
+      private static final DigestType[] VALUES = values();
+
       public static DigestType valueOf(
           com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
         if (desc.getType() != getDescriptor()) {
@@ -224,83 +477,203 @@ public final class DataFormats {
         }
         return VALUES[desc.getIndex()];
       }
-      
+
       private final int index;
       private final int value;
-      
+
       private DigestType(int index, int value) {
         this.index = index;
         this.value = value;
       }
-      
+
       // @@protoc_insertion_point(enum_scope:LedgerMetadataFormat.DigestType)
     }
-    
-    public interface SegmentOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
-      
-      // repeated string ensembleMember = 1;
-      java.util.List<String> getEnsembleMemberList();
+
+    public interface SegmentOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:LedgerMetadataFormat.Segment)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <code>repeated string ensembleMember = 1;</code>
+       */
+      com.google.protobuf.ProtocolStringList
+          getEnsembleMemberList();
+      /**
+       * <code>repeated string ensembleMember = 1;</code>
+       */
       int getEnsembleMemberCount();
-      String getEnsembleMember(int index);
-      
-      // required int64 firstEntryId = 2;
+      /**
+       * <code>repeated string ensembleMember = 1;</code>
+       */
+      java.lang.String getEnsembleMember(int index);
+      /**
+       * <code>repeated string ensembleMember = 1;</code>
+       */
+      com.google.protobuf.ByteString
+          getEnsembleMemberBytes(int index);
+
+      /**
+       * <code>required int64 firstEntryId = 2;</code>
+       */
       boolean hasFirstEntryId();
+      /**
+       * <code>required int64 firstEntryId = 2;</code>
+       */
       long getFirstEntryId();
     }
+    /**
+     * Protobuf type {@code LedgerMetadataFormat.Segment}
+     */
     public static final class Segment extends
-        com.google.protobuf.GeneratedMessage
-        implements SegmentOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:LedgerMetadataFormat.Segment)
+        SegmentOrBuilder {
       // Use Segment.newBuilder() to construct.
-      private Segment(Builder builder) {
+      private Segment(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
+        this.unknownFields = builder.getUnknownFields();
       }
-      private Segment(boolean noInit) {}
-      
+      private Segment(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
       private static final Segment defaultInstance;
       public static Segment getDefaultInstance() {
         return defaultInstance;
       }
-      
+
       public Segment getDefaultInstanceForType() {
         return defaultInstance;
       }
-      
+
+      private final com.google.protobuf.UnknownFieldSet unknownFields;
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+          getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Segment(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        initFields();
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(input, unknownFields,
+                                       extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+              case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                  ensembleMember_ = new com.google.protobuf.LazyStringArrayList();
+                  mutable_bitField0_ |= 0x00000001;
+                }
+                ensembleMember_.add(bs);
+                break;
+              }
+              case 16: {
+                bitField0_ |= 0x00000001;
+                firstEntryId_ = input.readInt64();
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e.getMessage()).setUnfinishedMessage(this);
+        } finally {
+          if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+            ensembleMember_ = ensembleMember_.getUnmodifiableView();
+          }
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_Segment_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_Segment_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_Segment_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.class, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder.class);
       }
-      
+
+      public static com.google.protobuf.Parser<Segment> PARSER =
+          new com.google.protobuf.AbstractParser<Segment>() {
+        public Segment parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Segment(input, extensionRegistry);
+        }
+      };
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Segment> getParserForType() {
+        return PARSER;
+      }
+
       private int bitField0_;
-      // repeated string ensembleMember = 1;
       public static final int ENSEMBLEMEMBER_FIELD_NUMBER = 1;
       private com.google.protobuf.LazyStringList ensembleMember_;
-      public java.util.List<String>
+      /**
+       * <code>repeated string ensembleMember = 1;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
           getEnsembleMemberList() {
         return ensembleMember_;
       }
+      /**
+       * <code>repeated string ensembleMember = 1;</code>
+       */
       public int getEnsembleMemberCount() {
         return ensembleMember_.size();
       }
-      public String getEnsembleMember(int index) {
+      /**
+       * <code>repeated string ensembleMember = 1;</code>
+       */
+      public java.lang.String getEnsembleMember(int index) {
         return ensembleMember_.get(index);
       }
-      
-      // required int64 firstEntryId = 2;
+      /**
+       * <code>repeated string ensembleMember = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getEnsembleMemberBytes(int index) {
+        return ensembleMember_.getByteString(index);
+      }
+
       public static final int FIRSTENTRYID_FIELD_NUMBER = 2;
       private long firstEntryId_;
+      /**
+       * <code>required int64 firstEntryId = 2;</code>
+       */
       public boolean hasFirstEntryId() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
+      /**
+       * <code>required int64 firstEntryId = 2;</code>
+       */
       public long getFirstEntryId() {
         return firstEntryId_;
       }
-      
+
       private void initFields() {
         ensembleMember_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         firstEntryId_ = 0L;
@@ -308,8 +681,9 @@ public final class DataFormats {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
-        
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
         if (!hasFirstEntryId()) {
           memoizedIsInitialized = 0;
           return false;
@@ -317,7 +691,7 @@ public final class DataFormats {
         memoizedIsInitialized = 1;
         return true;
       }
-      
+
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
         getSerializedSize();
@@ -329,12 +703,12 @@ public final class DataFormats {
         }
         getUnknownFields().writeTo(output);
       }
-      
+
       private int memoizedSerializedSize = -1;
       public int getSerializedSize() {
         int size = memoizedSerializedSize;
         if (size != -1) return size;
-      
+
         size = 0;
         {
           int dataSize = 0;
@@ -353,113 +727,106 @@ public final class DataFormats {
         memoizedSerializedSize = size;
         return size;
       }
-      
+
       private static final long serialVersionUID = 0L;
       @java.lang.Override
       protected java.lang.Object writeReplace()
           throws java.io.ObjectStreamException {
         return super.writeReplace();
       }
-      
+
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return newBuilder().mergeFrom(data).buildParsed();
+        return PARSER.parseFrom(data);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseFrom(
           com.google.protobuf.ByteString data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return newBuilder().mergeFrom(data, extensionRegistry)
-                 .buildParsed();
+        return PARSER.parseFrom(data, extensionRegistry);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseFrom(byte[] data)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return newBuilder().mergeFrom(data).buildParsed();
+        return PARSER.parseFrom(data);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseFrom(
           byte[] data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return newBuilder().mergeFrom(data, extensionRegistry)
-                 .buildParsed();
+        return PARSER.parseFrom(data, extensionRegistry);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseFrom(java.io.InputStream input)
           throws java.io.IOException {
-        return newBuilder().mergeFrom(input).buildParsed();
+        return PARSER.parseFrom(input);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return newBuilder().mergeFrom(input, extensionRegistry)
-                 .buildParsed();
+        return PARSER.parseFrom(input, extensionRegistry);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
-        Builder builder = newBuilder();
-        if (builder.mergeDelimitedFrom(input)) {
-          return builder.buildParsed();
-        } else {
-          return null;
-        }
+        return PARSER.parseDelimitedFrom(input);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        Builder builder = newBuilder();
-        if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-          return builder.buildParsed();
-        } else {
-          return null;
-        }
+        return PARSER.parseDelimitedFrom(input, extensionRegistry);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
-        return newBuilder().mergeFrom(input).buildParsed();
+        return PARSER.parseFrom(input);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return newBuilder().mergeFrom(input, extensionRegistry)
-                 .buildParsed();
+        return PARSER.parseFrom(input, extensionRegistry);
       }
-      
+
       public static Builder newBuilder() { return Builder.create(); }
       public Builder newBuilderForType() { return newBuilder(); }
       public static Builder newBuilder(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment prototype) {
         return newBuilder().mergeFrom(prototype);
       }
       public Builder toBuilder() { return newBuilder(this); }
-      
+
       @java.lang.Override
       protected Builder newBuilderForType(
           com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         Builder builder = new Builder(parent);
         return builder;
       }
+      /**
+       * Protobuf type {@code LedgerMetadataFormat.Segment}
+       */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:LedgerMetadataFormat.Segment)
+          org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_Segment_descriptor;
         }
-        
+
         protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_Segment_fieldAccessorTable;
+          return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_Segment_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.class, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder.class);
         }
-        
+
         // Construct using org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.newBuilder()
         private Builder() {
           maybeForceBuilderInitialization();
         }
-        
-        private Builder(BuilderParent parent) {
+
+        private Builder(
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
           super(parent);
           maybeForceBuilderInitialization();
         }
@@ -470,7 +837,7 @@ public final class DataFormats {
         private static Builder create() {
           return new Builder();
         }
-        
+
         public Builder clear() {
           super.clear();
           ensembleMember_ = com.google.protobuf.LazyStringArrayList.EMPTY;
@@ -479,20 +846,20 @@ public final class DataFormats {
           bitField0_ = (bitField0_ & ~0x00000002);
           return this;
         }
-        
+
         public Builder clone() {
           return create().mergeFrom(buildPartial());
         }
-        
+
         public com.google.protobuf.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.getDescriptor();
+          return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_Segment_descriptor;
         }
-        
+
         public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment getDefaultInstanceForType() {
           return org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.getDefaultInstance();
         }
-        
+
         public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment build() {
           org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment result = buildPartial();
           if (!result.isInitialized()) {
@@ -500,24 +867,13 @@ public final class DataFormats {
           }
           return result;
         }
-        
-        private org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment buildParsed()
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment result = buildPartial();
-          if (!result.isInitialized()) {
-            throw newUninitializedMessageException(
-              result).asInvalidProtocolBufferException();
-          }
-          return result;
-        }
-        
+
         public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment buildPartial() {
           org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment result = new org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment(this);
           int from_bitField0_ = bitField0_;
           int to_bitField0_ = 0;
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            ensembleMember_ = new com.google.protobuf.UnmodifiableLazyStringList(
-                ensembleMember_);
+            ensembleMember_ = ensembleMember_.getUnmodifiableView();
             bitField0_ = (bitField0_ & ~0x00000001);
           }
           result.ensembleMember_ = ensembleMember_;
@@ -529,7 +885,7 @@ public final class DataFormats {
           onBuilt();
           return result;
         }
-        
+
         public Builder mergeFrom(com.google.protobuf.Message other) {
           if (other instanceof org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment) {
             return mergeFrom((org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment)other);
@@ -538,7 +894,7 @@ public final class DataFormats {
             return this;
           }
         }
-        
+
         public Builder mergeFrom(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment other) {
           if (other == org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.getDefaultInstance()) return this;
           if (!other.ensembleMember_.isEmpty()) {
@@ -557,7 +913,7 @@ public final class DataFormats {
           this.mergeUnknownFields(other.getUnknownFields());
           return this;
         }
-        
+
         public final boolean isInitialized() {
           if (!hasFirstEntryId()) {
             
@@ -565,47 +921,26 @@ public final class DataFormats {
           }
           return true;
         }
-        
+
         public Builder mergeFrom(
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-            com.google.protobuf.UnknownFieldSet.newBuilder(
-              this.getUnknownFields());
-          while (true) {
-            int tag = input.readTag();
-            switch (tag) {
-              case 0:
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              default: {
-                if (!parseUnknownField(input, unknownFields,
-                                       extensionRegistry, tag)) {
-                  this.setUnknownFields(unknownFields.build());
-                  onChanged();
-                  return this;
-                }
-                break;
-              }
-              case 10: {
-                ensureEnsembleMemberIsMutable();
-                ensembleMember_.add(input.readBytes());
-                break;
-              }
-              case 16: {
-                bitField0_ |= 0x00000002;
-                firstEntryId_ = input.readInt64();
-                break;
-              }
+          org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment) e.getUnfinishedMessage();
+            throw e;
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
             }
           }
+          return this;
         }
-        
         private int bitField0_;
-        
-        // repeated string ensembleMember = 1;
+
         private com.google.protobuf.LazyStringList ensembleMember_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         private void ensureEnsembleMemberIsMutable() {
           if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -613,18 +948,37 @@ public final class DataFormats {
             bitField0_ |= 0x00000001;
            }
         }
-        public java.util.List<String>
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
+        public com.google.protobuf.ProtocolStringList
             getEnsembleMemberList() {
-          return java.util.Collections.unmodifiableList(ensembleMember_);
+          return ensembleMember_.getUnmodifiableView();
         }
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
         public int getEnsembleMemberCount() {
           return ensembleMember_.size();
         }
-        public String getEnsembleMember(int index) {
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
+        public java.lang.String getEnsembleMember(int index) {
           return ensembleMember_.get(index);
         }
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
+        public com.google.protobuf.ByteString
+            getEnsembleMemberBytes(int index) {
+          return ensembleMember_.getByteString(index);
+        }
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
         public Builder setEnsembleMember(
-            int index, String value) {
+            int index, java.lang.String value) {
           if (value == null) {
     throw new NullPointerException();
   }
@@ -633,7 +987,11 @@ public final class DataFormats {
           onChanged();
           return this;
         }
-        public Builder addEnsembleMember(String value) {
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
+        public Builder addEnsembleMember(
+            java.lang.String value) {
           if (value == null) {
     throw new NullPointerException();
   }
@@ -642,139 +1000,270 @@ public final class DataFormats {
           onChanged();
           return this;
         }
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
         public Builder addAllEnsembleMember(
-            java.lang.Iterable<String> values) {
+            java.lang.Iterable<java.lang.String> values) {
           ensureEnsembleMemberIsMutable();
-          super.addAll(values, ensembleMember_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, ensembleMember_);
           onChanged();
           return this;
         }
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
         public Builder clearEnsembleMember() {
           ensembleMember_ = com.google.protobuf.LazyStringArrayList.EMPTY;
           bitField0_ = (bitField0_ & ~0x00000001);
           onChanged();
           return this;
         }
-        void addEnsembleMember(com.google.protobuf.ByteString value) {
-          ensureEnsembleMemberIsMutable();
+        /**
+         * <code>repeated string ensembleMember = 1;</code>
+         */
+        public Builder addEnsembleMemberBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureEnsembleMemberIsMutable();
           ensembleMember_.add(value);
           onChanged();
+          return this;
         }
-        
-        // required int64 firstEntryId = 2;
+
         private long firstEntryId_ ;
+        /**
+         * <code>required int64 firstEntryId = 2;</code>
+         */
         public boolean hasFirstEntryId() {
           return ((bitField0_ & 0x00000002) == 0x00000002);
         }
+        /**
+         * <code>required int64 firstEntryId = 2;</code>
+         */
         public long getFirstEntryId() {
           return firstEntryId_;
         }
+        /**
+         * <code>required int64 firstEntryId = 2;</code>
+         */
         public Builder setFirstEntryId(long value) {
           bitField0_ |= 0x00000002;
           firstEntryId_ = value;
           onChanged();
           return this;
         }
+        /**
+         * <code>required int64 firstEntryId = 2;</code>
+         */
         public Builder clearFirstEntryId() {
           bitField0_ = (bitField0_ & ~0x00000002);
           firstEntryId_ = 0L;
           onChanged();
           return this;
         }
-        
+
         // @@protoc_insertion_point(builder_scope:LedgerMetadataFormat.Segment)
       }
-      
+
       static {
         defaultInstance = new Segment(true);
         defaultInstance.initFields();
       }
-      
+
       // @@protoc_insertion_point(class_scope:LedgerMetadataFormat.Segment)
     }
-    
-    public interface cMetadataMapEntryOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
-      
-      // optional string key = 1;
+
+    public interface cMetadataMapEntryOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:LedgerMetadataFormat.cMetadataMapEntry)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <code>optional string key = 1;</code>
+       */
       boolean hasKey();
-      String getKey();
-      
-      // optional bytes value = 2;
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      java.lang.String getKey();
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      com.google.protobuf.ByteString
+          getKeyBytes();
+
+      /**
+       * <code>optional bytes value = 2;</code>
+       */
       boolean hasValue();
+      /**
+       * <code>optional bytes value = 2;</code>
+       */
       com.google.protobuf.ByteString getValue();
     }
+    /**
+     * Protobuf type {@code LedgerMetadataFormat.cMetadataMapEntry}
+     */
     public static final class cMetadataMapEntry extends
-        com.google.protobuf.GeneratedMessage
-        implements cMetadataMapEntryOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:LedgerMetadataFormat.cMetadataMapEntry)
+        cMetadataMapEntryOrBuilder {
       // Use cMetadataMapEntry.newBuilder() to construct.
-      private cMetadataMapEntry(Builder builder) {
+      private cMetadataMapEntry(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
+        this.unknownFields = builder.getUnknownFields();
       }
-      private cMetadataMapEntry(boolean noInit) {}
-      
+      private cMetadataMapEntry(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
       private static final cMetadataMapEntry defaultInstance;
       public static cMetadataMapEntry getDefaultInstance() {
         return defaultInstance;
       }
-      
+
       public cMetadataMapEntry getDefaultInstanceForType() {
         return defaultInstance;
       }
-      
+
+      private final com.google.protobuf.UnknownFieldSet unknownFields;
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+          getUnknownFields() {
+        return this.unknownFields;
+      }
+      private cMetadataMapEntry(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        initFields();
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(input, unknownFields,
+                                       extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+              case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                bitField0_ |= 0x00000001;
+                key_ = bs;
+                break;
+              }
+              case 18: {
+                bitField0_ |= 0x00000002;
+                value_ = input.readBytes();
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e.getMessage()).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_cMetadataMapEntry_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_cMetadataMapEntry_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_cMetadataMapEntry_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.class, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder.class);
       }
-      
+
+      public static com.google.protobuf.Parser<cMetadataMapEntry> PARSER =
+          new com.google.protobuf.AbstractParser<cMetadataMapEntry>() {
+        public cMetadataMapEntry parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new cMetadataMapEntry(input, extensionRegistry);
+        }
+      };
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<cMetadataMapEntry> getParserForType() {
+        return PARSER;
+      }
+
       private int bitField0_;
-      // optional string key = 1;
       public static final int KEY_FIELD_NUMBER = 1;
       private java.lang.Object key_;
+      /**
+       * <code>optional string key = 1;</code>
+       */
       public boolean hasKey() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
-      public String getKey() {
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      public java.lang.String getKey() {
         java.lang.Object ref = key_;
-        if (ref instanceof String) {
-          return (String) ref;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
         } else {
           com.google.protobuf.ByteString bs = 
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
-          if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
             key_ = s;
           }
           return s;
         }
       }
-      private com.google.protobuf.ByteString getKeyBytes() {
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getKeyBytes() {
         java.lang.Object ref = key_;
-        if (ref instanceof String) {
+        if (ref instanceof java.lang.String) {
           com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           key_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
         }
       }
-      
-      // optional bytes value = 2;
+
       public static final int VALUE_FIELD_NUMBER = 2;
       private com.google.protobuf.ByteString value_;
+      /**
+       * <code>optional bytes value = 2;</code>
+       */
       public boolean hasValue() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
+      /**
+       * <code>optional bytes value = 2;</code>
+       */
       public com.google.protobuf.ByteString getValue() {
         return value_;
       }
-      
+
       private void initFields() {
         key_ = "";
         value_ = com.google.protobuf.ByteString.EMPTY;
@@ -782,12 +1271,13 @@ public final class DataFormats {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
-        
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
         memoizedIsInitialized = 1;
         return true;
       }
-      
+
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
         getSerializedSize();
@@ -799,12 +1289,12 @@ public final class DataFormats {
         }
         getUnknownFields().writeTo(output);
       }
-      
+
       private int memoizedSerializedSize = -1;
       public int getSerializedSize() {
         int size = memoizedSerializedSize;
         if (size != -1) return size;
-      
+
         size = 0;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
           size += com.google.protobuf.CodedOutputStream
@@ -818,113 +1308,106 @@ public final class DataFormats {
         memoizedSerializedSize = size;
         return size;
       }
-      
+
       private static final long serialVersionUID = 0L;
       @java.lang.Override
       protected java.lang.Object writeReplace()
           throws java.io.ObjectStreamException {
         return super.writeReplace();
       }
-      
+
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return newBuilder().mergeFrom(data).buildParsed();
+        return PARSER.parseFrom(data);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseFrom(
           com.google.protobuf.ByteString data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return newBuilder().mergeFrom(data, extensionRegistry)
-                 .buildParsed();
+        return PARSER.parseFrom(data, extensionRegistry);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseFrom(byte[] data)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return newBuilder().mergeFrom(data).buildParsed();
+        return PARSER.parseFrom(data);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseFrom(
           byte[] data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return newBuilder().mergeFrom(data, extensionRegistry)
-                 .buildParsed();
+        return PARSER.parseFrom(data, extensionRegistry);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseFrom(java.io.InputStream input)
           throws java.io.IOException {
-        return newBuilder().mergeFrom(input).buildParsed();
+        return PARSER.parseFrom(input);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return newBuilder().mergeFrom(input, extensionRegistry)
-                 .buildParsed();
+        return PARSER.parseFrom(input, extensionRegistry);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
-        Builder builder = newBuilder();
-        if (builder.mergeDelimitedFrom(input)) {
-          return builder.buildParsed();
-        } else {
-          return null;
-        }
+        return PARSER.parseDelimitedFrom(input);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        Builder builder = newBuilder();
-        if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-          return builder.buildParsed();
-        } else {
-          return null;
-        }
+        return PARSER.parseDelimitedFrom(input, extensionRegistry);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
-        return newBuilder().mergeFrom(input).buildParsed();
+        return PARSER.parseFrom(input);
       }
       public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        return newBuilder().mergeFrom(input, extensionRegistry)
-                 .buildParsed();
+        return PARSER.parseFrom(input, extensionRegistry);
       }
-      
+
       public static Builder newBuilder() { return Builder.create(); }
       public Builder newBuilderForType() { return newBuilder(); }
       public static Builder newBuilder(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry prototype) {
         return newBuilder().mergeFrom(prototype);
       }
       public Builder toBuilder() { return newBuilder(this); }
-      
+
       @java.lang.Override
       protected Builder newBuilderForType(
           com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         Builder builder = new Builder(parent);
         return builder;
       }
+      /**
+       * Protobuf type {@code LedgerMetadataFormat.cMetadataMapEntry}
+       */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:LedgerMetadataFormat.cMetadataMapEntry)
+          org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_cMetadataMapEntry_descriptor;
         }
-        
+
         protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_cMetadataMapEntry_fieldAccessorTable;
+          return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_cMetadataMapEntry_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.class, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder.class);
         }
-        
+
         // Construct using org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.newBuilder()
         private Builder() {
           maybeForceBuilderInitialization();
         }
-        
-        private Builder(BuilderParent parent) {
+
+        private Builder(
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
           super(parent);
           maybeForceBuilderInitialization();
         }
@@ -935,7 +1418,7 @@ public final class DataFormats {
         private static Builder create() {
           return new Builder();
         }
-        
+
         public Builder clear() {
           super.clear();
           key_ = "";
@@ -944,20 +1427,20 @@ public final class DataFormats {
           bitField0_ = (bitField0_ & ~0x00000002);
           return this;
         }
-        
+
         public Builder clone() {
           return create().mergeFrom(buildPartial());
         }
-        
+
         public com.google.protobuf.Descriptors.Descriptor
             getDescriptorForType() {
-          return org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.getDescriptor();
+          return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_cMetadataMapEntry_descriptor;
         }
-        
+
         public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry getDefaultInstanceForType() {
           return org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.getDefaultInstance();
         }
-        
+
         public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry build() {
           org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry result = buildPartial();
           if (!result.isInitialized()) {
@@ -965,17 +1448,7 @@ public final class DataFormats {
           }
           return result;
         }
-        
-        private org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry buildParsed()
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry result = buildPartial();
-          if (!result.isInitialized()) {
-            throw newUninitializedMessageException(
-              result).asInvalidProtocolBufferException();
-          }
-          return result;
-        }
-        
+
         public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry buildPartial() {
           org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry result = new org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry(this);
           int from_bitField0_ = bitField0_;
@@ -992,7 +1465,7 @@ public final class DataFormats {
           onBuilt();
           return result;
         }
-        
+
         public Builder mergeFrom(com.google.protobuf.Message other) {
           if (other instanceof org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry) {
             return mergeFrom((org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry)other);
@@ -1001,11 +1474,13 @@ public final class DataFormats {
             return this;
           }
         }
-        
+
         public Builder mergeFrom(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry other) {
           if (other == org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.getDefaultInstance()) return this;
           if (other.hasKey()) {
-            setKey(other.getKey());
+            bitField0_ |= 0x00000001;
+            key_ = other.key_;
+            onChanged();
           }
           if (other.hasValue()) {
             setValue(other.getValue());
@@ -1013,66 +1488,75 @@ public final class DataFormats {
           this.mergeUnknownFields(other.getUnknownFields());
           return this;
         }
-        
+
         public final boolean isInitialized() {
           return true;
         }
-        
+
         public Builder mergeFrom(
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-            com.google.protobuf.UnknownFieldSet.newBuilder(
-              this.getUnknownFields());
-          while (true) {
-            int tag = input.readTag();
-            switch (tag) {
-              case 0:
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              default: {
-                if (!parseUnknownField(input, unknownFields,
-                                       extensionRegistry, tag)) {
-                  this.setUnknownFields(unknownFields.build());
-                  onChanged();
-                  return this;
-                }
-                break;
-              }
-              case 10: {
-                bitField0_ |= 0x00000001;
-                key_ = input.readBytes();
-                break;
-              }
-              case 18: {
-                bitField0_ |= 0x00000002;
-                value_ = input.readBytes();
-                break;
-              }
+          org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry) e.getUnfinishedMessage();
+            throw e;
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
             }
           }
+          return this;
         }
-        
         private int bitField0_;
-        
-        // optional string key = 1;
+
         private java.lang.Object key_ = "";
+        /**
+         * <code>optional string key = 1;</code>
+         */
         public boolean hasKey() {
           return ((bitField0_ & 0x00000001) == 0x00000001);
         }
-        public String getKey() {
+        /**
+         * <code>optional string key = 1;</code>
+         */
+        public java.lang.String getKey() {
           java.lang.Object ref = key_;
-          if (!(ref instanceof String)) {
-            String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-            key_ = s;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              key_ = s;
+            }
             return s;
           } else {
-            return (String) ref;
+            return (java.lang.String) ref;
           }
         }
-        public Builder setKey(String value) {
+        /**
+         * <code>optional string key = 1;</code>
+         */
+        public com.google.protobuf.ByteString
+            getKeyBytes() {
+          java.lang.Object ref = key_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b = 
+                com.google.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            key_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <code>optional string key = 1;</code>
+         */
+        public Builder setKey(
+            java.lang.String value) {
           if (value == null) {
     throw new NullPointerException();
   }
@@ -1081,26 +1565,45 @@ public final class DataFormats {
           onChanged();
           return this;
         }
+        /**
+         * <code>optional string key = 1;</code>
+         */
         public Builder clearKey() {
           bitField0_ = (bitField0_ & ~0x00000001);
           key_ = getDefaultInstance().getKey();
           onChanged();
           return this;
         }
-        void setKey(com.google.protobuf.ByteString value) {
-          bitField0_ |= 0x00000001;
+        /**
+         * <code>optional string key = 1;</code>
+         */
+        public Builder setKeyBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
           key_ = value;
           onChanged();
+          return this;
         }
-        
-        // optional bytes value = 2;
+
         private com.google.protobuf.ByteString value_ = com.google.protobuf.ByteString.EMPTY;
+        /**
+         * <code>optional bytes value = 2;</code>
+         */
         public boolean hasValue() {
           return ((bitField0_ & 0x00000002) == 0x00000002);
         }
+        /**
+         * <code>optional bytes value = 2;</code>
+         */
         public com.google.protobuf.ByteString getValue() {
           return value_;
         }
+        /**
+         * <code>optional bytes value = 2;</code>
+         */
         public Builder setValue(com.google.protobuf.ByteString value) {
           if (value == null) {
     throw new NullPointerException();
@@ -1110,157 +1613,233 @@ public final class DataFormats {
           onChanged();
           return this;
         }
+        /**
+         * <code>optional bytes value = 2;</code>
+         */
         public Builder clearValue() {
           bitField0_ = (bitField0_ & ~0x00000002);
           value_ = getDefaultInstance().getValue();
           onChanged();
           return this;
         }
-        
+
         // @@protoc_insertion_point(builder_scope:LedgerMetadataFormat.cMetadataMapEntry)
       }
-      
+
       static {
         defaultInstance = new cMetadataMapEntry(true);
         defaultInstance.initFields();
       }
-      
+
       // @@protoc_insertion_point(class_scope:LedgerMetadataFormat.cMetadataMapEntry)
     }
-    
+
     private int bitField0_;
-    // required int32 quorumSize = 1;
     public static final int QUORUMSIZE_FIELD_NUMBER = 1;
     private int quorumSize_;
+    /**
+     * <code>required int32 quorumSize = 1;</code>
+     */
     public boolean hasQuorumSize() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
+    /**
+     * <code>required int32 quorumSize = 1;</code>
+     */
     public int getQuorumSize() {
       return quorumSize_;
     }
-    
-    // required int32 ensembleSize = 2;
+
     public static final int ENSEMBLESIZE_FIELD_NUMBER = 2;
     private int ensembleSize_;
+    /**
+     * <code>required int32 ensembleSize = 2;</code>
+     */
     public boolean hasEnsembleSize() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
+    /**
+     * <code>required int32 ensembleSize = 2;</code>
+     */
     public int getEnsembleSize() {
       return ensembleSize_;
     }
-    
-    // required int64 length = 3;
+
     public static final int LENGTH_FIELD_NUMBER = 3;
     private long length_;
+    /**
+     * <code>required int64 length = 3;</code>
+     */
     public boolean hasLength() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
+    /**
+     * <code>required int64 length = 3;</code>
+     */
     public long getLength() {
       return length_;
     }
-    
-    // optional int64 lastEntryId = 4;
+
     public static final int LASTENTRYID_FIELD_NUMBER = 4;
     private long lastEntryId_;
+    /**
+     * <code>optional int64 lastEntryId = 4;</code>
+     */
     public boolean hasLastEntryId() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
+    /**
+     * <code>optional int64 lastEntryId = 4;</code>
+     */
     public long getLastEntryId() {
       return lastEntryId_;
     }
-    
-    // required .LedgerMetadataFormat.State state = 5 [default = OPEN];
+
     public static final int STATE_FIELD_NUMBER = 5;
     private org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State state_;
+    /**
+     * <code>required .LedgerMetadataFormat.State state = 5 [default = OPEN];</code>
+     */
     public boolean hasState() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
+    /**
+     * <code>required .LedgerMetadataFormat.State state = 5 [default = OPEN];</code>
+     */
     public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State getState() {
       return state_;
     }
-    
-    // repeated .LedgerMetadataFormat.Segment segment = 6;
+
     public static final int SEGMENT_FIELD_NUMBER = 6;
     private java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment> segment_;
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     public java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment> getSegmentList() {
       return segment_;
     }
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     public java.util.List<? extends org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder> 
         getSegmentOrBuilderList() {
       return segment_;
     }
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     public int getSegmentCount() {
       return segment_.size();
     }
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment getSegment(int index) {
       return segment_.get(index);
     }
+    /**
+     * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+     */
     public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder getSegmentOrBuilder(
         int index) {
       return segment_.get(index);
     }
-    
-    // optional .LedgerMetadataFormat.DigestType digestType = 7;
+
     public static final int DIGESTTYPE_FIELD_NUMBER = 7;
     private org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType digestType_;
+    /**
+     * <code>optional .LedgerMetadataFormat.DigestType digestType = 7;</code>
+     */
     public boolean hasDigestType() {
       return ((bitField0_ & 0x00000020) == 0x00000020);
     }
+    /**
+     * <code>optional .LedgerMetadataFormat.DigestType digestType = 7;</code>
+     */
     public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType getDigestType() {
       return digestType_;
     }
-    
-    // optional bytes password = 8;
+
     public static final int PASSWORD_FIELD_NUMBER = 8;
     private com.google.protobuf.ByteString password_;
+    /**
+     * <code>optional bytes password = 8;</code>
+     */
     public boolean hasPassword() {
       return ((bitField0_ & 0x00000040) == 0x00000040);
     }
+    /**
+     * <code>optional bytes password = 8;</code>
+     */
     public com.google.protobuf.ByteString getPassword() {
       return password_;
     }
-    
-    // optional int32 ackQuorumSize = 9;
+
     public static final int ACKQUORUMSIZE_FIELD_NUMBER = 9;
     private int ackQuorumSize_;
+    /**
+     * <code>optional int32 ackQuorumSize = 9;</code>
+     */
     public boolean hasAckQuorumSize() {
       return ((bitField0_ & 0x00000080) == 0x00000080);
     }
+    /**
+     * <code>optional int32 ackQuorumSize = 9;</code>
+     */
     public int getAckQuorumSize() {
       return ackQuorumSize_;
     }
-    
-    // optional int64 ctime = 10;
+
     public static final int CTIME_FIELD_NUMBER = 10;
     private long ctime_;
+    /**
+     * <code>optional int64 ctime = 10;</code>
+     */
     public boolean hasCtime() {
       return ((bitField0_ & 0x00000100) == 0x00000100);
     }
+    /**
+     * <code>optional int64 ctime = 10;</code>
+     */
     public long getCtime() {
       return ctime_;
     }
-    
-    // repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;
+
     public static final int CUSTOMMETADATA_FIELD_NUMBER = 11;
     private java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry> customMetadata_;
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     public java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry> getCustomMetadataList() {
       return customMetadata_;
     }
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     public java.util.List<? extends org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder> 
         getCustomMetadataOrBuilderList() {
       return customMetadata_;
     }
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     public int getCustomMetadataCount() {
       return customMetadata_.size();
     }
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry getCustomMetadata(int index) {
       return customMetadata_.get(index);
     }
+    /**
+     * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+     */
     public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder getCustomMetadataOrBuilder(
         int index) {
       return customMetadata_.get(index);
     }
-    
+
     private void initFields() {
       quorumSize_ = 0;
       ensembleSize_ = 0;
@@ -1277,8 +1856,9 @@ public final class DataFormats {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       if (!hasQuorumSize()) {
         memoizedIsInitialized = 0;
         return false;
@@ -1304,7 +1884,7 @@ public final class DataFormats {
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -1343,12 +1923,12 @@ public final class DataFormats {
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -1398,113 +1978,111 @@ public final class DataFormats {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code LedgerMetadataFormat}
+     *
+     * <pre>
+     **
+     * Metadata format for storing ledger information
+     * </pre>
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormatOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:LedgerMetadataFormat)
+        org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormatOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.class, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -1517,7 +2095,7 @@ public final class DataFormats {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         quorumSize_ = 0;
@@ -1552,20 +2130,20 @@ public final class DataFormats {
         }
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.getDescriptor();
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerMetadataFormat_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat build() {
         org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat result = buildPartial();
         if (!result.isInitialized()) {
@@ -1573,17 +2151,7 @@ public final class DataFormats {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat buildPartial() {
         org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat result = new org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat(this);
         int from_bitField0_ = bitField0_;
@@ -1646,7 +2214,7 @@ public final class DataFormats {
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat) {
           return mergeFrom((org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat)other);
@@ -1655,7 +2223,7 @@ public final class DataFormats {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat other) {
         if (other == org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.getDefaultInstance()) return this;
         if (other.hasQuorumSize()) {
@@ -1740,7 +2308,7 @@ public final class DataFormats {
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         if (!hasQuorumSize()) {
           
@@ -1766,197 +2334,170 @@ public final class DataFormats {
         }
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 8: {
-              bitField0_ |= 0x00000001;
-              quorumSize_ = input.readInt32();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              ensembleSize_ = input.readInt32();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              length_ = input.readInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              lastEntryId_ = input.readInt64();
-              break;
-            }
-            case 40: {
-              int rawValue = input.readEnum();
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State value = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(5, rawValue);
-              } else {
-                bitField0_ |= 0x00000010;
-                state_ = value;
-              }
-              break;
-            }
-            case 50: {
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder subBuilder = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.newBuilder();
-              input.readMessage(subBuilder, extensionRegistry);
-              addSegment(subBuilder.buildPartial());
-              break;
-            }
-            case 56: {
-              int rawValue = input.readEnum();
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType value = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(7, rawValue);
-              } else {
-                bitField0_ |= 0x00000040;
-                digestType_ = value;
-              }
-              break;
-            }
-            case 66: {
-              bitField0_ |= 0x00000080;
-              password_ = input.readBytes();
-              break;
-            }
-            case 72: {
-              bitField0_ |= 0x00000100;
-              ackQuorumSize_ = input.readInt32();
-              break;
-            }
-            case 80: {
-              bitField0_ |= 0x00000200;
-              ctime_ = input.readInt64();
-              break;
-            }
-            case 90: {
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder subBuilder = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.newBuilder();
-              input.readMessage(subBuilder, extensionRegistry);
-              addCustomMetadata(subBuilder.buildPartial());
-              break;
-            }
+        org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // required int32 quorumSize = 1;
+
       private int quorumSize_ ;
+      /**
+       * <code>required int32 quorumSize = 1;</code>
+       */
       public boolean hasQuorumSize() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
+      /**
+       * <code>required int32 quorumSize = 1;</code>
+       */
       public int getQuorumSize() {
         return quorumSize_;
       }
+      /**
+       * <code>required int32 quorumSize = 1;</code>
+       */
       public Builder setQuorumSize(int value) {
         bitField0_ |= 0x00000001;
         quorumSize_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required int32 quorumSize = 1;</code>
+       */
       public Builder clearQuorumSize() {
         bitField0_ = (bitField0_ & ~0x00000001);
         quorumSize_ = 0;
         onChanged();
         return this;
       }
-      
-      // required int32 ensembleSize = 2;
+
       private int ensembleSize_ ;
+      /**
+       * <code>required int32 ensembleSize = 2;</code>
+       */
       public boolean hasEnsembleSize() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
+      /**
+       * <code>required int32 ensembleSize = 2;</code>
+       */
       public int getEnsembleSize() {
         return ensembleSize_;
       }
+      /**
+       * <code>required int32 ensembleSize = 2;</code>
+       */
       public Builder setEnsembleSize(int value) {
         bitField0_ |= 0x00000002;
         ensembleSize_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required int32 ensembleSize = 2;</code>
+       */
       public Builder clearEnsembleSize() {
         bitField0_ = (bitField0_ & ~0x00000002);
         ensembleSize_ = 0;
         onChanged();
         return this;
       }
-      
-      // required int64 length = 3;
+
       private long length_ ;
+      /**
+       * <code>required int64 length = 3;</code>
+       */
       public boolean hasLength() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
+      /**
+       * <code>required int64 length = 3;</code>
+       */
       public long getLength() {
         return length_;
       }
+      /**
+       * <code>required int64 length = 3;</code>
+       */
       public Builder setLength(long value) {
         bitField0_ |= 0x00000004;
         length_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required int64 length = 3;</code>
+       */
       public Builder clearLength() {
         bitField0_ = (bitField0_ & ~0x00000004);
         length_ = 0L;
         onChanged();
         return this;
       }
-      
-      // optional int64 lastEntryId = 4;
+
       private long lastEntryId_ ;
+      /**
+       * <code>optional int64 lastEntryId = 4;</code>
+       */
       public boolean hasLastEntryId() {
         return ((bitField0_ & 0x00000008) == 0x00000008);
       }
+      /**
+       * <code>optional int64 lastEntryId = 4;</code>
+       */
       public long getLastEntryId() {
         return lastEntryId_;
       }
+      /**
+       * <code>optional int64 lastEntryId = 4;</code>
+       */
       public Builder setLastEntryId(long value) {
         bitField0_ |= 0x00000008;
         lastEntryId_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>optional int64 lastEntryId = 4;</code>
+       */
       public Builder clearLastEntryId() {
         bitField0_ = (bitField0_ & ~0x00000008);
         lastEntryId_ = 0L;
         onChanged();
         return this;
       }
-      
-      // required .LedgerMetadataFormat.State state = 5 [default = OPEN];
+
       private org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State state_ = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State.OPEN;
+      /**
+       * <code>required .LedgerMetadataFormat.State state = 5 [default = OPEN];</code>
+       */
       public boolean hasState() {
         return ((bitField0_ & 0x00000010) == 0x00000010);
       }
+      /**
+       * <code>required .LedgerMetadataFormat.State state = 5 [default = OPEN];</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State getState() {
         return state_;
       }
+      /**
+       * <code>required .LedgerMetadataFormat.State state = 5 [default = OPEN];</code>
+       */
       public Builder setState(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State value) {
         if (value == null) {
           throw new NullPointerException();
@@ -1966,14 +2507,16 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>required .LedgerMetadataFormat.State state = 5 [default = OPEN];</code>
+       */
       public Builder clearState() {
         bitField0_ = (bitField0_ & ~0x00000010);
         state_ = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State.OPEN;
         onChanged();
         return this;
       }
-      
-      // repeated .LedgerMetadataFormat.Segment segment = 6;
+
       private java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment> segment_ =
         java.util.Collections.emptyList();
       private void ensureSegmentIsMutable() {
@@ -1982,10 +2525,13 @@ public final class DataFormats {
           bitField0_ |= 0x00000020;
          }
       }
-      
+
       private com.google.protobuf.RepeatedFieldBuilder<
           org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder> segmentBuilder_;
-      
+
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment> getSegmentList() {
         if (segmentBuilder_ == null) {
           return java.util.Collections.unmodifiableList(segment_);
@@ -1993,6 +2539,9 @@ public final class DataFormats {
           return segmentBuilder_.getMessageList();
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public int getSegmentCount() {
         if (segmentBuilder_ == null) {
           return segment_.size();
@@ -2000,6 +2549,9 @@ public final class DataFormats {
           return segmentBuilder_.getCount();
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment getSegment(int index) {
         if (segmentBuilder_ == null) {
           return segment_.get(index);
@@ -2007,6 +2559,9 @@ public final class DataFormats {
           return segmentBuilder_.getMessage(index);
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder setSegment(
           int index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment value) {
         if (segmentBuilder_ == null) {
@@ -2021,6 +2576,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder setSegment(
           int index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder builderForValue) {
         if (segmentBuilder_ == null) {
@@ -2032,6 +2590,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder addSegment(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment value) {
         if (segmentBuilder_ == null) {
           if (value == null) {
@@ -2045,6 +2606,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder addSegment(
           int index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment value) {
         if (segmentBuilder_ == null) {
@@ -2059,6 +2623,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder addSegment(
           org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder builderForValue) {
         if (segmentBuilder_ == null) {
@@ -2070,6 +2637,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder addSegment(
           int index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder builderForValue) {
         if (segmentBuilder_ == null) {
@@ -2081,17 +2651,24 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder addAllSegment(
           java.lang.Iterable<? extends org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment> values) {
         if (segmentBuilder_ == null) {
           ensureSegmentIsMutable();
-          super.addAll(values, segment_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, segment_);
           onChanged();
         } else {
           segmentBuilder_.addAllMessages(values);
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder clearSegment() {
         if (segmentBuilder_ == null) {
           segment_ = java.util.Collections.emptyList();
@@ -2102,6 +2679,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public Builder removeSegment(int index) {
         if (segmentBuilder_ == null) {
           ensureSegmentIsMutable();
@@ -2112,10 +2692,16 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder getSegmentBuilder(
           int index) {
         return getSegmentFieldBuilder().getBuilder(index);
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder getSegmentOrBuilder(
           int index) {
         if (segmentBuilder_ == null) {
@@ -2123,6 +2709,9 @@ public final class DataFormats {
           return segmentBuilder_.getMessageOrBuilder(index);
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public java.util.List<? extends org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.SegmentOrBuilder> 
            getSegmentOrBuilderList() {
         if (segmentBuilder_ != null) {
@@ -2131,15 +2720,24 @@ public final class DataFormats {
           return java.util.Collections.unmodifiableList(segment_);
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder addSegmentBuilder() {
         return getSegmentFieldBuilder().addBuilder(
             org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.getDefaultInstance());
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder addSegmentBuilder(
           int index) {
         return getSegmentFieldBuilder().addBuilder(
             index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.getDefaultInstance());
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.Segment segment = 6;</code>
+       */
       public java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder> 
            getSegmentBuilderList() {
         return getSegmentFieldBuilder().getBuilderList();
@@ -2158,15 +2756,23 @@ public final class DataFormats {
         }
         return segmentBuilder_;
       }
-      
-      // optional .LedgerMetadataFormat.DigestType digestType = 7;
+
       private org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType digestType_ = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType.CRC32;
+      /**
+       * <code>optional .LedgerMetadataFormat.DigestType digestType = 7;</code>
+       */
       public boolean hasDigestType() {
         return ((bitField0_ & 0x00000040) == 0x00000040);
       }
+      /**
+       * <code>optional .LedgerMetadataFormat.DigestType digestType = 7;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType getDigestType() {
         return digestType_;
       }
+      /**
+       * <code>optional .LedgerMetadataFormat.DigestType digestType = 7;</code>
+       */
       public Builder setDigestType(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType value) {
         if (value == null) {
           throw new NullPointerException();
@@ -2176,21 +2782,32 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>optional .LedgerMetadataFormat.DigestType digestType = 7;</code>
+       */
       public Builder clearDigestType() {
         bitField0_ = (bitField0_ & ~0x00000040);
         digestType_ = org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType.CRC32;
         onChanged();
         return this;
       }
-      
-      // optional bytes password = 8;
+
       private com.google.protobuf.ByteString password_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes password = 8;</code>
+       */
       public boolean hasPassword() {
         return ((bitField0_ & 0x00000080) == 0x00000080);
       }
+      /**
+       * <code>optional bytes password = 8;</code>
+       */
       public com.google.protobuf.ByteString getPassword() {
         return password_;
       }
+      /**
+       * <code>optional bytes password = 8;</code>
+       */
       public Builder setPassword(com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -2200,56 +2817,80 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>optional bytes password = 8;</code>
+       */
       public Builder clearPassword() {
         bitField0_ = (bitField0_ & ~0x00000080);
         password_ = getDefaultInstance().getPassword();
         onChanged();
         return this;
       }
-      
-      // optional int32 ackQuorumSize = 9;
+
       private int ackQuorumSize_ ;
+      /**
+       * <code>optional int32 ackQuorumSize = 9;</code>
+       */
       public boolean hasAckQuorumSize() {
         return ((bitField0_ & 0x00000100) == 0x00000100);
       }
+      /**
+       * <code>optional int32 ackQuorumSize = 9;</code>
+       */
       public int getAckQuorumSize() {
         return ackQuorumSize_;
       }
+      /**
+       * <code>optional int32 ackQuorumSize = 9;</code>
+       */
       public Builder setAckQuorumSize(int value) {
         bitField0_ |= 0x00000100;
         ackQuorumSize_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>optional int32 ackQuorumSize = 9;</code>
+       */
       public Builder clearAckQuorumSize() {
         bitField0_ = (bitField0_ & ~0x00000100);
         ackQuorumSize_ = 0;
         onChanged();
         return this;
       }
-      
-      // optional int64 ctime = 10;
+
       private long ctime_ ;
+      /**
+       * <code>optional int64 ctime = 10;</code>
+       */
       public boolean hasCtime() {
         return ((bitField0_ & 0x00000200) == 0x00000200);
       }
+      /**
+       * <code>optional int64 ctime = 10;</code>
+       */
       public long getCtime() {
         return ctime_;
       }
+      /**
+       * <code>optional int64 ctime = 10;</code>
+       */
       public Builder setCtime(long value) {
         bitField0_ |= 0x00000200;
         ctime_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>optional int64 ctime = 10;</code>
+       */
       public Builder clearCtime() {
         bitField0_ = (bitField0_ & ~0x00000200);
         ctime_ = 0L;
         onChanged();
         return this;
       }
-      
-      // repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;
+
       private java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry> customMetadata_ =
         java.util.Collections.emptyList();
       private void ensureCustomMetadataIsMutable() {
@@ -2258,10 +2899,13 @@ public final class DataFormats {
           bitField0_ |= 0x00000400;
          }
       }
-      
+
       private com.google.protobuf.RepeatedFieldBuilder<
           org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder> customMetadataBuilder_;
-      
+
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry> getCustomMetadataList() {
         if (customMetadataBuilder_ == null) {
           return java.util.Collections.unmodifiableList(customMetadata_);
@@ -2269,6 +2913,9 @@ public final class DataFormats {
           return customMetadataBuilder_.getMessageList();
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public int getCustomMetadataCount() {
         if (customMetadataBuilder_ == null) {
           return customMetadata_.size();
@@ -2276,6 +2923,9 @@ public final class DataFormats {
           return customMetadataBuilder_.getCount();
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry getCustomMetadata(int index) {
         if (customMetadataBuilder_ == null) {
           return customMetadata_.get(index);
@@ -2283,6 +2933,9 @@ public final class DataFormats {
           return customMetadataBuilder_.getMessage(index);
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder setCustomMetadata(
           int index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry value) {
         if (customMetadataBuilder_ == null) {
@@ -2297,6 +2950,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder setCustomMetadata(
           int index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder builderForValue) {
         if (customMetadataBuilder_ == null) {
@@ -2308,6 +2964,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder addCustomMetadata(org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry value) {
         if (customMetadataBuilder_ == null) {
           if (value == null) {
@@ -2321,6 +2980,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder addCustomMetadata(
           int index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry value) {
         if (customMetadataBuilder_ == null) {
@@ -2335,6 +2997,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder addCustomMetadata(
           org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder builderForValue) {
         if (customMetadataBuilder_ == null) {
@@ -2346,6 +3011,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder addCustomMetadata(
           int index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder builderForValue) {
         if (customMetadataBuilder_ == null) {
@@ -2357,17 +3025,24 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder addAllCustomMetadata(
           java.lang.Iterable<? extends org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry> values) {
         if (customMetadataBuilder_ == null) {
           ensureCustomMetadataIsMutable();
-          super.addAll(values, customMetadata_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, customMetadata_);
           onChanged();
         } else {
           customMetadataBuilder_.addAllMessages(values);
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder clearCustomMetadata() {
         if (customMetadataBuilder_ == null) {
           customMetadata_ = java.util.Collections.emptyList();
@@ -2378,6 +3053,9 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public Builder removeCustomMetadata(int index) {
         if (customMetadataBuilder_ == null) {
           ensureCustomMetadataIsMutable();
@@ -2388,10 +3066,16 @@ public final class DataFormats {
         }
         return this;
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder getCustomMetadataBuilder(
           int index) {
         return getCustomMetadataFieldBuilder().getBuilder(index);
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder getCustomMetadataOrBuilder(
           int index) {
         if (customMetadataBuilder_ == null) {
@@ -2399,6 +3083,9 @@ public final class DataFormats {
           return customMetadataBuilder_.getMessageOrBuilder(index);
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public java.util.List<? extends org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntryOrBuilder> 
            getCustomMetadataOrBuilderList() {
         if (customMetadataBuilder_ != null) {
@@ -2407,15 +3094,24 @@ public final class DataFormats {
           return java.util.Collections.unmodifiableList(customMetadata_);
         }
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder addCustomMetadataBuilder() {
         return getCustomMetadataFieldBuilder().addBuilder(
             org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.getDefaultInstance());
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder addCustomMetadataBuilder(
           int index) {
         return getCustomMetadataFieldBuilder().addBuilder(
             index, org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.getDefaultInstance());
       }
+      /**
+       * <code>repeated .LedgerMetadataFormat.cMetadataMapEntry customMetadata = 11;</code>
+       */
       public java.util.List<org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder> 
            getCustomMetadataBuilderList() {
         return getCustomMetadataFieldBuilder().getBuilderList();
@@ -2434,100 +3130,205 @@ public final class DataFormats {
         }
         return customMetadataBuilder_;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:LedgerMetadataFormat)
     }
-    
+
     static {
       defaultInstance = new LedgerMetadataFormat(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:LedgerMetadataFormat)
   }
-  
-  public interface LedgerRereplicationLayoutFormatOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // required string type = 1;
+
+  public interface LedgerRereplicationLayoutFormatOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:LedgerRereplicationLayoutFormat)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required string type = 1;</code>
+     */
     boolean hasType();
-    String getType();
-    
-    // required int32 version = 2;
+    /**
+     * <code>required string type = 1;</code>
+     */
+    java.lang.String getType();
+    /**
+     * <code>required string type = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getTypeBytes();
+
+    /**
+     * <code>required int32 version = 2;</code>
+     */
     boolean hasVersion();
+    /**
+     * <code>required int32 version = 2;</code>
+     */
     int getVersion();
   }
+  /**
+   * Protobuf type {@code LedgerRereplicationLayoutFormat}
+   */
   public static final class LedgerRereplicationLayoutFormat extends
-      com.google.protobuf.GeneratedMessage
-      implements LedgerRereplicationLayoutFormatOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:LedgerRereplicationLayoutFormat)
+      LedgerRereplicationLayoutFormatOrBuilder {
     // Use LedgerRereplicationLayoutFormat.newBuilder() to construct.
-    private LedgerRereplicationLayoutFormat(Builder builder) {
+    private LedgerRereplicationLayoutFormat(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private LedgerRereplicationLayoutFormat(boolean noInit) {}
-    
+    private LedgerRereplicationLayoutFormat(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final LedgerRereplicationLayoutFormat defaultInstance;
     public static LedgerRereplicationLayoutFormat getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public LedgerRereplicationLayoutFormat getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private LedgerRereplicationLayoutFormat(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              type_ = bs;
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              version_ = input.readInt32();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerRereplicationLayoutFormat_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerRereplicationLayoutFormat_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerRereplicationLayoutFormat_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.class, org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<LedgerRereplicationLayoutFormat> PARSER =
+        new com.google.protobuf.AbstractParser<LedgerRereplicationLayoutFormat>() {
+      public LedgerRereplicationLayoutFormat parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new LedgerRereplicationLayoutFormat(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<LedgerRereplicationLayoutFormat> getParserForType() {
+      return PARSER;
+    }
+
     private int bitField0_;
-    // required string type = 1;
     public static final int TYPE_FIELD_NUMBER = 1;
     private java.lang.Object type_;
+    /**
+     * <code>required string type = 1;</code>
+     */
     public boolean hasType() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
-    public String getType() {
+    /**
+     * <code>required string type = 1;</code>
+     */
+    public java.lang.String getType() {
       java.lang.Object ref = type_;
-      if (ref instanceof String) {
-        return (String) ref;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
-        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
           type_ = s;
         }
         return s;
       }
     }
-    private com.google.protobuf.ByteString getTypeBytes() {
+    /**
+     * <code>required string type = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getTypeBytes() {
       java.lang.Object ref = type_;
-      if (ref instanceof String) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         type_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
-    
-    // required int32 version = 2;
+
     public static final int VERSION_FIELD_NUMBER = 2;
     private int version_;
+    /**
+     * <code>required int32 version = 2;</code>
+     */
     public boolean hasVersion() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
+    /**
+     * <code>required int32 version = 2;</code>
+     */
     public int getVersion() {
       return version_;
     }
-    
+
     private void initFields() {
       type_ = "";
       version_ = 0;
@@ -2535,8 +3336,9 @@ public final class DataFormats {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       if (!hasType()) {
         memoizedIsInitialized = 0;
         return false;
@@ -2548,7 +3350,7 @@ public final class DataFormats {
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -2560,12 +3362,12 @@ public final class DataFormats {
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -2579,113 +3381,106 @@ public final class DataFormats {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code LedgerRereplicationLayoutFormat}
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormatOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:LedgerRereplicationLayoutFormat)
+        org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormatOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerRereplicationLayoutFormat_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerRereplicationLayoutFormat_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerRereplicationLayoutFormat_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.class, org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -2696,7 +3491,7 @@ public final class DataFormats {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         type_ = "";
@@ -2705,20 +3500,20 @@ public final class DataFormats {
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.getDescriptor();
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_LedgerRereplicationLayoutFormat_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat build() {
         org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat result = buildPartial();
         if (!result.isInitialized()) {
@@ -2726,17 +3521,7 @@ public final class DataFormats {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat buildPartial() {
         org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat result = new org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat(this);
         int from_bitField0_ = bitField0_;
@@ -2753,7 +3538,7 @@ public final class DataFormats {
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat) {
           return mergeFrom((org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat)other);
@@ -2762,11 +3547,13 @@ public final class DataFormats {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat other) {
         if (other == org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.getDefaultInstance()) return this;
         if (other.hasType()) {
-          setType(other.getType());
+          bitField0_ |= 0x00000001;
+          type_ = other.type_;
+          onChanged();
         }
         if (other.hasVersion()) {
           setVersion(other.getVersion());
@@ -2774,7 +3561,7 @@ public final class DataFormats {
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         if (!hasType()) {
           
@@ -2786,62 +3573,71 @@ public final class DataFormats {
         }
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              type_ = input.readBytes();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              version_ = input.readInt32();
-              break;
-            }
+        org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // required string type = 1;
+
       private java.lang.Object type_ = "";
+      /**
+       * <code>required string type = 1;</code>
+       */
       public boolean hasType() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
-      public String getType() {
+      /**
+       * <code>required string type = 1;</code>
+       */
+      public java.lang.String getType() {
         java.lang.Object ref = type_;
-        if (!(ref instanceof String)) {
-          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-          type_ = s;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            type_ = s;
+          }
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
-      public Builder setType(String value) {
+      /**
+       * <code>required string type = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getTypeBytes() {
+        java.lang.Object ref = type_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          type_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string type = 1;</code>
+       */
+      public Builder setType(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -2850,112 +3646,240 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>required string type = 1;</code>
+       */
       public Builder clearType() {
         bitField0_ = (bitField0_ & ~0x00000001);
         type_ = getDefaultInstance().getType();
         onChanged();
         return this;
       }
-      void setType(com.google.protobuf.ByteString value) {
-        bitField0_ |= 0x00000001;
+      /**
+       * <code>required string type = 1;</code>
+       */
+      public Builder setTypeBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         type_ = value;
         onChanged();
+        return this;
       }
-      
-      // required int32 version = 2;
+
       private int version_ ;
+      /**
+       * <code>required int32 version = 2;</code>
+       */
       public boolean hasVersion() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
+      /**
+       * <code>required int32 version = 2;</code>
+       */
       public int getVersion() {
         return version_;
       }
+      /**
+       * <code>required int32 version = 2;</code>
+       */
       public Builder setVersion(int value) {
         bitField0_ |= 0x00000002;
         version_ = value;
         onChanged();
         return this;
       }
+      /**
+       * <code>required int32 version = 2;</code>
+       */
       public Builder clearVersion() {
         bitField0_ = (bitField0_ & ~0x00000002);
         version_ = 0;
         onChanged();
         return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:LedgerRereplicationLayoutFormat)
     }
-    
+
     static {
       defaultInstance = new LedgerRereplicationLayoutFormat(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:LedgerRereplicationLayoutFormat)
   }
-  
-  public interface UnderreplicatedLedgerFormatOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // repeated string replica = 1;
-    java.util.List<String> getReplicaList();
+
+  public interface UnderreplicatedLedgerFormatOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:UnderreplicatedLedgerFormat)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>repeated string replica = 1;</code>
+     */
+    com.google.protobuf.ProtocolStringList
+        getReplicaList();
+    /**
+     * <code>repeated string replica = 1;</code>
+     */
     int getReplicaCount();
-    String getReplica(int index);
+    /**
+     * <code>repeated string replica = 1;</code>
+     */
+    java.lang.String getReplica(int index);
+    /**
+     * <code>repeated string replica = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getReplicaBytes(int index);
   }
+  /**
+   * Protobuf type {@code UnderreplicatedLedgerFormat}
+   */
   public static final class UnderreplicatedLedgerFormat extends
-      com.google.protobuf.GeneratedMessage
-      implements UnderreplicatedLedgerFormatOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:UnderreplicatedLedgerFormat)
+      UnderreplicatedLedgerFormatOrBuilder {
     // Use UnderreplicatedLedgerFormat.newBuilder() to construct.
-    private UnderreplicatedLedgerFormat(Builder builder) {
+    private UnderreplicatedLedgerFormat(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private UnderreplicatedLedgerFormat(boolean noInit) {}
-    
+    private UnderreplicatedLedgerFormat(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final UnderreplicatedLedgerFormat defaultInstance;
     public static UnderreplicatedLedgerFormat getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public UnderreplicatedLedgerFormat getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private UnderreplicatedLedgerFormat(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                replica_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              replica_.add(bs);
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          replica_ = replica_.getUnmodifiableView();
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.DataFormats.internal_static_UnderreplicatedLedgerFormat_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.DataFormats.internal_static_UnderreplicatedLedgerFormat_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.DataFormats.internal_static_UnderreplicatedLedgerFormat_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.class, org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.Builder.class);
     }
-    
-    // repeated string replica = 1;
+
+    public static com.google.protobuf.Parser<UnderreplicatedLedgerFormat> PARSER =
+        new com.google.protobuf.AbstractParser<UnderreplicatedLedgerFormat>() {
+      public UnderreplicatedLedgerFormat parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new UnderreplicatedLedgerFormat(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<UnderreplicatedLedgerFormat> getParserForType() {
+      return PARSER;
+    }
+
     public static final int REPLICA_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList replica_;
-    public java.util.List<String>
+    /**
+     * <code>repeated string replica = 1;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
         getReplicaList() {
       return replica_;
     }
+    /**
+     * <code>repeated string replica = 1;</code>
+     */
     public int getReplicaCount() {
       return replica_.size();
     }
-    public String getReplica(int index) {
+    /**
+     * <code>repeated string replica = 1;</code>
+     */
+    public java.lang.String getReplica(int index) {
       return replica_.get(index);
     }
-    
+    /**
+     * <code>repeated string replica = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getReplicaBytes(int index) {
+      return replica_.getByteString(index);
+    }
+
     private void initFields() {
       replica_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -2964,12 +3888,12 @@ public final class DataFormats {
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       {
         int dataSize = 0;
@@ -2984,113 +3908,106 @@ public final class DataFormats {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code UnderreplicatedLedgerFormat}
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormatOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:UnderreplicatedLedgerFormat)
+        org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormatOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.internal_static_UnderreplicatedLedgerFormat_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.DataFormats.internal_static_UnderreplicatedLedgerFormat_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_UnderreplicatedLedgerFormat_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.class, org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -3101,27 +4018,27 @@ public final class DataFormats {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         replica_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.getDescriptor();
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_UnderreplicatedLedgerFormat_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat build() {
         org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat result = buildPartial();
         if (!result.isInitialized()) {
@@ -3129,30 +4046,19 @@ public final class DataFormats {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat buildPartial() {
         org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat result = new org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat(this);
         int from_bitField0_ = bitField0_;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          replica_ = new com.google.protobuf.UnmodifiableLazyStringList(
-              replica_);
+          replica_ = replica_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.replica_ = replica_;
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat) {
           return mergeFrom((org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat)other);
@@ -3161,7 +4067,7 @@ public final class DataFormats {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat other) {
         if (other == org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.getDefaultInstance()) return this;
         if (!other.replica_.isEmpty()) {
@@ -3177,46 +4083,30 @@ public final class DataFormats {
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 10: {
-              ensureReplicaIsMutable();
-              replica_.add(input.readBytes());
-              break;
-            }
+        org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // repeated string replica = 1;
+
       private com.google.protobuf.LazyStringList replica_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureReplicaIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3224,18 +4114,37 @@ public final class DataFormats {
           bitField0_ |= 0x00000001;
          }
       }
-      public java.util.List<String>
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
           getReplicaList() {
-        return java.util.Collections.unmodifiableList(replica_);
+        return replica_.getUnmodifiableView();
       }
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
       public int getReplicaCount() {
         return replica_.size();
       }
-      public String getReplica(int index) {
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
+      public java.lang.String getReplica(int index) {
         return replica_.get(index);
       }
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getReplicaBytes(int index) {
+        return replica_.getByteString(index);
+      }
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
       public Builder setReplica(
-          int index, String value) {
+          int index, java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -3244,7 +4153,11 @@ public final class DataFormats {
         onChanged();
         return this;
       }
-      public Builder addReplica(String value) {
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
+      public Builder addReplica(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -3253,212 +4166,400 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
       public Builder addAllReplica(
-          java.lang.Iterable<String> values) {
+          java.lang.Iterable<java.lang.String> values) {
         ensureReplicaIsMutable();
-        super.addAll(values, replica_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, replica_);
         onChanged();
         return this;
       }
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
       public Builder clearReplica() {
         replica_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
-      void addReplica(com.google.protobuf.ByteString value) {
-        ensureReplicaIsMutable();
+      /**
+       * <code>repeated string replica = 1;</code>
+       */
+      public Builder addReplicaBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureReplicaIsMutable();
         replica_.add(value);
         onChanged();
+        return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:UnderreplicatedLedgerFormat)
     }
-    
+
     static {
       defaultInstance = new UnderreplicatedLedgerFormat(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:UnderreplicatedLedgerFormat)
   }
-  
-  public interface CookieFormatOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // required string bookieHost = 1;
+
+  public interface CookieFormatOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:CookieFormat)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required string bookieHost = 1;</code>
+     */
     boolean hasBookieHost();
-    String getBookieHost();
-    
-    // required string journalDir = 2;
+    /**
+     * <code>required string bookieHost = 1;</code>
+     */
+    java.lang.String getBookieHost();
+    /**
+     * <code>required string bookieHost = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getBookieHostBytes();
+
+    /**
+     * <code>required string journalDir = 2;</code>
+     */
     boolean hasJournalDir();
-    String getJournalDir();
-    
-    // required string ledgerDirs = 3;
+    /**
+     * <code>required string journalDir = 2;</code>
+     */
+    java.lang.String getJournalDir();
+    /**
+     * <code>required string journalDir = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getJournalDirBytes();
+
+    /**
+     * <code>required string ledgerDirs = 3;</code>
+     */
     boolean hasLedgerDirs();
-    String getLedgerDirs();
-    
-    // optional string instanceId = 4;
+    /**
+     * <code>required string ledgerDirs = 3;</code>
+     */
+    java.lang.String getLedgerDirs();
+    /**
+     * <code>required string ledgerDirs = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getLedgerDirsBytes();
+
+    /**
+     * <code>optional string instanceId = 4;</code>
+     */
     boolean hasInstanceId();
-    String getInstanceId();
+    /**
+     * <code>optional string instanceId = 4;</code>
+     */
+    java.lang.String getInstanceId();
+    /**
+     * <code>optional string instanceId = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getInstanceIdBytes();
   }
+  /**
+   * Protobuf type {@code CookieFormat}
+   *
+   * <pre>
+   **
+   * Cookie format for storing cookie information
+   * </pre>
+   */
   public static final class CookieFormat extends
-      com.google.protobuf.GeneratedMessage
-      implements CookieFormatOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:CookieFormat)
+      CookieFormatOrBuilder {
     // Use CookieFormat.newBuilder() to construct.
-    private CookieFormat(Builder builder) {
+    private CookieFormat(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private CookieFormat(boolean noInit) {}
-    
+    private CookieFormat(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final CookieFormat defaultInstance;
     public static CookieFormat getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public CookieFormat getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private CookieFormat(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              bookieHost_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              journalDir_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              ledgerDirs_ = bs;
+              break;
+            }
+            case 34: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000008;
+              instanceId_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.DataFormats.internal_static_CookieFormat_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.DataFormats.internal_static_CookieFormat_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.DataFormats.internal_static_CookieFormat_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.DataFormats.CookieFormat.class, org.apache.bookkeeper.proto.DataFormats.CookieFormat.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<CookieFormat> PARSER =
+        new com.google.protobuf.AbstractParser<CookieFormat>() {
+      public CookieFormat parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CookieFormat(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<CookieFormat> getParserForType() {
+      return PARSER;
+    }
+
     private int bitField0_;
-    // required string bookieHost = 1;
     public static final int BOOKIEHOST_FIELD_NUMBER = 1;
     private java.lang.Object bookieHost_;
+    /**
+     * <code>required string bookieHost = 1;</code>
+     */
     public boolean hasBookieHost() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
-    public String getBookieHost() {
+    /**
+     * <code>required string bookieHost = 1;</code>
+     */
+    public java.lang.String getBookieHost() {
       java.lang.Object ref = bookieHost_;
-      if (ref instanceof String) {
-        return (String) ref;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
-        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
           bookieHost_ = s;
         }
         return s;
       }
     }
-    private com.google.protobuf.ByteString getBookieHostBytes() {
+    /**
+     * <code>required string bookieHost = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getBookieHostBytes() {
       java.lang.Object ref = bookieHost_;
-      if (ref instanceof String) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         bookieHost_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
-    
-    // required string journalDir = 2;
+
     public static final int JOURNALDIR_FIELD_NUMBER = 2;
     private java.lang.Object journalDir_;
+    /**
+     * <code>required string journalDir = 2;</code>
+     */
     public boolean hasJournalDir() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
-    public String getJournalDir() {
+    /**
+     * <code>required string journalDir = 2;</code>
+     */
+    public java.lang.String getJournalDir() {
       java.lang.Object ref = journalDir_;
-      if (ref instanceof String) {
-        return (String) ref;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
-        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
           journalDir_ = s;
         }
         return s;
       }
     }
-    private com.google.protobuf.ByteString getJournalDirBytes() {
+    /**
+     * <code>required string journalDir = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getJournalDirBytes() {
       java.lang.Object ref = journalDir_;
-      if (ref instanceof String) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         journalDir_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
-    
-    // required string ledgerDirs = 3;
+
     public static final int LEDGERDIRS_FIELD_NUMBER = 3;
     private java.lang.Object ledgerDirs_;
+    /**
+     * <code>required string ledgerDirs = 3;</code>
+     */
     public boolean hasLedgerDirs() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
-    public String getLedgerDirs() {
+    /**
+     * <code>required string ledgerDirs = 3;</code>
+     */
+    public java.lang.String getLedgerDirs() {
       java.lang.Object ref = ledgerDirs_;
-      if (ref instanceof String) {
-        return (String) ref;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
-        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
           ledgerDirs_ = s;
         }
         return s;
       }
     }
-    private com.google.protobuf.ByteString getLedgerDirsBytes() {
+    /**
+     * <code>required string ledgerDirs = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getLedgerDirsBytes() {
       java.lang.Object ref = ledgerDirs_;
-      if (ref instanceof String) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         ledgerDirs_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
-    
-    // optional string instanceId = 4;
+
     public static final int INSTANCEID_FIELD_NUMBER = 4;
     private java.lang.Object instanceId_;
+    /**
+     * <code>optional string instanceId = 4;</code>
+     */
     public boolean hasInstanceId() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
-    public String getInstanceId() {
+    /**
+     * <code>optional string instanceId = 4;</code>
+     */
+    public java.lang.String getInstanceId() {
       java.lang.Object ref = instanceId_;
-      if (ref instanceof String) {
-        return (String) ref;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
-        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
           instanceId_ = s;
         }
         return s;
       }
     }
-    private com.google.protobuf.ByteString getInstanceIdBytes() {
+    /**
+     * <code>optional string instanceId = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getInstanceIdBytes() {
       java.lang.Object ref = instanceId_;
-      if (ref instanceof String) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         instanceId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
-    
+
     private void initFields() {
       bookieHost_ = "";
       journalDir_ = "";
@@ -3468,8 +4569,9 @@ public final class DataFormats {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       if (!hasBookieHost()) {
         memoizedIsInitialized = 0;
         return false;
@@ -3485,7 +4587,7 @@ public final class DataFormats {
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -3503,12 +4605,12 @@ public final class DataFormats {
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -3530,113 +4632,111 @@ public final class DataFormats {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.CookieFormat parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.DataFormats.CookieFormat prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code CookieFormat}
+     *
+     * <pre>
+     **
+     * Cookie format for storing cookie information
+     * </pre>
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.DataFormats.CookieFormatOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:CookieFormat)
+        org.apache.bookkeeper.proto.DataFormats.CookieFormatOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.internal_static_CookieFormat_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.DataFormats.internal_static_CookieFormat_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_CookieFormat_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.DataFormats.CookieFormat.class, org.apache.bookkeeper.proto.DataFormats.CookieFormat.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.DataFormats.CookieFormat.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -3647,7 +4747,7 @@ public final class DataFormats {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         bookieHost_ = "";
@@ -3660,20 +4760,20 @@ public final class DataFormats {
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.DataFormats.CookieFormat.getDescriptor();
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_CookieFormat_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.CookieFormat getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.DataFormats.CookieFormat.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.CookieFormat build() {
         org.apache.bookkeeper.proto.DataFormats.CookieFormat result = buildPartial();
         if (!result.isInitialized()) {
@@ -3681,17 +4781,7 @@ public final class DataFormats {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.DataFormats.CookieFormat buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.DataFormats.CookieFormat result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.CookieFormat buildPartial() {
         org.apache.bookkeeper.proto.DataFormats.CookieFormat result = new org.apache.bookkeeper.proto.DataFormats.CookieFormat(this);
         int from_bitField0_ = bitField0_;
@@ -3716,7 +4806,7 @@ public final class DataFormats {
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.DataFormats.CookieFormat) {
           return mergeFrom((org.apache.bookkeeper.proto.DataFormats.CookieFormat)other);
@@ -3725,25 +4815,33 @@ public final class DataFormats {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.DataFormats.CookieFormat other) {
         if (other == org.apache.bookkeeper.proto.DataFormats.CookieFormat.getDefaultInstance()) return this;
         if (other.hasBookieHost()) {
-          setBookieHost(other.getBookieHost());
+          bitField0_ |= 0x00000001;
+          bookieHost_ = other.bookieHost_;
+          onChanged();
         }
         if (other.hasJournalDir()) {
-          setJournalDir(other.getJournalDir());
+          bitField0_ |= 0x00000002;
+          journalDir_ = other.journalDir_;
+          onChanged();
         }
         if (other.hasLedgerDirs()) {
-          setLedgerDirs(other.getLedgerDirs());
+          bitField0_ |= 0x00000004;
+          ledgerDirs_ = other.ledgerDirs_;
+          onChanged();
         }
         if (other.hasInstanceId()) {
-          setInstanceId(other.getInstanceId());
+          bitField0_ |= 0x00000008;
+          instanceId_ = other.instanceId_;
+          onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         if (!hasBookieHost()) {
           
@@ -3759,72 +4857,71 @@ public final class DataFormats {
         }
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              bookieHost_ = input.readBytes();
-              break;
-            }
-            case 18: {
-              bitField0_ |= 0x00000002;
-              journalDir_ = input.readBytes();
-              break;
-            }
-            case 26: {
-              bitField0_ |= 0x00000004;
-              ledgerDirs_ = input.readBytes();
-              break;
-            }
-            case 34: {
-              bitField0_ |= 0x00000008;
-              instanceId_ = input.readBytes();
-              break;
-            }
+        org.apache.bookkeeper.proto.DataFormats.CookieFormat parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.DataFormats.CookieFormat) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // required string bookieHost = 1;
+
       private java.lang.Object bookieHost_ = "";
+      /**
+       * <code>required string bookieHost = 1;</code>
+       */
       public boolean hasBookieHost() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
-      public String getBookieHost() {
+      /**
+       * <code>required string bookieHost = 1;</code>
+       */
+      public java.lang.String getBookieHost() {
         java.lang.Object ref = bookieHost_;
-        if (!(ref instanceof String)) {
-          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-          bookieHost_ = s;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            bookieHost_ = s;
+          }
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
-      public Builder setBookieHost(String value) {
+      /**
+       * <code>required string bookieHost = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getBookieHostBytes() {
+        java.lang.Object ref = bookieHost_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          bookieHost_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string bookieHost = 1;</code>
+       */
+      public Builder setBookieHost(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -3833,34 +4930,74 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>required string bookieHost = 1;</code>
+       */
       public Builder clearBookieHost() {
         bitField0_ = (bitField0_ & ~0x00000001);
         bookieHost_ = getDefaultInstance().getBookieHost();
         onChanged();
         return this;
       }
-      void setBookieHost(com.google.protobuf.ByteString value) {
-        bitField0_ |= 0x00000001;
+      /**
+       * <code>required string bookieHost = 1;</code>
+       */
+      public Builder setBookieHostBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         bookieHost_ = value;
         onChanged();
+        return this;
       }
-      
-      // required string journalDir = 2;
+
       private java.lang.Object journalDir_ = "";
+      /**
+       * <code>required string journalDir = 2;</code>
+       */
       public boolean hasJournalDir() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
-      public String getJournalDir() {
+      /**
+       * <code>required string journalDir = 2;</code>
+       */
+      public java.lang.String getJournalDir() {
         java.lang.Object ref = journalDir_;
-        if (!(ref instanceof String)) {
-          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-          journalDir_ = s;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            journalDir_ = s;
+          }
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
-      public Builder setJournalDir(String value) {
+      /**
+       * <code>required string journalDir = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getJournalDirBytes() {
+        java.lang.Object ref = journalDir_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          journalDir_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string journalDir = 2;</code>
+       */
+      public Builder setJournalDir(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -3869,34 +5006,74 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>required string journalDir = 2;</code>
+       */
       public Builder clearJournalDir() {
         bitField0_ = (bitField0_ & ~0x00000002);
         journalDir_ = getDefaultInstance().getJournalDir();
         onChanged();
         return this;
       }
-      void setJournalDir(com.google.protobuf.ByteString value) {
-        bitField0_ |= 0x00000002;
+      /**
+       * <code>required string journalDir = 2;</code>
+       */
+      public Builder setJournalDirBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
         journalDir_ = value;
         onChanged();
+        return this;
       }
-      
-      // required string ledgerDirs = 3;
+
       private java.lang.Object ledgerDirs_ = "";
+      /**
+       * <code>required string ledgerDirs = 3;</code>
+       */
       public boolean hasLedgerDirs() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
-      public String getLedgerDirs() {
+      /**
+       * <code>required string ledgerDirs = 3;</code>
+       */
+      public java.lang.String getLedgerDirs() {
         java.lang.Object ref = ledgerDirs_;
-        if (!(ref instanceof String)) {
-          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-          ledgerDirs_ = s;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            ledgerDirs_ = s;
+          }
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
-      public Builder setLedgerDirs(String value) {
+      /**
+       * <code>required string ledgerDirs = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getLedgerDirsBytes() {
+        java.lang.Object ref = ledgerDirs_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          ledgerDirs_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string ledgerDirs = 3;</code>
+       */
+      public Builder setLedgerDirs(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -3905,34 +5082,74 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>required string ledgerDirs = 3;</code>
+       */
       public Builder clearLedgerDirs() {
         bitField0_ = (bitField0_ & ~0x00000004);
         ledgerDirs_ = getDefaultInstance().getLedgerDirs();
         onChanged();
         return this;
       }
-      void setLedgerDirs(com.google.protobuf.ByteString value) {
-        bitField0_ |= 0x00000004;
+      /**
+       * <code>required string ledgerDirs = 3;</code>
+       */
+      public Builder setLedgerDirsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
         ledgerDirs_ = value;
         onChanged();
+        return this;
       }
-      
-      // optional string instanceId = 4;
+
       private java.lang.Object instanceId_ = "";
+      /**
+       * <code>optional string instanceId = 4;</code>
+       */
       public boolean hasInstanceId() {
         return ((bitField0_ & 0x00000008) == 0x00000008);
       }
-      public String getInstanceId() {
+      /**
+       * <code>optional string instanceId = 4;</code>
+       */
+      public java.lang.String getInstanceId() {
         java.lang.Object ref = instanceId_;
-        if (!(ref instanceof String)) {
-          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-          instanceId_ = s;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            instanceId_ = s;
+          }
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
-      public Builder setInstanceId(String value) {
+      /**
+       * <code>optional string instanceId = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getInstanceIdBytes() {
+        java.lang.Object ref = instanceId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          instanceId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string instanceId = 4;</code>
+       */
+      public Builder setInstanceId(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -3941,109 +5158,216 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>optional string instanceId = 4;</code>
+       */
       public Builder clearInstanceId() {
         bitField0_ = (bitField0_ & ~0x00000008);
         instanceId_ = getDefaultInstance().getInstanceId();
         onChanged();
         return this;
       }
-      void setInstanceId(com.google.protobuf.ByteString value) {
-        bitField0_ |= 0x00000008;
+      /**
+       * <code>optional string instanceId = 4;</code>
+       */
+      public Builder setInstanceIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
         instanceId_ = value;
         onChanged();
+        return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:CookieFormat)
     }
-    
+
     static {
       defaultInstance = new CookieFormat(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:CookieFormat)
   }
-  
-  public interface LockDataFormatOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // optional string bookieId = 1;
+
+  public interface LockDataFormatOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:LockDataFormat)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
     boolean hasBookieId();
-    String getBookieId();
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
+    java.lang.String getBookieId();
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getBookieIdBytes();
   }
+  /**
+   * Protobuf type {@code LockDataFormat}
+   *
+   * <pre>
+   **
+   * Debug information for locks
+   * </pre>
+   */
   public static final class LockDataFormat extends
-      com.google.protobuf.GeneratedMessage
-      implements LockDataFormatOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:LockDataFormat)
+      LockDataFormatOrBuilder {
     // Use LockDataFormat.newBuilder() to construct.
-    private LockDataFormat(Builder builder) {
+    private LockDataFormat(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private LockDataFormat(boolean noInit) {}
-    
+    private LockDataFormat(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final LockDataFormat defaultInstance;
     public static LockDataFormat getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public LockDataFormat getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private LockDataFormat(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              bookieId_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.DataFormats.internal_static_LockDataFormat_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.DataFormats.internal_static_LockDataFormat_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.DataFormats.internal_static_LockDataFormat_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.DataFormats.LockDataFormat.class, org.apache.bookkeeper.proto.DataFormats.LockDataFormat.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<LockDataFormat> PARSER =
+        new com.google.protobuf.AbstractParser<LockDataFormat>() {
+      public LockDataFormat parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new LockDataFormat(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<LockDataFormat> getParserForType() {
+      return PARSER;
+    }
+
     private int bitField0_;
-    // optional string bookieId = 1;
     public static final int BOOKIEID_FIELD_NUMBER = 1;
     private java.lang.Object bookieId_;
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
     public boolean hasBookieId() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
-    public String getBookieId() {
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
+    public java.lang.String getBookieId() {
       java.lang.Object ref = bookieId_;
-      if (ref instanceof String) {
-        return (String) ref;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
-        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
           bookieId_ = s;
         }
         return s;
       }
     }
-    private com.google.protobuf.ByteString getBookieIdBytes() {
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getBookieIdBytes() {
       java.lang.Object ref = bookieId_;
-      if (ref instanceof String) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         bookieId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
-    
+
     private void initFields() {
       bookieId_ = "";
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -4052,12 +5376,12 @@ public final class DataFormats {
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -4067,113 +5391,111 @@ public final class DataFormats {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.LockDataFormat parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.DataFormats.LockDataFormat prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code LockDataFormat}
+     *
+     * <pre>
+     **
+     * Debug information for locks
+     * </pre>
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.DataFormats.LockDataFormatOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:LockDataFormat)
+        org.apache.bookkeeper.proto.DataFormats.LockDataFormatOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.internal_static_LockDataFormat_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.DataFormats.internal_static_LockDataFormat_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_LockDataFormat_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.DataFormats.LockDataFormat.class, org.apache.bookkeeper.proto.DataFormats.LockDataFormat.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.DataFormats.LockDataFormat.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -4184,27 +5506,27 @@ public final class DataFormats {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         bookieId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.DataFormats.LockDataFormat.getDescriptor();
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_LockDataFormat_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LockDataFormat getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.DataFormats.LockDataFormat.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LockDataFormat build() {
         org.apache.bookkeeper.proto.DataFormats.LockDataFormat result = buildPartial();
         if (!result.isInitialized()) {
@@ -4212,17 +5534,7 @@ public final class DataFormats {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.DataFormats.LockDataFormat buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.DataFormats.LockDataFormat result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.LockDataFormat buildPartial() {
         org.apache.bookkeeper.proto.DataFormats.LockDataFormat result = new org.apache.bookkeeper.proto.DataFormats.LockDataFormat(this);
         int from_bitField0_ = bitField0_;
@@ -4235,7 +5547,7 @@ public final class DataFormats {
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.DataFormats.LockDataFormat) {
           return mergeFrom((org.apache.bookkeeper.proto.DataFormats.LockDataFormat)other);
@@ -4244,70 +5556,86 @@ public final class DataFormats {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.DataFormats.LockDataFormat other) {
         if (other == org.apache.bookkeeper.proto.DataFormats.LockDataFormat.getDefaultInstance()) return this;
         if (other.hasBookieId()) {
-          setBookieId(other.getBookieId());
+          bitField0_ |= 0x00000001;
+          bookieId_ = other.bookieId_;
+          onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              bookieId_ = input.readBytes();
-              break;
-            }
+        org.apache.bookkeeper.proto.DataFormats.LockDataFormat parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.DataFormats.LockDataFormat) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // optional string bookieId = 1;
+
       private java.lang.Object bookieId_ = "";
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
       public boolean hasBookieId() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
-      public String getBookieId() {
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
+      public java.lang.String getBookieId() {
         java.lang.Object ref = bookieId_;
-        if (!(ref instanceof String)) {
-          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-          bookieId_ = s;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            bookieId_ = s;
+          }
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
-      public Builder setBookieId(String value) {
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getBookieIdBytes() {
+        java.lang.Object ref = bookieId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          bookieId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
+      public Builder setBookieId(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -4316,109 +5644,216 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
       public Builder clearBookieId() {
         bitField0_ = (bitField0_ & ~0x00000001);
         bookieId_ = getDefaultInstance().getBookieId();
         onChanged();
         return this;
       }
-      void setBookieId(com.google.protobuf.ByteString value) {
-        bitField0_ |= 0x00000001;
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
+      public Builder setBookieIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         bookieId_ = value;
         onChanged();
+        return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:LockDataFormat)
     }
-    
+
     static {
       defaultInstance = new LockDataFormat(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:LockDataFormat)
   }
-  
-  public interface AuditorVoteFormatOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
-    
-    // optional string bookieId = 1;
+
+  public interface AuditorVoteFormatOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:AuditorVoteFormat)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
     boolean hasBookieId();
-    String getBookieId();
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
+    java.lang.String getBookieId();
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getBookieIdBytes();
   }
+  /**
+   * Protobuf type {@code AuditorVoteFormat}
+   *
+   * <pre>
+   **
+   * Debug information for auditor votes
+   * </pre>
+   */
   public static final class AuditorVoteFormat extends
-      com.google.protobuf.GeneratedMessage
-      implements AuditorVoteFormatOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:AuditorVoteFormat)
+      AuditorVoteFormatOrBuilder {
     // Use AuditorVoteFormat.newBuilder() to construct.
-    private AuditorVoteFormat(Builder builder) {
+    private AuditorVoteFormat(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
+      this.unknownFields = builder.getUnknownFields();
     }
-    private AuditorVoteFormat(boolean noInit) {}
-    
+    private AuditorVoteFormat(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
     private static final AuditorVoteFormat defaultInstance;
     public static AuditorVoteFormat getDefaultInstance() {
       return defaultInstance;
     }
-    
+
     public AuditorVoteFormat getDefaultInstanceForType() {
       return defaultInstance;
     }
-    
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AuditorVoteFormat(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              bookieId_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.apache.bookkeeper.proto.DataFormats.internal_static_AuditorVoteFormat_descriptor;
     }
-    
+
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return org.apache.bookkeeper.proto.DataFormats.internal_static_AuditorVoteFormat_fieldAccessorTable;
+      return org.apache.bookkeeper.proto.DataFormats.internal_static_AuditorVoteFormat_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.class, org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.Builder.class);
     }
-    
+
+    public static com.google.protobuf.Parser<AuditorVoteFormat> PARSER =
+        new com.google.protobuf.AbstractParser<AuditorVoteFormat>() {
+      public AuditorVoteFormat parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AuditorVoteFormat(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AuditorVoteFormat> getParserForType() {
+      return PARSER;
+    }
+
     private int bitField0_;
-    // optional string bookieId = 1;
     public static final int BOOKIEID_FIELD_NUMBER = 1;
     private java.lang.Object bookieId_;
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
     public boolean hasBookieId() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
-    public String getBookieId() {
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
+    public java.lang.String getBookieId() {
       java.lang.Object ref = bookieId_;
-      if (ref instanceof String) {
-        return (String) ref;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
-        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
           bookieId_ = s;
         }
         return s;
       }
     }
-    private com.google.protobuf.ByteString getBookieIdBytes() {
+    /**
+     * <code>optional string bookieId = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getBookieIdBytes() {
       java.lang.Object ref = bookieId_;
-      if (ref instanceof String) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         bookieId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
-    
+
     private void initFields() {
       bookieId_ = "";
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-      
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
       memoizedIsInitialized = 1;
       return true;
     }
-    
+
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -4427,12 +5862,12 @@ public final class DataFormats {
       }
       getUnknownFields().writeTo(output);
     }
-    
+
     private int memoizedSerializedSize = -1;
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
-    
+
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
@@ -4442,113 +5877,111 @@ public final class DataFormats {
       memoizedSerializedSize = size;
       return size;
     }
-    
+
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
         throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
-    
+
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data).buildParsed();
+      return PARSER.parseFrom(data);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return newBuilder().mergeFrom(data, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(data, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      Builder builder = newBuilder();
-      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
-        return builder.buildParsed();
-      } else {
-        return null;
-      }
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input).buildParsed();
+      return PARSER.parseFrom(input);
     }
     public static org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return newBuilder().mergeFrom(input, extensionRegistry)
-               .buildParsed();
+      return PARSER.parseFrom(input, extensionRegistry);
     }
-    
+
     public static Builder newBuilder() { return Builder.create(); }
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat prototype) {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
+
     @java.lang.Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
+    /**
+     * Protobuf type {@code AuditorVoteFormat}
+     *
+     * <pre>
+     **
+     * Debug information for auditor votes
+     * </pre>
+     */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormatOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:AuditorVoteFormat)
+        org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormatOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.apache.bookkeeper.proto.DataFormats.internal_static_AuditorVoteFormat_descriptor;
       }
-      
+
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return org.apache.bookkeeper.proto.DataFormats.internal_static_AuditorVoteFormat_fieldAccessorTable;
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_AuditorVoteFormat_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.class, org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.Builder.class);
       }
-      
+
       // Construct using org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
-      
-      private Builder(BuilderParent parent) {
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -4559,27 +5992,27 @@ public final class DataFormats {
       private static Builder create() {
         return new Builder();
       }
-      
+
       public Builder clear() {
         super.clear();
         bookieId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
-      
+
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
-      
+
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.getDescriptor();
+        return org.apache.bookkeeper.proto.DataFormats.internal_static_AuditorVoteFormat_descriptor;
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat getDefaultInstanceForType() {
         return org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.getDefaultInstance();
       }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat build() {
         org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat result = buildPartial();
         if (!result.isInitialized()) {
@@ -4587,17 +6020,7 @@ public final class DataFormats {
         }
         return result;
       }
-      
-      private org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat buildParsed()
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(
-            result).asInvalidProtocolBufferException();
-        }
-        return result;
-      }
-      
+
       public org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat buildPartial() {
         org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat result = new org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat(this);
         int from_bitField0_ = bitField0_;
@@ -4610,7 +6033,7 @@ public final class DataFormats {
         onBuilt();
         return result;
       }
-      
+
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat) {
           return mergeFrom((org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat)other);
@@ -4619,70 +6042,86 @@ public final class DataFormats {
           return this;
         }
       }
-      
+
       public Builder mergeFrom(org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat other) {
         if (other == org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.getDefaultInstance()) return this;
         if (other.hasBookieId()) {
-          setBookieId(other.getBookieId());
+          bitField0_ |= 0x00000001;
+          bookieId_ = other.bookieId_;
+          onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
-      
+
       public final boolean isInitialized() {
         return true;
       }
-      
+
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder(
-            this.getUnknownFields());
-        while (true) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              this.setUnknownFields(unknownFields.build());
-              onChanged();
-              return this;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                this.setUnknownFields(unknownFields.build());
-                onChanged();
-                return this;
-              }
-              break;
-            }
-            case 10: {
-              bitField0_ |= 0x00000001;
-              bookieId_ = input.readBytes();
-              break;
-            }
+        org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
           }
         }
+        return this;
       }
-      
       private int bitField0_;
-      
-      // optional string bookieId = 1;
+
       private java.lang.Object bookieId_ = "";
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
       public boolean hasBookieId() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
-      public String getBookieId() {
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
+      public java.lang.String getBookieId() {
         java.lang.Object ref = bookieId_;
-        if (!(ref instanceof String)) {
-          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
-          bookieId_ = s;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            bookieId_ = s;
+          }
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
-      public Builder setBookieId(String value) {
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getBookieIdBytes() {
+        java.lang.Object ref = bookieId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          bookieId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
+      public Builder setBookieId(
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -4691,70 +6130,81 @@ public final class DataFormats {
         onChanged();
         return this;
       }
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
       public Builder clearBookieId() {
         bitField0_ = (bitField0_ & ~0x00000001);
         bookieId_ = getDefaultInstance().getBookieId();
         onChanged();
         return this;
       }
-      void setBookieId(com.google.protobuf.ByteString value) {
-        bitField0_ |= 0x00000001;
+      /**
+       * <code>optional string bookieId = 1;</code>
+       */
+      public Builder setBookieIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         bookieId_ = value;
         onChanged();
+        return this;
       }
-      
+
       // @@protoc_insertion_point(builder_scope:AuditorVoteFormat)
     }
-    
+
     static {
       defaultInstance = new AuditorVoteFormat(true);
       defaultInstance.initFields();
     }
-    
+
     // @@protoc_insertion_point(class_scope:AuditorVoteFormat)
   }
-  
-  private static com.google.protobuf.Descriptors.Descriptor
+
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_LedgerMetadataFormat_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_LedgerMetadataFormat_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_LedgerMetadataFormat_Segment_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_LedgerMetadataFormat_Segment_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_LedgerMetadataFormat_cMetadataMapEntry_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_LedgerMetadataFormat_cMetadataMapEntry_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_LedgerRereplicationLayoutFormat_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_LedgerRereplicationLayoutFormat_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_UnderreplicatedLedgerFormat_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_UnderreplicatedLedgerFormat_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_CookieFormat_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_CookieFormat_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_LockDataFormat_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_LockDataFormat_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_AuditorVoteFormat_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_AuditorVoteFormat_fieldAccessorTable;
-  
+
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
@@ -4788,82 +6238,66 @@ public final class DataFormats {
       "\001 \001(\tB\037\n\033org.apache.bookkeeper.protoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-        public com.google.protobuf.ExtensionRegistry assignDescriptors(
-            com.google.protobuf.Descriptors.FileDescriptor root) {
-          descriptor = root;
-          internal_static_LedgerMetadataFormat_descriptor =
-            getDescriptor().getMessageTypes().get(0);
-          internal_static_LedgerMetadataFormat_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_LedgerMetadataFormat_descriptor,
-              new java.lang.String[] { "QuorumSize", "EnsembleSize", "Length", "LastEntryId", "State", "Segment", "DigestType", "Password", "AckQuorumSize", "Ctime", "CustomMetadata", },
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.class,
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Builder.class);
-          internal_static_LedgerMetadataFormat_Segment_descriptor =
-            internal_static_LedgerMetadataFormat_descriptor.getNestedTypes().get(0);
-          internal_static_LedgerMetadataFormat_Segment_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_LedgerMetadataFormat_Segment_descriptor,
-              new java.lang.String[] { "EnsembleMember", "FirstEntryId", },
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.class,
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.Segment.Builder.class);
-          internal_static_LedgerMetadataFormat_cMetadataMapEntry_descriptor =
-            internal_static_LedgerMetadataFormat_descriptor.getNestedTypes().get(1);
-          internal_static_LedgerMetadataFormat_cMetadataMapEntry_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_LedgerMetadataFormat_cMetadataMapEntry_descriptor,
-              new java.lang.String[] { "Key", "Value", },
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.class,
-              org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.cMetadataMapEntry.Builder.class);
-          internal_static_LedgerRereplicationLayoutFormat_descriptor =
-            getDescriptor().getMessageTypes().get(1);
-          internal_static_LedgerRereplicationLayoutFormat_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_LedgerRereplicationLayoutFormat_descriptor,
-              new java.lang.String[] { "Type", "Version", },
-              org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.class,
-              org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat.Builder.class);
-          internal_static_UnderreplicatedLedgerFormat_descriptor =
-            getDescriptor().getMessageTypes().get(2);
-          internal_static_UnderreplicatedLedgerFormat_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_UnderreplicatedLedgerFormat_descriptor,
-              new java.lang.String[] { "Replica", },
-              org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.class,
-              org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat.Builder.class);
-          internal_static_CookieFormat_descriptor =
-            getDescriptor().getMessageTypes().get(3);
-          internal_static_CookieFormat_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_CookieFormat_descriptor,
-              new java.lang.String[] { "BookieHost", "JournalDir", "LedgerDirs", "InstanceId", },
-              org.apache.bookkeeper.proto.DataFormats.CookieFormat.class,
-              org.apache.bookkeeper.proto.DataFormats.CookieFormat.Builder.class);
-          internal_static_LockDataFormat_descriptor =
-            getDescriptor().getMessageTypes().get(4);
-          internal_static_LockDataFormat_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_LockDataFormat_descriptor,
-              new java.lang.String[] { "BookieId", },
-              org.apache.bookkeeper.proto.DataFormats.LockDataFormat.class,
-              org.apache.bookkeeper.proto.DataFormats.LockDataFormat.Builder.class);
-          internal_static_AuditorVoteFormat_descriptor =
-            getDescriptor().getMessageTypes().get(5);
-          internal_static_AuditorVoteFormat_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_AuditorVoteFormat_descriptor,
-              new java.lang.String[] { "BookieId", },
-              org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.class,
-              org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat.Builder.class);
-          return null;
-        }
-      };
+        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+          public com.google.protobuf.ExtensionRegistry assignDescriptors(
+              com.google.protobuf.Descriptors.FileDescriptor root) {
+            descriptor = root;
+            return null;
+          }
+        };
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
+    internal_static_LedgerMetadataFormat_descriptor =
+      getDescriptor().getMessageTypes().get(0);
+    internal_static_LedgerMetadataFormat_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_LedgerMetadataFormat_descriptor,
+        new java.lang.String[] { "QuorumSize", "EnsembleSize", "Length", "LastEntryId", "State", "Segment", "DigestType", "Password", "AckQuorumSize", "Ctime", "CustomMetadata", });
+    internal_static_LedgerMetadataFormat_Segment_descriptor =
+      internal_static_LedgerMetadataFormat_descriptor.getNestedTypes().get(0);
+    internal_static_LedgerMetadataFormat_Segment_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_LedgerMetadataFormat_Segment_descriptor,
+        new java.lang.String[] { "EnsembleMember", "FirstEntryId", });
+    internal_static_LedgerMetadataFormat_cMetadataMapEntry_descriptor =
+      internal_static_LedgerMetadataFormat_descriptor.getNestedTypes().get(1);
+    internal_static_LedgerMetadataFormat_cMetadataMapEntry_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_LedgerMetadataFormat_cMetadataMapEntry_descriptor,
+        new java.lang.String[] { "Key", "Value", });
+    internal_static_LedgerRereplicationLayoutFormat_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_LedgerRereplicationLayoutFormat_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_LedgerRereplicationLayoutFormat_descriptor,
+        new java.lang.String[] { "Type", "Version", });
+    internal_static_UnderreplicatedLedgerFormat_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_UnderreplicatedLedgerFormat_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_UnderreplicatedLedgerFormat_descriptor,
+        new java.lang.String[] { "Replica", });
+    internal_static_CookieFormat_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_CookieFormat_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_CookieFormat_descriptor,
+        new java.lang.String[] { "BookieHost", "JournalDir", "LedgerDirs", "InstanceId", });
+    internal_static_LockDataFormat_descriptor =
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_LockDataFormat_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_LockDataFormat_descriptor,
+        new java.lang.String[] { "BookieId", });
+    internal_static_AuditorVoteFormat_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_AuditorVoteFormat_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_AuditorVoteFormat_descriptor,
+        new java.lang.String[] { "BookieId", });
   }
-  
+
   // @@protoc_insertion_point(outer_class_scope)
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestDataFormats.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestDataFormats.java
@@ -9,20 +9,41 @@ public final class TestDataFormats {
       com.google.protobuf.ExtensionRegistry registry) {
     registry.add(org.apache.bookkeeper.proto.TestDataFormats.messageType);
   }
+  /**
+   * Protobuf enum {@code AuthMessageType}
+   */
   public enum AuthMessageType
       implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>SUCCESS_RESPONSE = 1;</code>
+     */
     SUCCESS_RESPONSE(0, 1),
+    /**
+     * <code>FAILURE_RESPONSE = 2;</code>
+     */
     FAILURE_RESPONSE(1, 2),
+    /**
+     * <code>PAYLOAD_MESSAGE = 3;</code>
+     */
     PAYLOAD_MESSAGE(2, 3),
     ;
-    
+
+    /**
+     * <code>SUCCESS_RESPONSE = 1;</code>
+     */
     public static final int SUCCESS_RESPONSE_VALUE = 1;
+    /**
+     * <code>FAILURE_RESPONSE = 2;</code>
+     */
     public static final int FAILURE_RESPONSE_VALUE = 2;
+    /**
+     * <code>PAYLOAD_MESSAGE = 3;</code>
+     */
     public static final int PAYLOAD_MESSAGE_VALUE = 3;
-    
-    
+
+
     public final int getNumber() { return value; }
-    
+
     public static AuthMessageType valueOf(int value) {
       switch (value) {
         case 1: return SUCCESS_RESPONSE;
@@ -31,7 +52,7 @@ public final class TestDataFormats {
         default: return null;
       }
     }
-    
+
     public static com.google.protobuf.Internal.EnumLiteMap<AuthMessageType>
         internalGetValueMap() {
       return internalValueMap;
@@ -43,7 +64,7 @@ public final class TestDataFormats {
               return AuthMessageType.valueOf(number);
             }
           };
-    
+
     public final com.google.protobuf.Descriptors.EnumValueDescriptor
         getValueDescriptor() {
       return getDescriptor().getValues().get(index);
@@ -56,11 +77,9 @@ public final class TestDataFormats {
         getDescriptor() {
       return org.apache.bookkeeper.proto.TestDataFormats.getDescriptor().getEnumTypes().get(0);
     }
-    
-    private static final AuthMessageType[] VALUES = {
-      SUCCESS_RESPONSE, FAILURE_RESPONSE, PAYLOAD_MESSAGE, 
-    };
-    
+
+    private static final AuthMessageType[] VALUES = values();
+
     public static AuthMessageType valueOf(
         com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
       if (desc.getType() != getDescriptor()) {
@@ -69,19 +88,22 @@ public final class TestDataFormats {
       }
       return VALUES[desc.getIndex()];
     }
-    
+
     private final int index;
     private final int value;
-    
+
     private AuthMessageType(int index, int value) {
       this.index = index;
       this.value = value;
     }
-    
+
     // @@protoc_insertion_point(enum_scope:AuthMessageType)
   }
-  
+
   public static final int MESSAGETYPE_FIELD_NUMBER = 1000;
+  /**
+   * <code>extend .AuthMessage { ... }</code>
+   */
   public static final
     com.google.protobuf.GeneratedMessage.GeneratedExtension<
       org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage,
@@ -89,7 +111,7 @@ public final class TestDataFormats {
           .newFileScopedGeneratedExtension(
         org.apache.bookkeeper.proto.TestDataFormats.AuthMessageType.class,
         null);
-  
+
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
@@ -102,25 +124,26 @@ public final class TestDataFormats {
       "src/main/proto/BookkeeperProtocol.proto*" +
       "R\n\017AuthMessageType\022\024\n\020SUCCESS_RESPONSE\020\001" +
       "\022\024\n\020FAILURE_RESPONSE\020\002\022\023\n\017PAYLOAD_MESSAG" +
-      "E\020\003:4\n\013messageType\022\014.AuthMessage\030\350\007 \002(\0162" +
+      "E\020\003:4\n\013messageType\022\014.AuthMessage\030\350\007 \001(\0162" +
       "\020.AuthMessageTypeB\037\n\033org.apache.bookkeep" +
       "er.protoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-        public com.google.protobuf.ExtensionRegistry assignDescriptors(
-            com.google.protobuf.Descriptors.FileDescriptor root) {
-          descriptor = root;
-          messageType.internalInit(descriptor.getExtensions().get(0));
-          return null;
-        }
-      };
+        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+          public com.google.protobuf.ExtensionRegistry assignDescriptors(
+              com.google.protobuf.Descriptors.FileDescriptor root) {
+            descriptor = root;
+            return null;
+          }
+        };
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           org.apache.bookkeeper.proto.BookkeeperProtocol.getDescriptor(),
         }, assigner);
+    messageType.internalInit(descriptor.getExtensions().get(0));
+    org.apache.bookkeeper.proto.BookkeeperProtocol.getDescriptor();
   }
-  
+
   // @@protoc_insertion_point(outer_class_scope)
 }

--- a/bookkeeper-server/src/test/proto/TestDataFormats.proto
+++ b/bookkeeper-server/src/test/proto/TestDataFormats.proto
@@ -30,5 +30,5 @@ enum AuthMessageType {
  *
  */
 extend AuthMessage {
-    required AuthMessageType messageType = 1000;
+    optional AuthMessageType messageType = 1000;
 }

--- a/compat-deps/bookkeeper-server-compat-4.0.0/pom.xml
+++ b/compat-deps/bookkeeper-server-compat-4.0.0/pom.xml
@@ -33,6 +33,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.4.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>4.0.0</version>
@@ -54,6 +59,7 @@
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <artifactSet>
                 <includes>
+                  <include>com.google.protobuf:protobuf-java</include>
                   <include>org.apache.*:*</include>
                   <include>org.jboss.*:*</include>
                   <include>commons-*:*</include>
@@ -63,6 +69,10 @@
                 </excludes>
               </artifactSet>
               <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>bk-shade.com.google.proto_bk_v4_0_0</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>org.apache</pattern>
                   <shadedPattern>org.apache.bk_v4_0_0</shadedPattern>

--- a/compat-deps/bookkeeper-server-compat-4.1.0/pom.xml
+++ b/compat-deps/bookkeeper-server-compat-4.1.0/pom.xml
@@ -33,6 +33,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.4.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>4.1.0</version>
@@ -54,6 +59,7 @@
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <artifactSet>
                 <includes>
+                  <include>com.google.protobuf:protobuf-java</include>
                   <include>org.apache.*:*</include>
                   <include>org.jboss.*:*</include>
                   <include>commons-*:*</include>
@@ -63,6 +69,10 @@
                 </excludes>
               </artifactSet>
               <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>bk-shade.com.google.proto_bk_v4_1_0</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>org.apache.commons</pattern>
                   <shadedPattern>org.apache.bk_v4_1_0.commons</shadedPattern>

--- a/compat-deps/bookkeeper-server-compat-4.2.0/pom.xml
+++ b/compat-deps/bookkeeper-server-compat-4.2.0/pom.xml
@@ -33,6 +33,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.4.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>4.2.0</version>
@@ -54,6 +59,7 @@
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <artifactSet>
                 <includes>
+                  <include>com.google.protobuf:protobuf-java</include>
                   <include>org.apache.*:*</include>
                   <include>org.jboss.*:*</include>
                   <include>commons-*:*</include>
@@ -63,6 +69,10 @@
                 </excludes>
               </artifactSet>
               <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>bk-shade.com.google.proto_bk_v4_2_0</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>org.apache.commons</pattern>
                   <shadedPattern>org.apache.bk_v4_2_0.commons</shadedPattern>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <protobuf.version>2.4.1</protobuf.version>
+    <protobuf.version>2.6.1</protobuf.version>
     <guava.version>13.0.1</guava.version>
     <netty.version>3.9.4.Final</netty.version>
     <zookeeper.version>3.4.6</zookeeper.version>


### PR DESCRIPTION
protobuf/protoc 2.4 cannot be installed with brew on mac and building it on mac always result is build errors hence leaves an option of switching to linux to run protoc.
I upgraded to 2.6 instead. It is compatible with 2.4 on the wire and shaded so should not create any problems. All tests passed.
Please ignore changes in java files in attached patch during review; these are auto-generated.

protobuf 2.4 in compat* dependencies is shaded now to not conflict with 2.6.