### PR TITLE
BOOKKEEPER-965: Long Polling Part I: Changes in the write path

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -1305,6 +1305,11 @@ public class Bookie extends BookieCriticalThread {
         }
     }
 
+    public long readLastAddConfirmed(long ledgerId) throws IOException {
+        LedgerDescriptor handle = handles.getReadOnlyHandle(ledgerId);
+        return handle.getLastAddConfirmed();
+    }
+
     // The rest of the code is test stuff
     static class CounterCallback implements WriteCallback {
         int count;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -80,6 +80,9 @@ class FileInfo {
     private int stateBits;
     private boolean needFlushHeader = false;
 
+    // lac
+    private Long lac = null;
+
     // file access mode
     protected String mode;
 
@@ -88,6 +91,17 @@ class FileInfo {
 
         this.masterKey = masterKey;
         mode = "rw";
+    }
+
+    synchronized Long getLastAddConfirmed() {
+        return lac;
+    }
+
+    synchronized long setLastAddConfirmed(long lac) {
+        if (null == this.lac || this.lac < lac) {
+            this.lac = lac;
+        }
+        return this.lac;
     }
 
     public File getLf() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -318,6 +318,30 @@ public class IndexPersistenceMgr {
         fileInfoCache.clear();
     }
 
+    Long getLastAddConfirmed(long ledgerId) throws IOException {
+        FileInfo fi = null;
+        try {
+            fi = getFileInfo(ledgerId, null);
+            return fi.getLastAddConfirmed();
+        } finally {
+            if (null != fi) {
+                fi.release();
+            }
+        }
+    }
+
+    long updateLastAddConfirmed(long ledgerId, long lac) throws IOException {
+        FileInfo fi = null;
+        try {
+            fi = getFileInfo(ledgerId, null);
+            return fi.setLastAddConfirmed(lac);
+        } finally {
+            if (null != fi) {
+                fi.release();
+            }
+        }
+    }
+
     byte[] readMasterKey(long ledgerId) throws IOException, BookieException {
         FileInfo fi = fileInfoCache.get(ledgerId);
         if (fi == null) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
@@ -44,6 +44,9 @@ interface LedgerCache extends Closeable {
     void flushLedger(boolean doAll) throws IOException;
     long getLastEntry(long ledgerId) throws IOException;
 
+    Long getLastAddConfirmed(long ledgerId) throws IOException;
+    long updateLastAddConfirmed(long ledgerId, long lac) throws IOException;
+
     void deleteLedger(long ledgerId) throws IOException;
 
     LedgerCacheBean getJMXBean();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
@@ -73,6 +73,16 @@ public class LedgerCacheImpl implements LedgerCache {
     }
 
     @Override
+    public Long getLastAddConfirmed(long ledgerId) throws IOException {
+        return indexPersistenceManager.getLastAddConfirmed(ledgerId);
+    }
+
+    @Override
+    public long updateLastAddConfirmed(long ledgerId, long lac) throws IOException {
+        return indexPersistenceManager.updateLastAddConfirmed(ledgerId, lac);
+    }
+
+    @Override
     public void putEntryOffset(long ledger, long entry, long offset) throws IOException {
         indexPageManager.putEntryOffset(ledger, entry, offset);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
@@ -59,4 +59,5 @@ public abstract class LedgerDescriptor {
 
     abstract long addEntry(ByteBuffer entry) throws IOException;
     abstract ByteBuffer readEntry(long entryId) throws IOException;
+    abstract long getLastAddConfirmed() throws IOException;
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -84,4 +84,9 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
     ByteBuffer readEntry(long entryId) throws IOException {
         return ledgerStorage.getEntry(ledgerId, entryId);
     }
+
+    @Override
+    long getLastAddConfirmed() throws IOException {
+        return ledgerStorage.getLastAddConfirmed(ledgerId);
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -109,6 +109,16 @@ public interface LedgerStorage {
     ByteBuffer getEntry(long ledgerId, long entryId) throws IOException;
 
     /**
+     * Get last add confirmed.
+     *
+     * @param ledgerId
+     *          ledger id.
+     * @return last add confirmed.
+     * @throws IOException
+     */
+    long getLastAddConfirmed(long ledgerId) throws IOException;
+
+    /**
      * Flushes all data in the storage. Once this is called,
      * add data written to the LedgerStorage up until this point
      * has been persisted to perminant storage

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -96,8 +96,10 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
     public long addEntry(ByteBuffer entry) throws IOException {
         long ledgerId = entry.getLong();
         long entryId = entry.getLong();
+        long lac = entry.getLong();
         entry.rewind();
         memTable.addEntry(ledgerId, entryId, entry, this);
+        ledgerCache.updateLastAddConfirmed(ledgerId, lac);
         return entryId;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
@@ -325,6 +325,11 @@ public class TestSyncThread {
         }
 
         @Override
+        public long getLastAddConfirmed(long ledgerId) throws IOException {
+            return 0;
+        }
+
+        @Override
         public void flush() throws IOException {
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -161,6 +161,11 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         }
 
         @Override
+        public long getLastAddConfirmed(long ledgerId) throws IOException {
+            return 0;
+        }
+
+        @Override
         public void flush() throws IOException {
         }
 


### PR DESCRIPTION
This is the first in the series of changes for enabling long polling between bookkeeper client and the bookkeeper server. The changes were originally implemented in the Twitter fork and these pull request combine multiple commits from Twitter's bookkeeper fork as they include not only the changes made initially but also bug fixes added since. 

The first change captures the changes on the write path (AddEntry). We track the last add confirmed in the FileInfo so that we can trigger actions when the value is updated