### PR TITLE
BOOKKEEPER-963: Allow to use multiple journals in bookie

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -84,6 +84,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_ADD_ENTRY;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_ADD_ENTRY_BYTES;
@@ -105,14 +106,14 @@ public class Bookie extends BookieCriticalThread {
 
     private final static Logger LOG = LoggerFactory.getLogger(Bookie.class);
 
-    final File journalDirectory;
+    final List<File> journalDirectories;
     final ServerConfiguration conf;
 
     final SyncThread syncThread;
     final LedgerManagerFactory ledgerManagerFactory;
     final LedgerManager ledgerManager;
     final LedgerStorage ledgerStorage;
-    final Journal journal;
+    final List<Journal> journals;
 
     final HandleFactory handles;
 
@@ -321,28 +322,37 @@ public class Bookie extends BookieCriticalThread {
             allLedgerDirs.addAll(indexDirsManager.getAllLedgerDirs());
         }
         if (zk == null) { // exists only for testing, just make sure directories are correct
-            checkDirectoryStructure(journalDirectory);
+            for (File journalDirectory : journalDirectories) {
+                checkDirectoryStructure(journalDirectory);
+            }
             for (File dir : allLedgerDirs) {
-                    checkDirectoryStructure(dir);
+                checkDirectoryStructure(dir);
             }
             return;
         }
         try {
             boolean newEnv = false;
             List<File> missedCookieDirs = new ArrayList<File>();
-            Cookie journalCookie = null;
-            // try to read cookie from journal directory.
-            try {
-                journalCookie = Cookie.readFromDirectory(journalDirectory);
-                if (journalCookie.isBookieHostCreatedFromIp()) {
-                    conf.setUseHostNameAsBookieID(false);
-                } else {
-                    conf.setUseHostNameAsBookieID(true);
+            List<Cookie> journalCookies = Lists.newArrayList();
+
+            // try to read cookie from journal directory
+            for (File journalDirectory : journalDirectories) {
+                try {
+                    checkDirectoryStructure(journalDirectory);
+                    Cookie journalCookie = Cookie.readFromDirectory(journalDirectory);
+                    journalCookies.add(journalCookie);
+
+                    if (journalCookie.isBookieHostCreatedFromIp()) {
+                        conf.setUseHostNameAsBookieID(false);
+                    } else {
+                        conf.setUseHostNameAsBookieID(true);
+                    }
+                } catch (FileNotFoundException fnf) {
+                    newEnv = true;
+                    missedCookieDirs.add(journalDirectory);
                 }
-            } catch (FileNotFoundException fnf) {
-                newEnv = true;
-                missedCookieDirs.add(journalDirectory);
             }
+
             String instanceId = getInstanceId(zk);
             Cookie.Builder builder = Cookie.generateCookie(conf);
             if (null != instanceId) {
@@ -357,10 +367,15 @@ public class Bookie extends BookieCriticalThread {
                 // 1) new environment or
                 // 2) done only metadata format and started bookie server.
             }
-            checkDirectoryStructure(journalDirectory);
 
-            if(!newEnv){
-                journalCookie.verify(masterCookie);
+            for (File journalDirectory : journalDirectories) {
+                checkDirectoryStructure(journalDirectory);
+            }
+
+            if (!newEnv){
+                for (Cookie journalCookie : journalCookies) {
+                    journalCookie.verify(masterCookie);
+                }
             }
             for (File dir : allLedgerDirs) {
                 checkDirectoryStructure(dir);
@@ -380,7 +395,10 @@ public class Bookie extends BookieCriticalThread {
             if (newEnv) {
                 if (missedCookieDirs.size() > 0) {
                     LOG.debug("Directories missing cookie file are {}", missedCookieDirs);
-                    masterCookie.writeToDirectory(journalDirectory);
+                    for (File journalDirectory : journalDirectories) {
+                        masterCookie.writeToDirectory(journalDirectory);
+                    }
+
                     for (File dir : allLedgerDirs) {
                         masterCookie.writeToDirectory(dir);
                     }
@@ -478,7 +496,11 @@ public class Bookie extends BookieCriticalThread {
         this.bookieReadonlyRegistrationPath =
             this.bookieRegistrationPath + BookKeeperConstants.READONLY;
         this.conf = conf;
-        this.journalDirectory = getCurrentDirectory(conf.getJournalDir());
+        this.journalDirectories = Lists.newArrayList();
+        for (File journalDirectory : conf.getJournalDirs()) {
+            journalDirectories.add(getCurrentDirectory(journalDirectory));
+        }
+
         this.ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
                 statsLogger.scope(LD_LEDGER_SCOPE));
         File[] idxDirs = conf.getIndexDirs();
@@ -500,16 +522,28 @@ public class Bookie extends BookieCriticalThread {
         // configured directories. When disk errors or all the ledger
         // directories are full, would throws exception and fail bookie startup.
         this.ledgerDirsManager.init();
-        // instantiate the journal
-        journal = new Journal(conf, ledgerDirsManager, statsLogger.scope(JOURNAL_SCOPE));
+
+        // instantiate the journals
+        if (journalDirectories.size() == 1) {
+            journals = Lists.newArrayList(new Journal(journalDirectories.get(0), conf, ledgerDirsManager, statsLogger
+                    .scope(JOURNAL_SCOPE)));
+        } else {
+            journals = Lists.newArrayList();
+            for (int idx = 0; idx < journalDirectories.size(); idx++) {
+                journals.add(new Journal(journalDirectories.get(idx), conf, ledgerDirsManager, statsLogger
+                        .scope(JOURNAL_SCOPE + "-" + idx)));
+            }
+        }
+
+        CheckpointSource checkpointSource = new CheckpointSourceList(journals);
 
         // Instantiate the ledger storage implementation
         String ledgerStorageClass = conf.getLedgerStorageClass();
         LOG.info("Using ledger storage: {}", ledgerStorageClass);
         ledgerStorage = LedgerStorageFactory.createLedgerStorage(ledgerStorageClass);
-        ledgerStorage.initialize(conf, ledgerManager, ledgerDirsManager, indexDirsManager, journal, statsLogger);
+        ledgerStorage.initialize(conf, ledgerManager, ledgerDirsManager, indexDirsManager, checkpointSource, statsLogger);
         syncThread = new SyncThread(conf, getLedgerDirsListener(),
-                                    ledgerStorage, journal);
+                                    ledgerStorage, checkpointSource);
 
         handles = new HandleFactoryImpl(ledgerStorage);
 
@@ -545,8 +579,7 @@ public class Bookie extends BookieCriticalThread {
     }
 
     void readJournal() throws IOException, BookieException {
-        long startTs = MathUtils.now();
-        journal.replay(new JournalScanner() {
+        JournalScanner scanner = new JournalScanner() {
             @Override
             public void process(int journalVersion, long offset, ByteBuffer recBuff) throws IOException {
                 long ledgerId = recBuff.getLong();
@@ -594,7 +627,14 @@ public class Bookie extends BookieCriticalThread {
                     throw new IOException(be);
                 }
             }
-        });
+        };
+
+        long startTs = MathUtils.now();
+
+        for (Journal journal : journals) {
+            journal.replay(scanner);
+        }
+
         long elapsedTs = MathUtils.now() - startTs;
         LOG.info("Finished replaying journal in {} ms.", elapsedTs);
     }
@@ -602,12 +642,13 @@ public class Bookie extends BookieCriticalThread {
     @Override
     synchronized public void start() {
         setDaemon(true);
-        LOG.debug("I'm starting a bookie with journal directory {}", journalDirectory.getName());
+        LOG.debug("I'm starting a bookie with journal directories {}", journalDirectories);
         //Start DiskChecker thread
         ledgerDirsManager.start();
         if (indexDirsManager != ledgerDirsManager) {
             indexDirsManager.start();
         }
+
         // replay journals
         try {
             readJournal();
@@ -1044,11 +1085,17 @@ public class Bookie extends BookieCriticalThread {
     public void run() {
         // bookie thread wait for journal thread
         try {
-            // start journal
-            journal.start();
-            // wait until journal quits
-            journal.join();
-            LOG.info("Journal thread quits.");
+            // start journals
+            for (Journal journal : journals) {
+                journal.start();
+            }
+
+            // wait until journals quit
+            for (Journal journal : journals) {
+                journal.join();
+            }
+
+            LOG.info("Journal threads quits.");
         } catch (InterruptedException ie) {
             LOG.warn("Interrupted on running journal thread : ", ie);
         }
@@ -1104,8 +1151,11 @@ public class Bookie extends BookieCriticalThread {
                 // Shutdown the state service
                 stateService.shutdown();
 
-                // Shutdown journal
-                journal.shutdown();
+                // Shutdown journals
+                for (Journal journal : journals) {
+                    journal.shutdown();
+                }
+
                 this.join();
                 syncThread.shutdown();
 
@@ -1160,7 +1210,7 @@ public class Bookie extends BookieCriticalThread {
             bb.flip();
 
             if (null == masterKeyCache.putIfAbsent(ledgerId, masterKey)) {
-                journal.logAddEntry(bb, new NopWriteCallback(), null);
+                getJournal(ledgerId).logAddEntry(bb, new NopWriteCallback(), null);
             }
         }
         return l;
@@ -1179,7 +1229,7 @@ public class Bookie extends BookieCriticalThread {
         writeBytes.add(entry.remaining());
 
         LOG.trace("Adding {}@{}", entryId, ledgerId);
-        journal.logAddEntry(entry, cb, ctx);
+        getJournal(ledgerId).logAddEntry(entry, cb, ctx);
     }
 
     /**
@@ -1272,7 +1322,7 @@ public class Bookie extends BookieCriticalThread {
 
             FutureWriteCallback fwc = new FutureWriteCallback();
             LOG.debug("record fenced state for ledger {} in journal.", ledgerId);
-            journal.logAddEntry(bb, fwc, null);
+            getJournal(ledgerId).logAddEntry(bb, fwc, null);
             return fwc.getResult();
         } else {
             // already fenced
@@ -1343,37 +1393,38 @@ public class Bookie extends BookieCriticalThread {
      */
     public static boolean format(ServerConfiguration conf,
             boolean isInteractive, boolean force) {
-        File journalDir = conf.getJournalDir();
-        String[] journalDirFiles =
-                journalDir.exists() && journalDir.isDirectory() ? journalDir.list() : null;
-        if (journalDirFiles != null && journalDirFiles.length != 0) {
-            try {
-                boolean confirm = false;
-                if (!isInteractive) {
-                    // If non interactive and force is set, then delete old
-                    // data.
-                    if (force) {
-                        confirm = true;
-                    } else {
-                        confirm = false;
-                    }
-                } else {
-                    confirm = IOUtils
-                            .confirmPrompt("Are you sure to format Bookie data..?");
-                }
 
-                if (!confirm) {
-                    LOG.error("Bookie format aborted!!");
+        boolean alreadyConfirmed = false;
+        for (File journalDir : conf.getJournalDirs()) {
+            if (journalDir.exists() && journalDir.isDirectory() && journalDir.list().length != 0) {
+                try {
+                    boolean confirm = false;
+                    if (!isInteractive) {
+                        // If non interactive and force is set, then delete old
+                        // data.
+                        if (force) {
+                            confirm = true;
+                        } else {
+                            confirm = false;
+                        }
+                    } else {
+                        confirm = alreadyConfirmed || IOUtils.confirmPrompt("Are you sure to format Bookie data..?");
+                        alreadyConfirmed = true;
+                    }
+
+                    if (!confirm) {
+                        LOG.error("Bookie format aborted!!");
+                        return false;
+                    }
+                } catch (IOException e) {
+                    LOG.error("Error during bookie format", e);
                     return false;
                 }
-            } catch (IOException e) {
-                LOG.error("Error during bookie format", e);
+            }
+            if (!cleanDir(journalDir)) {
+                LOG.error("Formatting journal directory failed");
                 return false;
             }
-        }
-        if (!cleanDir(journalDir)) {
-            LOG.error("Formatting journal directory failed");
-            return false;
         }
 
         File[] ledgerDirs = conf.getLedgerDirs();
@@ -1450,5 +1501,9 @@ public class Bookie extends BookieCriticalThread {
      */
     public int getExitCode() {
         return exitCode;
+    }
+
+    Journal getJournal(long ledgerId) {
+        return journals.get(MathUtils.signSafeMod(ledgerId, journals.size()));
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieBean.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieBean.java
@@ -45,7 +45,12 @@ public class BookieBean implements BookieMXBean, BKMBeanInfo {
 
     @Override
     public int getQueueLength() {
-        return bk.journal.getJournalQueueLength();
+        int totalLength = 0;
+        for (Journal journal : bk.journals) {
+            totalLength += journal.getJournalQueueLength(); 
+        }
+
+        return totalLength;
     }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -79,6 +79,7 @@ import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AbstractFuture;
 
 /**
@@ -113,10 +114,10 @@ public class BookieShell implements Tool {
     final ServerConfiguration bkConf = new ServerConfiguration();
     File[] indexDirectories;
     File[] ledgerDirectories;
-    File journalDirectory;
+    File[] journalDirectories;
 
     EntryLogger entryLogger = null;
-    Journal journal = null;
+    List<Journal> journals = null;
     EntryFormatter formatter;
 
     int pageSize;
@@ -925,6 +926,7 @@ public class BookieShell implements Tool {
 
         ReadJournalCmd() {
             super(CMD_READJOURNAL);
+            rjOpts.addOption("dir", false, "Journal directory (needed if more than one journal configured)");
             rjOpts.addOption("m", "msg", false, "Print message body");
         }
 
@@ -941,6 +943,32 @@ public class BookieShell implements Tool {
             if (cmdLine.hasOption("m")) {
                 printMsg = true;
             }
+
+            Journal journal = null;
+            if (getJournals().size() > 1) {
+                if (!cmdLine.hasOption("dir")) {
+                    System.err.println("ERROR: missing journal directory");
+                    printUsage();
+                    return -1;
+                }
+
+                File journalDir = new File(cmdLine.getOptionValue("dir"));
+                for (Journal j : getJournals()) {
+                    if (j.getJournalDirectory().equals(journalDir)) {
+                        journal = j;
+                        break;
+                    }
+                }
+
+                if (journal == null) {
+                    System.err.println("ERROR: journal directory not found");
+                    printUsage();
+                    return -1;
+                }
+            } else {
+                journal = getJournals().get(0);
+            }
+
             long journalId;
             try {
                 journalId = Long.parseLong(leftArgs[0]);
@@ -958,7 +986,7 @@ public class BookieShell implements Tool {
                 journalId = Long.parseLong(idString, 16);
             }
             // scan journal
-            scanJournal(journalId, printMsg);
+            scanJournal(journal, journalId, printMsg);
             return 0;
         }
 
@@ -1317,7 +1345,7 @@ public class BookieShell implements Tool {
                     return -1;
                 }
                 Cookie newCookie = Cookie.newBuilder(oldCookie.getValue()).setBookieHost(newBookieId).build();
-                boolean hasCookieUpdatedInDirs = verifyCookie(newCookie, journalDirectory);
+                boolean hasCookieUpdatedInDirs = verifyCookie(newCookie, journalDirectories[0]);
                 for (File dir : ledgerDirectories) {
                     hasCookieUpdatedInDirs &= verifyCookie(newCookie, dir);
                 }
@@ -1340,8 +1368,11 @@ public class BookieShell implements Tool {
                     }
                 } else {
                     // writes newcookie to local dirs
-                    newCookie.writeToDirectory(journalDirectory);
-                    LOG.info("Updated cookie file present in journalDirectory {}", journalDirectory);
+                    for (File journalDirectory : journalDirectories) {
+                        newCookie.writeToDirectory(journalDirectory);
+                        LOG.info("Updated cookie file present in journalDirectory {}", journalDirectory);
+                    }
+
                     for (File dir : ledgerDirectories) {
                         newCookie.writeToDirectory(dir);
                     }
@@ -1526,7 +1557,7 @@ public class BookieShell implements Tool {
     @Override
     public void setConf(Configuration conf) throws Exception {
         bkConf.loadConf(conf);
-        journalDirectory = Bookie.getCurrentDirectory(bkConf.getJournalDir());
+        journalDirectories = Bookie.getCurrentDirectories(bkConf.getJournalDirs());
         ledgerDirectories = Bookie.getCurrentDirectories(bkConf.getLedgerDirs());
         if (null == bkConf.getIndexDirs()) {
             indexDirectories = ledgerDirectories;
@@ -1661,11 +1692,14 @@ public class BookieShell implements Tool {
         entryLogger.scanEntryLog(logId, scanner);
     }
 
-    private synchronized Journal getJournal() throws IOException {
-        if (null == journal) {
-            journal = new Journal(bkConf, new LedgerDirsManager(bkConf, bkConf.getLedgerDirs()));
+    private synchronized List<Journal> getJournals() throws IOException {
+        if (null == journals) {
+            journals = Lists.newArrayListWithCapacity(bkConf.getJournalDirNames().length);
+            for (File journalDir : bkConf.getJournalDirs()) {
+                journals.add(new Journal(journalDir, bkConf, new LedgerDirsManager(bkConf, bkConf.getLedgerDirs())));
+            }
         }
-        return journal;
+        return journals;
     }
 
     /**
@@ -1676,8 +1710,8 @@ public class BookieShell implements Tool {
      * @param scanner
      *          Journal File Scanner
      */
-    protected void scanJournal(long journalId, JournalScanner scanner) throws IOException {
-        getJournal().scanJournal(journalId, 0L, scanner);
+    protected void scanJournal(Journal journal, long journalId, JournalScanner scanner) throws IOException {
+        journal.scanJournal(journalId, 0L, scanner);
     }
 
     ///
@@ -1786,9 +1820,9 @@ public class BookieShell implements Tool {
      * @param printMsg
      *          Whether printing the entry data.
      */
-    protected void scanJournal(long journalId, final boolean printMsg) throws Exception {
+    protected void scanJournal(Journal journal, long journalId, final boolean printMsg) throws Exception {
         System.out.println("Scan journal " + journalId + " (" + Long.toHexString(journalId) + ".txn)");
-        scanJournal(journalId, new JournalScanner() {
+        scanJournal(journal, journalId, new JournalScanner() {
             boolean printJournalVersion = false;
             @Override
             public void process(int journalVersion, long offset, ByteBuffer entry) throws IOException {
@@ -1805,10 +1839,11 @@ public class BookieShell implements Tool {
      * Print last log mark
      */
     protected void printLastLogMark() throws IOException {
-        LogMark lastLogMark = getJournal().getLastLogMark().getCurMark();
-        System.out.println("LastLogMark: Journal Id - " + lastLogMark.getLogFileId() + "("
-                + Long.toHexString(lastLogMark.getLogFileId()) + ".txn), Pos - "
-                + lastLogMark.getLogFileOffset());
+        for (Journal journal : getJournals()) {
+            LogMark lastLogMark = journal.getLastLogMark().getCurMark();
+            System.out.println(journal.getJournalDirectory() + " - LastLogMark: Journal Id - " + lastLogMark.getLogFileId() + "("
+                    + Long.toHexString(lastLogMark.getLogFileId()) + ".txn), Pos - " + lastLogMark.getLogFileOffset());
+        }
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/CheckpointSourceList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/CheckpointSourceList.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.bookie;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+public class CheckpointSourceList implements CheckpointSource {
+
+    private final List<? extends CheckpointSource> checkpointSourcesList;
+
+    public CheckpointSourceList(List<? extends CheckpointSource> checkpointSourcesList) {
+        this.checkpointSourcesList = checkpointSourcesList;
+    }
+
+    @Override
+    public Checkpoint newCheckpoint() {
+        return new CheckpointList(this);
+    }
+
+    @Override
+    public void checkpointComplete(Checkpoint checkpoint, boolean compact) throws IOException {
+        if (checkpoint == Checkpoint.MAX || checkpoint == Checkpoint.MIN) {
+            return;
+        }
+
+        checkArgument(checkpoint instanceof CheckpointList);
+        CheckpointList checkpointList = (CheckpointList) checkpoint;
+
+        checkArgument(checkpointList.source == this);
+        checkpointList.checkpointComplete(compact);
+    }
+
+    private static class CheckpointList implements Checkpoint {
+        private final CheckpointSourceList source;
+        private final List<Checkpoint> checkpoints;
+
+        public CheckpointList(CheckpointSourceList source) {
+            this.source = source;
+            this.checkpoints = Lists.newArrayListWithCapacity(source.checkpointSourcesList.size());
+            for (CheckpointSource checkpointSource : source.checkpointSourcesList) {
+                checkpoints.add(checkpointSource.newCheckpoint());
+            }
+        }
+
+        private void checkpointComplete(boolean compact) throws IOException {
+            for (int i = 0; i < source.checkpointSourcesList.size(); i++) {
+                source.checkpointSourcesList.get(i).checkpointComplete(checkpoints.get(i), compact);
+            }
+        }
+
+        @Override
+        public int compareTo(Checkpoint o) {
+            if (o == Checkpoint.MAX) {
+                return -1;
+            } else if (o == Checkpoint.MIN) {
+                return 1;
+            }
+
+            checkArgument(o instanceof CheckpointList);
+            CheckpointList other = (CheckpointList) o;
+            if (checkpoints.size() != other.checkpoints.size()) {
+                return Integer.compare(checkpoints.size(), other.checkpoints.size());
+            }
+
+            for (int i = 0; i < checkpoints.size(); i++) {
+                int res = checkpoints.get(i).compareTo(other.checkpoints.get(i));
+                if (res != 0) {
+                    return res;
+                }
+            }
+
+            return 0;
+        }
+
+    }
+
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
@@ -21,6 +21,19 @@
 
 package org.apache.bookkeeper.bookie;
 
+import static com.google.common.base.Charsets.UTF_8;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Scanner;
+
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.bookkeeper.util.HardLink;
@@ -28,29 +41,18 @@ import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.bookkeeper.zookeeper.BoundExponentialBackoffRetryPolicy;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.cli.BasicParser;
-import org.apache.commons.cli.Options;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.net.MalformedURLException;
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Scanner;
-import java.util.NoSuchElementException;
 
-import static com.google.common.base.Charsets.UTF_8;
+import com.google.common.collect.Lists;
 
 /**
  * Application for upgrading the bookkeeper filesystem
@@ -98,7 +100,7 @@ public class FileSystemUpgrade {
 
     private static List<File> getAllDirectories(ServerConfiguration conf) {
         List<File> dirs = new ArrayList<File>();
-        dirs.add(conf.getJournalDir());
+        dirs.addAll(Lists.newArrayList(conf.getJournalDirs()));
         for (File d: conf.getLedgerDirs()) {
             dirs.add(d);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -530,15 +530,15 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
     private final Counter flushEmptyQueueCounter;
     private final Counter journalWriteBytes;
 
-    public Journal(ServerConfiguration conf, LedgerDirsManager ledgerDirsManager) {
-        this(conf, ledgerDirsManager, NullStatsLogger.INSTANCE);
+    public Journal(File journalDir, ServerConfiguration conf, LedgerDirsManager ledgerDirsManager) {
+        this(journalDir, conf, ledgerDirsManager, NullStatsLogger.INSTANCE);
     }
 
-    public Journal(ServerConfiguration conf, LedgerDirsManager ledgerDirsManager, StatsLogger statsLogger) {
+    public Journal(File journalDir, ServerConfiguration conf, LedgerDirsManager ledgerDirsManager, StatsLogger statsLogger) {
         super("BookieJournal-" + conf.getBookiePort());
         this.ledgerDirsManager = ledgerDirsManager;
         this.conf = conf;
-        this.journalDirectory = Bookie.getCurrentDirectory(conf.getJournalDir());
+        this.journalDirectory = journalDir;
         this.maxJournalSize = conf.getMaxJournalSizeMB() * MB;
         this.journalPreAllocSize = conf.getJournalPreAllocSizeMB() * MB;
         this.journalWriteBufferSize = conf.getJournalWriteBufferSizeKB() * KB;
@@ -775,6 +775,7 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
      */
     @Override
     public void run() {
+        LOG.info("Starting journal on {}", journalDirectory);
         LinkedList<QueueEntry> toFlush = new LinkedList<QueueEntry>();
         ByteBuffer lenBuff = ByteBuffer.allocate(4);
         ByteBuffer paddingBuff = ByteBuffer.allocate(2 * conf.getJournalAlignmentSize());
@@ -926,6 +927,8 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
             LOG.error("I/O exception in Journal thread!", ioe);
         } catch (InterruptedException ie) {
             LOG.warn("Journal exits when shutting down", ie);
+        } catch (Throwable e) {
+            LOG.error("Journal error", e);
         } finally {
             // There could be packets queued for forceWrite on this logFile
             // That is fine as this exception is going to anyway take down the
@@ -959,6 +962,10 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
         } catch (InterruptedException ie) {
             LOG.warn("Interrupted during shutting down journal : ", ie);
         }
+    }
+
+    public File getJournalDirectory() {
+        return journalDirectory;
     }
 
     private static int fullRead(JournalChannel fc, ByteBuffer bb) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -82,6 +82,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     protected final static String ALLOW_LOOPBACK = "allowLoopback";
 
     protected final static String JOURNAL_DIR = "journalDirectory";
+    protected final static String JOURNAL_DIRS = "journalDirectories";
     protected final static String LEDGER_DIRS = "ledgerDirectories";
     protected final static String INDEX_DIRS = "indexDirectories";
     // NIO Parameters
@@ -524,8 +525,22 @@ public class ServerConfiguration extends AbstractConfiguration {
      *
      * @return journal dir name
      */
+    @Deprecated
     public String getJournalDirName() {
         return this.getString(JOURNAL_DIR, "/tmp/bk-txn");
+    }
+    
+    /**
+     * Get dir name to store journal files
+     *
+     * @return journal dir name
+     */
+    public String[] getJournalDirNames() {
+        String[] journalDirs = this.getStringArray(JOURNAL_DIRS);
+        if (null == journalDirs || journalDirs.length == 0) {
+            return new String[] { getJournalDirName() };
+        }
+        return journalDirs;
     }
 
     /**
@@ -536,7 +551,19 @@ public class ServerConfiguration extends AbstractConfiguration {
      * @return server configuration
      */
     public ServerConfiguration setJournalDirName(String journalDir) {
-        this.setProperty(JOURNAL_DIR, journalDir);
+        this.setProperty(JOURNAL_DIRS, new String[] { journalDir });
+        return this;
+    }
+
+    /**
+     * Set dir name to store journal files
+     *
+     * @param journalDir
+     *          Dir to store journal files
+     * @return server configuration
+     */
+    public ServerConfiguration setJournalDirNames(String[] journalDirs) {
+        this.setProperty(JOURNAL_DIRS, journalDirs);
         return this;
     }
 
@@ -545,12 +572,16 @@ public class ServerConfiguration extends AbstractConfiguration {
      *
      * @return journal dir, if no journal dir provided return null
      */
-    public File getJournalDir() {
-        String journalDirName = getJournalDirName();
-        if (null == journalDirName) {
+    public File[] getJournalDirs() {
+        String[] journalDirNames = getJournalDirNames();
+        if (null == journalDirNames) {
             return null;
         }
-        return new File(journalDirName);
+        File[] journalDirs = new File[journalDirNames.length];
+        for (int i = 0; i < journalDirNames.length; i++) {
+            journalDirs[i] = new File(journalDirNames[i]);
+        }
+        return journalDirs;
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -374,7 +374,7 @@ public class BookieServer {
         String hello = String.format(
                            "Hello, I'm your bookie, listening on port %1$s. ZKServers are on %2$s. Journals are in %3$s. Ledgers are stored in %4$s.",
                            conf.getBookiePort(), conf.getZkServers(),
-                           conf.getJournalDirName(), sb);
+                           conf.getJournalDirNames(), sb);
         LOG.info(hello);
         try {
             // Initialize Stats Provider

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieAccessor.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieAccessor.java
@@ -32,8 +32,11 @@ public class BookieAccessor {
      * Force a bookie to flush its ledger storage
      */
     public static void forceFlush(Bookie b) throws IOException {
-        Checkpoint cp = b.journal.newCheckpoint();
+        CheckpointSourceList source = new CheckpointSourceList(b.journals);
+        Checkpoint checkpoint = source.newCheckpoint();
+
         b.ledgerStorage.flush();
-        b.journal.checkpointComplete(cp, true);
+
+        source.checkpointComplete(checkpoint, true);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -219,7 +219,9 @@ public class CompactionTest extends BookKeeperClusterTestCase {
                 // Do nothing.
             }
         };
-        Bookie.checkDirectoryStructure(conf.getJournalDir());
+        for (File journalDir : conf.getJournalDirs()) {
+            Bookie.checkDirectoryStructure(journalDir);
+        }
         for (File dir : dirManager.getAllLedgerDirs()) {
             Bookie.checkDirectoryStructure(dir);
         }
@@ -602,7 +604,10 @@ public class CompactionTest extends BookKeeperClusterTestCase {
                 // Do nothing.
             }
         };
-        Bookie.checkDirectoryStructure(conf.getJournalDir());
+
+        for (File journalDir : conf.getJournalDirs()) {
+            Bookie.checkDirectoryStructure(journalDir);
+        }
         for (File dir : dirManager.getAllLedgerDirs()) {
             Bookie.checkDirectoryStructure(dir);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpdateCookieCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpdateCookieCmdTest.java
@@ -192,9 +192,12 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
         Assert.assertEquals("Wrongly updated cookie!", useHostNameAsBookieID, !cookie.isBookieHostCreatedFromIp());
         verifyCookieInZooKeeper(newconf, 1);
 
-        File journalDir = Bookie.getCurrentDirectory(conf.getJournalDir());
-        Cookie jCookie = Cookie.readFromDirectory(journalDir);
-        jCookie.verify(cookie);
+        for (File journalDir : conf.getJournalDirs()) {
+            journalDir = Bookie.getCurrentDirectory(journalDir);
+            Cookie jCookie = Cookie.readFromDirectory(journalDir);
+            jCookie.verify(cookie);
+        }
+
         File[] ledgerDir = Bookie.getCurrentDirectories(conf.getLedgerDirs());
         for (File dir : ledgerDir) {
             Cookie lCookie = Cookie.readFromDirectory(dir);


### PR DESCRIPTION
By configuring multiple journals, we can take advantage of the IO of multiple
disks to increase the write throughput of a single bookie.

Each journal will have its own journal and sync threads and writes will be
assigned to a particular journal by hashing on the ledger id.

In addition to using multiple physical disks, there can improvements even by
using multiple journal on a single SSD device, because these disks can handle
well multiple concurrent writes in different blocks of the disk.