### PR TITLE
BOOKKEEPER-948: Provide an option to add more ledger/index directorie…

### DIFF
--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -57,6 +57,10 @@ ledgerDirectories=/tmp/bk-data
 # Directories to store index files. If not specified, will use ledgerDirectories to store.
 # indexDirectories=/tmp/bk-data
 
+# Allow the expansion of bookie storage capacity. Newly added ledger
+# and index dirs must be empty.
+# allowStorageExpansion=false
+
 # Ledger Manager Class
 # What kind of ledger manager is used to manage how ledgers are stored, managed
 # and garbage collected. Try to read 'BookKeeper Internals' for detail info.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Arrays;
 import java.util.Formatter;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -79,6 +80,7 @@ import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AbstractFuture;
 
 /**
@@ -107,6 +109,7 @@ public class BookieShell implements Tool {
     static final String CMD_AUTORECOVERY = "autorecovery";
     static final String CMD_LISTBOOKIES = "listbookies";
     static final String CMD_UPDATECOOKIE = "updatecookie";
+    static final String CMD_EXPANDSTORAGE = "expandstorage";
     static final String CMD_UPDATELEDGER = "updateledgers";
     static final String CMD_HELP = "help";
 
@@ -1386,6 +1389,63 @@ public class BookieShell implements Tool {
     }
 
     /**
+     * Expand the storage directories owned by a bookie
+     */
+    class ExpandStorageCmd extends MyCommand {
+        Options opts = new Options();
+
+        ExpandStorageCmd() {
+            super(CMD_EXPANDSTORAGE);
+        }
+
+        @Override
+        Options getOptions() {
+            return opts;
+        }
+
+        @Override
+        String getDescription() {
+            return "Add new empty ledger/index directories. Update the directories"
+                   + "info in the conf file before running the command.";
+        }
+
+        @Override
+        String getUsage() {
+            return "expandstorage";
+        }
+
+        @Override
+        int runCmd(CommandLine cmdLine) {
+            ServerConfiguration conf = new ServerConfiguration(bkConf);
+            ZooKeeper zk;
+            try {
+                zk = ZooKeeperClient.newBuilder()
+                        .connectString(bkConf.getZkServers())
+                        .sessionTimeoutMs(bkConf.getZkTimeout()).build();
+            } catch (KeeperException | InterruptedException | IOException e) {
+                LOG.error("Exception while establishing zookeeper connection.", e);
+                return -1;
+            }
+
+            List<File> allLedgerDirs = Lists.newArrayList();
+            allLedgerDirs.addAll(Arrays.asList(ledgerDirectories));
+            if (indexDirectories != ledgerDirectories) {
+                allLedgerDirs.addAll(Arrays.asList(indexDirectories));
+            }
+
+            try {
+                Bookie.checkEnvironmentWithStorageExpansion(conf, zk,
+                        journalDirectory, allLedgerDirs);
+            } catch (BookieException | IOException e) {
+                LOG.error(
+                        "Exception while updating cookie for storage expansion", e);
+                return -1;
+            }
+            return 0;
+        }
+    }
+
+    /**
      * Update ledger command
      */
     class UpdateLedgerCmd extends MyCommand {
@@ -1519,6 +1579,7 @@ public class BookieShell implements Tool {
         commands.put(CMD_AUTORECOVERY, new AutoRecoveryCmd());
         commands.put(CMD_LISTBOOKIES, new ListBookiesCmd());
         commands.put(CMD_UPDATECOOKIE, new UpdateCookieCmd());
+        commands.put(CMD_EXPANDSTORAGE, new ExpandStorageCmd());
         commands.put(CMD_UPDATELEDGER, new UpdateLedgerCmd());
         commands.put(CMD_HELP, new HelpCmd());
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -84,6 +84,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     protected final static String JOURNAL_DIR = "journalDirectory";
     protected final static String LEDGER_DIRS = "ledgerDirectories";
     protected final static String INDEX_DIRS = "indexDirectories";
+    protected final static String ALLOW_STORAGE_EXPANSION = "allowStorageExpansion";
     // NIO Parameters
     protected final static String SERVER_TCP_NODELAY = "serverTcpNoDelay";
     // Zookeeper Parameters
@@ -516,6 +517,28 @@ public class ServerConfiguration extends AbstractConfiguration {
      */
     public ServerConfiguration setAllowLoopback(boolean allow) {
         this.setProperty(ALLOW_LOOPBACK, allow);
+        return this;
+    }
+
+    /**
+     * Return whether we should allow addition of ledger/index dirs to an existing bookie.
+     *
+     * @return true if the addition is allowed; false otherwise
+     */
+    public boolean getAllowStorageExpansion() {
+        return this.getBoolean(ALLOW_STORAGE_EXPANSION, false);
+    }
+
+    /**
+     * Change the setting of whether or not we should allow ledger/index
+     * dirs to be added to the current set of dirs.
+     *
+     * @param val - true if new ledger/index dirs can be added; false otherwise.
+     *
+     * @return server configuration
+     */
+    public ServerConfiguration setAllowStorageExpansion(boolean val) {
+        this.setProperty(ALLOW_STORAGE_EXPANSION, val);
         return this;
     }
 


### PR DESCRIPTION
…s to a bookie

This change allows the addition of new ledger and index directories to a bookie. Thus
increasing ts storage capacity. The option is exposed via 'allowStorageExpansion'
boolean configuration option. Also, the newly added directories need to be empty to be
accepted. Two new test cases have been added to test this functionality.
