### PR TITLE
BOOKKEEPER-955: in listLedgers method currentRange variable has to be…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1008,10 +1008,9 @@ public class BookKeeperAdmin {
                     }
 
                     @Override
-                    public Long next()
-                    throws NoSuchElementException {
-                        try{
-                            if (currentRange == null) {
+                    public Long next() throws NoSuchElementException {
+                        try {
+                            if ((currentRange == null) || (!currentRange.hasNext())) {
                                 currentRange = iterator.next().getLedgers().iterator();
                             }
                         } catch (IOException e) {


### PR DESCRIPTION
… updated to the next iterator

in BookKeeperAdmin listLedgers method currentRange variable is not getting updated to next iterator
when it has run out of elements
