### PR TITLE
BOOKKEEPER-874: Explict LAC from Writer to Bookies

### DIFF
--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -91,6 +91,9 @@ ledgerDirectories=/tmp/bk-data
 # If it is set to less than zero, the minor compaction is disabled. 
 # minorCompactionInterval=3600
 
+# Interval between sending an explicit LAC in seconds
+explicitLacInterval = 1
+
 # Threshold of major compaction
 # For those entry log files whose remaining size percentage reaches below
 # this threshold will be compacted in a major compaction.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
@@ -35,6 +35,8 @@ public interface BookKeeperServerStats {
     public final static String READ_ENTRY_FENCE_REQUEST = "READ_ENTRY_FENCE_REQUEST";
     public final static String READ_ENTRY_FENCE_WAIT = "READ_ENTRY_FENCE_WAIT";
     public final static String READ_ENTRY_FENCE_READ = "READ_ENTRY_FENCE_READ";
+    public final static String WRITE_LAC = "WRITE_LAC";
+    public final static String READ_LAC = "READ_LAC";
 
     // Bookie Operations
     public final static String BOOKIE_ADD_ENTRY_BYTES = "BOOKIE_ADD_ENTRY_BYTES";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -389,6 +389,34 @@ public class IndexPersistenceMgr {
         }
     }
 
+    void setExplicitLac(long ledgerId, ByteBuffer lac) throws IOException {
+        FileInfo fi = null;
+        try {
+            fi = getFileInfo(ledgerId, null);
+            fi.setExplicitLac(lac);
+            return;
+        } finally {
+            if (null != fi) {
+                fi.release();
+            }
+        }
+    }
+
+    public ByteBuffer getExplicitLac(long ledgerId) {
+        FileInfo fi = null;
+        try {
+            fi = getFileInfo(ledgerId, null);
+            return fi.getExplicitLac();
+        } catch (IOException e) {
+            LOG.error("Exception during getLastAddConfirmed: {}", e);
+            return null;
+        } finally {
+            if (null != fi) {
+                fi.release();
+            }
+        }
+    }
+
     int getOpenFileLimit() {
         return openFileLimit;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -215,6 +215,14 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         return ledgerCache.isFenced(ledgerId);
     }
 
