### PR TITLE
BOOKKEEPER-956: Fix for HierarchicalLedgerRangeIterator

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManager.java
@@ -311,7 +311,9 @@ class HierarchicalLedgerManager extends AbstractZkLedgerManager {
                 boolean hasMoreElements = false;
                 try {
                     if (l1NodesIter == null) {
-                        l1NodesIter = zk.getChildren(ledgerRootPath, null).iterator();
+                        List<String> l1Nodes = zk.getChildren(ledgerRootPath, null);
+                        Collections.sort(l1Nodes);
+                        l1NodesIter = l1Nodes.iterator();
                         hasMoreElements = nextL1Node();
                     } else if (l2NodesIter == null || !l2NodesIter.hasNext()) {
                         hasMoreElements = nextL1Node();


### PR DESCRIPTION
Fix for HierarchicalLedgerRangeIterator, to make it work
for LedgerIds of length 9 and 10
