### PR TITLE
BOOKKEEPER-986: Handle memtable flush failure

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -39,7 +39,7 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
         implements LedgerStorage, CacheCallback, SkipListFlusher {
     private final static Logger LOG = LoggerFactory.getLogger(SortedLedgerStorage.class);
 
-    private EntryMemTable memTable;
+    EntryMemTable memTable;
     private ScheduledExecutorService scheduler;
 
     public SortedLedgerStorage() {


### PR DESCRIPTION
- If the memtable flush is failed previously then
for the next addEntry call it will try to flush the
existing snapshot