### PR TITLE
BOOKKEEPER-961 - Assing read/write requests for same ledger to a single thread

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -19,15 +19,15 @@ package org.apache.bookkeeper.proto;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.proto.BookieProtocol.Request;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.jboss.netty.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-abstract class PacketProcessorBase implements Runnable {
+abstract class PacketProcessorBase extends SafeRunnable {
     private final static Logger logger = LoggerFactory.getLogger(PacketProcessorBase.class);
     final Request request;
     final Channel channel;
@@ -64,7 +64,7 @@ abstract class PacketProcessorBase implements Runnable {
     }
 
     @Override
-    public void run() {
+    public void safeRun() {
         if (!isVersionCompatible()) {
             sendResponse(BookieProtocol.EBADVERSION,
                          ResponseBuilder.buildErrorResponse(BookieProtocol.EBADVERSION, request),

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
@@ -28,9 +28,10 @@ import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.jboss.netty.channel.Channel;
 
-public abstract class PacketProcessorBaseV3 {
+public abstract class PacketProcessorBaseV3 extends SafeRunnable {
 
     final Request request;
     final Channel channel;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.protobuf.ByteString;
 
-class ReadEntryProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
+class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
 
     private final static Logger LOG = LoggerFactory.getLogger(ReadEntryProcessorV3.class);
 
@@ -148,7 +148,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
     }
 
     @Override
-    public void run() {
+    public void safeRun() {
         ReadResponse readResponse = getReadResponse();
         sendResponse(readResponse);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
@@ -36,7 +36,7 @@ import org.jboss.netty.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class WriteEntryProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
+class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
     private final static Logger logger = LoggerFactory.getLogger(WriteEntryProcessorV3.class);
 
     public WriteEntryProcessorV3(Request request, Channel channel,
@@ -138,7 +138,7 @@ class WriteEntryProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
     }
 
     @Override
-    public void run() {
+    public void safeRun() {
         AddResponse addResponse = getAddResponse();
         if (null != addResponse) {
             // This means there was an error and we should send this back.


### PR DESCRIPTION
When entries for the same ledger are processed by the bookie we should avoid
the reordering of the request. Currently, if multiple read/write threads are
configured, the requests will be passed to the executor and writes for same
ledger will be spread across multiple threads.

This poses 2 issues:
 1. Mutex contention to access the LedgerDescriptor
 2. If the client receives add-entry acks out of order it has anyway to wait
    for the acks of previous entries before acknowledging the whole sequence
    to the application. In practice, the reordering is increasing the latency
   experienced by the application.