### PR TITLE
BOOKKEEPER-946 Provide an option to delay auto recovery of lost bookies

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -364,6 +364,9 @@ public class AuditorLedgerCheckerTest extends MultiLedgerManagerTestCase {
      */
     @Test(timeout=60000)
     public void testDelayedAuditOfLostBookies() throws Exception {
+        // wait for a second so that the initial periodic check finishes
+        Thread.sleep(1000);
+
         _testDelayedAuditOfLostBookies();
     }
 


### PR DESCRIPTION
Fixing a bug in the test AuditorLedgerCheckerTest.testDelayedAuditOfLostBookies which
fails sometimes with:
AuditorLedgerCheckerTest.testDelayedAuditOfLostBookies:367->_testDelayedAuditOfLostBookies:345 audit of lost bookie isn't delayed