### PR TITLE
BOOKKEEPER-873: CreateLedgerAPI to accept ledgerId

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -738,7 +738,114 @@ public class BookKeeper implements AutoCloseable {
                 return;
             }
             new LedgerCreateOp(BookKeeper.this, ensSize, writeQuorumSize,
-                               ackQuorumSize, digestType, passwd, cb, ctx, customMetadata).initiateAdv();
+                               ackQuorumSize, digestType, passwd, cb, ctx, customMetadata).initiateAdv((long)(-1));
+        } finally {
+            closeLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Synchronously creates a new ledger using the interface which accepts a ledgerId as input.
+     * This method returns {@link LedgerHandleAdv} which can accept entryId.
+     * Parameters must match those of
+     * {@link #asyncCreateLedgerAdvWithLedgerId(byte[], long, int, int, int, DigestType, byte[],
+     *                           AsyncCallback.CreateCallback, Object)}
+     * @param ledgerId
+     * @param ensSize
+     * @param writeQuorumSize
+     * @param ackQuorumSize
+     * @param digestType
+     * @param passwd
+     * @param customMetadata
+     * @return a handle to the newly created ledger
+     * @throws InterruptedException
+     * @throws BKException
+     */
+    public LedgerHandle createLedgerAdv(final long ledgerId,
+                                        int ensSize,
+                                        int writeQuorumSize,
+                                        int ackQuorumSize,
+                                        DigestType digestType,
+                                        byte passwd[],
+                                        final Map<String, byte[]> customMetadata) throws InterruptedException, BKException{
+        CompletableFuture<LedgerHandle> counter = new CompletableFuture<>();
+
+        /*
+         * Calls asynchronous version
+         */
+        asyncCreateLedgerAdv(ledgerId, ensSize, writeQuorumSize, ackQuorumSize, digestType, passwd,
+                             new SyncCreateCallback(), counter, customMetadata);
+
+        LedgerHandle lh = SynchCallbackUtils.waitForResult(counter);
+        if (lh == null) {
+            LOG.error("Unexpected condition : no ledger handle returned for a success ledger creation");
+            throw BKException.create(BKException.Code.UnexpectedConditionException);
+        } else if (ledgerId != lh.getId()) {
+            LOG.error("Unexpected condition : Expected ledgerId: {} but got: {}", ledgerId, lh.getId());
+            throw BKException.create(BKException.Code.UnexpectedConditionException);
+        }
+
+        LOG.info("Ensemble: {} for ledger: {}", lh.getLedgerMetadata().getEnsemble(0L),
+                lh.getId());
+
+        return lh;
+    }
+
+    /**
+     * Asynchronously creates a new ledger using the interface which accepts a ledgerId as input.
+     * This method returns {@link LedgerHandleAdv} which can accept entryId.
+     * Ledgers created with this call have ability to accept
+     * a separate write quorum and ack quorum size. The write quorum must be larger than
+     * the ack quorum.
+     *
+     * Separating the write and the ack quorum allows the BookKeeper client to continue
+     * writing when a bookie has failed but the failure has not yet been detected. Detecting
+     * a bookie has failed can take a number of seconds, as configured by the read timeout
+     * {@link ClientConfiguration#getReadTimeout()}. Once the bookie failure is detected,
+     * that bookie will be removed from the ensemble.
+     *
+     * The other parameters match those of {@link #asyncCreateLedger(long, int, int, DigestType, byte[],
+     *                                      AsyncCallback.CreateCallback, Object)}
+     *
+     * @param ledgerId
+     *          ledger Id to use for the newly created ledger
+     * @param ensSize
+     *          number of bookies over which to stripe entries
+     * @param writeQuorumSize
+     *          number of bookies each entry will be written to
+     * @param ackQuorumSize
+     *          number of bookies which must acknowledge an entry before the call is completed
+     * @param digestType
+     *          digest type, either MAC or CRC32
+     * @param passwd
+     *          password
+     * @param cb
+     *          createCallback implementation
+     * @param ctx
+     *          optional control object
+     * @param customMetadata
+     *          optional customMetadata that holds user specified metadata
+     */
+    public void asyncCreateLedgerAdv(final long ledgerId,
+                                     final int ensSize,
+                                     final int writeQuorumSize,
+                                     final int ackQuorumSize,
+                                     final DigestType digestType,
+                                     final byte[] passwd,
+                                     final CreateCallback cb,
+                                     final Object ctx,
+                                     final Map<String, byte[]> customMetadata) {
+        if (writeQuorumSize < ackQuorumSize) {
+            throw new IllegalArgumentException("Write quorum must be larger than ack quorum");
+        }
+        closeLock.readLock().lock();
+        try {
+            if (closed) {
+                cb.createComplete(BKException.Code.ClientClosedException, null, ctx);
+                return;
+            }
+            new LedgerCreateOp(BookKeeper.this, ensSize, writeQuorumSize,
+                               ackQuorumSize, digestType, passwd, cb, ctx, customMetadata).initiateAdv(ledgerId);
         } finally {
             closeLock.readLock().unlock();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -48,7 +48,7 @@ class LedgerCreateOp implements GenericCallback<Void> {
     CreateCallback cb;
     LedgerMetadata metadata;
     LedgerHandle lh;
-    Long ledgerId;
+    Long ledgerId = -1L;
     Object ctx;
     byte[] passwd;
     BookKeeper bk;
@@ -56,6 +56,7 @@ class LedgerCreateOp implements GenericCallback<Void> {
     long startTime;
     OpStatsLogger createOpLogger;
     boolean adv = false;
+    boolean generateLedgerId = true;
 
     /**
      * Constructor
@@ -119,12 +120,16 @@ class LedgerCreateOp implements GenericCallback<Void> {
          * Add ensemble to the configuration
          */
         metadata.addEnsemble(0L, ensemble);
-
-        createLedger();
+        if (this.generateLedgerId) {
+            generateLedgerIdAndCreateLedger();
+        } else {
+            // Create ledger with supplied ledgerId
+            bk.getLedgerManager().createLedgerMetadata(ledgerId, metadata, LedgerCreateOp.this);
+        }
     }
 
-    void createLedger() {
-        // generate a ledger id and then create the ledger with metadata
+    void generateLedgerIdAndCreateLedger() {
+        // generate a ledgerId
         final LedgerIdGenerator ledgerIdGenerator = bk.getLedgerIdGenerator();
         ledgerIdGenerator.generateLedgerId(new GenericCallback<Long>() {
             @Override
@@ -133,7 +138,6 @@ class LedgerCreateOp implements GenericCallback<Void> {
                     createComplete(rc, null);
                     return;
                 }
-
                 LedgerCreateOp.this.ledgerId = ledgerId;
                 // create a ledger with metadata
                 bk.getLedgerManager().createLedgerMetadata(ledgerId, metadata, LedgerCreateOp.this);
@@ -144,8 +148,12 @@ class LedgerCreateOp implements GenericCallback<Void> {
     /**
      * Initiates the operation to return LedgerHandleAdv.
      */
-    public void initiateAdv() {
+    public void initiateAdv(final long ledgerId) {
         this.adv = true;
+        this.ledgerId = ledgerId;
+        if (this.ledgerId != -1L) {
+            this.generateLedgerId = false;
+        }
         initiate();
     }
 
@@ -154,9 +162,9 @@ class LedgerCreateOp implements GenericCallback<Void> {
      */
     @Override
     public void operationComplete(int rc, Void result) {
-        if (BKException.Code.LedgerExistException == rc) {
+        if (this.generateLedgerId && (BKException.Code.LedgerExistException == rc)) {
             // retry to generate a new ledger id
-            createLedger();
+            generateLedgerIdAndCreateLedger();
             return;
         } else if (BKException.Code.OK != rc) {
             createComplete(rc, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManager.java
@@ -64,7 +64,7 @@ class FlatLedgerManager extends AbstractZkLedgerManager {
     public String getLedgerPath(long ledgerId) {
         StringBuilder sb = new StringBuilder();
         sb.append(ledgerPrefix)
-          .append(StringUtils.getZKStringId(ledgerId));
+          .append(StringUtils.getZKStringIdForFlat(ledgerId));
         return sb.toString();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/StringUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/StringUtils.java
@@ -41,6 +41,16 @@ public class StringUtils {
     }
 
     /**
+     * Formats ledger ID according to ZooKeeper rules
+     *
+     * @param id
+     *            znode id
+     */
+    public static String getZKStringIdForFlat(long id) {
+        return String.format("%019d", id);
+    }
+
+    /**
      * Get the hierarchical ledger path according to the ledger id
      *
      * @param ledgerId


### PR DESCRIPTION
Add ledgerCreateAdv with ledgerId interface to Bookkeeper
and corresponding Junit tests.

Reviewed-by: Tony Menges <amenges@salesforce.com>
Reviewed-by: Charan Reddy Guttapalem <cguttapalem@salesforce.com>
Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>
Signed-off-by: Charan Reddy Guttapalem <cguttapalem@salesforce.com>