### PR TITLE
BOOKKEEPER-950: Ledger placement policy to accomodate different storage capacity of bookies

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
@@ -37,6 +37,7 @@ public interface BookKeeperServerStats {
     public final static String READ_ENTRY_FENCE_READ = "READ_ENTRY_FENCE_READ";
     public final static String WRITE_LAC = "WRITE_LAC";
     public final static String READ_LAC = "READ_LAC";
+    public final static String GET_BOOKIE_INFO = "GET_BOOKIE_INFO";
 
     // Bookie Operations
     public final static String BOOKIE_ADD_ENTRY_BYTES = "BOOKIE_ADD_ENTRY_BYTES";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -622,6 +622,14 @@ public class Bookie extends BookieCriticalThread {
         return indexDirsManager;
     }
 
+    public long getTotalDiskSpace() {
+        return getLedgerDirsManager().getTotalDiskSpace();
+    }
+
+    public long getTotalFreeSpace() {
+        return getLedgerDirsManager().getTotalFreeSpace();
+    }
+
     public static File getCurrentDirectory(File dir) {
         return new File(dir, BookKeeperConstants.CURRENT_DIR);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -24,12 +24,14 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
+import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,6 +43,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.bookie.BookieException.InvalidCookieException;
@@ -48,6 +51,8 @@ import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
 import org.apache.bookkeeper.bookie.Journal.JournalScanner;
 import org.apache.bookkeeper.bookie.Journal;
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookieInfoReader;
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
@@ -63,7 +68,10 @@ import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
 import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieClient;
+import org.apache.bookkeeper.proto.BookkeeperProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GetBookieInfoCallback;
 import org.apache.bookkeeper.replication.AuditorElector;
 import org.apache.bookkeeper.util.EntryFormatter;
 import org.apache.bookkeeper.util.IOUtils;
@@ -78,6 +86,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -126,6 +135,7 @@ public class BookieShell implements Tool {
     static final String CMD_EXPANDSTORAGE = "expandstorage";
     static final String CMD_UPDATELEDGER = "updateledgers";
     static final String CMD_DELETELEDGER = "deleteledger";
+    static final String CMD_BOOKIEINFO = "bookieinfo";
     static final String CMD_HELP = "help";
 
     final ServerConfiguration bkConf = new ServerConfiguration();
@@ -1752,6 +1762,74 @@ public class BookieShell implements Tool {
         }
     }
 
+    /*
+     * Command to retrieve bookie information like free disk space, etc from all
+     * the bookies in the cluster.
+     */
+    class BookieInfoCmd extends MyCommand {
+        Options lOpts = new Options();
+
+        BookieInfoCmd() {
+            super(CMD_BOOKIEINFO);
+        }
+
+        @Override
+        String getDescription() {
+            return "Retrieve bookie info such as free and total disk space";
+        }
+
+        @Override
+        String getUsage() {
+            return "bookieinfo";
+        }
+
+        @Override
+        Options getOptions() {
+            return lOpts;
+        }
+
+        String getReadable(long val) {
+            String unit[] = {"", "KB", "MB", "GB", "TB" };
+            int cnt = 0;
+            double d = val;
+            while (d >= 1000 && cnt < unit.length-1) {
+                d = d/1000;
+                cnt++;
+            }
+            DecimalFormat df = new DecimalFormat("#.###");
+            df.setRoundingMode(RoundingMode.DOWN);
+            return cnt > 0 ? "(" + df.format(d) + unit[cnt] + ")" : unit[cnt];
+        }
+
+        @Override
+        public int runCmd(CommandLine cmdLine) throws Exception {
+            ClientConfiguration clientConf = new ClientConfiguration(bkConf);
+            clientConf.setDiskWeightBasedPlacementEnabled(true);
+            BookKeeper bk = new BookKeeper(clientConf);
+
+            Map<BookieSocketAddress, BookieInfo> map = bk.getBookieInfo();
+            if (map.size() == 0) {
+                System.out.println("Failed to retrieve bookie information from any of the bookies");
+                bk.close();
+                return 0;
+            }
+
+            System.out.println("Free disk space info:");
+            long totalFree = 0, total=0;
+            for (Map.Entry<BookieSocketAddress, BookieInfo> e : map.entrySet()) {
+                BookieInfo bInfo = e.getValue();
+                System.out.println(e.getKey() + ":\tFree: " + bInfo.getFreeDiskSpace() +  getReadable(bInfo.getFreeDiskSpace()) +
+                        "\tTotal: " + bInfo.getTotalDiskSpace() +  getReadable(bInfo.getTotalDiskSpace()));
+                totalFree += bInfo.getFreeDiskSpace();
+                total += bInfo.getTotalDiskSpace();
+            }
+            System.out.println("Total free disk space in the cluster:\t" + totalFree + getReadable(totalFree));
+            System.out.println("Total disk capacity in the cluster:\t" + total + getReadable(total));
+            bk.close();
+            return 0;
+        }
+    }
+
     /**
      * A facility for reporting update ledger progress.
      */
@@ -1782,6 +1860,7 @@ public class BookieShell implements Tool {
         commands.put(CMD_EXPANDSTORAGE, new ExpandStorageCmd());
         commands.put(CMD_UPDATELEDGER, new UpdateLedgerCmd());
         commands.put(CMD_DELETELEDGER, new DeleteLedgerCmd());
+        commands.put(CMD_BOOKIEINFO, new BookieInfoCmd());
         commands.put(CMD_HELP, new HelpCmd());
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -119,6 +119,34 @@ public class LedgerDirsManager {
     }
 
     /**
+     * Calculate the total amount of free space available
+     * in all of the ledger directories put together.
+     *
+     * @return totalDiskSpace in bytes
+     */
+    public long getTotalFreeSpace() {
+        long totalFreeSpace = 0;
+        for (File dir: this.ledgerDirectories) {
+            totalFreeSpace += dir.getFreeSpace();
+        }
+        return totalFreeSpace;
+    }
+
+    /**
+     * Calculate the total amount of free space available
+     * in all of the ledger directories put together.
+     *
+     * @return freeDiskSpace in bytes
+     */
+    public long getTotalDiskSpace() {
+        long totalDiskSpace = 0;
+        for (File dir: this.ledgerDirectories) {
+            totalDiskSpace += dir.getTotalSpace();
+        }
+        return totalDiskSpace;
+    }
+
+    /**
      * Get only writable ledger dirs.
      */
     public List<File> getWritableLedgerDirs()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LocalBookieEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LocalBookieEnsemblePlacementPolicy.java
@@ -23,20 +23,22 @@ import java.net.UnknownHostException;
 import java.util.*;
 
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.feature.FeatureProvider;
 import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.net.DNSToSwitchMapping;
-import org.jboss.netty.util.HashedWheelTimer;
+import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.commons.configuration.Configuration;
+import com.google.common.collect.Lists;
+import org.jboss.netty.util.HashedWheelTimer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Lists;
 
 /**
  * Special ensemble placement policy that always return local bookie. Only works with ledgers with ensemble=1.
@@ -100,4 +102,8 @@ public class LocalBookieEnsemblePlacementPolicy implements EnsemblePlacementPoli
         return Lists.newArrayList(bookieAddress);
     }
 
+    @Override
+    public void updateBookieInfo(Map<BookieSocketAddress, BookieInfo> bookieToFreeSpaceMap) {
+        return;
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -34,6 +34,7 @@ public interface BookKeeperClientStats {
     public final static String ENSEMBLE_CHANGES = "NUM_ENSEMBLE_CHANGE";
     public final static String LAC_UPDATE_HITS = "LAC_UPDATE_HITS";
     public final static String LAC_UPDATE_MISSES = "LAC_UPDATE_MISSES";
+    public final static String GET_BOOKIE_INFO_OP = "GET_BOOKIE_INFO";
 
     // per channel stats
     public final static String CHANNEL_SCOPE = "per_channel_bookie_client";
@@ -46,4 +47,5 @@ public interface BookKeeperClientStats {
     public final static String CHANNEL_TIMEOUT_WRITE_LAC = "TIMEOUT_WRITE_LAC";
     public final static String CHANNEL_READ_LAC_OP = "READ_LAC";
     public final static String CHANNEL_TIMEOUT_READ_LAC = "TIMEOUT_READ_LAC";
+    public final static String TIMEOUT_GET_BOOKIE_INFO = "TIMEOUT_GET_BOOKIE_INFO";
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.bookkeeper.client.WeightedRandomSelection.WeightedObject;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieClient;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GetBookieInfoCallback;
+import org.apache.bookkeeper.proto.BookkeeperProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BookieInfoReader {
+    private static final Logger LOG = LoggerFactory.getLogger(BookieInfoReader.class);
+    private final ScheduledExecutorService scheduler;
+    private final BookKeeper bk;
+    private final ClientConfiguration conf;
+    private ConcurrentMap<BookieSocketAddress, BookieInfo> bookieInfoMap = new ConcurrentHashMap<BookieSocketAddress, BookieInfo>();
+    private Collection<BookieSocketAddress> bookies;
+    private final AtomicInteger totalSent = new AtomicInteger();
+    private final AtomicInteger completedCnt = new AtomicInteger();
+    private final AtomicBoolean instanceRunning = new AtomicBoolean();
+    private final AtomicBoolean isQueued = new AtomicBoolean();
+    private final AtomicBoolean refreshBookieList = new AtomicBoolean();
+
+    public static class BookieInfo implements WeightedObject {
+        private final long freeDiskSpace;
+        private final long totalDiskSpace;
+        public BookieInfo() {
+            this(0L, 0L);
+        }
+        public BookieInfo(long totalDiskSpace, long freeDiskSpace) {
+            this.totalDiskSpace = totalDiskSpace;
+            this.freeDiskSpace = freeDiskSpace;
+        }
+        public long getFreeDiskSpace() {
+            return freeDiskSpace;
+        }
+        public long getTotalDiskSpace() {
+            return totalDiskSpace;
+        }
+        @Override
+        public long getWeight() {
+            return freeDiskSpace;
+        }
+        public String toString() {
+            return "FreeDiskSpace: " + this.freeDiskSpace + " TotalDiskCapacity: " + this.totalDiskSpace;
+        }
+    }
+
+    BookieInfoReader(BookKeeper bk,
+                          ClientConfiguration conf,
+                          ScheduledExecutorService scheduler) {
+        this.bk = bk;
+        this.conf = conf;
+        this.scheduler = scheduler;
+    }
+    void start() {
+        scheduler.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                LOG.debug("Running periodic BookieInfo scan");
+                getReadWriteBookieInfo(null);
+            }
+        }, 0, conf.getGetBookieInfoIntervalSeconds(), TimeUnit.SECONDS);
+    }
+    void submitTask(final Collection<BookieSocketAddress> newBookies) {
+        scheduler.submit(new Runnable() {
+            @Override
+            public void run() {
+                getReadWriteBookieInfo(newBookies);
+            }
+        });
+    }
+    void availableBookiesChanged(Set<BookieSocketAddress> newBookies) {
+        LOG.info("Scheduling bookie info read due to changes in available bookies.");
+        submitTask(newBookies);
+    }
+
+    /*
+     * This routine is responsible for issuing bookieInfoGet messages to all the read write bookies.
+     * instanceRunning will be true until we have sent the bookieInfoGet requests to
+     * all the readwrite bookies and have processed all the callbacks. Only then is it reset to
+     * false. At that time, if any pending tasks are queued, they are scheduled by the
+     * last callback processing task. isQueued variable is used to indicate the pending
+     * tasks. refreshBookieList is used to indicate that we need to read we need to explicitly
+     * retireve the bookies list from zk because we don't remember the bookie list for
+     * queued ops.
+     */
+    @SuppressWarnings("unchecked")
+    void getReadWriteBookieInfo(Collection<BookieSocketAddress> newBookiesList) {
+        if (instanceRunning.get() == false) {
+            instanceRunning.compareAndSet(false, true);
+        } else {
+            isQueued.set(true);
+            if (newBookiesList != null) {
+                refreshBookieList.set(true);
+            }
+            LOG.debug("Exiting due to running instance");
+            return;
+        }
+        Collection<BookieSocketAddress> deadBookies = null, joinedBookies=null;
+        if (newBookiesList == null) {
+            try {
+                if (this.bookies == null) {
+                    joinedBookies = this.bookies = bk.bookieWatcher.getBookies();
+                } else if (refreshBookieList.get()) {
+                    LOG.debug("Refreshing bookie list");
+                    newBookiesList = bk.bookieWatcher.getBookies();
+                    refreshBookieList.set(false);
+                } else {
+                    // the bookie list is already up to date, just retrieve their info
+                    joinedBookies = this.bookies;
+                }
+            } catch (BKException e) {
+                LOG.error("Unable to get the available bookies ", e);
+                onExit();
+                return;
+            }
+        }
+        if (newBookiesList != null) {
+            if (this.bookies != null) {
+                joinedBookies = CollectionUtils.subtract(newBookiesList, this.bookies);
+                deadBookies = CollectionUtils.subtract(this.bookies, newBookiesList);
+                for (BookieSocketAddress b : deadBookies) {
+                    bookieInfoMap.remove(b);
+                    this.bookies.remove(b);
+                }
+                for (BookieSocketAddress b : joinedBookies) {
+                    this.bookies.add(b);
+                }
+            } else {
+                joinedBookies = this.bookies = newBookiesList;
+            }
+        }
+
+        BookieClient bkc = bk.getBookieClient();
+        final long requested = BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE |
+                               BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE;
+        totalSent.set(0);
+        completedCnt.set(0);
+        LOG.debug("Getting bookie info for: {}", joinedBookies);
+        for (BookieSocketAddress b : joinedBookies) {
+            bkc.getBookieInfo(b, requested,
+                    new GetBookieInfoCallback() {
+                        void processReadInfoComplete(int rc, BookieInfo bInfo, Object ctx) {
+                            BookieSocketAddress b = (BookieSocketAddress) ctx;
+                            if (rc != BKException.Code.OK) {
+                                LOG.error("Reading bookie info from bookie {} failed due to error: {}.", b, rc);
+                                // if there was data earlier, don't overwrite it
+                                // create a new one only if the key was missing
+                                bookieInfoMap.putIfAbsent(b, new BookieInfo());
+                            } else {
+                                LOG.debug("Bookie Info for bookie {} is {}", b, bInfo);
+                                bookieInfoMap.put(b, bInfo);
+                            }
+                            if (completedCnt.incrementAndGet() == totalSent.get()) {
+                                bk.placementPolicy.updateBookieInfo(bookieInfoMap);
+                                onExit();
+                            }
+                        }
+                        @Override
+                        public void getBookieInfoComplete(final int rc, final BookieInfo bInfo, final Object ctx) {
+                            scheduler.submit(
+                                new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        processReadInfoComplete(rc, bInfo, ctx);
+                                    }
+                                });
+                        }
+                    }, b);
+            totalSent.incrementAndGet();
+        }
+        if (totalSent.get() == 0) {
+            if (deadBookies != null) {
+                // if no new bookies joined but some existing bookies went away
+                // we need to inform the placementPloicy
+                bk.placementPolicy.updateBookieInfo(bookieInfoMap);
+            }
+            onExit();
+        }
+    }
+
+    void onExit() {
+        if (isQueued.get()) {
+            LOG.debug("Scheduling a queued task");
+            submitTask(null);
+        }
+        isQueued.set(false);
+        instanceRunning.set(false);
+    }
+
+    Map<BookieSocketAddress, BookieInfo> getBookieInfo() throws BKException, InterruptedException {
+        BookieClient bkc = bk.getBookieClient();
+        final AtomicInteger totalSent = new AtomicInteger();
+        final AtomicInteger totalCompleted = new AtomicInteger();
+        final ConcurrentMap<BookieSocketAddress, BookieInfo> map = new ConcurrentHashMap<BookieSocketAddress, BookieInfo>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        long requested = BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE |
+                         BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE;
+
+        Collection<BookieSocketAddress> bookies;
+        bookies = bk.bookieWatcher.getBookies();
+        bookies.addAll(bk.bookieWatcher.getReadOnlyBookies());
+
+        totalSent.set(bookies.size());
+        for (BookieSocketAddress b : bookies) {
+            bkc.getBookieInfo(b, requested, new GetBookieInfoCallback() {
+                        @Override
+                        public void getBookieInfoComplete(int rc, BookieInfo bInfo, Object ctx) {
+                            BookieSocketAddress b = (BookieSocketAddress) ctx;
+                            if (rc != BKException.Code.OK) {
+                                LOG.error("Reading bookie info from bookie {} failed due to error: {}.", b, rc);
+                            } else {
+                                LOG.debug("Free disk space on bookie {} is {}.", b, bInfo.getFreeDiskSpace());
+                                map.put(b, bInfo);
+                            }
+                            if (totalCompleted.incrementAndGet() == totalSent.get()) {
+                                latch.countDown();
+                            }
+                        }
+                    }, b);
+        }
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            LOG.error("Received InterruptedException ", e);
+            throw e;
+        }
+        return map;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcher.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcher.java
@@ -184,6 +184,10 @@ class BookieWatcher implements Watcher, ChildrenCallback {
         synchronized (this) {
             Set<BookieSocketAddress> readonlyBookies = readOnlyBookieWatcher.getReadOnlyBookies();
             placementPolicy.onClusterChanged(newBookieAddrs, readonlyBookies);
+            if (bk.conf.getDiskWeightBasedPlacementEnabled()) {
+                // start collecting bookieInfo for the newly joined bookies, if any
+                bk.bookieInfoReader.availableBookiesChanged(newBookieAddrs);
+            }
         }
 
         // we don't need to close clients here, because:

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import com.google.common.base.Optional;
 
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.feature.FeatureProvider;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -135,4 +136,13 @@ public interface EnsemblePlacementPolicy {
      */
     public List<Integer> reorderReadLACSequence(ArrayList<BookieSocketAddress> ensemble,
                                                 List<Integer> writeSet, Map<BookieSocketAddress, Long> bookieFailureHistory);
+
+    /**
+     * Send the bookie info details.
+     * 
+     * @param bookieInfoMap
+     *          A map that has the bookie to BookieInfo
+     */
+    default public void updateBookieInfo(Map<BookieSocketAddress, BookieInfo> bookieInfoMap) {
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
@@ -22,8 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.net.DNSToSwitchMapping;
 import org.apache.bookkeeper.net.Node;
@@ -32,7 +30,6 @@ import org.jboss.netty.util.HashedWheelTimer;
 
 public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacementPolicyImpl
         implements ITopologyAwareEnsemblePlacementPolicy<TopologyAwareEnsemblePlacementPolicy.BookieNode> {
-
     RackawareEnsemblePlacementPolicyImpl slave = null;
 
     RackawareEnsemblePlacementPolicy() {
@@ -48,13 +45,17 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
                                                           HashedWheelTimer timer,
                                                           boolean reorderReadsRandom,
                                                           int stabilizePeriodSeconds,
+                                                          boolean isWeighted,
+                                                          int maxWeightMultiple,
                                                           StatsLogger statsLogger) {
         if (stabilizePeriodSeconds > 0) {
-            super.initialize(dnsResolver, timer, reorderReadsRandom, 0, statsLogger);
+            super.initialize(dnsResolver, timer, reorderReadsRandom, 0, isWeighted, maxWeightMultiple, statsLogger);
             slave = new RackawareEnsemblePlacementPolicyImpl(enforceDurability);
-            slave.initialize(dnsResolver, timer, reorderReadsRandom, stabilizePeriodSeconds, statsLogger);
+            slave.initialize(dnsResolver, timer, reorderReadsRandom, stabilizePeriodSeconds, isWeighted,
+                    maxWeightMultiple, statsLogger);
         } else {
-            super.initialize(dnsResolver, timer, reorderReadsRandom, stabilizePeriodSeconds, statsLogger);
+            super.initialize(dnsResolver, timer, reorderReadsRandom, stabilizePeriodSeconds, isWeighted,
+                    maxWeightMultiple, statsLogger);
             slave = null;
         }
         return this;
@@ -96,7 +97,7 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
     public BookieSocketAddress replaceBookie(
         int ensembleSize, int writeQuorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Collection<BookieSocketAddress> currentEnsemble, BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies)
             throws BKException.BKNotEnoughBookiesException {
-        try {
+       try {
             return super.replaceBookie(ensembleSize, writeQuorumSize, ackQuorumSize, customMetadata,
                     currentEnsemble, bookieToReplace, excludeBookies);
         } catch (BKException.BKNotEnoughBookiesException bnebe) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -125,7 +125,8 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             String region = getLocalRegion(node);
             if (null == perRegionPlacement.get(region)) {
                 perRegionPlacement.put(region, new RackawareEnsemblePlacementPolicy()
-                        .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds, statsLogger));
+                        .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds, 
+                                this.isWeighted, this.maxWeightMultiple, statsLogger));
             }
 
             Set<BookieSocketAddress> regionSet = perRegionClusterChange.get(region);
@@ -160,7 +161,6 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
         super.initialize(conf, optionalDnsResolver, timer, featureProvider, statsLogger);
         myRegion = getLocalRegion(localNode);
         enableValidation = conf.getBoolean(REPP_ENABLE_VALIDATION, true);
-
         // We have to statically provide regions we want the writes to go through and how many regions
         // are required for durability. This decision cannot be driven by the active bookies as the
         // current topology will not be indicative of constraints that must be enforced for durability
@@ -171,7 +171,8 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             String[] regions = regionsString.split(";");
             for (String region: regions) {
                 perRegionPlacement.put(region, new RackawareEnsemblePlacementPolicy(true)
-                        .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds, statsLogger));
+                        .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds,
+                                this.isWeighted, this.maxWeightMultiple, statsLogger));
             }
             minRegionsForDurability = conf.getInt(REPP_MINIMUM_REGIONS_FOR_DURABILITY, MINIMUM_REGIONS_FOR_DURABILITY_DEFAULT);
             if (minRegionsForDurability > 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/WeightedRandomSelection.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/WeightedRandomSelection.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WeightedRandomSelection<T> {
+    static final Logger LOG = LoggerFactory.getLogger(WeightedRandomSelection.class);
+
+    interface WeightedObject {
+        long getWeight();
+    }
+    Double randomMax;
+    int maxProbabilityMultiplier;
+    Map<T, WeightedObject> map;
+    TreeMap<Double, T> cummulativeMap = new TreeMap<Double, T>();
+    ReadWriteLock rwLock = new ReentrantReadWriteLock(true);
+
+    WeightedRandomSelection() {
+        maxProbabilityMultiplier = -1;
+    }
+
+    WeightedRandomSelection(int maxMultiplier) {
+        this.maxProbabilityMultiplier = maxMultiplier;
+    }
+
+    public void setMaxProbabilityMultiplier(int max) {
+        this.maxProbabilityMultiplier = max;
+    }
+
+    void updateMap(Map<T, WeightedObject> map) {
+        // get the sum total of all the values; this will be used to
+        // calculate the weighted probability later on
+        Long totalWeight = 0L, min= Long.MAX_VALUE;
+        List<WeightedObject> values = new ArrayList<WeightedObject>(map.values());
+        Collections.sort(values, new Comparator<WeightedObject>() {
+            public int compare(WeightedObject o1, WeightedObject o2) {
+                long diff = o1.getWeight() - o2.getWeight();
+                if (diff < 0L) {
+                    return -1;
+                } else if (diff > 0L) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            }
+        });
+        for (int i=0; i < values.size(); i++) {
+            totalWeight += values.get(i).getWeight();
+            if (values.get(i).getWeight() != 0 && min > values.get(i).getWeight()) {
+                min = values.get(i).getWeight();
+            }
+        }
+
+        double median = 0;
+        if (totalWeight == 0) {
+            // all the values are zeros; assign a value of 1 to all and the totalWeight equal
+            // to the size of the values
+            min = 1L;
+            median = 1;
+            totalWeight = (long)values.size();
+        } else {
+            int mid = values.size()/2;
+            if ((values.size() % 2) == 1) {
+                median = values.get(mid).getWeight();
+            } else {
+                median = (double)(values.get(mid-1).getWeight() + values.get(mid).getWeight())/2;
+            }
+        }
+
+        double medianWeight, minWeight;
+        medianWeight = median/(double)totalWeight;
+        minWeight = (double)min/totalWeight;
+
+        LOG.debug("Updating weights map. MediaWeight: " + medianWeight + " MinWeight: " + minWeight);
+
+        double maxWeight = maxProbabilityMultiplier*medianWeight;
+        Map<T, Double> weightMap = new HashMap<T, Double>();
+        for (Map.Entry<T, WeightedObject> e : map.entrySet()) {
+            double weightedProbability;
+            if (e.getValue().getWeight() > 0) {
+                weightedProbability = (double)e.getValue().getWeight()/(double)totalWeight;
+            } else {
+                weightedProbability = minWeight;
+            }
+            if (maxWeight > 0 && weightedProbability > maxWeight) {
+                weightedProbability=maxWeight;
+                LOG.debug("Capping the probability to " + weightedProbability + " for " + e.getKey() + " Value: " + e.getValue());
+            }
+            weightMap.put(e.getKey(), weightedProbability);
+        }
+
+        // The probability of picking a bookie randomly is defaultPickProbability
+        // but we change that priority by looking at the weight that each bookie
+        // carries.
+        TreeMap<Double, T> tmpCummulativeMap = new TreeMap<Double, T>();
+        Double key=0.0;
+        for (Map.Entry<T, Double> e : weightMap.entrySet()) {
+            tmpCummulativeMap.put(key, e.getKey());
+            LOG.debug("Key: " + e.getKey() + " Value: " + e.getValue()
+                    + " AssignedKey: " + key + " AssignedWeight: " + e.getValue());
+            key += e.getValue();
+        }
+
+        rwLock.writeLock().lock();
+        try {
+            this.map = map;
+            cummulativeMap = tmpCummulativeMap;
+            randomMax = key;
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+
+    T getNextRandom() {
+        rwLock.readLock().lock();
+        try {
+            // pick a random number between 0 and randMax
+            Double randomNum = randomMax*Math.random();
+            // find the nearest key in the map corresponding to the randomNum
+            Double key = cummulativeMap.floorKey(randomNum);
+            //LOG.info("Random max: " + randomMax + " CummulativeMap size: " + cummulativeMap.size() + " selected key: " + key);
+            return cummulativeMap.get(key);
+        } finally {
+            rwLock.readLock().unlock();
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -78,7 +78,13 @@ public class ClientConfiguration extends AbstractConfiguration {
     protected final static String BOOKIE_ERROR_THRESHOLD_PER_INTERVAL = "bookieErrorThresholdPerInterval";
     protected final static String BOOKIE_QUARANTINE_TIME_SECONDS = "bookieQuarantineTimeSeconds";
 
-    // Number Worker Threads
+    // Bookie info poll interval
+    protected final static String DISK_WEIGHT_BASED_PLACEMENT_ENABLED = "diskWeightBasedPlacementEnabled";
+    protected final static String GET_BOOKIE_INFO_INTERVAL_SECONDS = "getBookieInfoIntervalSeconds";
+    protected final static String BOOKIE_MAX_MULTIPLE_FOR_WEIGHTED_PLACEMENT = "bookieMaxMultipleForWeightBasedPlacement";
+    protected final static String GET_BOOKIE_INFO_TIMEOUT_SECS = "getBookieInfoTimeoutSecs";
+
+    // Number Woker Threads
     protected final static String NUM_WORKER_THREADS = "numWorkerThreads";
 
     // Ensemble Placement Policy
@@ -937,6 +943,82 @@ public class ClientConfiguration extends AbstractConfiguration {
     @Override
     public ClientConfiguration setNettyMaxFrameSizeBytes(int maxSize) {
         super.setNettyMaxFrameSizeBytes(maxSize);
+        return this;
+    }
+ 
+    /**
+     * Get the time interval between successive calls for bookie get info. Default is 24 hours.
+     *
+     * @return
+     */
+    public int getGetBookieInfoIntervalSeconds() {
+        return getInt(GET_BOOKIE_INFO_INTERVAL_SECONDS, 24*60*60);
+    }
+
+    /**
+     * Return whether disk weight based placement policy is enabled
+     * @return
+     */
+    public boolean getDiskWeightBasedPlacementEnabled() {
+        return getBoolean(DISK_WEIGHT_BASED_PLACEMENT_ENABLED, false);
+    }
+
+    /**
+     * Returns the max multiple to use for nodes with very high weight
+     * @return max multiple
+     */
+    public int getBookieMaxWeightMultipleForWeightBasedPlacement() {
+        return getInt(BOOKIE_MAX_MULTIPLE_FOR_WEIGHTED_PLACEMENT, 3);
+    }
+
+    /**
+     * Return the timeout value for getBookieInfo request
+     * @return
+     */
+    public int getBookieInfoTimeout() {
+        return getInteger(GET_BOOKIE_INFO_TIMEOUT_SECS, 5);
+    }
+
+    /**
+     * Set whether or not disk weight based placement is enabled.
+     *
+     * @param isEnabled - boolean indicating enabled or not
+     * @return client configuration
+     */
+    public ClientConfiguration setDiskWeightBasedPlacementEnabled(boolean isEnabled) {
+        setProperty(DISK_WEIGHT_BASED_PLACEMENT_ENABLED, isEnabled);
+        return this;
+    }
+
+    /**
+     * Set the time interval between successive polls for bookie get info.
+     *
+     * @param pollInterval
+     * @param unit
+     * @return client configuration
+     */
+    public ClientConfiguration setGetBookieInfoIntervalSeconds(int pollInterval, TimeUnit unit) {
+        setProperty(GET_BOOKIE_INFO_INTERVAL_SECONDS, unit.toSeconds(pollInterval));
+        return this;
+    }
+
+    /**
+     * Set the max multiple to use for nodes with very high weight
+     * @param multiple
+     * @return client configuration
+     */
+    public ClientConfiguration setBookieMaxWeightMultipleForWeightBasedPlacement(int multiple) {
+        setProperty(BOOKIE_MAX_MULTIPLE_FOR_WEIGHTED_PLACEMENT, multiple);
+        return this;
+    }
+
+    /**
+     * Set the timeout value in secs for the GET_BOOKIE_INFO request
+     * @param timeout
+     * @return client configuration
+     */
+    public ClientConfiguration setGetBookieInfoTimeout(int timeoutSecs) {
+        setProperty(GET_BOOKIE_INFO_TIMEOUT_SECS, timeoutSecs);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -43,7 +43,7 @@ import static org.apache.bookkeeper.bookie.BookKeeperServerStats.READ_ENTRY;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.READ_ENTRY_REQUEST;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.WRITE_LAC;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.READ_LAC;
-
+import static org.apache.bookkeeper.bookie.BookKeeperServerStats.GET_BOOKIE_INFO;
 
 public class BookieRequestProcessor implements RequestProcessor {
 
@@ -78,6 +78,7 @@ public class BookieRequestProcessor implements RequestProcessor {
     final OpStatsLogger readEntryStats;
     final OpStatsLogger writeLacStats;
     final OpStatsLogger readLacStats;
+    final OpStatsLogger getBookieInfoStats;
 
     public BookieRequestProcessor(ServerConfiguration serverCfg, Bookie bookie,
                                   StatsLogger statsLogger) {
@@ -93,6 +94,7 @@ public class BookieRequestProcessor implements RequestProcessor {
         this.readRequestStats = statsLogger.getOpStatsLogger(READ_ENTRY_REQUEST);
         this.writeLacStats = statsLogger.getOpStatsLogger(WRITE_LAC);
         this.readLacStats = statsLogger.getOpStatsLogger(READ_LAC);
+        this.getBookieInfoStats = statsLogger.getOpStatsLogger(GET_BOOKIE_INFO);
     }
 
     @Override
@@ -147,6 +149,9 @@ public class BookieRequestProcessor implements RequestProcessor {
                     break;
                 case READ_LAC:
                     processReadLacRequestV3(r,c);
+                    break;
+                case GET_BOOKIE_INFO:
+                    processGetBookieInfoRequestV3(r,c);
                     break;
                 default:
                     LOG.info("Unknown operation type {}", header.getOperation());
@@ -213,6 +218,15 @@ public class BookieRequestProcessor implements RequestProcessor {
             readLac.run();
         } else {
             readThreadPool.submit(readLac);
+        }
+    }
+
+    private void processGetBookieInfoRequestV3(final BookkeeperProtocol.Request r, final Channel c) {
+        GetBookieInfoProcessorV3 getBookieInfo = new GetBookieInfoProcessorV3(r, c, this);
+        if (null == readThreadPool) {
+            getBookieInfo.run();
+        } else {
+            readThreadPool.submit(getBookieInfo);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
@@ -25,6 +25,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.client.LedgerMetadata;
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.zookeeper.AsyncCallback;
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -86,6 +87,10 @@ public class BookkeeperInternalCallbacks {
 
     public interface ReadEntryCallback {
         void readEntryComplete(int rc, long ledgerId, long entryId, ChannelBuffer buffer, Object ctx);
+    }
+
+    public interface GetBookieInfoCallback {
+        void getBookieInfoComplete(int rc, BookieInfo bInfo, Object ctx);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperProtocol.java
@@ -312,6 +312,10 @@ public final class BookkeeperProtocol {
      * <code>READ_LAC = 7;</code>
      */
     READ_LAC(6, 7),
+    /**
+     * <code>GET_BOOKIE_INFO = 8;</code>
+     */
+    GET_BOOKIE_INFO(7, 8),
     ;
 
     /**
@@ -346,6 +350,10 @@ public final class BookkeeperProtocol {
      * <code>READ_LAC = 7;</code>
      */
     public static final int READ_LAC_VALUE = 7;
+    /**
+     * <code>GET_BOOKIE_INFO = 8;</code>
+     */
+    public static final int GET_BOOKIE_INFO_VALUE = 8;
 
 
     public final int getNumber() { return value; }
@@ -359,6 +367,7 @@ public final class BookkeeperProtocol {
         case 5: return AUTH;
         case 6: return WRITE_LAC;
         case 7: return READ_LAC;
+        case 8: return GET_BOOKIE_INFO;
         default: return null;
       }
     }
@@ -1108,6 +1117,19 @@ public final class BookkeeperProtocol {
      * <code>optional .ReadLacRequest readLacRequest = 104;</code>
      */
     org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequestOrBuilder getReadLacRequestOrBuilder();
+
+    /**
+     * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+     */
+    boolean hasGetBookieInfoRequest();
+    /**
+     * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest getGetBookieInfoRequest();
+    /**
+     * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequestOrBuilder getGetBookieInfoRequestOrBuilder();
   }
   /**
    * Protobuf type {@code Request}
@@ -1237,6 +1259,19 @@ public final class BookkeeperProtocol {
                 readLacRequest_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000020;
+              break;
+            }
+            case 842: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000040) == 0x00000040)) {
+                subBuilder = getBookieInfoRequest_.toBuilder();
+              }
+              getBookieInfoRequest_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(getBookieInfoRequest_);
+                getBookieInfoRequest_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000040;
               break;
             }
           }
@@ -1417,6 +1452,27 @@ public final class BookkeeperProtocol {
       return readLacRequest_;
     }
 
+    public static final int GETBOOKIEINFOREQUEST_FIELD_NUMBER = 105;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest getBookieInfoRequest_;
+    /**
+     * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+     */
+    public boolean hasGetBookieInfoRequest() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest getGetBookieInfoRequest() {
+      return getBookieInfoRequest_;
+    }
+    /**
+     * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequestOrBuilder getGetBookieInfoRequestOrBuilder() {
+      return getBookieInfoRequest_;
+    }
+
     private void initFields() {
       header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
       readRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest.getDefaultInstance();
@@ -1424,6 +1480,7 @@ public final class BookkeeperProtocol {
       authRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
       writeLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest.getDefaultInstance();
       readLacRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest.getDefaultInstance();
+      getBookieInfoRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1494,6 +1551,9 @@ public final class BookkeeperProtocol {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeMessage(104, readLacRequest_);
       }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeMessage(105, getBookieInfoRequest_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -1526,6 +1586,10 @@ public final class BookkeeperProtocol {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(104, readLacRequest_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(105, getBookieInfoRequest_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1642,6 +1706,7 @@ public final class BookkeeperProtocol {
           getAuthRequestFieldBuilder();
           getWriteLacRequestFieldBuilder();
           getReadLacRequestFieldBuilder();
+          getGetBookieInfoRequestFieldBuilder();
         }
       }
       private static Builder create() {
@@ -1686,6 +1751,12 @@ public final class BookkeeperProtocol {
           readLacRequestBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000020);
+        if (getBookieInfoRequestBuilder_ == null) {
+          getBookieInfoRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.getDefaultInstance();
+        } else {
+          getBookieInfoRequestBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -1762,6 +1833,14 @@ public final class BookkeeperProtocol {
         } else {
           result.readLacRequest_ = readLacRequestBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        if (getBookieInfoRequestBuilder_ == null) {
+          result.getBookieInfoRequest_ = getBookieInfoRequest_;
+        } else {
+          result.getBookieInfoRequest_ = getBookieInfoRequestBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1795,6 +1874,9 @@ public final class BookkeeperProtocol {
         }
         if (other.hasReadLacRequest()) {
           mergeReadLacRequest(other.getReadLacRequest());
+        }
+        if (other.hasGetBookieInfoRequest()) {
+          mergeGetBookieInfoRequest(other.getGetBookieInfoRequest());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -2591,6 +2673,122 @@ public final class BookkeeperProtocol {
           readLacRequest_ = null;
         }
         return readLacRequestBuilder_;
+      }
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest getBookieInfoRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequestOrBuilder> getBookieInfoRequestBuilder_;
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      public boolean hasGetBookieInfoRequest() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest getGetBookieInfoRequest() {
+        if (getBookieInfoRequestBuilder_ == null) {
+          return getBookieInfoRequest_;
+        } else {
+          return getBookieInfoRequestBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      public Builder setGetBookieInfoRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest value) {
+        if (getBookieInfoRequestBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          getBookieInfoRequest_ = value;
+          onChanged();
+        } else {
+          getBookieInfoRequestBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      public Builder setGetBookieInfoRequest(
+          org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.Builder builderForValue) {
+        if (getBookieInfoRequestBuilder_ == null) {
+          getBookieInfoRequest_ = builderForValue.build();
+          onChanged();
+        } else {
+          getBookieInfoRequestBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      public Builder mergeGetBookieInfoRequest(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest value) {
+        if (getBookieInfoRequestBuilder_ == null) {
+          if (((bitField0_ & 0x00000040) == 0x00000040) &&
+              getBookieInfoRequest_ != org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.getDefaultInstance()) {
+            getBookieInfoRequest_ =
+              org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.newBuilder(getBookieInfoRequest_).mergeFrom(value).buildPartial();
+          } else {
+            getBookieInfoRequest_ = value;
+          }
+          onChanged();
+        } else {
+          getBookieInfoRequestBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      public Builder clearGetBookieInfoRequest() {
+        if (getBookieInfoRequestBuilder_ == null) {
+          getBookieInfoRequest_ = org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.getDefaultInstance();
+          onChanged();
+        } else {
+          getBookieInfoRequestBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000040);
+        return this;
+      }
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.Builder getGetBookieInfoRequestBuilder() {
+        bitField0_ |= 0x00000040;
+        onChanged();
+        return getGetBookieInfoRequestFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequestOrBuilder getGetBookieInfoRequestOrBuilder() {
+        if (getBookieInfoRequestBuilder_ != null) {
+          return getBookieInfoRequestBuilder_.getMessageOrBuilder();
+        } else {
+          return getBookieInfoRequest_;
+        }
+      }
+      /**
+       * <code>optional .GetBookieInfoRequest getBookieInfoRequest = 105;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequestOrBuilder> 
+          getGetBookieInfoRequestFieldBuilder() {
+        if (getBookieInfoRequestBuilder_ == null) {
+          getBookieInfoRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequestOrBuilder>(
+                  getGetBookieInfoRequest(),
+                  getParentForChildren(),
+                  isClean());
+          getBookieInfoRequest_ = null;
+        }
+        return getBookieInfoRequestBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:Request)
@@ -5303,6 +5501,517 @@ public final class BookkeeperProtocol {
     // @@protoc_insertion_point(class_scope:ReadLacRequest)
   }
 
+  public interface GetBookieInfoRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:GetBookieInfoRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int64 requested = 1;</code>
+     *
+     * <pre>
+     * bitwise OR of Flags
+     * </pre>
+     */
+    boolean hasRequested();
+    /**
+     * <code>optional int64 requested = 1;</code>
+     *
+     * <pre>
+     * bitwise OR of Flags
+     * </pre>
+     */
+    long getRequested();
+  }
+  /**
+   * Protobuf type {@code GetBookieInfoRequest}
+   */
+  public static final class GetBookieInfoRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:GetBookieInfoRequest)
+      GetBookieInfoRequestOrBuilder {
+    // Use GetBookieInfoRequest.newBuilder() to construct.
+    private GetBookieInfoRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private GetBookieInfoRequest(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final GetBookieInfoRequest defaultInstance;
+    public static GetBookieInfoRequest getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public GetBookieInfoRequest getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GetBookieInfoRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              requested_ = input.readInt64();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoRequest_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<GetBookieInfoRequest> PARSER =
+        new com.google.protobuf.AbstractParser<GetBookieInfoRequest>() {
+      public GetBookieInfoRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GetBookieInfoRequest(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GetBookieInfoRequest> getParserForType() {
+      return PARSER;
+    }
+
+    /**
+     * Protobuf enum {@code GetBookieInfoRequest.Flags}
+     */
+    public enum Flags
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>TOTAL_DISK_CAPACITY = 1;</code>
+       */
+      TOTAL_DISK_CAPACITY(0, 1),
+      /**
+       * <code>FREE_DISK_SPACE = 2;</code>
+       */
+      FREE_DISK_SPACE(1, 2),
+      ;
+
+      /**
+       * <code>TOTAL_DISK_CAPACITY = 1;</code>
+       */
+      public static final int TOTAL_DISK_CAPACITY_VALUE = 1;
+      /**
+       * <code>FREE_DISK_SPACE = 2;</code>
+       */
+      public static final int FREE_DISK_SPACE_VALUE = 2;
+
+
+      public final int getNumber() { return value; }
+
+      public static Flags valueOf(int value) {
+        switch (value) {
+          case 1: return TOTAL_DISK_CAPACITY;
+          case 2: return FREE_DISK_SPACE;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<Flags>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static com.google.protobuf.Internal.EnumLiteMap<Flags>
+          internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<Flags>() {
+              public Flags findValueByNumber(int number) {
+                return Flags.valueOf(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(index);
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final Flags[] VALUES = values();
+
+      public static Flags valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int index;
+      private final int value;
+
+      private Flags(int index, int value) {
+        this.index = index;
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:GetBookieInfoRequest.Flags)
+    }
+
+    private int bitField0_;
+    public static final int REQUESTED_FIELD_NUMBER = 1;
+    private long requested_;
+    /**
+     * <code>optional int64 requested = 1;</code>
+     *
+     * <pre>
+     * bitwise OR of Flags
+     * </pre>
+     */
+    public boolean hasRequested() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional int64 requested = 1;</code>
+     *
+     * <pre>
+     * bitwise OR of Flags
+     * </pre>
+     */
+    public long getRequested() {
+      return requested_;
+    }
+
+    private void initFields() {
+      requested_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, requested_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, requested_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code GetBookieInfoRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:GetBookieInfoRequest)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoRequest_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.class, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        requested_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoRequest_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest result = new org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.requested_ = requested_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest.getDefaultInstance()) return this;
+        if (other.hasRequested()) {
+          setRequested(other.getRequested());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long requested_ ;
+      /**
+       * <code>optional int64 requested = 1;</code>
+       *
+       * <pre>
+       * bitwise OR of Flags
+       * </pre>
+       */
+      public boolean hasRequested() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional int64 requested = 1;</code>
+       *
+       * <pre>
+       * bitwise OR of Flags
+       * </pre>
+       */
+      public long getRequested() {
+        return requested_;
+      }
+      /**
+       * <code>optional int64 requested = 1;</code>
+       *
+       * <pre>
+       * bitwise OR of Flags
+       * </pre>
+       */
+      public Builder setRequested(long value) {
+        bitField0_ |= 0x00000001;
+        requested_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 requested = 1;</code>
+       *
+       * <pre>
+       * bitwise OR of Flags
+       * </pre>
+       */
+      public Builder clearRequested() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        requested_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:GetBookieInfoRequest)
+    }
+
+    static {
+      defaultInstance = new GetBookieInfoRequest(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:GetBookieInfoRequest)
+  }
+
   public interface ResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Response)
       com.google.protobuf.MessageOrBuilder {
@@ -5415,6 +6124,19 @@ public final class BookkeeperProtocol {
      * <code>optional .ReadLacResponse readLacResponse = 104;</code>
      */
     org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponseOrBuilder getReadLacResponseOrBuilder();
+
+    /**
+     * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+     */
+    boolean hasGetBookieInfoResponse();
+    /**
+     * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse getGetBookieInfoResponse();
+    /**
+     * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponseOrBuilder getGetBookieInfoResponseOrBuilder();
   }
   /**
    * Protobuf type {@code Response}
@@ -5555,6 +6277,19 @@ public final class BookkeeperProtocol {
                 readLacResponse_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000040;
+              break;
+            }
+            case 842: {
+              org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000080) == 0x00000080)) {
+                subBuilder = getBookieInfoResponse_.toBuilder();
+              }
+              getBookieInfoResponse_ = input.readMessage(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(getBookieInfoResponse_);
+                getBookieInfoResponse_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000080;
               break;
             }
           }
@@ -5760,6 +6495,27 @@ public final class BookkeeperProtocol {
       return readLacResponse_;
     }
 
+    public static final int GETBOOKIEINFORESPONSE_FIELD_NUMBER = 105;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse getBookieInfoResponse_;
+    /**
+     * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+     */
+    public boolean hasGetBookieInfoResponse() {
+      return ((bitField0_ & 0x00000080) == 0x00000080);
+    }
+    /**
+     * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse getGetBookieInfoResponse() {
+      return getBookieInfoResponse_;
+    }
+    /**
+     * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponseOrBuilder getGetBookieInfoResponseOrBuilder() {
+      return getBookieInfoResponse_;
+    }
+
     private void initFields() {
       header_ = org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader.getDefaultInstance();
       status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
@@ -5768,6 +6524,7 @@ public final class BookkeeperProtocol {
       authResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage.getDefaultInstance();
       writeLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse.getDefaultInstance();
       readLacResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse.getDefaultInstance();
+      getBookieInfoResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -5817,6 +6574,12 @@ public final class BookkeeperProtocol {
           return false;
         }
       }
+      if (hasGetBookieInfoResponse()) {
+        if (!getGetBookieInfoResponse().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -5844,6 +6607,9 @@ public final class BookkeeperProtocol {
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         output.writeMessage(104, readLacResponse_);
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        output.writeMessage(105, getBookieInfoResponse_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -5881,6 +6647,10 @@ public final class BookkeeperProtocol {
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(104, readLacResponse_);
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(105, getBookieInfoResponse_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -5997,6 +6767,7 @@ public final class BookkeeperProtocol {
           getAuthResponseFieldBuilder();
           getWriteLacResponseFieldBuilder();
           getReadLacResponseFieldBuilder();
+          getGetBookieInfoResponseFieldBuilder();
         }
       }
       private static Builder create() {
@@ -6043,6 +6814,12 @@ public final class BookkeeperProtocol {
           readLacResponseBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000040);
+        if (getBookieInfoResponseBuilder_ == null) {
+          getBookieInfoResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.getDefaultInstance();
+        } else {
+          getBookieInfoResponseBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000080);
         return this;
       }
 
@@ -6123,6 +6900,14 @@ public final class BookkeeperProtocol {
         } else {
           result.readLacResponse_ = readLacResponseBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000080;
+        }
+        if (getBookieInfoResponseBuilder_ == null) {
+          result.getBookieInfoResponse_ = getBookieInfoResponse_;
+        } else {
+          result.getBookieInfoResponse_ = getBookieInfoResponseBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -6159,6 +6944,9 @@ public final class BookkeeperProtocol {
         }
         if (other.hasReadLacResponse()) {
           mergeReadLacResponse(other.getReadLacResponse());
+        }
+        if (other.hasGetBookieInfoResponse()) {
+          mergeGetBookieInfoResponse(other.getGetBookieInfoResponse());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -6203,6 +6991,12 @@ public final class BookkeeperProtocol {
         }
         if (hasReadLacResponse()) {
           if (!getReadLacResponse().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasGetBookieInfoResponse()) {
+          if (!getGetBookieInfoResponse().isInitialized()) {
             
             return false;
           }
@@ -7014,6 +7808,122 @@ public final class BookkeeperProtocol {
           readLacResponse_ = null;
         }
         return readLacResponseBuilder_;
+      }
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse getBookieInfoResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponseOrBuilder> getBookieInfoResponseBuilder_;
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      public boolean hasGetBookieInfoResponse() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse getGetBookieInfoResponse() {
+        if (getBookieInfoResponseBuilder_ == null) {
+          return getBookieInfoResponse_;
+        } else {
+          return getBookieInfoResponseBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      public Builder setGetBookieInfoResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse value) {
+        if (getBookieInfoResponseBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          getBookieInfoResponse_ = value;
+          onChanged();
+        } else {
+          getBookieInfoResponseBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      public Builder setGetBookieInfoResponse(
+          org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.Builder builderForValue) {
+        if (getBookieInfoResponseBuilder_ == null) {
+          getBookieInfoResponse_ = builderForValue.build();
+          onChanged();
+        } else {
+          getBookieInfoResponseBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      public Builder mergeGetBookieInfoResponse(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse value) {
+        if (getBookieInfoResponseBuilder_ == null) {
+          if (((bitField0_ & 0x00000080) == 0x00000080) &&
+              getBookieInfoResponse_ != org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.getDefaultInstance()) {
+            getBookieInfoResponse_ =
+              org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.newBuilder(getBookieInfoResponse_).mergeFrom(value).buildPartial();
+          } else {
+            getBookieInfoResponse_ = value;
+          }
+          onChanged();
+        } else {
+          getBookieInfoResponseBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      public Builder clearGetBookieInfoResponse() {
+        if (getBookieInfoResponseBuilder_ == null) {
+          getBookieInfoResponse_ = org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.getDefaultInstance();
+          onChanged();
+        } else {
+          getBookieInfoResponseBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000080);
+        return this;
+      }
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.Builder getGetBookieInfoResponseBuilder() {
+        bitField0_ |= 0x00000080;
+        onChanged();
+        return getGetBookieInfoResponseFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponseOrBuilder getGetBookieInfoResponseOrBuilder() {
+        if (getBookieInfoResponseBuilder_ != null) {
+          return getBookieInfoResponseBuilder_.getMessageOrBuilder();
+        } else {
+          return getBookieInfoResponse_;
+        }
+      }
+      /**
+       * <code>optional .GetBookieInfoResponse getBookieInfoResponse = 105;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponseOrBuilder> 
+          getGetBookieInfoResponseFieldBuilder() {
+        if (getBookieInfoResponseBuilder_ == null) {
+          getBookieInfoResponseBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.Builder, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponseOrBuilder>(
+                  getGetBookieInfoResponse(),
+                  getParentForChildren(),
+                  isClean());
+          getBookieInfoResponse_ = null;
+        }
+        return getBookieInfoResponseBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:Response)
@@ -10079,6 +10989,576 @@ public final class BookkeeperProtocol {
     // @@protoc_insertion_point(class_scope:ReadLacResponse)
   }
 
+  public interface GetBookieInfoResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:GetBookieInfoResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    boolean hasStatus();
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus();
+
+    /**
+     * <code>optional int64 totalDiskCapacity = 2;</code>
+     */
+    boolean hasTotalDiskCapacity();
+    /**
+     * <code>optional int64 totalDiskCapacity = 2;</code>
+     */
+    long getTotalDiskCapacity();
+
+    /**
+     * <code>optional int64 freeDiskSpace = 3;</code>
+     */
+    boolean hasFreeDiskSpace();
+    /**
+     * <code>optional int64 freeDiskSpace = 3;</code>
+     */
+    long getFreeDiskSpace();
+  }
+  /**
+   * Protobuf type {@code GetBookieInfoResponse}
+   */
+  public static final class GetBookieInfoResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:GetBookieInfoResponse)
+      GetBookieInfoResponseOrBuilder {
+    // Use GetBookieInfoResponse.newBuilder() to construct.
+    private GetBookieInfoResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private GetBookieInfoResponse(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final GetBookieInfoResponse defaultInstance;
+    public static GetBookieInfoResponse getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public GetBookieInfoResponse getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GetBookieInfoResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              int rawValue = input.readEnum();
+              org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(1, rawValue);
+              } else {
+                bitField0_ |= 0x00000001;
+                status_ = value;
+              }
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              totalDiskCapacity_ = input.readInt64();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              freeDiskSpace_ = input.readInt64();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoResponse_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<GetBookieInfoResponse> PARSER =
+        new com.google.protobuf.AbstractParser<GetBookieInfoResponse>() {
+      public GetBookieInfoResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GetBookieInfoResponse(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GetBookieInfoResponse> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int STATUS_FIELD_NUMBER = 1;
+    private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_;
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    public boolean hasStatus() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required .StatusCode status = 1;</code>
+     */
+    public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
+      return status_;
+    }
+
+    public static final int TOTALDISKCAPACITY_FIELD_NUMBER = 2;
+    private long totalDiskCapacity_;
+    /**
+     * <code>optional int64 totalDiskCapacity = 2;</code>
+     */
+    public boolean hasTotalDiskCapacity() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional int64 totalDiskCapacity = 2;</code>
+     */
+    public long getTotalDiskCapacity() {
+      return totalDiskCapacity_;
+    }
+
+    public static final int FREEDISKSPACE_FIELD_NUMBER = 3;
+    private long freeDiskSpace_;
+    /**
+     * <code>optional int64 freeDiskSpace = 3;</code>
+     */
+    public boolean hasFreeDiskSpace() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional int64 freeDiskSpace = 3;</code>
+     */
+    public long getFreeDiskSpace() {
+      return freeDiskSpace_;
+    }
+
+    private void initFields() {
+      status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      totalDiskCapacity_ = 0L;
+      freeDiskSpace_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasStatus()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeEnum(1, status_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(2, totalDiskCapacity_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt64(3, freeDiskSpace_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(1, status_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, totalDiskCapacity_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(3, freeDiskSpace_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code GetBookieInfoResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:GetBookieInfoResponse)
+        org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoResponse_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.class, org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.Builder.class);
+      }
+
+      // Construct using org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        totalDiskCapacity_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        freeDiskSpace_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.internal_static_GetBookieInfoResponse_descriptor;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse getDefaultInstanceForType() {
+        return org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.getDefaultInstance();
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse build() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse buildPartial() {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse result = new org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.status_ = status_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.totalDiskCapacity_ = totalDiskCapacity_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.freeDiskSpace_ = freeDiskSpace_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse) {
+          return mergeFrom((org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse other) {
+        if (other == org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse.getDefaultInstance()) return this;
+        if (other.hasStatus()) {
+          setStatus(other.getStatus());
+        }
+        if (other.hasTotalDiskCapacity()) {
+          setTotalDiskCapacity(other.getTotalDiskCapacity());
+        }
+        if (other.hasFreeDiskSpace()) {
+          setFreeDiskSpace(other.getFreeDiskSpace());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasStatus()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public boolean hasStatus() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode getStatus() {
+        return status_;
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public Builder setStatus(org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
+        status_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required .StatusCode status = 1;</code>
+       */
+      public Builder clearStatus() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        status_ = org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode.EOK;
+        onChanged();
+        return this;
+      }
+
+      private long totalDiskCapacity_ ;
+      /**
+       * <code>optional int64 totalDiskCapacity = 2;</code>
+       */
+      public boolean hasTotalDiskCapacity() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional int64 totalDiskCapacity = 2;</code>
+       */
+      public long getTotalDiskCapacity() {
+        return totalDiskCapacity_;
+      }
+      /**
+       * <code>optional int64 totalDiskCapacity = 2;</code>
+       */
+      public Builder setTotalDiskCapacity(long value) {
+        bitField0_ |= 0x00000002;
+        totalDiskCapacity_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 totalDiskCapacity = 2;</code>
+       */
+      public Builder clearTotalDiskCapacity() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        totalDiskCapacity_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long freeDiskSpace_ ;
+      /**
+       * <code>optional int64 freeDiskSpace = 3;</code>
+       */
+      public boolean hasFreeDiskSpace() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional int64 freeDiskSpace = 3;</code>
+       */
+      public long getFreeDiskSpace() {
+        return freeDiskSpace_;
+      }
+      /**
+       * <code>optional int64 freeDiskSpace = 3;</code>
+       */
+      public Builder setFreeDiskSpace(long value) {
+        bitField0_ |= 0x00000004;
+        freeDiskSpace_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 freeDiskSpace = 3;</code>
+       */
+      public Builder clearFreeDiskSpace() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        freeDiskSpace_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:GetBookieInfoResponse)
+    }
+
+    static {
+      defaultInstance = new GetBookieInfoResponse(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:GetBookieInfoResponse)
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_BKPacketHeader_descriptor;
   private static
@@ -10110,6 +11590,11 @@ public final class BookkeeperProtocol {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ReadLacRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_GetBookieInfoRequest_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_GetBookieInfoRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_Response_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -10139,6 +11624,11 @@ public final class BookkeeperProtocol {
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ReadLacResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_GetBookieInfoResponse_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_GetBookieInfoResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -10151,49 +11641,57 @@ public final class BookkeeperProtocol {
       "\n\'src/main/proto/BookkeeperProtocol.prot" +
       "o\"e\n\016BKPacketHeader\022!\n\007version\030\001 \002(\0162\020.P" +
       "rotocolVersion\022!\n\toperation\030\002 \002(\0162\016.Oper" +
-      "ationType\022\r\n\005txnId\030\003 \002(\004\"\345\001\n\007Request\022\037\n\006" +
+      "ationType\022\r\n\005txnId\030\003 \002(\004\"\232\002\n\007Request\022\037\n\006" +
       "header\030\001 \002(\0132\017.BKPacketHeader\022!\n\013readReq" +
       "uest\030d \001(\0132\014.ReadRequest\022\037\n\naddRequest\030e" +
       " \001(\0132\013.AddRequest\022!\n\013authRequest\030f \001(\0132\014" +
       ".AuthMessage\022)\n\017writeLacRequest\030g \001(\0132\020." +
       "WriteLacRequest\022\'\n\016readLacRequest\030h \001(\0132" +
-      "\017.ReadLacRequest\"~\n\013ReadRequest\022\037\n\004flag\030",
-      "d \001(\0162\021.ReadRequest.Flag\022\020\n\010ledgerId\030\001 \002" +
-      "(\003\022\017\n\007entryId\030\002 \002(\003\022\021\n\tmasterKey\030\003 \001(\014\"\030" +
-      "\n\004Flag\022\020\n\014FENCE_LEDGER\020\001\"\212\001\n\nAddRequest\022" +
-      "\036\n\004flag\030d \001(\0162\020.AddRequest.Flag\022\020\n\010ledge" +
-      "rId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\022\021\n\tmasterKey\030" +
-      "\003 \002(\014\022\014\n\004body\030\004 \002(\014\"\030\n\004Flag\022\020\n\014RECOVERY_" +
-      "ADD\020\001\"Q\n\017WriteLacRequest\022\020\n\010ledgerId\030\001 \002" +
-      "(\003\022\013\n\003lac\030\002 \002(\003\022\021\n\tmasterKey\030\003 \002(\014\022\014\n\004bo" +
-      "dy\030\004 \002(\014\"\"\n\016ReadLacRequest\022\020\n\010ledgerId\030\001" +
-      " \002(\003\"\214\002\n\010Response\022\037\n\006header\030\001 \002(\0132\017.BKPa",
-      "cketHeader\022\033\n\006status\030\002 \002(\0162\013.StatusCode\022" +
-      "#\n\014readResponse\030d \001(\0132\r.ReadResponse\022!\n\013" +
-      "addResponse\030e \001(\0132\014.AddResponse\022\"\n\014authR" +
-      "esponse\030f \001(\0132\014.AuthMessage\022+\n\020writeLacR" +
-      "esponse\030g \001(\0132\021.WriteLacResponse\022)\n\017read" +
-      "LacResponse\030h \001(\0132\020.ReadLacResponse\"\\\n\014R" +
-      "eadResponse\022\033\n\006status\030\001 \002(\0162\013.StatusCode" +
-      "\022\020\n\010ledgerId\030\002 \002(\003\022\017\n\007entryId\030\003 \002(\003\022\014\n\004b" +
-      "ody\030\004 \001(\014\"M\n\013AddResponse\022\033\n\006status\030\001 \002(\016" +
-      "2\013.StatusCode\022\020\n\010ledgerId\030\002 \002(\003\022\017\n\007entry",
-      "Id\030\003 \002(\003\"6\n\013AuthMessage\022\026\n\016authPluginNam" +
-      "e\030\001 \002(\t\022\017\n\007payload\030\002 \002(\014\"A\n\020WriteLacResp" +
-      "onse\022\033\n\006status\030\001 \002(\0162\013.StatusCode\022\020\n\010led" +
-      "gerId\030\002 \002(\003\"h\n\017ReadLacResponse\022\033\n\006status" +
+      "\017.ReadLacRequest\0223\n\024getBookieInfoRequest",
+      "\030i \001(\0132\025.GetBookieInfoRequest\"~\n\013ReadReq" +
+      "uest\022\037\n\004flag\030d \001(\0162\021.ReadRequest.Flag\022\020\n" +
+      "\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\022\021\n\tmast" +
+      "erKey\030\003 \001(\014\"\030\n\004Flag\022\020\n\014FENCE_LEDGER\020\001\"\212\001" +
+      "\n\nAddRequest\022\036\n\004flag\030d \001(\0162\020.AddRequest." +
+      "Flag\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\022" +
+      "\021\n\tmasterKey\030\003 \002(\014\022\014\n\004body\030\004 \002(\014\"\030\n\004Flag" +
+      "\022\020\n\014RECOVERY_ADD\020\001\"Q\n\017WriteLacRequest\022\020\n" +
+      "\010ledgerId\030\001 \002(\003\022\013\n\003lac\030\002 \002(\003\022\021\n\tmasterKe" +
+      "y\030\003 \002(\014\022\014\n\004body\030\004 \002(\014\"\"\n\016ReadLacRequest\022",
+      "\020\n\010ledgerId\030\001 \002(\003\"`\n\024GetBookieInfoReques" +
+      "t\022\021\n\trequested\030\001 \001(\003\"5\n\005Flags\022\027\n\023TOTAL_D" +
+      "ISK_CAPACITY\020\001\022\023\n\017FREE_DISK_SPACE\020\002\"\303\002\n\010" +
+      "Response\022\037\n\006header\030\001 \002(\0132\017.BKPacketHeade" +
+      "r\022\033\n\006status\030\002 \002(\0162\013.StatusCode\022#\n\014readRe" +
+      "sponse\030d \001(\0132\r.ReadResponse\022!\n\013addRespon" +
+      "se\030e \001(\0132\014.AddResponse\022\"\n\014authResponse\030f" +
+      " \001(\0132\014.AuthMessage\022+\n\020writeLacResponse\030g" +
+      " \001(\0132\021.WriteLacResponse\022)\n\017readLacRespon" +
+      "se\030h \001(\0132\020.ReadLacResponse\0225\n\025getBookieI",
+      "nfoResponse\030i \001(\0132\026.GetBookieInfoRespons" +
+      "e\"\\\n\014ReadResponse\022\033\n\006status\030\001 \002(\0162\013.Stat" +
+      "usCode\022\020\n\010ledgerId\030\002 \002(\003\022\017\n\007entryId\030\003 \002(" +
+      "\003\022\014\n\004body\030\004 \001(\014\"M\n\013AddResponse\022\033\n\006status" +
       "\030\001 \002(\0162\013.StatusCode\022\020\n\010ledgerId\030\002 \002(\003\022\017\n" +
-      "\007lacBody\030\003 \001(\014\022\025\n\rlastEntryBody\030\004 \001(\014*F\n" +
-      "\017ProtocolVersion\022\017\n\013VERSION_ONE\020\001\022\017\n\013VER" +
-      "SION_TWO\020\002\022\021\n\rVERSION_THREE\020\003*\206\001\n\nStatus" +
-      "Code\022\007\n\003EOK\020\000\022\016\n\tENOLEDGER\020\222\003\022\r\n\010ENOENTR" +
-      "Y\020\223\003\022\014\n\007EBADREQ\020\224\003\022\010\n\003EIO\020\365\003\022\010\n\003EUA\020\366\003\022\020",
-      "\n\013EBADVERSION\020\367\003\022\014\n\007EFENCED\020\370\003\022\016\n\tEREADO" +
-      "NLY\020\371\003*\200\001\n\rOperationType\022\016\n\nREAD_ENTRY\020\001" +
-      "\022\r\n\tADD_ENTRY\020\002\022\024\n\020RANGE_READ_ENTRY\020\003\022\023\n" +
-      "\017RANGE_ADD_ENTRY\020\004\022\010\n\004AUTH\020\005\022\r\n\tWRITE_LA" +
-      "C\020\006\022\014\n\010READ_LAC\020\007B\037\n\033org.apache.bookkeep" +
-      "er.protoH\001"
+      "\007entryId\030\003 \002(\003\"6\n\013AuthMessage\022\026\n\016authPlu" +
+      "ginName\030\001 \002(\t\022\017\n\007payload\030\002 \002(\014\"A\n\020WriteL" +
+      "acResponse\022\033\n\006status\030\001 \002(\0162\013.StatusCode\022" +
+      "\020\n\010ledgerId\030\002 \002(\003\"h\n\017ReadLacResponse\022\033\n\006" +
+      "status\030\001 \002(\0162\013.StatusCode\022\020\n\010ledgerId\030\002 ",
+      "\002(\003\022\017\n\007lacBody\030\003 \001(\014\022\025\n\rlastEntryBody\030\004 " +
+      "\001(\014\"f\n\025GetBookieInfoResponse\022\033\n\006status\030\001" +
+      " \002(\0162\013.StatusCode\022\031\n\021totalDiskCapacity\030\002" +
+      " \001(\003\022\025\n\rfreeDiskSpace\030\003 \001(\003*F\n\017ProtocolV" +
+      "ersion\022\017\n\013VERSION_ONE\020\001\022\017\n\013VERSION_TWO\020\002" +
+      "\022\021\n\rVERSION_THREE\020\003*\206\001\n\nStatusCode\022\007\n\003EO" +
+      "K\020\000\022\016\n\tENOLEDGER\020\222\003\022\r\n\010ENOENTRY\020\223\003\022\014\n\007EB" +
+      "ADREQ\020\224\003\022\010\n\003EIO\020\365\003\022\010\n\003EUA\020\366\003\022\020\n\013EBADVERS" +
+      "ION\020\367\003\022\014\n\007EFENCED\020\370\003\022\016\n\tEREADONLY\020\371\003*\225\001\n" +
+      "\rOperationType\022\016\n\nREAD_ENTRY\020\001\022\r\n\tADD_EN",
+      "TRY\020\002\022\024\n\020RANGE_READ_ENTRY\020\003\022\023\n\017RANGE_ADD" +
+      "_ENTRY\020\004\022\010\n\004AUTH\020\005\022\r\n\tWRITE_LAC\020\006\022\014\n\010REA" +
+      "D_LAC\020\007\022\023\n\017GET_BOOKIE_INFO\020\010B\037\n\033org.apac" +
+      "he.bookkeeper.protoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -10218,7 +11716,7 @@ public final class BookkeeperProtocol {
     internal_static_Request_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Request_descriptor,
-        new java.lang.String[] { "Header", "ReadRequest", "AddRequest", "AuthRequest", "WriteLacRequest", "ReadLacRequest", });
+        new java.lang.String[] { "Header", "ReadRequest", "AddRequest", "AuthRequest", "WriteLacRequest", "ReadLacRequest", "GetBookieInfoRequest", });
     internal_static_ReadRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_ReadRequest_fieldAccessorTable = new
@@ -10243,42 +11741,54 @@ public final class BookkeeperProtocol {
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ReadLacRequest_descriptor,
         new java.lang.String[] { "LedgerId", });
-    internal_static_Response_descriptor =
+    internal_static_GetBookieInfoRequest_descriptor =
       getDescriptor().getMessageTypes().get(6);
+    internal_static_GetBookieInfoRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_GetBookieInfoRequest_descriptor,
+        new java.lang.String[] { "Requested", });
+    internal_static_Response_descriptor =
+      getDescriptor().getMessageTypes().get(7);
     internal_static_Response_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Response_descriptor,
-        new java.lang.String[] { "Header", "Status", "ReadResponse", "AddResponse", "AuthResponse", "WriteLacResponse", "ReadLacResponse", });
+        new java.lang.String[] { "Header", "Status", "ReadResponse", "AddResponse", "AuthResponse", "WriteLacResponse", "ReadLacResponse", "GetBookieInfoResponse", });
     internal_static_ReadResponse_descriptor =
-      getDescriptor().getMessageTypes().get(7);
+      getDescriptor().getMessageTypes().get(8);
     internal_static_ReadResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ReadResponse_descriptor,
         new java.lang.String[] { "Status", "LedgerId", "EntryId", "Body", });
     internal_static_AddResponse_descriptor =
-      getDescriptor().getMessageTypes().get(8);
+      getDescriptor().getMessageTypes().get(9);
     internal_static_AddResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_AddResponse_descriptor,
         new java.lang.String[] { "Status", "LedgerId", "EntryId", });
     internal_static_AuthMessage_descriptor =
-      getDescriptor().getMessageTypes().get(9);
+      getDescriptor().getMessageTypes().get(10);
     internal_static_AuthMessage_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_AuthMessage_descriptor,
         new java.lang.String[] { "AuthPluginName", "Payload", });
     internal_static_WriteLacResponse_descriptor =
-      getDescriptor().getMessageTypes().get(10);
+      getDescriptor().getMessageTypes().get(11);
     internal_static_WriteLacResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_WriteLacResponse_descriptor,
         new java.lang.String[] { "Status", "LedgerId", });
     internal_static_ReadLacResponse_descriptor =
-      getDescriptor().getMessageTypes().get(11);
+      getDescriptor().getMessageTypes().get(12);
     internal_static_ReadLacResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ReadLacResponse_descriptor,
         new java.lang.String[] { "Status", "LedgerId", "LacBody", "LastEntryBody", });
+    internal_static_GetBookieInfoResponse_descriptor =
+      getDescriptor().getMessageTypes().get(13);
+    internal_static_GetBookieInfoResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_GetBookieInfoResponse_descriptor,
+        new java.lang.String[] { "Status", "TotalDiskCapacity", "FreeDiskSpace", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetBookieInfoProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetBookieInfoProcessorV3.java
@@ -1,0 +1,90 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.proto;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.Response;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
+import org.apache.bookkeeper.util.MathUtils;
+import org.jboss.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GetBookieInfoProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
+    private final static Logger LOG = LoggerFactory.getLogger(GetBookieInfoProcessorV3.class);
+
+    public GetBookieInfoProcessorV3(Request request, Channel channel,
+                                     BookieRequestProcessor requestProcessor) {
+        super(request, channel, requestProcessor);
+    }
+
+    private GetBookieInfoResponse getGetBookieInfoResponse() {
+        long startTimeNanos = MathUtils.nowInNano();
+        GetBookieInfoRequest getBookieInfoRequest = request.getGetBookieInfoRequest();
+        long requested = getBookieInfoRequest.getRequested();
+
+        GetBookieInfoResponse.Builder getBookieInfoResponse = GetBookieInfoResponse.newBuilder();
+
+        if (!isVersionCompatible()) {
+            getBookieInfoResponse.setStatus(StatusCode.EBADVERSION);
+            requestProcessor.getBookieInfoStats.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos),
+                    TimeUnit.NANOSECONDS);
+            return getBookieInfoResponse.build();
+        }
+
+        LOG.debug("Received new getBookieInfo request: {}", request);
+        StatusCode status = StatusCode.EOK;
+        long freeDiskSpace = 0L, totalDiskSpace = 0L;
+        if ((requested & GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE) != 0) {
+            freeDiskSpace = requestProcessor.bookie.getTotalFreeSpace();
+            getBookieInfoResponse.setFreeDiskSpace(freeDiskSpace);
+        }
+        if ((requested & GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE) != 0) {
+            totalDiskSpace = requestProcessor.bookie.getTotalDiskSpace();
+            getBookieInfoResponse.setTotalDiskCapacity(totalDiskSpace);
+        }
+        LOG.debug("FreeDiskSpace info is " + freeDiskSpace + " totalDiskSpace is: " + totalDiskSpace);
+        getBookieInfoResponse.setStatus(status);
+        requestProcessor.getBookieInfoStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),
+                TimeUnit.NANOSECONDS);
+        return getBookieInfoResponse.build();
+    }
+
+    @Override
+    public void safeRun() {
+        GetBookieInfoResponse getBookieInfoResponse = getGetBookieInfoResponse();
+        sendResponse(getBookieInfoResponse);
+    }
+
+    private void sendResponse(GetBookieInfoResponse getBookieInfoResponse) {
+        Response.Builder response = Response.newBuilder()
+                .setHeader(getHeader())
+                .setStatus(getBookieInfoResponse.getStatus())
+                .setGetBookieInfoResponse(getBookieInfoResponse);
+        sendResponse(response.getStatus(),
+                     response.build(),
+                     requestProcessor.getBookieInfoStats);
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -32,25 +32,29 @@ import org.apache.bookkeeper.auth.ClientAuthProvider;
 import com.google.protobuf.ByteString;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeperClientStats;
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GetBookieInfoCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader;
-import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest;
-import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion;
-import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest;
-import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadLacResponse;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.Response;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
@@ -127,6 +131,7 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
     final int addEntryTimeout;
     final int readEntryTimeout;
     final int maxFrameSize;
+    final int getBookieInfoTimeout;
 
     private final ConcurrentHashMap<CompletionKey, CompletionValue> completionObjects = new ConcurrentHashMap<CompletionKey, CompletionValue>();
 
@@ -139,6 +144,8 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
     private final OpStatsLogger addTimeoutOpLogger;
     private final OpStatsLogger writeLacTimeoutOpLogger;
     private final OpStatsLogger readLacTimeoutOpLogger;
+    private final OpStatsLogger getBookieInfoOpLogger;
+    private final OpStatsLogger getBookieInfoTimeoutOpLogger;
 
     /**
      * The following member variables do not need to be concurrent, or volatile
@@ -194,6 +201,7 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
         this.requestTimer = requestTimer;
         this.addEntryTimeout = conf.getAddEntryTimeout();
         this.readEntryTimeout = conf.getReadEntryTimeout();
+        this.getBookieInfoTimeout = conf.getBookieInfoTimeout();
 
         this.authProviderFactory = authProviderFactory;
         this.extRegistry = extRegistry;
@@ -209,10 +217,12 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
         addEntryOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_ADD_OP);
         writeLacOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_WRITE_LAC_OP);
         readLacOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_READ_LAC_OP);
+        getBookieInfoOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.GET_BOOKIE_INFO_OP);
         readTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_READ);
         addTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_ADD);
         writeLacTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_WRITE_LAC);
         readLacTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_READ_LAC);
+        getBookieInfoTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.TIMEOUT_GET_BOOKIE_INFO);
 
         this.pcbcPool = pcbcPool;
 
@@ -675,6 +685,58 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
         }
     }
 
+    public void getBookieInfo(final long requested, GetBookieInfoCallback cb, Object ctx) {
+        final long txnId = getTxnId();
+        final CompletionKey completionKey = new CompletionKey(txnId, OperationType.GET_BOOKIE_INFO);
+        completionObjects.put(completionKey,
+                new GetBookieInfoCompletion(this, getBookieInfoOpLogger, cb, ctx,
+                                   scheduleTimeout(completionKey, getBookieInfoTimeout)));
+
+        // Build the request and calculate the total size to be included in the packet.
+        BKPacketHeader.Builder headerBuilder = BKPacketHeader.newBuilder()
+                .setVersion(ProtocolVersion.VERSION_THREE)
+                .setOperation(OperationType.GET_BOOKIE_INFO)
+                .setTxnId(txnId);
+
+        GetBookieInfoRequest.Builder getBookieInfoBuilder = GetBookieInfoRequest.newBuilder()
+                .setRequested(requested);
+
+        final Request getBookieInfoRequest = Request.newBuilder()
+                .setHeader(headerBuilder)
+                .setGetBookieInfoRequest(getBookieInfoBuilder)
+                .build();
+
+        final Channel c = channel;
+        if (c == null) {
+            errorOutReadKey(completionKey);
+            return;
+        }
+
+        try{
+            ChannelFuture future = c.write(getBookieInfoRequest);
+            future.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    if (future.isSuccess()) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Successfully wrote request {} to {}",
+                                    getBookieInfoRequest, c.getRemoteAddress());
+                        }
+                    } else {
+                        if (!(future.getCause() instanceof ClosedChannelException)) {
+                            LOG.warn("Writing GetBookieInfoRequest(flags={}) to channel {} failed : ",
+                                    new Object[] { requested, c, future.getCause() });
+                        }
+                        errorOutReadKey(completionKey);
+                    }
+                }
+            });
+        } catch(Throwable e) {
+            LOG.warn("Get metadata operation {} failed", getBookieInfoRequest, e);
+            errorOutReadKey(completionKey);
+        }
+    }
+
     /**
      * Disconnects the bookie client. It can be reused.
      */
@@ -849,6 +911,29 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
         });
     }
 
+    void errorOutGetBookieInfoKey(final CompletionKey key) {
+        errorOutGetBookieInfoKey(key, BKException.Code.BookieHandleNotAvailableException);
+    }
+
+    void errorOutGetBookieInfoKey(final CompletionKey key, final int rc) {
+        final GetBookieInfoCompletion getBookieInfoCompletion = (GetBookieInfoCompletion)completionObjects.remove(key);
+        if (null == getBookieInfoCompletion) {
+            return;
+        }
+        executor.submit(new SafeRunnable() {
+            @Override
+            public void safeRun() {
+                String bAddress = "null";
+                Channel c = channel;
+                if (c != null) {
+                    bAddress = c.getRemoteAddress().toString();
+                }
+                LOG.debug("Could not write getBookieInfo request for bookie: {}", new Object[] {bAddress});
+                getBookieInfoCompletion.cb.getBookieInfoComplete(rc, new BookieInfo(), getBookieInfoCompletion.ctx);
+            }
+        });
+    }
+
     /**
      * Errors out pending entries. We call this method from one thread to avoid
      * concurrent executions to QuorumOpMonitor (implements callbacks). It seems
@@ -1010,6 +1095,9 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
                         case READ_LAC:
                             handleReadLacResponse(response.getReadLacResponse(), completionValue);
                             break;
+                        case GET_BOOKIE_INFO:
+                            handleGetBookieInfoResponse(response, completionValue);
+                            break;
                         default:
                             LOG.error("Unexpected response, type:{} received from bookie:{}, ignoring",
                                       type, addr);
@@ -1135,6 +1223,33 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
         rc.cb.readEntryComplete(rcToRet, ledgerId, entryId, buffer.slice(), rc.ctx);
     }
 
+    void handleGetBookieInfoResponse(Response response, CompletionValue completionValue) {
+        // The completion value should always be an instance of a GetBookieInfoCompletion object when we reach here.
+        GetBookieInfoCompletion rc = (GetBookieInfoCompletion)completionValue;
+        GetBookieInfoResponse getBookieInfoResponse = response.getGetBookieInfoResponse();
+
+        long freeDiskSpace = getBookieInfoResponse.hasFreeDiskSpace() ? getBookieInfoResponse.getFreeDiskSpace() : 0L;
+        long totalDiskCapacity = getBookieInfoResponse.hasTotalDiskCapacity() ? getBookieInfoResponse.getTotalDiskCapacity() : 0L;
+
+        StatusCode status = response.getStatus() == StatusCode.EOK ? getBookieInfoResponse.getStatus() : response.getStatus();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Got response for read metadata request from bookie: {} rc {}", addr, rc);
+        }
+
+        // convert to BKException code because thats what the upper
+        // layers expect. This is UGLY, there should just be one set of
+        // error codes.
+        Integer rcToRet = statusCodeToExceptionCode(status);
+        if (null == rcToRet) {
+            LOG.error("Read metadata failed on bookie:{} with code:{}",
+                      new Object[] { addr, status });
+            rcToRet = BKException.Code.ReadException;
+        }
+        LOG.debug("Response received from bookie info read: freeDiskSpace=" +  freeDiskSpace + " totalDiskSpace:" + totalDiskCapacity);
+        rc.cb.getBookieInfoComplete(rcToRet, new BookieInfo(totalDiskCapacity, freeDiskSpace), rc.ctx);
+    }
+
     /**
      * Boiler-plate wrapper classes follow
      *
@@ -1258,6 +1373,42 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
     }
 
     // visible for testing
+    static class GetBookieInfoCompletion extends CompletionValue {
+        final GetBookieInfoCallback cb;
+
+        public GetBookieInfoCompletion(final PerChannelBookieClient pcbc, GetBookieInfoCallback cb, Object ctx) {
+            this(pcbc, null, cb, ctx, null);
+        }
+
+        public GetBookieInfoCompletion(final PerChannelBookieClient pcbc, final OpStatsLogger getBookieInfoOpLogger,
+                              final GetBookieInfoCallback originalCallback,
+                              final Object originalCtx, final Timeout timeout) {
+            super(originalCtx, 0L, 0L, timeout);
+            final long startTime = MathUtils.nowInNano();
+            this.cb = (null == getBookieInfoOpLogger) ? originalCallback : new GetBookieInfoCallback() {
+                @Override
+                public void getBookieInfoComplete(int rc, BookieInfo bInfo, Object ctx) {
+                    cancelTimeout();
+                    if (getBookieInfoOpLogger != null) {
+                        long latency = MathUtils.elapsedNanos(startTime);
+                        if (rc != BKException.Code.OK) {
+                            getBookieInfoOpLogger.registerFailedEvent(latency, TimeUnit.NANOSECONDS);
+                        } else {
+                            getBookieInfoOpLogger.registerSuccessfulEvent(latency, TimeUnit.NANOSECONDS);
+                        }
+                    }
+
+                    if (rc != BKException.Code.OK && !expectedBkOperationErrors.contains(rc)) {
+                        pcbc.recordError();
+                    }
+
+                    originalCallback.getBookieInfoComplete(rc, bInfo, originalCtx);
+                }
+            };
+        }
+    }
+
+    // visible for testing
     static class AddCompletion extends CompletionValue {
         final WriteCallback cb;
 
@@ -1356,9 +1507,12 @@ public class PerChannelBookieClient extends SimpleChannelHandler implements Chan
             } else if (OperationType.WRITE_LAC == operationType) {
                 errorOutWriteLacKey(this, BKException.Code.TimeoutException);
                 writeLacTimeoutOpLogger.registerSuccessfulEvent(elapsedTime(), TimeUnit.NANOSECONDS);
-            } else {
+            } else if (OperationType.READ_LAC == operationType) {
                 errorOutReadLacKey(this, BKException.Code.TimeoutException);
                 readLacTimeoutOpLogger.registerSuccessfulEvent(elapsedTime(), TimeUnit.NANOSECONDS);
+            } else {
+                errorOutGetBookieInfoKey(this, BKException.Code.TimeoutException);
+                getBookieInfoTimeoutOpLogger.registerSuccessfulEvent(elapsedTime(), TimeUnit.NANOSECONDS);
             }
 	}
     }

--- a/bookkeeper-server/src/main/proto/BookkeeperProtocol.proto
+++ b/bookkeeper-server/src/main/proto/BookkeeperProtocol.proto
@@ -59,6 +59,7 @@ enum OperationType {
     AUTH = 5;
     WRITE_LAC = 6;
     READ_LAC = 7;
+    GET_BOOKIE_INFO = 8;
 }
 
 /**
@@ -78,6 +79,7 @@ message Request {
     optional AuthMessage authRequest = 102;
     optional WriteLacRequest writeLacRequest = 103;
     optional ReadLacRequest readLacRequest = 104;
+    optional GetBookieInfoRequest getBookieInfoRequest = 105;
 }
 
 message ReadRequest {
@@ -114,6 +116,15 @@ message ReadLacRequest {
     required int64 ledgerId = 1;
 }
 
+message GetBookieInfoRequest {
+    enum Flags {
+        TOTAL_DISK_CAPACITY = 0x01;
+        FREE_DISK_SPACE = 0x02;
+    }
+    // bitwise OR of Flags
+    optional int64 requested = 1;
+}
+
 message Response {
 
     required BKPacketHeader header = 1;
@@ -126,6 +137,7 @@ message Response {
     optional AuthMessage authResponse = 102;
     optional WriteLacResponse writeLacResponse = 103;
     optional ReadLacResponse readLacResponse = 104;
+    optional GetBookieInfoResponse getBookieInfoResponse = 105;
 }
 
 message ReadResponse {
@@ -156,4 +168,10 @@ message ReadLacResponse {
     required int64 ledgerId = 2;
     optional bytes lacBody = 3; // lac sent by PutLacRequest
     optional bytes lastEntryBody = 4; // Actual last entry on the disk
+}
+
+message GetBookieInfoResponse {
+    required StatusCode status = 1;
+    optional int64 totalDiskCapacity = 2;
+    optional int64 freeDiskSpace = 3;
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
@@ -1,0 +1,452 @@
+package org.apache.bookkeeper.client;
+/*
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*/
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.util.MathUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests of the main BookKeeper client
+ */
+public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperClusterTestCase {
+    private final static Logger LOG = LoggerFactory.getLogger(BookKeeperDiskSpaceWeightedLedgerPlacementTest.class);
+
+    public BookKeeperDiskSpaceWeightedLedgerPlacementTest() {
+        super(10);
+    }
+    
+    private BookieServer restartBookie(ServerConfiguration conf, final long initialFreeDiskSpace,
+            final long finallFreeDiskSpace, final int delaySecs) throws Exception {
+        Bookie bookieWithCustomFreeDiskSpace = new Bookie(conf) {
+            long startTime = System.currentTimeMillis();
+            @Override
+            public long getTotalFreeSpace() {
+                if (startTime == 0) {
+                    startTime = System.currentTimeMillis();
+                }
+                if (delaySecs == 0 || ((System.currentTimeMillis()) - startTime < delaySecs*1000)) {
+                    return initialFreeDiskSpace;
+                } else {
+                    // after delaySecs, advertise finallFreeDiskSpace; before that advertise initialFreeDiskSpace
+                    return finallFreeDiskSpace;
+                }
+            }
+        };
+        bsConfs.add(conf);
+        BookieServer server = startBookie(conf, bookieWithCustomFreeDiskSpace);
+        bs.add(server);
+        return server;
+    }
+
+    private BookieServer replaceBookieWithCustomFreeDiskSpaceBookie(int bookieIdx, final long freeDiskSpace)
+            throws Exception {
+        LOG.info("Killing bookie " + bs.get(bookieIdx).getLocalAddress());
+        bs.get(bookieIdx).getLocalAddress();
+        ServerConfiguration conf = killBookie(bookieIdx);
+        return restartBookie(conf, freeDiskSpace, freeDiskSpace, 0);
+    }
+
+    private BookieServer replaceBookieWithCustomFreeDiskSpaceBookie(BookieServer bookie, final long freeDiskSpace)
+            throws Exception {
+        for (int i=0; i < bs.size(); i++) {
+            if (bs.get(i).getLocalAddress().equals(bookie.getLocalAddress())) {
+                return replaceBookieWithCustomFreeDiskSpaceBookie(i, freeDiskSpace);
+            }
+        }
+        return null;
+    }
+
+    private BookieServer replaceBookieWithCustomFreeDiskSpaceBookie(int bookieIdx, long initialFreeDiskSpace,
+             long finalFreeDiskSpace, int delay) throws Exception {
+        LOG.info("Killing bookie " + bs.get(bookieIdx).getLocalAddress());
+        bs.get(bookieIdx).getLocalAddress();
+        ServerConfiguration conf = killBookie(bookieIdx);
+        return restartBookie(conf, initialFreeDiskSpace, finalFreeDiskSpace, delay);
+    }
+
+    /**
+     * Test to show that weight based selection honors the disk weight of bookies
+     */
+    @Test(timeout=60000)
+    public void testDiskSpaceWeightedBookieSelection() throws Exception {
+        long freeDiskSpace=1000000L;
+        int multiple=3;
+        for (int i=0; i < numBookies; i++) {
+            // the first 8 bookies have freeDiskSpace of 1MB; While the remaining 2 have 3MB
+            if (i < numBookies-2) {
+                replaceBookieWithCustomFreeDiskSpaceBookie(0, freeDiskSpace);
+            } else {
+                replaceBookieWithCustomFreeDiskSpaceBookie(0, multiple*freeDiskSpace);
+            }
+        }
+        Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+
+        // wait a 100 msecs each for the bookies to come up and the bookieInfo to be retrieved by the client
+        ClientConfiguration conf = new ClientConfiguration()
+            .setZkServers(zkUtil.getZooKeeperConnectString()).setDiskWeightBasedPlacementEnabled(true).
+            setBookieMaxWeightMultipleForWeightBasedPlacement(multiple);
+        Thread.sleep(200);
+        final BookKeeper client = new BookKeeper(conf);
+        Thread.sleep(200);
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+        client.close();
+        // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
+        // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
+        for (int i=0; i < numBookies-2; i++) {
+            double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
+            double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        }
+    }
+
+    /**
+     * Test to show that weight based selection honors the disk weight of bookies and also adapts
+     * when the bookies's weight changes.
+     */
+    @Test(timeout=60000)
+    public void testDiskSpaceWeightedBookieSelectionWithChangingWeights() throws Exception {
+        long freeDiskSpace=1000000L;
+        int multiple=3;
+        for (int i=0; i < numBookies; i++) {
+            // the first 8 bookies have freeDiskSpace of 1MB; While the remaining 2 have 3MB
+            if (i < numBookies-2) {
+                replaceBookieWithCustomFreeDiskSpaceBookie(0, freeDiskSpace);
+            } else {
+                replaceBookieWithCustomFreeDiskSpaceBookie(0, multiple*freeDiskSpace);
+            }
+        }
+        Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+
+        // wait a 100 msecs each for the bookies to come up and the bookieInfo to be retrieved by the client
+        ClientConfiguration conf = new ClientConfiguration()
+            .setZkServers(zkUtil.getZooKeeperConnectString()).setDiskWeightBasedPlacementEnabled(true).
+            setBookieMaxWeightMultipleForWeightBasedPlacement(multiple);
+        Thread.sleep(100);
+        final BookKeeper client = new BookKeeper(conf);
+        Thread.sleep(100);
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+
+        // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
+        // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
+        for (int i=0; i < numBookies-2; i++) {
+            double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
+            double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        }
+
+        // Restart the bookies in such a way that the first 2 bookies go from 1MB to 3MB free space and the last
+        // 2 bookies go from 3MB to 1MB
+        BookieServer server1 = bs.get(0);
+        BookieServer server2 = bs.get(1);
+        BookieServer server3 = bs.get(numBookies-2);
+        BookieServer server4 = bs.get(numBookies-1);
+
+        server1 = replaceBookieWithCustomFreeDiskSpaceBookie(server1, multiple*freeDiskSpace);
+        server2 = replaceBookieWithCustomFreeDiskSpaceBookie(server2, multiple*freeDiskSpace);
+        server3 = replaceBookieWithCustomFreeDiskSpaceBookie(server3, freeDiskSpace);
+        server4 = replaceBookieWithCustomFreeDiskSpaceBookie(server4, freeDiskSpace);
+
+        Thread.sleep(100);
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+
+        // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
+        // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
+        for (int i=0; i < numBookies; i++) {
+            if (server1.getLocalAddress().equals(bs.get(i).getLocalAddress()) ||
+                server2.getLocalAddress().equals(bs.get(i).getLocalAddress())) {
+                continue;
+            }
+            double ratio1 = (double)m.get(server1.getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
+            double ratio2 = (double)m.get(server2.getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        }
+        client.close();
+    }
+
+    /**
+     * Test to show that weight based selection honors the disk weight of bookies and also adapts
+     * when bookies go away permanently.
+     */
+    @Test(timeout=60000)
+    public void testDiskSpaceWeightedBookieSelectionWithBookiesDying() throws Exception {
+        long freeDiskSpace=1000000L;
+        int multiple=3;
+        for (int i=0; i < numBookies; i++) {
+            // the first 8 bookies have freeDiskSpace of 1MB; While the remaining 2 have 1GB
+            if (i < numBookies-2) {
+                replaceBookieWithCustomFreeDiskSpaceBookie(0, freeDiskSpace);
+            } else {
+                replaceBookieWithCustomFreeDiskSpaceBookie(0, multiple*freeDiskSpace);
+            }
+        }
+        Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+
+        // wait a couple of 100 msecs each for the bookies to come up and the bookieInfo to be retrieved by the client
+        ClientConfiguration conf = new ClientConfiguration()
+            .setZkServers(zkUtil.getZooKeeperConnectString()).setDiskWeightBasedPlacementEnabled(true).
+            setBookieMaxWeightMultipleForWeightBasedPlacement(multiple);
+        Thread.sleep(100);
+        final BookKeeper client = new BookKeeper(conf);
+        Thread.sleep(100);
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+
+        // make sure that bookies with higher weight are chosen 3X as often as the median;
+        // since the number of ledgers is small (2000), there may be variation 
+        double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(0).getLocalAddress());
+        assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
+        double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(1).getLocalAddress());
+        assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+
+        // Bring down the 2 bookies that had higher weight; after this the allocation to all
+        // the remaining bookies should be uniform
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+        BookieServer server1 = bs.get(numBookies-2);
+        BookieServer server2 = bs.get(numBookies-1);
+        killBookie(numBookies-1);
+        killBookie(numBookies-2);
+
+        // give some time for the cluster to become stable
+        Thread.sleep(100);
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+
+        // make sure that bookies with higher weight are chosen 3X as often as the median;
+        for (int i=0; i < numBookies-3; i++) {
+            double delta = Math.abs((double)m.get(bs.get(i).getLocalAddress())-(double)m.get(bs.get(i+1).getLocalAddress()));
+            delta = (delta*100)/(double)m.get(bs.get(i+1).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + delta, delta <= 30); // the deviation should be less than 30%
+        }
+        // since the following 2 bookies were down, they shouldn't ever be selected
+        assertTrue("Weigheted placement is not honored" + m.get(server1.getLocalAddress()),
+                m.get(server1.getLocalAddress()) == 0);
+        assertTrue("Weigheted placement is not honored" + m.get(server2.getLocalAddress()),
+                m.get(server2.getLocalAddress()) == 0);
+
+        client.close();
+    }
+
+    /**
+     * Test to show that weight based selection honors the disk weight of bookies and also adapts
+     * when bookies are added.
+     */
+    @Test(timeout=60000)
+    public void testDiskSpaceWeightedBookieSelectionWithBookiesBeingAdded() throws Exception {
+        long freeDiskSpace=1000000L;
+        int multiple=3;
+        for (int i=0; i < numBookies; i++) {
+            // all the bookies have freeDiskSpace of 1MB
+            replaceBookieWithCustomFreeDiskSpaceBookie(0, freeDiskSpace);
+        }
+        // let the last two bookies be down initially
+        ServerConfiguration conf1 = killBookie(numBookies-1);
+        ServerConfiguration conf2 = killBookie(numBookies-2);
+        Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+
+        // wait a bit for the bookies to come up and the bookieInfo to be retrieved by the client
+        ClientConfiguration conf = new ClientConfiguration()
+            .setZkServers(zkUtil.getZooKeeperConnectString()).setDiskWeightBasedPlacementEnabled(true).
+            setBookieMaxWeightMultipleForWeightBasedPlacement(multiple);
+        Thread.sleep(100);
+        final BookKeeper client = new BookKeeper(conf);
+        Thread.sleep(100);
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+
+        // make sure that bookies with higher weight are chosen 3X as often as the median;
+        // since the number of ledgers is small (2000), there may be variation
+        for (int i=0; i < numBookies-3; i++) {
+            double delta = Math.abs((double)m.get(bs.get(i).getLocalAddress())-(double)m.get(bs.get(i+1).getLocalAddress()));
+            delta = (delta*100)/(double)m.get(bs.get(i+1).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + delta, delta <= 30); // the deviation should be less than 30%
+        }
+
+        // bring up the two dead bookies; they'll also have 3X more free space than the rest of the bookies
+        restartBookie(conf1, multiple*freeDiskSpace, multiple*freeDiskSpace, 0);
+        restartBookie(conf2, multiple*freeDiskSpace, multiple*freeDiskSpace, 0);
+
+        // give some time for the cluster to become stable
+        Thread.sleep(100);
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+
+        // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
+        // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
+        for (int i=0; i < numBookies-2; i++) {
+            double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
+            double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        }
+        client.close();
+    }
+
+    /**
+     * Tests that the bookie selection is based on the amount of free disk space a bookie has. Also make sure that
+     * the periodic bookieInfo read is working and causes the new weights to be taken into account.
+     */
+    @Test(timeout=60000)
+    public void testDiskSpaceWeightedBookieSelectionWithPeriodicBookieInfoUpdate() throws Exception {
+        long freeDiskSpace=1000000L;
+        int multiple=3;
+        for (int i=0; i < numBookies; i++) {
+            // the first 8 bookies have freeDiskSpace of 1MB; the remaining 2 will advertise 1MB for
+            // the first 3 seconds but then they'll advertise 3MB after the first 3 seconds
+            if (i < numBookies-2) {
+                replaceBookieWithCustomFreeDiskSpaceBookie(0, freeDiskSpace);
+            } else {
+                replaceBookieWithCustomFreeDiskSpaceBookie(0, freeDiskSpace, multiple*freeDiskSpace, 2);
+            }
+        }
+        Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+
+        // the periodic bookieInfo is read once every 7 seconds
+        int updateIntervalSecs = 6;
+        ClientConfiguration conf = new ClientConfiguration()
+            .setZkServers(zkUtil.getZooKeeperConnectString()).setDiskWeightBasedPlacementEnabled(true).
+            setBookieMaxWeightMultipleForWeightBasedPlacement(multiple).
+            setGetBookieInfoIntervalSeconds(updateIntervalSecs, TimeUnit.SECONDS);
+        // wait a bit for the bookies to come up and the bookieInfo to be retrieved by the client
+        Thread.sleep(100);
+        final BookKeeper client = new BookKeeper(conf);
+        Thread.sleep(100);
+        long startMsecs = MathUtils.now();
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+        long elapsedMsecs = MathUtils.now() - startMsecs;
+
+        // make sure that all the bookies are chosen pretty much uniformly
+        int bookiesToCheck = numBookies-1;
+        if (elapsedMsecs > updateIntervalSecs*1000) {
+            // if this task longer than updateIntervalSecs, the weight for the last 2 bookies will be
+            // higher, so skip checking them
+            bookiesToCheck = numBookies-3;
+        }
+        for (int i=0; i < bookiesToCheck; i++) {
+            double delta = Math.abs((double)m.get(bs.get(i).getLocalAddress())-(double)m.get(bs.get(i+1).getLocalAddress()));
+            delta = (delta*100)/(double)m.get(bs.get(i+1).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + delta, delta <= 30); // the deviation should be <30%
+        }
+
+        if (elapsedMsecs < updateIntervalSecs*1000) {
+            // sleep until periodic bookie info retrieval kicks in and it gets the updated
+            // freeDiskSpace for the last 2 bookies
+            Thread.sleep(updateIntervalSecs*1000 - elapsedMsecs);
+        }
+
+        for (BookieServer b : bs) {
+            m.put(b.getLocalAddress(), 0);
+        }
+        for (int i = 0; i < 2000; i++) {
+            LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
+            for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
+                m.put(b, m.get(b)+1);
+            }
+        }
+
+        // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
+        // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
+        for (int i=0; i < numBookies-2; i++) {
+            double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
+            double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        }
+
+        client.close();
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestGetBookieInfoTimeout.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestGetBookieInfoTimeout.java
@@ -1,0 +1,141 @@
+package org.apache.bookkeeper.client;
+
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+
+import org.apache.bookkeeper.client.BKException.Code;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieClient;
+import org.apache.bookkeeper.proto.BookkeeperProtocol;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GetBookieInfoCallback;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.util.OrderedSafeExecutor;
+import org.jboss.netty.channel.socket.ClientSocketChannelFactory;
+import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This unit test tests timeout of GetBookieInfo request;
+ *
+ */
+public class TestGetBookieInfoTimeout extends BookKeeperClusterTestCase {
+    private final static Logger LOG = LoggerFactory.getLogger(TestGetBookieInfoTimeout.class);
+    DigestType digestType;
+    public ClientSocketChannelFactory channelFactory;
+    public OrderedSafeExecutor executor;
+
+    public TestGetBookieInfoTimeout() {
+        super(10);
+        this.digestType = DigestType.CRC32;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        channelFactory = new NioClientSocketChannelFactory(Executors.newCachedThreadPool(), Executors
+                .newCachedThreadPool());
+        executor = OrderedSafeExecutor.newBuilder()
+                .name("BKClientOrderedSafeExecutor")
+                .numThreads(2)
+                .build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        channelFactory.releaseExternalResources();
+        executor.shutdown();
+    }
+
+    @Test(timeout=60000)
+    public void testGetBookieInfoTimeout() throws Exception {
+
+        // connect to the bookies and create a ledger
+        LedgerHandle writelh = bkc.createLedger(3,3,digestType, "testPasswd".getBytes());
+        String tmp = "Foobar";
+        final int numEntries = 10;
+        for (int i = 0; i < numEntries; i++) {
+            writelh.addEntry(tmp.getBytes());
+        }
+
+        // set timeout for getBookieInfo to be 2 secs and cause one of the bookies to go to sleep for 3X that time
+        ClientConfiguration cConf = new ClientConfiguration();
+        cConf.setGetBookieInfoTimeout(2);
+
+        final BookieSocketAddress bookieToSleep = writelh.getLedgerMetadata().getEnsemble(0).get(0);
+        int sleeptime = cConf.getBookieInfoTimeout()*3;
+        CountDownLatch latch = sleepBookie(bookieToSleep, sleeptime);
+        latch.await();
+
+        // try to get bookie info from the sleeping bookie. It should fail with timeout error
+        BookieSocketAddress addr = new BookieSocketAddress(bookieToSleep.getSocketAddress().getHostString(),
+                bookieToSleep.getPort());
+        BookieClient bc = new BookieClient(cConf, channelFactory, executor);
+        long flags = BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE |
+                BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE;
+
+        class CallbackObj {
+            int rc;
+            long requested;
+            @SuppressWarnings("unused")
+            long freeDiskSpace, totalDiskCapacity;
+            CountDownLatch latch = new CountDownLatch(1);
+            CallbackObj(long requested) {
+                this.requested = requested;
+                this.rc = 0;
+                this.freeDiskSpace = 0L;
+                this.totalDiskCapacity = 0L;
+            }
+        };
+        CallbackObj obj = new CallbackObj(flags);
+        bc.getBookieInfo(addr, flags, new GetBookieInfoCallback() {
+            @Override
+            public void getBookieInfoComplete(int rc, BookieInfo bInfo, Object ctx) {
+                CallbackObj obj = (CallbackObj)ctx;
+                obj.rc=rc;
+                if (rc == Code.OK) {
+                    if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE) != 0) {
+                        obj.freeDiskSpace = bInfo.getFreeDiskSpace();
+                    }
+                    if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE) != 0) {
+                        obj.totalDiskCapacity = bInfo.getTotalDiskSpace();
+                    }
+                }
+                obj.latch.countDown();
+            }
+
+        }, obj);
+        obj.latch.await();
+        LOG.debug("Return code: " + obj.rc);
+        assertTrue("GetBookieInfo failed with unexpected error code: " + obj.rc, obj.rc == Code.TimeoutException);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWeightedRandomSelection.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWeightedRandomSelection.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.client;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.bookkeeper.client.WeightedRandomSelection.WeightedObject;
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestWeightedRandomSelection {
+
+    static final Logger LOG = LoggerFactory.getLogger(TestWeightedRandomSelection.class);
+
+    static class TestObj implements WeightedObject {
+        long val;
+        TestObj(long value) {
+            this.val = value;
+        }
+        @Override
+        public long getWeight() {
+            return val;
+        }
+    }
+
+    WeightedRandomSelection<String> wRS;
+    Configuration conf = new CompositeConfiguration();
+    int multiplier = 3;
+
+    @Before
+    public void setUp() throws Exception {
+        wRS = new WeightedRandomSelection<String>();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test(timeout = 60000)
+    public void testSelectionWithEqualWeights() throws Exception {
+        Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
+
+        Long val=100L;
+        int numKeys = 50,  totalTries = 1000000;
+        Map<String, Integer> randomSelection = new HashMap<String, Integer>();
+        for (Integer i=0; i < numKeys; i++) {
+            map.put(i.toString(), new TestObj(val));
+            randomSelection.put(i.toString(), 0);
+        }
+
+        wRS.updateMap(map);
+        for (int i = 0; i < totalTries; i++) {
+            String key = wRS.getNextRandom();
+            randomSelection.put(key, randomSelection.get(key)+1);
+        }
+
+        // there should be uniform distribution
+        double expectedPct = ((double)1/(double)numKeys)*100;
+        for (Map.Entry<String, Integer> e : randomSelection.entrySet()) {
+            double actualPct = ((double)e.getValue()/(double)totalTries)*100;
+            double delta = (Math.abs(expectedPct-actualPct)/expectedPct)*100;
+            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue() + " Expected: " + expectedPct + " Actual: " + actualPct);
+            // should be within 5% of expected
+            assertTrue("Not doing uniform selection when weights are equal", delta < 5);
+        }
+    }
+
+    @Test(timeout = 60000)
+    public void testSelectionWithAllZeroWeights() throws Exception {
+        Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
+
+        int numKeys = 50,  totalTries = 1000000;
+        Map<String, Integer> randomSelection = new HashMap<String, Integer>();
+        for (Integer i=0; i < numKeys; i++) {
+            map.put(i.toString(), new TestObj(0L));
+            randomSelection.put(i.toString(), 0);
+        }
+
+        wRS.updateMap(map);
+        for (int i = 0; i < totalTries; i++) {
+            String key = wRS.getNextRandom();
+            randomSelection.put(key, randomSelection.get(key)+1);
+        }
+
+        // when all the values are zeros, there should be uniform distribution
+        double expectedPct = ((double)1/(double)numKeys)*100;
+        for (Map.Entry<String, Integer> e : randomSelection.entrySet()) {
+            double actualPct = ((double)e.getValue()/(double)totalTries)*100;
+            double delta = (Math.abs(expectedPct-actualPct)/expectedPct)*100;
+            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue() + " Expected: " + expectedPct + " Actual: " + actualPct);
+            // should be within 5% of expected
+            assertTrue("Not doing uniform selection when weights are equal", delta < 5);
+        }
+    }
+
+    void verifyResult(Map<String, WeightedObject> map, Map<String, Integer> randomSelection, int multiplier,
+            long minWeight, long medianWeight, long totalWeight, int totalTries) {
+        List<Integer> values = new ArrayList<Integer>(randomSelection.values());
+        Collections.sort(values);
+        double medianObserved, medianObservedWeight, medianExpectedWeight;
+        int mid = values.size()/2;
+        if ((values.size() % 2) == 1) {
+            medianObserved = values.get(mid);
+        } else {
+            medianObserved = (double)(values.get(mid-1) + values.get(mid))/2;
+        }
+
+        medianObservedWeight = (double)medianObserved/(double)totalTries;
+        medianExpectedWeight = (double)medianWeight/totalWeight;
+
+        for (Map.Entry<String, Integer> e : randomSelection.entrySet()) {
+            double observed = (((double)e.getValue()/(double)totalTries));
+
+            double expected;
+            if (map.get(e.getKey()).getWeight() == 0) {
+                // if the value is 0 for any key, we make it equal to the first non zero value
+                expected = (double)minWeight/(double)totalWeight;
+            } else {
+                expected = (double)map.get(e.getKey()).getWeight()/(double)totalWeight;
+            }
+            if (multiplier > 0 && expected > multiplier*medianExpectedWeight) {
+                expected = multiplier*medianExpectedWeight;
+            }
+            // We can't compare these weights because they are derived from different
+            // values. But if we express them as a multiple of the min in each, then
+            // they should be comparable
+            double expectedMultiple = expected/medianExpectedWeight;
+            double observedMultiple = observed/medianObservedWeight;
+            double delta = (Math.abs(expectedMultiple-observedMultiple)/expectedMultiple)*100;
+            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue() 
+                    + " Expected " + expectedMultiple + " actual " + observedMultiple + " delta " + delta + "%");
+
+            // the observed should be within 5% of expected
+            assertTrue("Not doing uniform selection when weights are equal", delta < 5);
+        }
+    }
+
+    @Test(timeout = 60000)
+    public void testSelectionWithSomeZeroWeights() throws Exception {
+        Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
+        Map<String, Integer> randomSelection = new HashMap<String, Integer>();
+        int numKeys = 50;
+        multiplier=3;
+        long val=0L, total=0L, minWeight = 100L, medianWeight=minWeight;
+        wRS.setMaxProbabilityMultiplier(multiplier);
+        for (Integer i=0; i < numKeys; i++) {
+            if (i < numKeys/3) {
+                val = 0L;
+            } else if (i < 2*(numKeys/3)){
+                val = minWeight;
+            } else {
+                val = 2*minWeight;
+            }
+            total += val;
+            map.put(i.toString(), new TestObj(val));
+            randomSelection.put(i.toString(), 0);
+        }
+
+        wRS.updateMap(map);
+        int totalTries = 10000000;
+        for (int i = 0; i < totalTries; i++) {
+            String key = wRS.getNextRandom();
+            randomSelection.put(key, randomSelection.get(key)+1);
+        }
+        verifyResult(map, randomSelection, multiplier, minWeight, medianWeight, total, totalTries);
+    }
+
+    @Test(timeout = 60000)
+    public void testSelectionWithUnequalWeights() throws Exception {
+        Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
+        Map<String, Integer> randomSelection = new HashMap<String, Integer>();
+        int numKeys = 50;
+        multiplier=4;
+        long val=0L, total=0L, minWeight=100L, medianWeight=2*minWeight;
+        wRS.setMaxProbabilityMultiplier(multiplier);
+        for (Integer i=0; i < numKeys; i++) {
+            if (i < numKeys/3) {
+                val = minWeight;
+            } else if (i < 2*(numKeys/3)){
+                val = 2*minWeight;
+            } else {
+                val = 10*minWeight;
+            }
+            total += val;
+            map.put(i.toString(), new TestObj(val));
+            randomSelection.put(i.toString(), 0);
+        }
+
+        wRS.updateMap(map);
+        int totalTries = 10000000;
+        for (int i = 0; i < totalTries; i++) {
+            String key = wRS.getNextRandom();
+            randomSelection.put(key, randomSelection.get(key)+1);
+        }
+        verifyResult(map, randomSelection, multiplier, minWeight, medianWeight, total, totalTries);
+    }
+
+    @Test(timeout = 60000)
+    public void testSelectionWithHotNode() throws Exception {
+        Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
+        Map<String, Integer> randomSelection = new HashMap<String, Integer>();
+
+        multiplier=3; // no max
+        int numKeys = 50;
+        long total=0L, minWeight = 100L, val = minWeight, medianWeight=minWeight;
+        wRS.setMaxProbabilityMultiplier(multiplier);
+        for (Integer i=0; i < numKeys; i++) {
+            if (i == numKeys-1) {
+                // last one has 10X more weight than the rest put together
+                val=10*(numKeys-1)*100L;
+            }
+            total += val;
+            map.put(i.toString(), new TestObj(val));
+            randomSelection.put(i.toString(), 0);
+        }
+
+        wRS.updateMap(map);
+        int totalTries = 10000000;
+        for (int i = 0; i < totalTries; i++) {
+            String key = wRS.getNextRandom();
+            randomSelection.put(key, randomSelection.get(key)+1);
+        }
+        verifyResult(map, randomSelection, multiplier, minWeight, medianWeight, total, totalTries);
+    }
+
+    @Test(timeout = 60000)
+    public void testSelectionWithHotNodeWithLimit() throws Exception {
+        Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
+        Map<String, Integer> randomSelection = new HashMap<String, Integer>();
+
+        multiplier=3; // limit the max load on hot node to be 3X
+        int numKeys = 50;
+        long total=0L, minWeight = 100L, val = minWeight, medianWeight=minWeight;
+        wRS.setMaxProbabilityMultiplier(multiplier);
+        for (Integer i=0; i < numKeys; i++) {
+            if (i == numKeys-1) {
+                // last one has 10X more weight than the rest put together
+                val=10*(numKeys-1)*100L;
+            }
+            total += val;
+            map.put(i.toString(), new TestObj(val));
+            randomSelection.put(i.toString(), 0);
+        }
+
+        wRS.updateMap(map);
+        int totalTries = 10000000;
+        for (int i = 0; i < totalTries; i++) {
+            String key = wRS.getNextRandom();
+            randomSelection.put(key, randomSelection.get(key)+1);
+        }
+        verifyResult(map, randomSelection, multiplier, minWeight, medianWeight, total, totalTries);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
@@ -22,11 +22,15 @@ package org.apache.bookkeeper.test;
  */
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BKException.Code;
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -34,6 +38,8 @@ import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GetBookieInfoCallback;
+import org.apache.bookkeeper.proto.BookkeeperProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
@@ -249,5 +255,49 @@ public class BookieClientTest {
             arc.wait(1000);
             assertEquals(BKException.Code.NoSuchLedgerExistsException, arc.rc);
         }
+    }
+
+    @Test(timeout=60000)
+    public void testGetBookieInfo() throws IOException, InterruptedException {
+        BookieSocketAddress addr = new BookieSocketAddress("127.0.0.1", port);
+        BookieClient bc = new BookieClient(new ClientConfiguration(), channelFactory, executor);
+        long flags = BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE |
+                BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE;
+
+        class CallbackObj {
+            int rc;
+            long requested;
+            long freeDiskSpace, totalDiskCapacity;
+            CountDownLatch latch = new CountDownLatch(1);
+            CallbackObj(long requested) {
+                this.requested = requested;
+                this.rc = 0;
+                this.freeDiskSpace = 0L;
+                this.totalDiskCapacity = 0L;
+            }
+        };
+        CallbackObj obj = new CallbackObj(flags);
+        bc.getBookieInfo(addr, flags, new GetBookieInfoCallback() {
+            @Override
+            public void getBookieInfoComplete(int rc, BookieInfo bInfo, Object ctx) {
+                CallbackObj obj = (CallbackObj)ctx;
+                obj.rc=rc;
+                if (rc == Code.OK) {
+                    if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE) != 0) {
+                        obj.freeDiskSpace = bInfo.getFreeDiskSpace();
+                    }
+                    if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE) != 0) {
+                        obj.totalDiskCapacity = bInfo.getTotalDiskSpace();
+                    }
+                }
+                obj.latch.countDown();
+            }
+
+        }, obj);
+        obj.latch.await();
+        System.out.println("Return code: " + obj.rc + "FreeDiskSpace: " + obj.freeDiskSpace + " TotalCapacity: " + obj.totalDiskCapacity);
+        assertTrue("GetBookieInfo failed with error " + obj.rc, obj.rc == Code.OK);
+        assertTrue("GetBookieInfo failed with error " + obj.rc, obj.freeDiskSpace <= obj.totalDiskCapacity);
+        assertTrue("GetBookieInfo failed with error " + obj.rc, obj.totalDiskCapacity > 0);
     }
 }


### PR DESCRIPTION
…ge capacity of bookies

This change introduces Disk weight based ledger placement. Currently free disk space is the only supported
weight for a bookie. This change also introduces a new protocol message between bk client and server
called GET_BOOKIE_INFO. This message is used by the client to retrieve the free disk space info from
all the bookies. The existing placement policies: DefaultPlacementPolicy and RackAwarePlacementPolicy
have been enhanced to make use of the weight while selecting bookies. New test cases have been added to
test RackawarePlacement with weights. A new test class has been added to test the weight based selection
algorithm in a stand alone fashion.