### PR TITLE
BOOKKEEPER-987 BookKeeper build is broken due to the shade plugin

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -184,7 +184,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.4.3</version>
         <configuration>
           <!-- put your configurations here -->
         </configuration>


### PR DESCRIPTION
This is simply an upgrade of the maven-shade-plugin to version 2.4.3