### PR TITLE
BOOKKEEPER-949: Allow entryLog creation for compaction

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -1823,8 +1824,11 @@ public class BookieShell implements Tool {
         Collections.sort(completeFilesList, new FilesTimeComparator());
         return completeFilesList;
     }
-    
-    private static class FilesTimeComparator implements Comparator<File> {
+
+    private static class FilesTimeComparator implements Comparator<File>, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
         @Override
         public int compare(File file1, File file2) {
             Path file1Path = Paths.get(file1.getAbsolutePath());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -549,7 +549,7 @@ public class EntryLogger {
          * Allocate a new log file.
          */
         BufferedLogChannel allocateNewLog() throws IOException {
-            List<File> list = ledgerDirsManager.getWritableLedgerDirs();
+            List<File> list = ledgerDirsManager.getWritableLedgerDirsForNewLog();
             Collections.shuffle(list);
             // It would better not to overwrite existing entry log files
             File newLogFile = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -504,7 +504,7 @@ public class GarbageCollectorThread extends BookieThread {
         // closed and corrupted.
         if (!compacting.compareAndSet(false, true)) {
             // set compacting flag failed, means compacting is true now
-            // indicates another thread wants to interrupt gc thread to exit
+            // indicates that compaction is in progress for this EntryLogId.
             return;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -60,6 +60,8 @@ public class LedgerDirsManager {
     private final Random rand = new Random();
     private final ConcurrentMap<File, Float> diskUsages =
             new ConcurrentHashMap<File, Float>();
+    private final long entryLogSize;
+    private boolean forceGCAllowWhenNoSpace;
 
     public LedgerDirsManager(ServerConfiguration conf, File[] dirs) {
         this(conf, dirs, NullStatsLogger.INSTANCE);
@@ -78,6 +80,8 @@ public class LedgerDirsManager {
         this.listeners = new ArrayList<LedgerDirsListener>();
         this.diskChecker = diskChecker;
         this.monitor = new LedgerDirsMonitor(conf.getDiskCheckInterval());
+        this.forceGCAllowWhenNoSpace = conf.getIsForceGCAllowWhenNoSpace();
+        this.entryLogSize = conf.getEntryLogSizeLimit();
         for (File dir : dirs) {
             diskUsages.put(dir, 0f);
             String statName = "dir_" + dir.getPath().replace('/', '_') + "_usage";
@@ -127,6 +131,46 @@ public class LedgerDirsManager {
             throw e;
         }
         return writableLedgerDirectories;
+    }
+
+    public List<File> getWritableLedgerDirsForNewLog()
+        throws NoWritableLedgerDirException {
+
+        if (!writableLedgerDirectories.isEmpty()) {
+            return writableLedgerDirectories;
+        }
+
+        // If Force GC is not allowed under no space
+        if (!forceGCAllowWhenNoSpace) {
+            String errMsg = "All ledger directories are non writable and force GC is not enabled.";
+            NoWritableLedgerDirException e = new NoWritableLedgerDirException(errMsg);
+            LOG.error(errMsg, e);
+            throw e;
+        }
+
+        // We don't have writable Ledger Dirs.
+        // That means we must have turned readonly but the compaction
+        // must have started running and it needs to allocate
+        // a new log file to move forward with the compaction.
+        List<File> fullLedgerDirsToAccomodateNewEntryLog = new ArrayList<File>();
+        for (File dir: this.ledgerDirectories) {
+            // Pick dirs which can accommodate little more than an entry log.
+            if (dir.getUsableSpace() > (this.entryLogSize * 1.2) ) {
+                fullLedgerDirsToAccomodateNewEntryLog.add(dir);
+            }
+        }
+
+        if (!fullLedgerDirsToAccomodateNewEntryLog.isEmpty()) {
+            LOG.info("No writable ledger dirs. Trying to go beyond to accomodate compaction."
+                    + "Dirs that can accomodate new entryLog are: {}", fullLedgerDirsToAccomodateNewEntryLog);
+            return fullLedgerDirsToAccomodateNewEntryLog;
+        }
+
+        // We will reach here when we have no option of creating a new log file for compaction
+        String errMsg = "All ledger directories are non writable and no reserved space left for creating entry log file.";
+        NoWritableLedgerDirException e = new NoWritableLedgerDirException(errMsg);
+        LOG.error(errMsg, e);
+        throw e;
     }
 
     /**


### PR DESCRIPTION
Allow entryLog creation even when bookie
is in RO mode for compaction

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>
Reviewed-by: Andrey Yegorov <ayegorov@salesforce.com>
Reviewed-by: Charan Reddy Guttapalem <cguttapalem@salesforce.com>