+    public void setExplicitlac(long ledgerId, ByteBuffer lac) throws IOException {
+        ledgerCache.setExplicitLac(ledgerId, lac);
+    }
+
+    public ByteBuffer getExplicitLac(long ledgerId) {
+        return ledgerCache.getExplicitLac(ledgerId);
+    }
+
     @Override
     public void setMasterKey(long ledgerId, byte[] masterKey) throws IOException {
         ledgerCache.setMasterKey(ledgerId, masterKey);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
@@ -23,6 +23,7 @@ package org.apache.bookkeeper.bookie;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * This class maps a ledger entry number into a location (entrylogid, offset) in
@@ -50,4 +51,6 @@ interface LedgerCache extends Closeable {
     void deleteLedger(long ledgerId) throws IOException;
 
     LedgerCacheBean getJMXBean();
+    void setExplicitLac(long ledgerId, ByteBuffer lac) throws IOException;
+    ByteBuffer getExplicitLac(long ledgerId);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
@@ -22,6 +22,7 @@
 package org.apache.bookkeeper.bookie;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -134,6 +135,14 @@ public class LedgerCacheImpl implements LedgerCache {
     @Override
     public boolean isFenced(long ledgerId) throws IOException {
         return indexPersistenceManager.isFenced(ledgerId);
+    }
+
+    public void setExplicitLac(long ledgerId, ByteBuffer lac) throws IOException {
+        indexPersistenceManager.setExplicitLac(ledgerId, lac);
+    }
+
+    public ByteBuffer getExplicitLac(long ledgerId) {
+        return indexPersistenceManager.getExplicitLac(ledgerId);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
@@ -59,5 +59,10 @@ public abstract class LedgerDescriptor {
 
     abstract long addEntry(ByteBuffer entry) throws IOException;
     abstract ByteBuffer readEntry(long entryId) throws IOException;
+
     abstract long getLastAddConfirmed() throws IOException;
+
+    abstract void setExplicitLac(ByteBuffer entry) throws IOException;
+
+    abstract  ByteBuffer getExplicitLac();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -69,6 +69,15 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
     }
 
     @Override
+    void setExplicitLac(ByteBuffer lac) throws IOException {
+        ledgerStorage.setExplicitlac(ledgerId, lac);
+    }
+
+    @Override
+    ByteBuffer getExplicitLac() {
+        return ledgerStorage.getExplicitLac(ledgerId);
+    }
+    @Override
     long addEntry(ByteBuffer entry) throws IOException {
         long ledgerId = entry.getLong();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -149,4 +149,8 @@ public interface LedgerStorage {
      * Get the JMX management bean for this LedgerStorage
      */
     BKMBeanInfo getJMXBean();
+
+    void setExplicitlac(long ledgerId, ByteBuffer lac) throws IOException;
+
+    ByteBuffer getExplicitLac(long ledgerId);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/AsyncCallback.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/AsyncCallback.java
@@ -36,6 +36,20 @@ public interface AsyncCallback {
         void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx);
     }
 
+    public interface AddLacCallback {
+        /**
+         * Callback declaration
+         *
+         * @param rc
+         *          return code
+         * @param lh
+         *          ledger handle
+         * @param ctx
+         *          context object
+         */
+        void addLacComplete(int rc, LedgerHandle lh, Object ctx);
+    }
+
     public interface CloseCallback {
         /**
          * Callback definition

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
@@ -40,7 +40,7 @@ public abstract class BKException extends Exception {
     /**
      * Create an exception from an error code
      * @param code return error code
-     * @return correponding exception
+     * @return corresponding exception
      */
     public static BKException create(int code) {
         switch (code) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -28,6 +28,8 @@ public interface BookKeeperClientStats {
     public final static String OPEN_OP = "LEDGER_OPEN";
     public final static String ADD_OP = "ADD_ENTRY";
     public final static String READ_OP = "READ_ENTRY";
+    public final static String WRITE_LAC_OP = "WRITE_LAC";
+    public final static String READ_LAC_OP = "READ_LAC";
     public final static String PENDING_ADDS = "NUM_PENDING_ADD";
     public final static String ENSEMBLE_CHANGES = "NUM_ENSEMBLE_CHANGE";
     public final static String LAC_UPDATE_HITS = "LAC_UPDATE_HITS";
@@ -40,4 +42,8 @@ public interface BookKeeperClientStats {
     public final static String CHANNEL_TIMEOUT_READ = "TIMEOUT_READ_ENTRY";
     public final static String CHANNEL_ADD_OP = "ADD_ENTRY";
     public final static String CHANNEL_TIMEOUT_ADD = "TIMEOUT_ADD_ENTRY";
+    public final static String CHANNEL_WRITE_LAC_OP = "WRITE_LAC";
+    public final static String CHANNEL_TIMEOUT_WRITE_LAC = "TIMEOUT_WRITE_LAC";
+    public final static String CHANNEL_READ_LAC_OP = "READ_LAC";
+    public final static String CHANNEL_TIMEOUT_READ_LAC = "TIMEOUT_READ_LAC";
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ExplicitLacFlushPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ExplicitLacFlushPolicy.java
@@ -1,0 +1,153 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+
+import org.apache.bookkeeper.client.LedgerHandle.LastAddConfirmedCallback;
+import org.apache.bookkeeper.util.SafeRunnable;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+interface ExplicitLacFlushPolicy {
+    void stopExplicitLacFlush();
+
+    void updatePiggyBackedLac(long piggyBackedLac);
+
+    static final ExplicitLacFlushPolicy VOID_EXPLICITLAC_FLUSH_POLICY = new ExplicitLacFlushPolicy() {
+        @Override
+        public void stopExplicitLacFlush() {
+            // void method
+        }
+
+        @Override
+        public void updatePiggyBackedLac(long piggyBackedLac) {
+            // void method
+        }
+    };
+
+    class ExplicitLacFlushPolicyImpl implements ExplicitLacFlushPolicy {
+        final static Logger LOG = LoggerFactory.getLogger(ExplicitLacFlushPolicyImpl.class);
+
+        volatile long piggyBackedLac = LedgerHandle.INVALID_ENTRY_ID;
+        volatile long explicitLac = LedgerHandle.INVALID_ENTRY_ID;
+        final LedgerHandle lh;
+        ScheduledFuture<?> scheduledFuture;
+
+        ExplicitLacFlushPolicyImpl(LedgerHandle lh) {
+            this.lh = lh;
+            scheduleExplictLacFlush();
+            LOG.debug("Scheduled Explicit Last Add Confirmed Update");
+        }
+
+        private long getExplicitLac() {
+            return explicitLac;
+        }
+
+        private void setExplicitLac(long explicitLac) {
+            this.explicitLac = explicitLac;
+        }
+
+        private long getPiggyBackedLac() {
+            return piggyBackedLac;
+        }
+
+        public void setPiggyBackedLac(long piggyBackedLac) {
+            this.piggyBackedLac = piggyBackedLac;
+        }
+
+        private void scheduleExplictLacFlush() {
+            int explicitLacIntervalInSec = lh.bk.getExplicitLacInterval();
+            final SafeRunnable updateLacTask = new SafeRunnable() {
+                @Override
+                public void safeRun() {
+                    // Made progress since previous explicitLAC through
+                    // Piggyback, so no need to send an explicit LAC update to
+                    // bookies.
+                    if (getExplicitLac() < getPiggyBackedLac()) {
+                        LOG.debug("ledgerid: {}", lh.getId());
+                        LOG.debug("explicitLac:{} piggybackLac:{}", getExplicitLac(),
+                                getPiggyBackedLac());
+                        setExplicitLac(getPiggyBackedLac());
+                        return;
+                    }
+
+                    if (lh.getLastAddConfirmed() > getExplicitLac()) {
+                        // Send Explicit LAC
+                        LOG.debug("ledgerid: {}", lh.getId());
+                        asyncExplicitLacFlush(lh.getLastAddConfirmed());
+                        setExplicitLac(lh.getLastAddConfirmed());
+                        LOG.debug("After sending explict LAC lac: {}  explicitLac:{}", lh.getLastAddConfirmed(),
+                                getExplicitLac());
+                    }
+                }
+
+                @Override
+                public String toString() {
+                    return String.format("UpdateLacTask ledgerId - (%d)", lh.getId());
+                }
+            };
+            try {
+                scheduledFuture = lh.bk.mainWorkerPool.scheduleAtFixedRateOrdered(lh.getId(), updateLacTask,
+                        explicitLacIntervalInSec, explicitLacIntervalInSec, SECONDS);
+            } catch (RejectedExecutionException re) {
+                LOG.error("Scheduling of ExplictLastAddConfirmedFlush for ledger: {} has failed because of {}",
+                        lh.getId(), re);
+            }
+        }
+
+        /**
+         * Make a LastAddUpdate request.
+         */
+        void asyncExplicitLacFlush(final long explicitLac) {
+            final LastAddConfirmedCallback cb = LastAddConfirmedCallback.INSTANCE;
+            final PendingWriteLacOp op = new PendingWriteLacOp(lh, cb, null);
+            op.setLac(explicitLac);
+            try {
+                LOG.debug("Sending Explicit LAC: {}", explicitLac);
+                lh.bk.mainWorkerPool.submit(new SafeRunnable() {
+                    @Override
+                    public void safeRun() {
+                        ChannelBuffer toSend = lh.macManager
+                                .computeDigestAndPackageForSendingLac(lh.getLastAddConfirmed());
+                        op.initiate(toSend);
+                    }
+                });
+            } catch (RejectedExecutionException e) {
+                cb.addLacComplete(lh.bk.getReturnRc(BKException.Code.InterruptedException), lh, null);
+            }
+        }
+
+        @Override
+        public void stopExplicitLacFlush() {
+            scheduledFuture.cancel(true);
+        }
+
+        @Override
+        public void updatePiggyBackedLac(long piggyBackedLac) {
+            setPiggyBackedLac(piggyBackedLac);
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client;
+
+import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
+import org.apache.bookkeeper.client.DigestManager.RecoveryData;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
+import org.apache.bookkeeper.proto.BookieProtocol;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadLacCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+/**
+ * This represents a pending ReadLac operation.
+ *
+ * LAC is stored in two places on bookies.
+ * 1. WriteLac operation sends Explicit LAC and is stored in memory on each bookie.
+ * 2. Each AddEntry operation piggy-backs LAC which is stored on bookie's disk.
+ *
+ * This operation returns both of those entries and we pick the latest LAC out of
+ * available answers.
+ *
+ * This is an optional protocol operations to facilitate tailing readers
+ * to be up to date with the writer. This is best effort to get latest LAC
+ * from bookies, and doesn't affect the correctness of the protocol.
+ */
+
+class PendingReadLacOp implements ReadLacCallback {
+    static final Logger LOG = LoggerFactory.getLogger(PendingReadLacOp.class);
+    LedgerHandle lh;
+    LacCallback cb;
+    int numResponsesPending;
+    volatile boolean completed = false;
+    int lastSeenError = BKException.Code.ReadException;
+    final DistributionSchedule.QuorumCoverageSet coverageSet;
+    long maxLac = LedgerHandle.INVALID_ENTRY_ID;
+
+    /*
+     * Wrapper to get Lac from the request
+     */
+    interface LacCallback {
+        public void getLacComplete(int rc, long lac);
+    }
+
+    PendingReadLacOp(LedgerHandle lh, LacCallback cb) {
+        this.lh = lh;
+        this.cb = cb;
+        this.numResponsesPending = lh.metadata.getEnsembleSize();
+        this.coverageSet = lh.distributionSchedule.getCoverageSet();
+    }
+
+    public void initiate() {
+        for (int i = 0; i < lh.metadata.currentEnsemble.size(); i++) {
+            lh.bk.bookieClient.readLac(lh.metadata.currentEnsemble.get(i),
+                    lh.ledgerId, this, i);
+        }
+    }
+
+    @Override
+    public void readLacComplete(int rc, long ledgerId, final ChannelBuffer lacBuffer, final ChannelBuffer lastEntryBuffer, Object ctx) {
+        int bookieIndex = (Integer) ctx;
+        numResponsesPending--;
+        boolean heardValidResponse = false;
+
+        if (completed) {
+            return;
+        }
+
+        if (rc == BKException.Code.OK) {
+            try {
+                // Each bookie may have two store LAC in two places.
+                // One is in-memory copy in FileInfo and other is
+                // piggy-backed LAC on the last entry.
+                // This routine picks both of them and compares to return
+                // the latest Lac.
+
+                // Extract lac from FileInfo on the ledger.
+                long lac = lh.macManager.verifyDigestAndReturnLac(lacBuffer);
+                if (lac > maxLac) {
+                    maxLac = lac;
+                }
+
+                // Extract lac from last entry on the disk
+                RecoveryData recoveryData = lh.macManager.verifyDigestAndReturnLastConfirmed(lastEntryBuffer);
+                if (recoveryData.lastAddConfirmed > maxLac) {
+                    maxLac = recoveryData.lastAddConfirmed;
+                }
+                heardValidResponse = true;
+            } catch (BKDigestMatchException e) {
+                // Too bad, this bookie did not give us a valid answer, we
+                // still might be able to recover. So, continue
+                LOG.error("Mac mismatch while reading  ledger: " + ledgerId + " LAC from bookie: "
+                        + lh.metadata.currentEnsemble.get(bookieIndex));
+                rc = BKException.Code.DigestMatchException;
+            }
+        }
+
+        if (rc == BKException.Code.NoSuchLedgerExistsException || rc == BKException.Code.NoSuchEntryException) {
+            heardValidResponse = true;
+        }
+
+        if (rc == BKException.Code.UnauthorizedAccessException && !completed) {
+            cb.getLacComplete(rc, maxLac);
+            completed = true;
+            return;
+        }
+
+        if (!heardValidResponse && BKException.Code.OK != rc) {
+            lastSeenError = rc;
+        }
+
+        // We don't consider a success until we have coverage set responses.
+        if (heardValidResponse
+                && coverageSet.addBookieAndCheckCovered(bookieIndex)
+                && !completed) {
+            completed = true;
+            LOG.debug("Read LAC complete with enough validResponse for ledger: {} LAC: {}",
+                    ledgerId, maxLac);
+            cb.getLacComplete(BKException.Code.OK, maxLac);
+            return;
+        }
+
+        if (numResponsesPending == 0 && !completed) {
+            LOG.info("While readLac ledger: " + ledgerId + " did not hear success responses from all of ensemble");
+            cb.getLacComplete(lastSeenError, maxLac);
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.bookkeeper.client.AsyncCallback.AddLacCallback;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteLacCallback;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This represents a pending WriteLac operation. When it has got
+ * success from Ack Quorum bookies, sends success back to the application,
+ * otherwise failure is sent back to the caller.
+ *
+ * This is an optional protocol operations to facilitate tailing readers
+ * to be up to date with the writer. This is best effort to get latest LAC
+ * from bookies, and doesn't affect the correctness of the protocol.
+ */
+class PendingWriteLacOp implements WriteLacCallback {
+    private final static Logger LOG = LoggerFactory.getLogger(PendingWriteLacOp.class);
+    ChannelBuffer toSend;
+    AddLacCallback cb;
+    long lac;
+    Object ctx;
+    Set<Integer> writeSet;
+    Set<Integer> receivedResponseSet;
+
+    DistributionSchedule.AckSet ackSet;
+    boolean completed = false;
+    int lastSeenError = BKException.Code.WriteException;
+
+    LedgerHandle lh;
+    OpStatsLogger putLacOpLogger;
+
+    PendingWriteLacOp(LedgerHandle lh, AddLacCallback cb, Object ctx) {
+        this.lh = lh;
+        this.cb = cb;
+        this.ctx = ctx;
+        this.lac = LedgerHandle.INVALID_ENTRY_ID;
+        ackSet = lh.distributionSchedule.getAckSet();
+        putLacOpLogger = lh.bk.getWriteLacOpLogger();
+    }
+
+    void setLac(long lac) {
+        this.lac = lac;
+        this.writeSet = new HashSet<Integer>(lh.distributionSchedule.getWriteSet(lac));
+        this.receivedResponseSet = new HashSet<Integer>(writeSet);
+    }
+
+    void sendWriteLacRequest(int bookieIndex) {
+        lh.bk.bookieClient.writeLac(lh.metadata.currentEnsemble.get(bookieIndex), lh.ledgerId, lh.ledgerKey,
+                lac, toSend, this, bookieIndex);
+    }
+
+    void initiate(ChannelBuffer toSend) {
+        this.toSend = toSend;
+        for (int bookieIndex: writeSet) {
+            sendWriteLacRequest(bookieIndex);
+        }
+    }
+
+    @Override
+    public void writeLacComplete(int rc, long ledgerId, BookieSocketAddress addr, Object ctx) {
+        int bookieIndex = (Integer) ctx;
+
+        if (completed) {
+            return;
+        }
+
+        if (BKException.Code.OK != rc) {
+            lastSeenError = rc;
+        }
+
+        // We got response.
+        receivedResponseSet.remove(bookieIndex);
+
+        if (rc == BKException.Code.OK) {
+            if (ackSet.addBookieAndCheck(bookieIndex) && !completed) {
+                completed = true;
+                cb.addLacComplete(rc, lh, ctx);
+                return;
+            }
+        } else {
+            LOG.warn("WriteLac did not succeed: Ledger {} on {}", new Object[] { ledgerId, addr });
+        }
+        
+        if(receivedResponseSet.isEmpty()){
+            completed = true;
+            cb.addLacComplete(lastSeenError, lh, ctx);
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
@@ -54,6 +54,10 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
                     ReadOnlyLedgerHandle.this.metadata.getVersion().compare(this.m.getVersion());
             if (Version.Occurred.BEFORE == occurred) {
                 LOG.info("Updated ledger metadata for ledger {} to {}.", ledgerId, this.m);
+                if (this.m.isClosed()) {
+                        ReadOnlyLedgerHandle.this.lastAddConfirmed = this.m.getLastEntryId();
+                        ReadOnlyLedgerHandle.this.length = this.m.getLength();
+                }
                 ReadOnlyLedgerHandle.this.metadata = this.m;
             }
         }
@@ -170,4 +174,8 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
         return String.format("ReadOnlyLedgerHandle(lid = %d, id = %d)", ledgerId, super.hashCode());
     }
 
+    @Override
+    protected void initializeExplicitLacFlushPolicy() {
+        explicitLacFlushPolicy = ExplicitLacFlushPolicy.VOID_EXPLICITLAC_FLUSH_POLICY;
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -65,6 +65,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     protected final static String ADD_ENTRY_QUORUM_TIMEOUT_SEC = "addEntryQuorumTimeoutSec";
     protected final static String READ_ENTRY_TIMEOUT_SEC = "readEntryTimeoutSec";
     protected final static String TIMEOUT_TASK_INTERVAL_MILLIS = "timeoutTaskIntervalMillis";
+    protected final static String EXPLICIT_LAC_INTERVAL = "explicitLacInterval";
     protected final static String PCBC_TIMEOUT_TIMER_TICK_DURATION_MS = "pcbcTimeoutTimerTickDurationMs";
     protected final static String PCBC_TIMEOUT_TIMER_NUM_TICKS = "pcbcTimeoutTimerNumTicks";
     protected final static String TIMEOUT_TIMER_TICK_DURATION_MS = "timeoutTimerTickDurationMs";
@@ -76,7 +77,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     protected final static String BOOKIE_ERROR_THRESHOLD_PER_INTERVAL = "bookieErrorThresholdPerInterval";
     protected final static String BOOKIE_QUARANTINE_TIME_SECONDS = "bookieQuarantineTimeSeconds";
 
-    // Number Woker Threads
+    // Number Worker Threads
     protected final static String NUM_WORKER_THREADS = "numWorkerThreads";
 
     // Ensemble Placement Policy
@@ -591,6 +592,29 @@ public class ClientConfiguration extends AbstractConfiguration {
     @Deprecated
     public ClientConfiguration setTimeoutTaskIntervalMillis(long timeoutMillis) {
         setProperty(TIMEOUT_TASK_INTERVAL_MILLIS, Long.toString(timeoutMillis));
+        return this;
+    }
+
+    /**
+     * Get the configured interval between  explicit LACs to bookies.
+     * Generally LACs are piggy-backed on writes, and user can configure
+     * the interval between these protocol messages. A value of '0' disables
+     * sending any explicit LACs.
+     *
+     * @return interval between explicit LACs
+     */
+    public int getExplictLacInterval() {
+        return getInt(EXPLICIT_LAC_INTERVAL, 0);
+    }
+
+    /**
+     * Set the interval to check the need for sending an explicit LAC.
+     * @param interval
+     *        Number of seconds between checking the need for sending an explict LAC.
+     * @return Client configuration.
+     */
+    public ClientConfiguration setExplictLacInterval(int interval) {
+        setProperty(EXPLICIT_LAC_INTERVAL, interval);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClient.java
@@ -33,10 +33,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.bookkeeper.auth.AuthProviderFactoryFactory;
 import org.apache.bookkeeper.auth.ClientAuthProvider;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadLacCallback;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteLacCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -166,6 +169,41 @@ public class BookieClient implements PerChannelBookieClientFactory {
         return clientPool;
     }
 
+    public void writeLac(final BookieSocketAddress addr, final long ledgerId, final byte[] masterKey,
+            final long lac, final ChannelBuffer toSend, final WriteLacCallback cb, final Object ctx) {
+        closeLock.readLock().lock();
+        try {
+            final PerChannelBookieClientPool client = lookupClient(addr, lac);
+            if (client == null) {
+                cb.writeLacComplete(getRc(BKException.Code.BookieHandleNotAvailableException),
+                                  ledgerId, addr, ctx);
+                return;
+            }
+
+            client.obtain(new GenericCallback<PerChannelBookieClient>() {
+                @Override
+                public void operationComplete(final int rc, PerChannelBookieClient pcbc) {
+                    if (rc != BKException.Code.OK) {
+                        try {
+                            executor.submitOrdered(ledgerId, new SafeRunnable() {
+                                @Override
+                                public void safeRun() {
+                                    cb.writeLacComplete(rc, ledgerId, addr, ctx);
+                                }
+                            });
+                        } catch (RejectedExecutionException re) {
+                            cb.writeLacComplete(getRc(BKException.Code.InterruptedException), ledgerId, addr, ctx);
+                        }
+                        return;
+                    }
+                    pcbc.writeLac(ledgerId, masterKey, lac, toSend, cb, ctx);
+                }
+            });
+        } finally {
+            closeLock.readLock().unlock();
+        }
+    }
+
     public void addEntry(final BookieSocketAddress addr, final long ledgerId, final byte[] masterKey,
             final long entryId,
             final ChannelBuffer toSend, final WriteCallback cb, final Object ctx, final int options) {
@@ -236,6 +274,39 @@ public class BookieClient implements PerChannelBookieClientFactory {
                         return;
                     }
                     pcbc.readEntryAndFenceLedger(ledgerId, masterKey, entryId, cb, ctx);
+                }
+            });
+        } finally {
+            closeLock.readLock().unlock();
+        }
+    }
+
+    public void readLac(final BookieSocketAddress addr, final long ledgerId, final ReadLacCallback cb, final Object ctx) {
+        closeLock.readLock().lock();
+        try {
+            final PerChannelBookieClientPool client = lookupClient(addr, BookieProtocol.LAST_ADD_CONFIRMED);
+            if (client == null) {
+                cb.readLacComplete(getRc(BKException.Code.BookieHandleNotAvailableException), ledgerId, null, null, ctx);
+                return;
+            }
+            client.obtain(new GenericCallback<PerChannelBookieClient>() {
+                @Override
+                public void operationComplete(final int rc,PerChannelBookieClient pcbc) {
+                    if (rc != BKException.Code.OK) {
+                        try {
+                            executor.submitOrdered(ledgerId, new SafeRunnable() {
+                                @Override
+                                public void safeRun() {
+                                    cb.readLacComplete(rc, ledgerId, null, null, ctx);
+                                }
+                            });
+                        } catch (RejectedExecutionException re) {
+                            cb.readLacComplete(getRc(BKException.Code.InterruptedException),
+                                    ledgerId, null, null, ctx);
+                        }
+                        return;
+                    }
+                    pcbc.readLac(ledgerId, cb, ctx);
                 }
             });
         } finally {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -41,6 +41,9 @@ import static org.apache.bookkeeper.bookie.BookKeeperServerStats.ADD_ENTRY;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.ADD_ENTRY_REQUEST;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.READ_ENTRY;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.READ_ENTRY_REQUEST;
+import static org.apache.bookkeeper.bookie.BookKeeperServerStats.WRITE_LAC;
+import static org.apache.bookkeeper.bookie.BookKeeperServerStats.READ_LAC;
+
 
 public class BookieRequestProcessor implements RequestProcessor {
 
@@ -73,6 +76,8 @@ public class BookieRequestProcessor implements RequestProcessor {
     final OpStatsLogger addEntryStats;
     final OpStatsLogger readRequestStats;
     final OpStatsLogger readEntryStats;
+    final OpStatsLogger writeLacStats;
+    final OpStatsLogger readLacStats;
 
     public BookieRequestProcessor(ServerConfiguration serverCfg, Bookie bookie,
                                   StatsLogger statsLogger) {
@@ -86,6 +91,8 @@ public class BookieRequestProcessor implements RequestProcessor {
         this.addRequestStats = statsLogger.getOpStatsLogger(ADD_ENTRY_REQUEST);
         this.readEntryStats = statsLogger.getOpStatsLogger(READ_ENTRY);
         this.readRequestStats = statsLogger.getOpStatsLogger(READ_ENTRY_REQUEST);
+        this.writeLacStats = statsLogger.getOpStatsLogger(WRITE_LAC);
+        this.readLacStats = statsLogger.getOpStatsLogger(READ_LAC);
     }
 
     @Override
@@ -135,6 +142,12 @@ public class BookieRequestProcessor implements RequestProcessor {
                             .setAuthResponse(message);
                     c.write(authResponse.build());
                     break;
+                case WRITE_LAC:
+                    processWriteLacRequestV3(r,c);
+                    break;
+                case READ_LAC:
+                    processReadLacRequestV3(r,c);
+                    break;
                 default:
                     LOG.info("Unknown operation type {}", header.getOperation());
                     BookkeeperProtocol.Response.Builder response =
@@ -182,6 +195,24 @@ public class BookieRequestProcessor implements RequestProcessor {
             read.run();
         } else {
             readThreadPool.submitOrdered(r.getReadRequest().getLedgerId(), read);
+        }
+    }
+
+    private void processWriteLacRequestV3(final BookkeeperProtocol.Request r, final Channel c) {
+        WriteLacProcessorV3 writeLac = new WriteLacProcessorV3(r, c, this);
+        if (null == writeThreadPool) {
+            writeLac.run();
+        } else {
+            writeThreadPool.submit(writeLac);
+        }
+    }
+
+    private void processReadLacRequestV3(final BookkeeperProtocol.Request r, final Channel c) {
+        ReadLacProcessorV3 readLac = new ReadLacProcessorV3(r, c, this);
+        if (null == readThreadPool) {
+            readLac.run();
+        } else {
+            readThreadPool.submit(readLac);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
@@ -65,6 +65,14 @@ public class BookkeeperInternalCallbacks {
         void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx);
     }
 
+    public interface ReadLacCallback {
+        void readLacComplete(int rc, long ledgerId, ChannelBuffer lac, ChannelBuffer buffer, Object ctx);
+    }
+
+    public interface WriteLacCallback {
+        void writeLacComplete(int rc, long ledgerId, BookieSocketAddress addr, Object ctx);
+    }
+
     public interface GenericCallback<T> {
         void operationComplete(int rc, T result);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperProtocol.java
@@ -304,6 +304,14 @@ public final class BookkeeperProtocol {
      * <code>AUTH = 5;</code>
      */
     AUTH(4, 5),
+    /**
+     * <code>WRITE_LAC = 6;</code>
+     */
+    WRITE_LAC(5, 6),
+    /**
+     * <code>READ_LAC = 7;</code>
+     */
+    READ_LAC(6, 7),
     ;
 
     /**
@@ -330,6 +338,14 @@ public final class BookkeeperProtocol {
      * <code>AUTH = 5;</code>
      */
     public static final int AUTH_VALUE = 5;
+    /**
+     * <code>WRITE_LAC = 6;</code>
+     */
+    public static final int WRITE_LAC_VALUE = 6;
+    /**
+     * <code>READ_LAC = 7;</code>
+     */
+    public static final int READ_LAC_VALUE = 7;
 
 
     public final int getNumber() { return value; }
@@ -341,6 +357,8 @@ public final class BookkeeperProtocol {
         case 3: return RANGE_READ_ENTRY;
         case 4: return RANGE_ADD_ENTRY;
         case 5: return AUTH;
+        case 6: return WRITE_LAC;
+        case 7: return READ_LAC;
         default: return null;
       }
     }
@@ -1064,6 +1082,32 @@ public final class BookkeeperProtocol {
      * <code>optional .AuthMessage authRequest = 102;</code>
      */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder getAuthRequestOrBuilder();
+
+    /**
+     * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+     */
+    boolean hasWriteLacRequest();
+    /**
+     * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest getWriteLacRequest();
+    /**
+     * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequestOrBuilder getWriteLacRequestOrBuilder();
+
+    /**
+     * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+     */
+    boolean hasReadLacRequest();
+    /**
+     * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest getReadLacRequest();
+    /**
+     * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequestOrBuilder getReadLacRequestOrBuilder();
   }
   /**
    * Protobuf type {@code Request}
@@ -1167,6 +1211,32 @@ public final class BookkeeperProtocol {
                 authRequest_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000008;
+              break;
+            }
+            case 826: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000010) == 0x00000010)) {
+                subBuilder = writeLacRequest_.toBuilder();
+              }
+              writeLacRequest_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(writeLacRequest_);
+                writeLacRequest_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000010;
+              break;
+            }
+            case 834: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                subBuilder = readLacRequest_.toBuilder();
+              }
+              readLacRequest_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(readLacRequest_);
+                readLacRequest_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000020;
               break;
             }
           }
@@ -1305,11 +1375,55 @@ public final class BookkeeperProtocol {
       return authRequest_;
     }
 
+    public static final int WRITELACREQUEST_FIELD_NUMBER = 103;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest writeLacRequest_;
+    /**
+     * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+     */
+    public boolean hasWriteLacRequest() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest getWriteLacRequest() {
+      return writeLacRequest_;
+    }
+    /**
+     * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequestOrBuilder getWriteLacRequestOrBuilder() {
+      return writeLacRequest_;
+    }
+
+    public static final int READLACREQUEST_FIELD_NUMBER = 104;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest readLacRequest_;
+    /**
+     * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+     */
+    public boolean hasReadLacRequest() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest getReadLacRequest() {
+      return readLacRequest_;
+    }
+    /**
+     * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequestOrBuilder getReadLacRequestOrBuilder() {
+      return readLacRequest_;
+    }
+
     private void initFields() {
       header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
       readRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance();
       addRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest.getDefaultInstance();
       authRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
+      writeLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.getDefaultInstance();
+      readLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1343,6 +1457,18 @@ public final class BookkeeperProtocol {
           return false;
         }
       }
+      if (hasWriteLacRequest()) {
+        if (!getWriteLacRequest().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasReadLacRequest()) {
+        if (!getReadLacRequest().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -1361,6 +1487,12 @@ public final class BookkeeperProtocol {
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeMessage(102, authRequest_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeMessage(103, writeLacRequest_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeMessage(104, readLacRequest_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -1386,6 +1518,14 @@ public final class BookkeeperProtocol {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(102, authRequest_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(103, writeLacRequest_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(104, readLacRequest_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1500,6 +1640,8 @@ public final class BookkeeperProtocol {
           getReadRequestFieldBuilder();
           getAddRequestFieldBuilder();
           getAuthRequestFieldBuilder();
+          getWriteLacRequestFieldBuilder();
+          getReadLacRequestFieldBuilder();
         }
       }
       private static Builder create() {
@@ -1532,6 +1674,18 @@ public final class BookkeeperProtocol {
           authRequestBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000008);
+        if (writeLacRequestBuilder_ == null) {
+          writeLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.getDefaultInstance();
+        } else {
+          writeLacRequestBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000010);
+        if (readLacRequestBuilder_ == null) {
+          readLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.getDefaultInstance();
+        } else {
+          readLacRequestBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -1592,6 +1746,22 @@ public final class BookkeeperProtocol {
         } else {
           result.authRequest_ = authRequestBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        if (writeLacRequestBuilder_ == null) {
+          result.writeLacRequest_ = writeLacRequest_;
+        } else {
+          result.writeLacRequest_ = writeLacRequestBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        if (readLacRequestBuilder_ == null) {
+          result.readLacRequest_ = readLacRequest_;
+        } else {
+          result.readLacRequest_ = readLacRequestBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1620,6 +1790,12 @@ public final class BookkeeperProtocol {
         if (other.hasAuthRequest()) {
           mergeAuthRequest(other.getAuthRequest());
         }
+        if (other.hasWriteLacRequest()) {
+          mergeWriteLacRequest(other.getWriteLacRequest());
+        }
+        if (other.hasReadLacRequest()) {
+          mergeReadLacRequest(other.getReadLacRequest());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -1647,6 +1823,18 @@ public final class BookkeeperProtocol {
         }
         if (hasAuthRequest()) {
           if (!getAuthRequest().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasWriteLacRequest()) {
+          if (!getWriteLacRequest().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasReadLacRequest()) {
+          if (!getReadLacRequest().isInitialized()) {
             
             return false;
           }
@@ -2171,6 +2359,238 @@ public final class BookkeeperProtocol {
           authRequest_ = null;
         }
         return authRequestBuilder_;
+      }
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest writeLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequestOrBuilder> writeLacRequestBuilder_;
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      public boolean hasWriteLacRequest() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest getWriteLacRequest() {
+        if (writeLacRequestBuilder_ == null) {
+          return writeLacRequest_;
+        } else {
+          return writeLacRequestBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      public Builder setWriteLacRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest value) {
+        if (writeLacRequestBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          writeLacRequest_ = value;
+          onChanged();
+        } else {
+          writeLacRequestBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      public Builder setWriteLacRequest(
+          org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.Builder builderForValue) {
+        if (writeLacRequestBuilder_ == null) {
+          writeLacRequest_ = builderForValue.build();
+          onChanged();
+        } else {
+          writeLacRequestBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      public Builder mergeWriteLacRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest value) {
+        if (writeLacRequestBuilder_ == null) {
+          if (((bitField0_ & 0x00000010) == 0x00000010) &&
+              writeLacRequest_ != org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.getDefaultInstance()) {
+            writeLacRequest_ =
+              org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.newBuilder(writeLacRequest_).mergeFrom(value).buildPartial();
+          } else {
+            writeLacRequest_ = value;
+          }
+          onChanged();
+        } else {
+          writeLacRequestBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000010;
+        return this;
+      }
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      public Builder clearWriteLacRequest() {
+        if (writeLacRequestBuilder_ == null) {
+          writeLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.getDefaultInstance();
+          onChanged();
+        } else {
+          writeLacRequestBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000010);
+        return this;
+      }
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.Builder getWriteLacRequestBuilder() {
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return getWriteLacRequestFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequestOrBuilder getWriteLacRequestOrBuilder() {
+        if (writeLacRequestBuilder_ != null) {
+          return writeLacRequestBuilder_.getMessageOrBuilder();
+        } else {
+          return writeLacRequest_;
+        }
+      }
+      /**
+       * <code>optional .WriteLacRequest writeLacRequest = 103;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequestOrBuilder> 
+          getWriteLacRequestFieldBuilder() {
+        if (writeLacRequestBuilder_ == null) {
+          writeLacRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequestOrBuilder>(
+                  getWriteLacRequest(),
+                  getParentForChildren(),
+                  isClean());
+          writeLacRequest_ = null;
+        }
+        return writeLacRequestBuilder_;
+      }
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest readLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequestOrBuilder> readLacRequestBuilder_;
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      public boolean hasReadLacRequest() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest getReadLacRequest() {
+        if (readLacRequestBuilder_ == null) {
+          return readLacRequest_;
+        } else {
+          return readLacRequestBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      public Builder setReadLacRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest value) {
+        if (readLacRequestBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          readLacRequest_ = value;
+          onChanged();
+        } else {
+          readLacRequestBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      public Builder setReadLacRequest(
+          org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.Builder builderForValue) {
+        if (readLacRequestBuilder_ == null) {
+          readLacRequest_ = builderForValue.build();
+          onChanged();
+        } else {
+          readLacRequestBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      public Builder mergeReadLacRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest value) {
+        if (readLacRequestBuilder_ == null) {
+          if (((bitField0_ & 0x00000020) == 0x00000020) &&
+              readLacRequest_ != org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.getDefaultInstance()) {
+            readLacRequest_ =
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.newBuilder(readLacRequest_).mergeFrom(value).buildPartial();
+          } else {
+            readLacRequest_ = value;
+          }
+          onChanged();
+        } else {
+          readLacRequestBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      public Builder clearReadLacRequest() {
+        if (readLacRequestBuilder_ == null) {
+          readLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.getDefaultInstance();
+          onChanged();
+        } else {
+          readLacRequestBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000020);
+        return this;
+      }
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.Builder getReadLacRequestBuilder() {
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return getReadLacRequestFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequestOrBuilder getReadLacRequestOrBuilder() {
+        if (readLacRequestBuilder_ != null) {
+          return readLacRequestBuilder_.getMessageOrBuilder();
+        } else {
+          return readLacRequest_;
+        }
+      }
+      /**
+       * <code>optional .ReadLacRequest readLacRequest = 104;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequestOrBuilder> 
+          getReadLacRequestFieldBuilder() {
+        if (readLacRequestBuilder_ == null) {
+          readLacRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequestOrBuilder>(
+                  getReadLacRequest(),
+                  getParentForChildren(),
+                  isClean());
+          readLacRequest_ = null;
+        }
+        return readLacRequestBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:Request)
@@ -3809,6 +4229,1080 @@ public final class BookkeeperProtocol {
     // @@protoc_insertion_point(class_scope:AddRequest)
   }
 
+  public interface WriteLacRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:WriteLacRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    boolean hasLedgerId();
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    long getLedgerId();
+
+    /**
+     * <code>required int64 lac = 2;</code>
+     */
+    boolean hasLac();
+    /**
+     * <code>required int64 lac = 2;</code>
+     */
+    long getLac();
+
+    /**
+     * <code>required bytes masterKey = 3;</code>
+     */
+    boolean hasMasterKey();
+    /**
+     * <code>required bytes masterKey = 3;</code>
+     */
+    com.google.protobuf.ByteString getMasterKey();
+
+    /**
+     * <code>required bytes body = 4;</code>
+     */
+    boolean hasBody();
+    /**
+     * <code>required bytes body = 4;</code>
+     */
+    com.google.protobuf.ByteString getBody();
+  }
+  /**
+   * Protobuf type {@code WriteLacRequest}
+   */
+  public static final class WriteLacRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:WriteLacRequest)
+      WriteLacRequestOrBuilder {
+    // Use WriteLacRequest.newBuilder() to construct.
+    private WriteLacRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private WriteLacRequest(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final WriteLacRequest defaultInstance;
+    public static WriteLacRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public WriteLacRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private WriteLacRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              ledgerId_ = input.readInt64();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              lac_ = input.readInt64();
+              break;
+            }
+            case 26: {
+              bitField0_ |= 0x00000004;
+              masterKey_ = input.readBytes();
+              break;
+            }
+            case 34: {
+              bitField0_ |= 0x00000008;
+              body_ = input.readBytes();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacRequest_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<WriteLacRequest> PARSER =
+        new com.google.protobuf.AbstractParser<WriteLacRequest>() {
+      public WriteLacRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new WriteLacRequest(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WriteLacRequest> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int LEDGERID_FIELD_NUMBER = 1;
+    private long ledgerId_;
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    public boolean hasLedgerId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    public long getLedgerId() {
+      return ledgerId_;
+    }
+
+    public static final int LAC_FIELD_NUMBER = 2;
+    private long lac_;
+    /**
+     * <code>required int64 lac = 2;</code>
+     */
+    public boolean hasLac() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required int64 lac = 2;</code>
+     */
+    public long getLac() {
+      return lac_;
+    }
+
+    public static final int MASTERKEY_FIELD_NUMBER = 3;
+    private com.google.protobuf.ByteString masterKey_;
+    /**
+     * <code>required bytes masterKey = 3;</code>
+     */
+    public boolean hasMasterKey() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>required bytes masterKey = 3;</code>
+     */
+    public com.google.protobuf.ByteString getMasterKey() {
+      return masterKey_;
+    }
+
+    public static final int BODY_FIELD_NUMBER = 4;
+    private com.google.protobuf.ByteString body_;
+    /**
+     * <code>required bytes body = 4;</code>
+     */
+    public boolean hasBody() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>required bytes body = 4;</code>
+     */
+    public com.google.protobuf.ByteString getBody() {
+      return body_;
+    }
+
+    private void initFields() {
+      ledgerId_ = 0L;
+      lac_ = 0L;
+      masterKey_ = com.google.protobuf.ByteString.EMPTY;
+      body_ = com.google.protobuf.ByteString.EMPTY;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasLedgerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasLac()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasMasterKey()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasBody()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(2, lac_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBytes(3, masterKey_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBytes(4, body_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, lac_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(3, masterKey_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(4, body_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code WriteLacRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:WriteLacRequest)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacRequest_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        ledgerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        lac_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        masterKey_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        body_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacRequest_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest result = new org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.ledgerId_ = ledgerId_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.lac_ = lac_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.masterKey_ = masterKey_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.body_ = body_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.getDefaultInstance()) return this;
+        if (other.hasLedgerId()) {
+          setLedgerId(other.getLedgerId());
+        }
+        if (other.hasLac()) {
+          setLac(other.getLac());
+        }
+        if (other.hasMasterKey()) {
+          setMasterKey(other.getMasterKey());
+        }
+        if (other.hasBody()) {
+          setBody(other.getBody());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasLedgerId()) {
+          
+          return false;
+        }
+        if (!hasLac()) {
+          
+          return false;
+        }
+        if (!hasMasterKey()) {
+          
+          return false;
+        }
+        if (!hasBody()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long ledgerId_ ;
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public boolean hasLedgerId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public long getLedgerId() {
+        return ledgerId_;
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public Builder setLedgerId(long value) {
+        bitField0_ |= 0x00000001;
+        ledgerId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public Builder clearLedgerId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        ledgerId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long lac_ ;
+      /**
+       * <code>required int64 lac = 2;</code>
+       */
+      public boolean hasLac() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required int64 lac = 2;</code>
+       */
+      public long getLac() {
+        return lac_;
+      }
+      /**
+       * <code>required int64 lac = 2;</code>
+       */
+      public Builder setLac(long value) {
+        bitField0_ |= 0x00000002;
+        lac_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 lac = 2;</code>
+       */
+      public Builder clearLac() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        lac_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString masterKey_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>required bytes masterKey = 3;</code>
+       */
+      public boolean hasMasterKey() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>required bytes masterKey = 3;</code>
+       */
+      public com.google.protobuf.ByteString getMasterKey() {
+        return masterKey_;
+      }
+      /**
+       * <code>required bytes masterKey = 3;</code>
+       */
+      public Builder setMasterKey(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        masterKey_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required bytes masterKey = 3;</code>
+       */
+      public Builder clearMasterKey() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        masterKey_ = getDefaultInstance().getMasterKey();
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString body_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>required bytes body = 4;</code>
+       */
+      public boolean hasBody() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>required bytes body = 4;</code>
+       */
+      public com.google.protobuf.ByteString getBody() {
+        return body_;
+      }
+      /**
+       * <code>required bytes body = 4;</code>
+       */
+      public Builder setBody(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        body_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required bytes body = 4;</code>
+       */
+      public Builder clearBody() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        body_ = getDefaultInstance().getBody();
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:WriteLacRequest)
+    }
+
+    static {
+      defaultInstance = new WriteLacRequest(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:WriteLacRequest)
+  }
+
+  public interface ReadLacRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:ReadLacRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    boolean hasLedgerId();
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    long getLedgerId();
+  }
+  /**
+   * Protobuf type {@code ReadLacRequest}
+   */
+  public static final class ReadLacRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:ReadLacRequest)
+      ReadLacRequestOrBuilder {
+    // Use ReadLacRequest.newBuilder() to construct.
+    private ReadLacRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private ReadLacRequest(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final ReadLacRequest defaultInstance;
+    public static ReadLacRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public ReadLacRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ReadLacRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              ledgerId_ = input.readInt64();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacRequest_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<ReadLacRequest> PARSER =
+        new com.google.protobuf.AbstractParser<ReadLacRequest>() {
+      public ReadLacRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ReadLacRequest(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ReadLacRequest> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int LEDGERID_FIELD_NUMBER = 1;
+    private long ledgerId_;
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    public boolean hasLedgerId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required int64 ledgerId = 1;</code>
+     */
+    public long getLedgerId() {
+      return ledgerId_;
+    }
+
+    private void initFields() {
+      ledgerId_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasLedgerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, ledgerId_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, ledgerId_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code ReadLacRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:ReadLacRequest)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacRequest_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        ledgerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacRequest_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest result = new org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.ledgerId_ = ledgerId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.getDefaultInstance()) return this;
+        if (other.hasLedgerId()) {
+          setLedgerId(other.getLedgerId());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasLedgerId()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long ledgerId_ ;
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public boolean hasLedgerId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public long getLedgerId() {
+        return ledgerId_;
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public Builder setLedgerId(long value) {
+        bitField0_ |= 0x00000001;
+        ledgerId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 ledgerId = 1;</code>
+       */
+      public Builder clearLedgerId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        ledgerId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:ReadLacRequest)
+    }
+
+    static {
+      defaultInstance = new ReadLacRequest(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:ReadLacRequest)
+  }
+
   public interface ResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Response)
       com.google.protobuf.MessageOrBuilder {
@@ -3895,6 +5389,32 @@ public final class BookkeeperProtocol {
      * <code>optional .AuthMessage authResponse = 102;</code>
      */
     org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessageOrBuilder getAuthResponseOrBuilder();
+
+    /**
+     * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+     */
+    boolean hasWriteLacResponse();
+    /**
+     * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse getWriteLacResponse();
+    /**
+     * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponseOrBuilder getWriteLacResponseOrBuilder();
+
+    /**
+     * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+     */
+    boolean hasReadLacResponse();
+    /**
+     * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse getReadLacResponse();
+    /**
+     * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponseOrBuilder getReadLacResponseOrBuilder();
   }
   /**
    * Protobuf type {@code Response}
@@ -4009,6 +5529,32 @@ public final class BookkeeperProtocol {
                 authResponse_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000010;
+              break;
+            }
+            case 826: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                subBuilder = writeLacResponse_.toBuilder();
+              }
+              writeLacResponse_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(writeLacResponse_);
+                writeLacResponse_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000020;
+              break;
+            }
+            case 834: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000040) == 0x00000040)) {
+                subBuilder = readLacResponse_.toBuilder();
+              }
+              readLacResponse_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(readLacResponse_);
+                readLacResponse_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000040;
               break;
             }
           }
@@ -4172,12 +5718,56 @@ public final class BookkeeperProtocol {
       return authResponse_;
     }
 
+    public static final int WRITELACRESPONSE_FIELD_NUMBER = 103;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse writeLacResponse_;
+    /**
+     * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+     */
+    public boolean hasWriteLacResponse() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse getWriteLacResponse() {
+      return writeLacResponse_;
+    }
+    /**
+     * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponseOrBuilder getWriteLacResponseOrBuilder() {
+      return writeLacResponse_;
+    }
+
+    public static final int READLACRESPONSE_FIELD_NUMBER = 104;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse readLacResponse_;
+    /**
+     * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+     */
+    public boolean hasReadLacResponse() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse getReadLacResponse() {
+      return readLacResponse_;
+    }
+    /**
+     * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponseOrBuilder getReadLacResponseOrBuilder() {
+      return readLacResponse_;
+    }
+
     private void initFields() {
       header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
       status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
       readResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse.getDefaultInstance();
       addResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse.getDefaultInstance();
       authResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
+      writeLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.getDefaultInstance();
+      readLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4215,6 +5805,18 @@ public final class BookkeeperProtocol {
           return false;
         }
       }
+      if (hasWriteLacResponse()) {
+        if (!getWriteLacResponse().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasReadLacResponse()) {
+        if (!getReadLacResponse().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -4236,6 +5838,12 @@ public final class BookkeeperProtocol {
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeMessage(102, authResponse_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeMessage(103, writeLacResponse_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeMessage(104, readLacResponse_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -4265,6 +5873,14 @@ public final class BookkeeperProtocol {
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(102, authResponse_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(103, writeLacResponse_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(104, readLacResponse_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -4379,6 +5995,8 @@ public final class BookkeeperProtocol {
           getReadResponseFieldBuilder();
           getAddResponseFieldBuilder();
           getAuthResponseFieldBuilder();
+          getWriteLacResponseFieldBuilder();
+          getReadLacResponseFieldBuilder();
         }
       }
       private static Builder create() {
@@ -4413,6 +6031,18 @@ public final class BookkeeperProtocol {
           authResponseBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000010);
+        if (writeLacResponseBuilder_ == null) {
+          writeLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.getDefaultInstance();
+        } else {
+          writeLacResponseBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000020);
+        if (readLacResponseBuilder_ == null) {
+          readLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.getDefaultInstance();
+        } else {
+          readLacResponseBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -4477,6 +6107,22 @@ public final class BookkeeperProtocol {
         } else {
           result.authResponse_ = authResponseBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        if (writeLacResponseBuilder_ == null) {
+          result.writeLacResponse_ = writeLacResponse_;
+        } else {
+          result.writeLacResponse_ = writeLacResponseBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        if (readLacResponseBuilder_ == null) {
+          result.readLacResponse_ = readLacResponse_;
+        } else {
+          result.readLacResponse_ = readLacResponseBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4507,6 +6153,12 @@ public final class BookkeeperProtocol {
         }
         if (other.hasAuthResponse()) {
           mergeAuthResponse(other.getAuthResponse());
+        }
+        if (other.hasWriteLacResponse()) {
+          mergeWriteLacResponse(other.getWriteLacResponse());
+        }
+        if (other.hasReadLacResponse()) {
+          mergeReadLacResponse(other.getReadLacResponse());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4539,6 +6191,18 @@ public final class BookkeeperProtocol {
         }
         if (hasAuthResponse()) {
           if (!getAuthResponse().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasWriteLacResponse()) {
+          if (!getWriteLacResponse().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasReadLacResponse()) {
+          if (!getReadLacResponse().isInitialized()) {
             
             return false;
           }
@@ -5118,6 +6782,238 @@ public final class BookkeeperProtocol {
           authResponse_ = null;
         }
         return authResponseBuilder_;
+      }
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse writeLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponseOrBuilder> writeLacResponseBuilder_;
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      public boolean hasWriteLacResponse() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse getWriteLacResponse() {
+        if (writeLacResponseBuilder_ == null) {
+          return writeLacResponse_;
+        } else {
+          return writeLacResponseBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      public Builder setWriteLacResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse value) {
+        if (writeLacResponseBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          writeLacResponse_ = value;
+          onChanged();
+        } else {
+          writeLacResponseBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      public Builder setWriteLacResponse(
+          org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.Builder builderForValue) {
+        if (writeLacResponseBuilder_ == null) {
+          writeLacResponse_ = builderForValue.build();
+          onChanged();
+        } else {
+          writeLacResponseBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      public Builder mergeWriteLacResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse value) {
+        if (writeLacResponseBuilder_ == null) {
+          if (((bitField0_ & 0x00000020) == 0x00000020) &&
+              writeLacResponse_ != org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.getDefaultInstance()) {
+            writeLacResponse_ =
+              org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.newBuilder(writeLacResponse_).mergeFrom(value).buildPartial();
+          } else {
+            writeLacResponse_ = value;
+          }
+          onChanged();
+        } else {
+          writeLacResponseBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      public Builder clearWriteLacResponse() {
+        if (writeLacResponseBuilder_ == null) {
+          writeLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.getDefaultInstance();
+          onChanged();
+        } else {
+          writeLacResponseBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000020);
+        return this;
+      }
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.Builder getWriteLacResponseBuilder() {
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return getWriteLacResponseFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponseOrBuilder getWriteLacResponseOrBuilder() {
+        if (writeLacResponseBuilder_ != null) {
+          return writeLacResponseBuilder_.getMessageOrBuilder();
+        } else {
+          return writeLacResponse_;
+        }
+      }
+      /**
+       * <code>optional .WriteLacResponse writeLacResponse = 103;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponseOrBuilder> 
+          getWriteLacResponseFieldBuilder() {
+        if (writeLacResponseBuilder_ == null) {
+          writeLacResponseBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponseOrBuilder>(
+                  getWriteLacResponse(),
+                  getParentForChildren(),
+                  isClean());
+          writeLacResponse_ = null;
+        }
+        return writeLacResponseBuilder_;
+      }
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse readLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponseOrBuilder> readLacResponseBuilder_;
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      public boolean hasReadLacResponse() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse getReadLacResponse() {
+        if (readLacResponseBuilder_ == null) {
+          return readLacResponse_;
+        } else {
+          return readLacResponseBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      public Builder setReadLacResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse value) {
+        if (readLacResponseBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          readLacResponse_ = value;
+          onChanged();
+        } else {
+          readLacResponseBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      public Builder setReadLacResponse(
+          org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.Builder builderForValue) {
+        if (readLacResponseBuilder_ == null) {
+          readLacResponse_ = builderForValue.build();
+          onChanged();
+        } else {
+          readLacResponseBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      public Builder mergeReadLacResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse value) {
+        if (readLacResponseBuilder_ == null) {
+          if (((bitField0_ & 0x00000040) == 0x00000040) &&
+              readLacResponse_ != org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.getDefaultInstance()) {
+            readLacResponse_ =
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.newBuilder(readLacResponse_).mergeFrom(value).buildPartial();
+          } else {
+            readLacResponse_ = value;
+          }
+          onChanged();
+        } else {
+          readLacResponseBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      public Builder clearReadLacResponse() {
+        if (readLacResponseBuilder_ == null) {
+          readLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.getDefaultInstance();
+          onChanged();
+        } else {
+          readLacResponseBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000040);
+        return this;
+      }
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.Builder getReadLacResponseBuilder() {
+        bitField0_ |= 0x00000040;
+        onChanged();
+        return getReadLacResponseFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponseOrBuilder getReadLacResponseOrBuilder() {
+        if (readLacResponseBuilder_ != null) {
+          return readLacResponseBuilder_.getMessageOrBuilder();
+        } else {
+          return readLacResponse_;
+        }
+      }
+      /**
+       * <code>optional .ReadLacResponse readLacResponse = 104;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponseOrBuilder> 
+          getReadLacResponseFieldBuilder() {
+        if (readLacResponseBuilder_ == null) {
+          readLacResponseBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponseOrBuilder>(
+                  getReadLacResponse(),
+                  getParentForChildren(),
+                  isClean());
+          readLacResponse_ = null;
+        }
+        return readLacResponseBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:Response)
@@ -6957,6 +8853,1232 @@ public final class BookkeeperProtocol {
     // @@protoc_insertion_point(class_scope:AuthMessage)
   }
 
+  public interface WriteLacResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:WriteLacResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    boolean hasStatus();
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus();
+
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    boolean hasLedgerId();
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    long getLedgerId();
+  }
+  /**
+   * Protobuf type {@code WriteLacResponse}
+   */
+  public static final class WriteLacResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:WriteLacResponse)
+      WriteLacResponseOrBuilder {
+    // Use WriteLacResponse.newBuilder() to construct.
+    private WriteLacResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private WriteLacResponse(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final WriteLacResponse defaultInstance;
+    public static WriteLacResponse getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public WriteLacResponse getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private WriteLacResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              int rawValue = input.readEnum();
+              org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(1, rawValue);
+              } else {
+                bitField0_ |= 0x00000001;
+                status_ = value;
+              }
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              ledgerId_ = input.readInt64();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<WriteLacResponse> PARSER =
+        new com.google.protobuf.AbstractParser<WriteLacResponse>() {
+      public WriteLacResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new WriteLacResponse(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<WriteLacResponse> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int STATUS_FIELD_NUMBER = 1;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_;
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    public boolean hasStatus() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
+      return status_;
+    }
+
+    public static final int LEDGERID_FIELD_NUMBER = 2;
+    private long ledgerId_;
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    public boolean hasLedgerId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    public long getLedgerId() {
+      return ledgerId_;
+    }
+
+    private void initFields() {
+      status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      ledgerId_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasStatus()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasLedgerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeEnum(1, status_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(2, ledgerId_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(1, status_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, ledgerId_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code WriteLacResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:WriteLacResponse)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        ledgerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_WriteLacResponse_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse result = new org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.status_ = status_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.ledgerId_ = ledgerId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.getDefaultInstance()) return this;
+        if (other.hasStatus()) {
+          setStatus(other.getStatus());
+        }
+        if (other.hasLedgerId()) {
+          setLedgerId(other.getLedgerId());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasStatus()) {
+          
+          return false;
+        }
+        if (!hasLedgerId()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public boolean hasStatus() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
+        return status_;
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public Builder setStatus(org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
+        status_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public Builder clearStatus() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+        onChanged();
+        return this;
+      }
+
+      private long ledgerId_ ;
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public boolean hasLedgerId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public long getLedgerId() {
+        return ledgerId_;
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public Builder setLedgerId(long value) {
+        bitField0_ |= 0x00000002;
+        ledgerId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public Builder clearLedgerId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        ledgerId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:WriteLacResponse)
+    }
+
+    static {
+      defaultInstance = new WriteLacResponse(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:WriteLacResponse)
+  }
+
+  public interface ReadLacResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:ReadLacResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    boolean hasStatus();
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus();
+
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    boolean hasLedgerId();
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    long getLedgerId();
+
+    /**
+     * <code>optional bytes lacBody = 3;</code>
+     *
+     * <pre>
+     * lac sent by PutLacRequest
+     * </pre>
+     */
+    boolean hasLacBody();
+    /**
+     * <code>optional bytes lacBody = 3;</code>
+     *
+     * <pre>
+     * lac sent by PutLacRequest
+     * </pre>
+     */
+    com.google.protobuf.ByteString getLacBody();
+
+    /**
+     * <code>optional bytes lastEntryBody = 4;</code>
+     *
+     * <pre>
+     * Actual last entry on the disk
+     * </pre>
+     */
+    boolean hasLastEntryBody();
+    /**
+     * <code>optional bytes lastEntryBody = 4;</code>
+     *
+     * <pre>
+     * Actual last entry on the disk
+     * </pre>
+     */
+    com.google.protobuf.ByteString getLastEntryBody();
+  }
+  /**
+   * Protobuf type {@code ReadLacResponse}
+   */
+  public static final class ReadLacResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:ReadLacResponse)
+      ReadLacResponseOrBuilder {
+    // Use ReadLacResponse.newBuilder() to construct.
+    private ReadLacResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private ReadLacResponse(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final ReadLacResponse defaultInstance;
+    public static ReadLacResponse getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public ReadLacResponse getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ReadLacResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              int rawValue = input.readEnum();
+              org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(1, rawValue);
+              } else {
+                bitField0_ |= 0x00000001;
+                status_ = value;
+              }
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              ledgerId_ = input.readInt64();
+              break;
+            }
+            case 26: {
+              bitField0_ |= 0x00000004;
+              lacBody_ = input.readBytes();
+              break;
+            }
+            case 34: {
+              bitField0_ |= 0x00000008;
+              lastEntryBody_ = input.readBytes();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<ReadLacResponse> PARSER =
+        new com.google.protobuf.AbstractParser<ReadLacResponse>() {
+      public ReadLacResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ReadLacResponse(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ReadLacResponse> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int STATUS_FIELD_NUMBER = 1;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_;
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    public boolean hasStatus() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
+      return status_;
+    }
+
+    public static final int LEDGERID_FIELD_NUMBER = 2;
+    private long ledgerId_;
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    public boolean hasLedgerId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required int64 ledgerId = 2;</code>
+     */
+    public long getLedgerId() {
+      return ledgerId_;
+    }
+
+    public static final int LACBODY_FIELD_NUMBER = 3;
+    private com.google.protobuf.ByteString lacBody_;
+    /**
+     * <code>optional bytes lacBody = 3;</code>
+     *
+     * <pre>
+     * lac sent by PutLacRequest
+     * </pre>
+     */
+    public boolean hasLacBody() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional bytes lacBody = 3;</code>
+     *
+     * <pre>
+     * lac sent by PutLacRequest
+     * </pre>
+     */
+    public com.google.protobuf.ByteString getLacBody() {
+      return lacBody_;
+    }
+
+    public static final int LASTENTRYBODY_FIELD_NUMBER = 4;
+    private com.google.protobuf.ByteString lastEntryBody_;
+    /**
+     * <code>optional bytes lastEntryBody = 4;</code>
+     *
+     * <pre>
+     * Actual last entry on the disk
+     * </pre>
+     */
+    public boolean hasLastEntryBody() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional bytes lastEntryBody = 4;</code>
+     *
+     * <pre>
+     * Actual last entry on the disk
+     * </pre>
+     */
+    public com.google.protobuf.ByteString getLastEntryBody() {
+      return lastEntryBody_;
+    }
+
+    private void initFields() {
+      status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      ledgerId_ = 0L;
+      lacBody_ = com.google.protobuf.ByteString.EMPTY;
+      lastEntryBody_ = com.google.protobuf.ByteString.EMPTY;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasStatus()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasLedgerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeEnum(1, status_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(2, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBytes(3, lacBody_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBytes(4, lastEntryBody_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(1, status_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(3, lacBody_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(4, lastEntryBody_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code ReadLacResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:ReadLacResponse)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        ledgerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        lacBody_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        lastEntryBody_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_ReadLacResponse_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse result = new org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.status_ = status_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.ledgerId_ = ledgerId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.lacBody_ = lacBody_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.lastEntryBody_ = lastEntryBody_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.getDefaultInstance()) return this;
+        if (other.hasStatus()) {
+          setStatus(other.getStatus());
+        }
+        if (other.hasLedgerId()) {
+          setLedgerId(other.getLedgerId());
+        }
+        if (other.hasLacBody()) {
+          setLacBody(other.getLacBody());
+        }
+        if (other.hasLastEntryBody()) {
+          setLastEntryBody(other.getLastEntryBody());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasStatus()) {
+          
+          return false;
+        }
+        if (!hasLedgerId()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public boolean hasStatus() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
+        return status_;
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public Builder setStatus(org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
+        status_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public Builder clearStatus() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+        onChanged();
+        return this;
+      }
+
+      private long ledgerId_ ;
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public boolean hasLedgerId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public long getLedgerId() {
+        return ledgerId_;
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public Builder setLedgerId(long value) {
+        bitField0_ |= 0x00000002;
+        ledgerId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required int64 ledgerId = 2;</code>
+       */
+      public Builder clearLedgerId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        ledgerId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString lacBody_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes lacBody = 3;</code>
+       *
+       * <pre>
+       * lac sent by PutLacRequest
+       * </pre>
+       */
+      public boolean hasLacBody() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional bytes lacBody = 3;</code>
+       *
+       * <pre>
+       * lac sent by PutLacRequest
+       * </pre>
+       */
+      public com.google.protobuf.ByteString getLacBody() {
+        return lacBody_;
+      }
+      /**
+       * <code>optional bytes lacBody = 3;</code>
+       *
+       * <pre>
+       * lac sent by PutLacRequest
+       * </pre>
+       */
+      public Builder setLacBody(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        lacBody_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes lacBody = 3;</code>
+       *
+       * <pre>
+       * lac sent by PutLacRequest
+       * </pre>
+       */
+      public Builder clearLacBody() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        lacBody_ = getDefaultInstance().getLacBody();
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString lastEntryBody_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes lastEntryBody = 4;</code>
+       *
+       * <pre>
+       * Actual last entry on the disk
+       * </pre>
+       */
+      public boolean hasLastEntryBody() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional bytes lastEntryBody = 4;</code>
+       *
+       * <pre>
+       * Actual last entry on the disk
+       * </pre>
+       */
+      public com.google.protobuf.ByteString getLastEntryBody() {
+        return lastEntryBody_;
+      }
+      /**
+       * <code>optional bytes lastEntryBody = 4;</code>
+       *
+       * <pre>
+       * Actual last entry on the disk
+       * </pre>
+       */
+      public Builder setLastEntryBody(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        lastEntryBody_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes lastEntryBody = 4;</code>
+       *
+       * <pre>
+       * Actual last entry on the disk
+       * </pre>
+       */
+      public Builder clearLastEntryBody() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        lastEntryBody_ = getDefaultInstance().getLastEntryBody();
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:ReadLacResponse)
+    }
+
+    static {
+      defaultInstance = new ReadLacResponse(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:ReadLacResponse)
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_BKPacketHeader_descriptor;
   private static
@@ -6978,6 +10100,16 @@ public final class BookkeeperProtocol {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_AddRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_WriteLacRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_WriteLacRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_ReadLacRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_ReadLacRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_Response_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -6997,6 +10129,16 @@ public final class BookkeeperProtocol {
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_AuthMessage_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_WriteLacResponse_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_WriteLacResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_ReadLacResponse_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_ReadLacResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -7009,36 +10151,49 @@ public final class BookkeeperProtocol {
       "\n\'src/main/proto/BookkeeperProtocol.prot" +
       "o\"e\n\016BKPacketHeader\022!\n\007version\030\001 \002(\0162\020.P" +
       "rotocolVersion\022!\n\toperation\030\002 \002(\0162\016.Oper" +
-      "ationType\022\r\n\005txnId\030\003 \002(\004\"\221\001\n\007Request\022\037\n\006" +
+      "ationType\022\r\n\005txnId\030\003 \002(\004\"\345\001\n\007Request\022\037\n\006" +
       "header\030\001 \002(\0132\017.BKPacketHeader\022!\n\013readReq" +
       "uest\030d \001(\0132\014.ReadRequest\022\037\n\naddRequest\030e" +
       " \001(\0132\013.AddRequest\022!\n\013authRequest\030f \001(\0132\014" +
-      ".AuthMessage\"~\n\013ReadRequest\022\037\n\004flag\030d \001(" +
-      "\0162\021.ReadRequest.Flag\022\020\n\010ledgerId\030\001 \002(\003\022\017" +
-      "\n\007entryId\030\002 \002(\003\022\021\n\tmasterKey\030\003 \001(\014\"\030\n\004Fl",
-      "ag\022\020\n\014FENCE_LEDGER\020\001\"\212\001\n\nAddRequest\022\036\n\004f" +
-      "lag\030d \001(\0162\020.AddRequest.Flag\022\020\n\010ledgerId\030" +
-      "\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\022\021\n\tmasterKey\030\003 \002(" +
-      "\014\022\014\n\004body\030\004 \002(\014\"\030\n\004Flag\022\020\n\014RECOVERY_ADD\020" +
-      "\001\"\264\001\n\010Response\022\037\n\006header\030\001 \002(\0132\017.BKPacke" +
-      "tHeader\022\033\n\006status\030\002 \002(\0162\013.StatusCode\022#\n\014" +
-      "readResponse\030d \001(\0132\r.ReadResponse\022!\n\013add" +
-      "Response\030e \001(\0132\014.AddResponse\022\"\n\014authResp" +
-      "onse\030f \001(\0132\014.AuthMessage\"\\\n\014ReadResponse" +
-      "\022\033\n\006status\030\001 \002(\0162\013.StatusCode\022\020\n\010ledgerI",
-      "d\030\002 \002(\003\022\017\n\007entryId\030\003 \002(\003\022\014\n\004body\030\004 \001(\014\"M" +
-      "\n\013AddResponse\022\033\n\006status\030\001 \002(\0162\013.StatusCo" +
-      "de\022\020\n\010ledgerId\030\002 \002(\003\022\017\n\007entryId\030\003 \002(\003\"6\n" +
-      "\013AuthMessage\022\026\n\016authPluginName\030\001 \002(\t\022\017\n\007" +
-      "payload\030\002 \002(\014*F\n\017ProtocolVersion\022\017\n\013VERS" +
-      "ION_ONE\020\001\022\017\n\013VERSION_TWO\020\002\022\021\n\rVERSION_TH" +
-      "REE\020\003*\206\001\n\nStatusCode\022\007\n\003EOK\020\000\022\016\n\tENOLEDG" +
-      "ER\020\222\003\022\r\n\010ENOENTRY\020\223\003\022\014\n\007EBADREQ\020\224\003\022\010\n\003EI" +
-      "O\020\365\003\022\010\n\003EUA\020\366\003\022\020\n\013EBADVERSION\020\367\003\022\014\n\007EFEN" +
-      "CED\020\370\003\022\016\n\tEREADONLY\020\371\003*c\n\rOperationType\022",
-      "\016\n\nREAD_ENTRY\020\001\022\r\n\tADD_ENTRY\020\002\022\024\n\020RANGE_" +
-      "READ_ENTRY\020\003\022\023\n\017RANGE_ADD_ENTRY\020\004\022\010\n\004AUT" +
-      "H\020\005B\037\n\033org.apache.bookkeeper.protoH\001"
+      ".AuthMessage\022)\n\017writeLacRequest\030g \001(\0132\020." +
+      "WriteLacRequest\022\'\n\016readLacRequest\030h \001(\0132" +
+      "\017.ReadLacRequest\"~\n\013ReadRequest\022\037\n\004flag\030",
+      "d \001(\0162\021.ReadRequest.Flag\022\020\n\010ledgerId\030\001 \002" +
+      "(\003\022\017\n\007entryId\030\002 \002(\003\022\021\n\tmasterKey\030\003 \001(\014\"\030" +
+      "\n\004Flag\022\020\n\014FENCE_LEDGER\020\001\"\212\001\n\nAddRequest\022" +
+      "\036\n\004flag\030d \001(\0162\020.AddRequest.Flag\022\020\n\010ledge" +
+      "rId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\022\021\n\tmasterKey\030" +
+      "\003 \002(\014\022\014\n\004body\030\004 \002(\014\"\030\n\004Flag\022\020\n\014RECOVERY_" +
+      "ADD\020\001\"Q\n\017WriteLacRequest\022\020\n\010ledgerId\030\001 \002" +
+      "(\003\022\013\n\003lac\030\002 \002(\003\022\021\n\tmasterKey\030\003 \002(\014\022\014\n\004bo" +
+      "dy\030\004 \002(\014\"\"\n\016ReadLacRequest\022\020\n\010ledgerId\030\001" +
+      " \002(\003\"\214\002\n\010Response\022\037\n\006header\030\001 \002(\0132\017.BKPa",
+      "cketHeader\022\033\n\006status\030\002 \002(\0162\013.StatusCode\022" +
+      "#\n\014readResponse\030d \001(\0132\r.ReadResponse\022!\n\013" +
+      "addResponse\030e \001(\0132\014.AddResponse\022\"\n\014authR" +
+      "esponse\030f \001(\0132\014.AuthMessage\022+\n\020writeLacR" +
+      "esponse\030g \001(\0132\021.WriteLacResponse\022)\n\017read" +
+      "LacResponse\030h \001(\0132\020.ReadLacResponse\"\\\n\014R" +
+      "eadResponse\022\033\n\006status\030\001 \002(\0162\013.StatusCode" +
+      "\022\020\n\010ledgerId\030\002 \002(\003\022\017\n\007entryId\030\003 \002(\003\022\014\n\004b" +
+      "ody\030\004 \001(\014\"M\n\013AddResponse\022\033\n\006status\030\001 \002(\016" +
+      "2\013.StatusCode\022\020\n\010ledgerId\030\002 \002(\003\022\017\n\007entry",
+      "Id\030\003 \002(\003\"6\n\013AuthMessage\022\026\n\016authPluginNam" +
+      "e\030\001 \002(\t\022\017\n\007payload\030\002 \002(\014\"A\n\020WriteLacResp" +
+      "onse\022\033\n\006status\030\001 \002(\0162\013.StatusCode\022\020\n\010led" +
+      "gerId\030\002 \002(\003\"h\n\017ReadLacResponse\022\033\n\006status" +
+      "\030\001 \002(\0162\013.StatusCode\022\020\n\010ledgerId\030\002 \002(\003\022\017\n" +
+      "\007lacBody\030\003 \001(\014\022\025\n\rlastEntryBody\030\004 \001(\014*F\n" +
+      "\017ProtocolVersion\022\017\n\013VERSION_ONE\020\001\022\017\n\013VER" +
+      "SION_TWO\020\002\022\021\n\rVERSION_THREE\020\003*\206\001\n\nStatus" +
+      "Code\022\007\n\003EOK\020\000\022\016\n\tENOLEDGER\020\222\003\022\r\n\010ENOENTR" +
+      "Y\020\223\003\022\014\n\007EBADREQ\020\224\003\022\010\n\003EIO\020\365\003\022\010\n\003EUA\020\366\003\022\020",
+      "\n\013EBADVERSION\020\367\003\022\014\n\007EFENCED\020\370\003\022\016\n\tEREADO" +
+      "NLY\020\371\003*\200\001\n\rOperationType\022\016\n\nREAD_ENTRY\020\001" +
+      "\022\r\n\tADD_ENTRY\020\002\022\024\n\020RANGE_READ_ENTRY\020\003\022\023\n" +
+      "\017RANGE_ADD_ENTRY\020\004\022\010\n\004AUTH\020\005\022\r\n\tWRITE_LA" +
+      "C\020\006\022\014\n\010READ_LAC\020\007B\037\n\033org.apache.bookkeep" +
+      "er.protoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -7063,7 +10218,7 @@ public final class BookkeeperProtocol {
     internal_static_Request_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Request_descriptor,
-        new java.lang.String[] { "Header", "ReadRequest", "AddRequest", "AuthRequest", });
+        new java.lang.String[] { "Header", "ReadRequest", "AddRequest", "AuthRequest", "WriteLacRequest", "ReadLacRequest", });
     internal_static_ReadRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_ReadRequest_fieldAccessorTable = new
@@ -7076,30 +10231,54 @@ public final class BookkeeperProtocol {
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_AddRequest_descriptor,
         new java.lang.String[] { "Flag", "LedgerId", "EntryId", "MasterKey", "Body", });
-    internal_static_Response_descriptor =
+    internal_static_WriteLacRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
+    internal_static_WriteLacRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_WriteLacRequest_descriptor,
+        new java.lang.String[] { "LedgerId", "Lac", "MasterKey", "Body", });
+    internal_static_ReadLacRequest_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_ReadLacRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_ReadLacRequest_descriptor,
+        new java.lang.String[] { "LedgerId", });
+    internal_static_Response_descriptor =
+      getDescriptor().getMessageTypes().get(6);
     internal_static_Response_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Response_descriptor,
-        new java.lang.String[] { "Header", "Status", "ReadResponse", "AddResponse", "AuthResponse", });
+        new java.lang.String[] { "Header", "Status", "ReadResponse", "AddResponse", "AuthResponse", "WriteLacResponse", "ReadLacResponse", });
     internal_static_ReadResponse_descriptor =
-      getDescriptor().getMessageTypes().get(5);
+      getDescriptor().getMessageTypes().get(7);
     internal_static_ReadResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ReadResponse_descriptor,
         new java.lang.String[] { "Status", "LedgerId", "EntryId", "Body", });
     internal_static_AddResponse_descriptor =
-      getDescriptor().getMessageTypes().get(6);
+      getDescriptor().getMessageTypes().get(8);
     internal_static_AddResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_AddResponse_descriptor,
         new java.lang.String[] { "Status", "LedgerId", "EntryId", });
     internal_static_AuthMessage_descriptor =
-      getDescriptor().getMessageTypes().get(7);
+      getDescriptor().getMessageTypes().get(9);
     internal_static_AuthMessage_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_AuthMessage_descriptor,
         new java.lang.String[] { "AuthPluginName", "Payload", });
+    internal_static_WriteLacResponse_descriptor =
+      getDescriptor().getMessageTypes().get(10);
+    internal_static_WriteLacResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_WriteLacResponse_descriptor,
+        new java.lang.String[] { "Status", "LedgerId", });
+    internal_static_ReadLacResponse_descriptor =
+      getDescriptor().getMessageTypes().get(11);
+    internal_static_ReadLacResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_ReadLacResponse_descriptor,
+        new java.lang.String[] { "Status", "LedgerId", "LacBody", "LastEntryBody", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
@@ -1,0 +1,108 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.proto;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.Response;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
+import org.apache.bookkeeper.util.MathUtils;
+import org.jboss.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.ByteString;
+
+class ReadLacProcessorV3 extends PacketProcessorBaseV3 {
+    private final static Logger logger = LoggerFactory.getLogger(ReadLacProcessorV3.class);
+
+    public ReadLacProcessorV3(Request request, Channel channel,
+                             BookieRequestProcessor requestProcessor) {
+        super(request, channel, requestProcessor);
+    }
+
+    // Returns null if there is no exception thrown
+    private ReadLacResponse getReadLacResponse() {
+        final long startTimeNanos = MathUtils.nowInNano();
+        ReadLacRequest readLacRequest = request.getReadLacRequest();
+        long ledgerId = readLacRequest.getLedgerId();
+
+        final ReadLacResponse.Builder readLacResponse = ReadLacResponse.newBuilder().setLedgerId(ledgerId);
+
+        if (!isVersionCompatible()) {
+            readLacResponse.setStatus(StatusCode.EBADVERSION);
+            return readLacResponse.build();
+        }
+
+        logger.debug("Received ReadLac request: {}", request);
+        StatusCode status = StatusCode.EOK;
+        ByteBuffer lastEntry;
+        ByteBuffer lac;
+        try {
+            lastEntry = requestProcessor.bookie.readEntry(ledgerId, BookieProtocol.LAST_ADD_CONFIRMED);
+            lac = requestProcessor.bookie.getExplicitLac(ledgerId);
+            if (lac != null) {
+                readLacResponse.setLacBody(ByteString.copyFrom(lac));
+                readLacResponse.setLastEntryBody(ByteString.copyFrom(lastEntry));
+            } else {
+                status = StatusCode.ENOENTRY;
+            }
+        } catch (Bookie.NoLedgerException e) {
+            status = StatusCode.ENOLEDGER;
+            logger.error("No ledger found while performing readLac from ledger: {}", ledgerId);
+        } catch (IOException e) {
+            status = StatusCode.EIO;
+            logger.error("IOException while performing readLac from ledger: {}", ledgerId);
+        }
+        if (status == StatusCode.EOK) {
+            requestProcessor.readLacStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),
+                    TimeUnit.NANOSECONDS);
+        } else {
+            requestProcessor.readLacStats.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos),
+                    TimeUnit.NANOSECONDS);
+        }
+        // Finally set the status and return
+        readLacResponse.setStatus(status);
+        return readLacResponse.build();
+    }
+
+    @Override
+    public void safeRun() {
+        ReadLacResponse readLacResponse = getReadLacResponse();
+        sendResponse(readLacResponse);
+    }
+
+    private void sendResponse(ReadLacResponse readLacResponse) {
+        Response.Builder response = Response.newBuilder()
+            .setHeader(getHeader())
+            .setStatus(readLacResponse.getStatus())
+            .setReadLacResponse(readLacResponse);
+        sendResponse(response.getStatus(),
+                response.build(),
+                requestProcessor.readRequestStats);
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -1,0 +1,113 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.proto;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.Response;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
+import org.apache.bookkeeper.util.MathUtils;
+import org.jboss.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class WriteLacProcessorV3 extends PacketProcessorBaseV3 {
+    private final static Logger logger = LoggerFactory.getLogger(WriteLacProcessorV3.class);
+
+    public WriteLacProcessorV3(Request request, Channel channel,
+                             BookieRequestProcessor requestProcessor) {
+        super(request, channel, requestProcessor);
+    }
+
+    // Returns null if there is no exception thrown
+    private WriteLacResponse getWriteLacResponse() {
+        final long startTimeNanos = MathUtils.nowInNano();
+        WriteLacRequest writeLacRequest = request.getWriteLacRequest();
+        long lac = writeLacRequest.getLac();
+        long ledgerId = writeLacRequest.getLedgerId();
+
+        final WriteLacResponse.Builder writeLacResponse = WriteLacResponse.newBuilder().setLedgerId(ledgerId);
+
+        if (!isVersionCompatible()) {
+            writeLacResponse.setStatus(StatusCode.EBADVERSION);
+            return writeLacResponse.build();
+        }
+
+        if (requestProcessor.bookie.isReadOnly()) {
+            logger.warn("BookieServer is running as readonly mode, so rejecting the request from the client!");
+            writeLacResponse.setStatus(StatusCode.EREADONLY);
+            return writeLacResponse.build();
+        }
+
+        StatusCode status = null;
+        ByteBuffer lacToAdd = writeLacRequest.getBody().asReadOnlyByteBuffer();
+        byte[] masterKey = writeLacRequest.getMasterKey().toByteArray();
+
+        try {
+            requestProcessor.bookie.setExplicitLac(lacToAdd, channel, masterKey);
+            status = StatusCode.EOK;
+        } catch (IOException e) {
+            logger.error("Error saving lac for ledger:{}",
+                          new Object[] { lac, ledgerId, e });
+            status = StatusCode.EIO;
+        } catch (BookieException e) {
+            logger.error("Unauthorized access to ledger:{} while adding lac:{}",
+                                                  ledgerId, lac);
+            status = StatusCode.EUA;
+        } catch (Throwable t) {
+            logger.error("Unexpected exception while writing {}@{} : ",
+                    new Object[] { lac, t });
+            // some bad request which cause unexpected exception
+            status = StatusCode.EBADREQ;
+        }
+
+        // If everything is okay, we return null so that the calling function
+        // dosn't return a response back to the caller.
+        if (status.equals(StatusCode.EOK)) {
+            requestProcessor.writeLacStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
+        } else {
+            requestProcessor.writeLacStats.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
+        }
+        writeLacResponse.setStatus(status);
+        return writeLacResponse.build();
+    }
+
+    @Override
+    public void safeRun() {
+        WriteLacResponse writeLacResponse = getWriteLacResponse();
+        if (null != writeLacResponse) {
+            Response.Builder response = Response.newBuilder()
+                    .setHeader(getHeader())
+                    .setStatus(writeLacResponse.getStatus())
+                    .setWriteLacResponse(writeLacResponse);
+            Response resp = response.build();
+            sendResponse(writeLacResponse.getStatus(), resp, requestProcessor.writeLacStats);
+        }
+    }
+}
+
+

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/OrderedSafeExecutor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/OrderedSafeExecutor.java
@@ -21,12 +21,15 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -58,9 +61,8 @@ import org.slf4j.LoggerFactory;
 public class OrderedSafeExecutor {
     final static long WARN_TIME_MICRO_SEC_DEFAULT = TimeUnit.SECONDS.toMicros(1);
     final String name;
-    final ThreadPoolExecutor threads[];
+    final ScheduledThreadPoolExecutor threads[];
     final long threadIds[];
-    final BlockingQueue<Runnable> queues[];
     final Random rand = new Random();
     final OpStatsLogger taskExecutionStats;
     final OpStatsLogger taskPendingStats;
@@ -173,17 +175,15 @@ public class OrderedSafeExecutor {
 
         this.warnTimeMicroSec = warnTimeMicroSec;
         name = baseName;
-        threads = new ThreadPoolExecutor[numThreads];
+        threads = new ScheduledThreadPoolExecutor[numThreads];
         threadIds = new long[numThreads];
-        queues = new BlockingQueue[numThreads];
         for (int i = 0; i < numThreads; i++) {
-            queues[i] = new LinkedBlockingQueue<Runnable>();
-            threads[i] =  new ThreadPoolExecutor(1, 1,
-                    0L, TimeUnit.MILLISECONDS, queues[i],
+            threads[i] =  new ScheduledThreadPoolExecutor(1,
                     new ThreadFactoryBuilder()
                         .setNameFormat(name + "-orderedsafeexecutor-" + i + "-%d")
                         .setThreadFactory(threadFactory)
                         .build());
+            threads[i].setMaximumPoolSize(1);
 
             // Save thread ids
             final int idx = i;
@@ -209,7 +209,7 @@ public class OrderedSafeExecutor {
 
                 @Override
                 public Number getSample() {
-                    return queues[idx].size();
+                    return threads[idx].getQueue().size();
                 }
             });
             statsLogger.registerGauge(String.format("%s-completed-tasks-%d", name, idx), new Gauge<Number>() {
@@ -242,7 +242,7 @@ public class OrderedSafeExecutor {
         this.traceTaskExecution = traceTaskExecution;
     }
 
-    ExecutorService chooseThread() {
+    ScheduledExecutorService chooseThread() {
         // skip random # generation in this special case
         if (threads.length == 1) {
             return threads[0];
@@ -252,7 +252,7 @@ public class OrderedSafeExecutor {
 
     }
 
-    ExecutorService chooseThread(Object orderingKey) {
+    ScheduledExecutorService chooseThread(Object orderingKey) {
         // skip hashcode generation in this special case
         if (threads.length == 1) {
             return threads[0];
@@ -284,6 +284,104 @@ public class OrderedSafeExecutor {
      */
     public void submitOrdered(Object orderingKey, SafeRunnable r) {
         chooseThread(orderingKey).submit(timedRunnable(r));
+    }
+
+    /**
+     * Creates and executes a one-shot action that becomes enabled after the given delay.
+     * 
+     * @param command - the SafeRunnable to execute
+     * @param delay - the time from now to delay execution
+     * @param unit - the time unit of the delay parameter
+     * @return a ScheduledFuture representing pending completion of the task and whose get() method will return null upon completion
+     */
+    public ScheduledFuture<?> schedule(SafeRunnable command, long delay, TimeUnit unit) {
+        return chooseThread().schedule(command, delay, unit);
+    }
+
+    /**
+     * Creates and executes a one-shot action that becomes enabled after the given delay.
+     * 
+     * @param orderingKey - the key used for ordering 
+     * @param command - the SafeRunnable to execute
+     * @param delay - the time from now to delay execution
+     * @param unit - the time unit of the delay parameter
+     * @return a ScheduledFuture representing pending completion of the task and whose get() method will return null upon completion
+     */
+    public ScheduledFuture<?> scheduleOrdered(Object orderingKey, SafeRunnable command, long delay, TimeUnit unit) {
+        return chooseThread(orderingKey).schedule(command, delay, unit);
+    }
+
+    /** 
+     * Creates and executes a periodic action that becomes enabled first after
+     * the given initial delay, and subsequently with the given period; 
+     * 
+     * For more details check scheduleAtFixedRate in interface ScheduledExecutorService
+     * 
+     * @param command - the SafeRunnable to execute
+     * @param initialDelay - the time to delay first execution
+     * @param period - the period between successive executions
+     * @param unit - the time unit of the initialDelay and period parameters
+     * @return a ScheduledFuture representing pending completion of the task, and whose get() 
+     * method will throw an exception upon cancellation
+     */
+    public ScheduledFuture<?> scheduleAtFixedRate(SafeRunnable command, long initialDelay, long period, TimeUnit unit) {
+        return chooseThread().scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    /** 
+     * Creates and executes a periodic action that becomes enabled first after
+     * the given initial delay, and subsequently with the given period; 
+     * 
+     * For more details check scheduleAtFixedRate in interface ScheduledExecutorService
+     * 
+     * @param orderingKey - the key used for ordering
+     * @param command - the SafeRunnable to execute
+     * @param initialDelay - the time to delay first execution
+     * @param period - the period between successive executions
+     * @param unit - the time unit of the initialDelay and period parameters
+     * @return a ScheduledFuture representing pending completion of the task, and whose get() method 
+     * will throw an exception upon cancellation
+     */
+    public ScheduledFuture<?> scheduleAtFixedRateOrdered(Object orderingKey, SafeRunnable command, long initialDelay,
+            long period, TimeUnit unit) {
+        return chooseThread(orderingKey).scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    /**
+     * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently 
+     * with the given delay between the termination of one execution and the commencement of the next.
+     * 
+     * For more details check scheduleWithFixedDelay in interface ScheduledExecutorService
+     * 
+     * @param command - the SafeRunnable to execute
+     * @param initialDelay - the time to delay first execution
+     * @param delay - the delay between the termination of one execution and the commencement of the next
+     * @param unit - the time unit of the initialDelay and delay parameters
+     * @return a ScheduledFuture representing pending completion of the task, and whose get() method 
+     * will throw an exception upon cancellation
+     */
+    public ScheduledFuture<?> scheduleWithFixedDelay(SafeRunnable command, long initialDelay, long delay,
+            TimeUnit unit) {
+        return chooseThread().scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    /**
+     * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently 
+     * with the given delay between the termination of one execution and the commencement of the next.
+     * 
+     * For more details check scheduleWithFixedDelay in interface ScheduledExecutorService
+     * 
+     * @param orderingKey - the key used for ordering
+     * @param command - the SafeRunnable to execute
+     * @param initialDelay - the time to delay first execution
+     * @param delay - the delay between the termination of one execution and the commencement of the next
+     * @param unit - the time unit of the initialDelay and delay parameters
+     * @return a ScheduledFuture representing pending completion of the task, and whose get() method 
+     * will throw an exception upon cancellation
+     */
+    public ScheduledFuture<?> scheduleWithFixedDelayOrdered(Object orderingKey, SafeRunnable command, long initialDelay,
+            long delay, TimeUnit unit) {
+        return chooseThread(orderingKey).scheduleWithFixedDelay(command, initialDelay, delay, unit);
     }
 
     private long getThreadID(Object orderingKey) {

--- a/bookkeeper-server/src/main/proto/BookkeeperProtocol.proto
+++ b/bookkeeper-server/src/main/proto/BookkeeperProtocol.proto
@@ -57,6 +57,8 @@ enum OperationType {
     RANGE_ADD_ENTRY = 4;
 
     AUTH = 5;
+    WRITE_LAC = 6;
+    READ_LAC = 7;
 }
 
 /**
@@ -74,6 +76,8 @@ message Request {
     optional ReadRequest readRequest = 100;
     optional AddRequest addRequest = 101;
     optional AuthMessage authRequest = 102;
+    optional WriteLacRequest writeLacRequest = 103;
+    optional ReadLacRequest readLacRequest = 104;
 }
 
 message ReadRequest {
@@ -99,6 +103,17 @@ message AddRequest {
     required bytes body = 4;
 }
 
+message WriteLacRequest {
+    required int64 ledgerId = 1;
+    required int64 lac = 2;
+    required bytes masterKey = 3;
+    required bytes body = 4;
+}
+
+message ReadLacRequest {
+    required int64 ledgerId = 1;
+}
+
 message Response {
 
     required BKPacketHeader header = 1;
@@ -109,6 +124,8 @@ message Response {
     optional ReadResponse readResponse = 100;
     optional AddResponse addResponse = 101;
     optional AuthMessage authResponse = 102;
+    optional WriteLacResponse writeLacResponse = 103;
+    optional ReadLacResponse readLacResponse = 104;
 }
 
 message ReadResponse {
@@ -127,4 +144,16 @@ message AddResponse {
 message AuthMessage {
     required string authPluginName = 1;
     required bytes payload = 2;
+}
+
+message WriteLacResponse {
+    required StatusCode status = 1;
+    required int64 ledgerId = 2;
+}
+
+message ReadLacResponse {
+    required StatusCode status = 1;
+    required int64 ledgerId = 2;
+    optional bytes lacBody = 3; // lac sent by PutLacRequest
+    optional bytes lastEntryBody = 4; // Actual last entry on the disk
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
@@ -334,6 +334,15 @@ public class TestSyncThread {
         }
 
         @Override
+        public void setExplicitlac(long ledgerId, ByteBuffer lac) {
+        }
+
+        @Override
+        public ByteBuffer getExplicitLac(long ledgerId) {
+            return null;
+        }
+
+        @Override
         public Checkpoint checkpoint(Checkpoint checkpoint)
                 throws IOException {
             return checkpoint;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -309,4 +309,128 @@ public class BookKeeperTest extends BaseTestCase {
         }
         Assert.assertTrue("BookKeeper should be closed!", _bkc.closed);
     }
+
+    @Test(timeout = 60000)
+    public void testReadHandleWithNoExplicitLAC() throws Exception {
+        ClientConfiguration confWithNoExplicitLAC = new ClientConfiguration()
+                .setZkServers(zkUtil.getZooKeeperConnectString());
+        confWithNoExplicitLAC.setExplictLacInterval(0);
+
+        BookKeeper bkcWithNoExplicitLAC = new BookKeeper(confWithNoExplicitLAC);
+
+        LedgerHandle wlh = bkcWithNoExplicitLAC.createLedger(digestType, "testPasswd".getBytes());
+        long ledgerId = wlh.getId();
+        int numOfEntries = 5;
+        for (int i = 0; i < numOfEntries; i++) {
+            wlh.addEntry(("foobar" + i).getBytes());
+        }
+
+        LedgerHandle rlh = bkcWithNoExplicitLAC.openLedgerNoRecovery(ledgerId, digestType, "testPasswd".getBytes());
+        Assert.assertTrue(
+                "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+        Enumeration<LedgerEntry> entries = rlh.readEntries(0, numOfEntries - 2);
+        int entryId = 0;
+        while (entries.hasMoreElements()) {
+            LedgerEntry entry = entries.nextElement();
+            String entryString = new String(entry.getEntry());
+            Assert.assertTrue("Expected entry String: " + ("foobar" + entryId) + " actual entry String: " + entryString,
+                    entryString.equals("foobar" + entryId));
+            entryId++;
+        }
+
+        for (int i = numOfEntries; i < 2 * numOfEntries; i++) {
+            wlh.addEntry(("foobar" + i).getBytes());
+        }
+
+        Thread.sleep(3000);
+        // since explicitlacflush policy is not enabled for writeledgerhandle, when we try
+        // to read explicitlac for rlh, it will be LedgerHandle.INVALID_ENTRY_ID. But it
+        // wont throw some exception.
+        long explicitlac = rlh.readExplicitLastConfirmed();
+        Assert.assertTrue(
+                "Expected Explicit LAC of rlh: " + LedgerHandle.INVALID_ENTRY_ID + " actual ExplicitLAC of rlh: " + explicitlac,
+                (explicitlac == LedgerHandle.INVALID_ENTRY_ID));
+        Assert.assertTrue(
+                "Expected LAC of wlh: " + (2 * numOfEntries - 1) + " actual LAC of rlh: " + wlh.getLastAddConfirmed(),
+                (wlh.getLastAddConfirmed() == (2 * numOfEntries - 1)));
+        Assert.assertTrue(
+                "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+        try {
+            rlh.readEntries(numOfEntries - 1, numOfEntries - 1);
+            fail("rlh readEntries beyond " + (numOfEntries - 2) + " should fail with ReadException");
+        } catch (BKException.BKReadException readException) {
+        }
+
+        rlh.close();
+        wlh.close();
+        bkcWithNoExplicitLAC.close();
+    }
+
+    @Test(timeout = 60000)
+    public void testReadHandleWithExplicitLAC() throws Exception {
+        ClientConfiguration confWithExplicitLAC = new ClientConfiguration()
+                .setZkServers(zkUtil.getZooKeeperConnectString());
+        int explictLacInterval = 1;
+        confWithExplicitLAC.setExplictLacInterval(explictLacInterval);
+
+        BookKeeper bkcWithExplicitLAC = new BookKeeper(confWithExplicitLAC);
+
+        LedgerHandle wlh = bkcWithExplicitLAC.createLedger(digestType, "testPasswd".getBytes());
+        long ledgerId = wlh.getId();
+        int numOfEntries = 5;
+        for (int i = 0; i < numOfEntries; i++) {
+            wlh.addEntry(("foobar" + i).getBytes());
+        }
+
+        LedgerHandle rlh = bkcWithExplicitLAC.openLedgerNoRecovery(ledgerId, digestType, "testPasswd".getBytes());
+
+        Assert.assertTrue(
+                "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+        for (int i = numOfEntries; i < 2 * numOfEntries; i++) {
+            wlh.addEntry(("foobar" + i).getBytes());
+        }
+
+        // we need to wait for atleast 2 explicitlacintervals,
+        // since in writehandle for the first call
+        // lh.getExplicitLastAddConfirmed() will be <
+        // lh.getPiggyBackedLastAddConfirmed(),
+        // so it wont make explicit writelac in the first run
+        Thread.sleep((2 * explictLacInterval + 1) * 1000);
+        Assert.assertTrue(
+                "Expected LAC of wlh: " + (2 * numOfEntries - 1) + " actual LAC of wlh: " + wlh.getLastAddConfirmed(),
+                (wlh.getLastAddConfirmed() == (2 * numOfEntries - 1)));
+        // readhandle's lastaddconfirmed wont be updated until readExplicitLastConfirmed call is made   
+        Assert.assertTrue(
+                "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+        
+        long explicitlac = rlh.readExplicitLastConfirmed();
+        Assert.assertTrue(
+                "Expected Explicit LAC of rlh: " + (2 * numOfEntries - 1) + " actual ExplicitLAC of rlh: " + explicitlac,
+                (explicitlac == (2 * numOfEntries - 1)));
+        // readExplicitLastConfirmed updates the lac of rlh.
+        Assert.assertTrue(
+                "Expected LAC of rlh: " + (2 * numOfEntries - 1) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                (rlh.getLastAddConfirmed() == (2 * numOfEntries - 1)));
+        
+        Enumeration<LedgerEntry> entries = rlh.readEntries(numOfEntries, 2 * numOfEntries - 1);
+        int entryId = numOfEntries;
+        while (entries.hasMoreElements()) {
+            LedgerEntry entry = entries.nextElement();
+            String entryString = new String(entry.getEntry());
+            Assert.assertTrue("Expected entry String: " + ("foobar" + entryId) + " actual entry String: " + entryString,
+                    entryString.equals("foobar" + entryId));
+            entryId++;
+        }
+
+        rlh.close();
+        wlh.close();
+        bkcWithExplicitLAC.close();
+    }	
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -206,5 +206,17 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         @Override
         public void flushEntriesLocationsIndex() throws IOException {
         }
+
+        @Override
+        public void setExplicitlac(long ledgerId, ByteBuffer lac) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public ByteBuffer getExplicitLac(long ledgerId) {
+            // TODO Auto-generated method stub
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Introduce a new feature for sending explicit LAC to bookies.
A writable LedgerHandle creates a timer thread to send explicit LACs
at the intervals specified through configuration paramenter,
explicitLacInterval. If this is set to zero, this feature is disabled,
no timer thread is created.

Explicit LAC is sent only if the client did not get a chance to send
LAC through piggyback method for "explicitLacInterval" time.
To implement this, introduced two new protocol messages to the
Bookkeeper protocol -  WRITE_LAC and READ_LAC, in addition to its
current READ_ENTRY and ADD_ENTRY.

Reviewed-by: Charan Reddy Guttapalem <cguttapalem@salesforce.com>
Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>
Co-Author : Charan Reddy Guttapalem <cguttapalem@salesforce.com>