### PR TITLE
BOOKKEEPER-1019 Support for reading entries after LAC

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -1051,4 +1051,5 @@ public class ClientConfiguration extends AbstractConfiguration {
     public String getClientRole() {
         return getString(CLIENT_ROLE, CLIENT_ROLE_STANDARD);
     }
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -1,5 +1,6 @@
 package org.apache.bookkeeper.client;
 
+import java.util.Collections;
 import java.util.Enumeration;
 
 /*
@@ -432,5 +433,222 @@ public class BookKeeperTest extends BaseTestCase {
         rlh.close();
         wlh.close();
         bkcWithExplicitLAC.close();
-    }	
+    }
+
+    @Test(timeout = 60000)
+    public void testReadAfterLastAddConfirmed() throws Exception {
+
+        ClientConfiguration clientConfiguration = new ClientConfiguration()
+            .setZkServers(zkUtil.getZooKeeperConnectString());
+
+        try (BookKeeper bkWriter = new BookKeeper(clientConfiguration);) {
+            LedgerHandle writeLh = bkWriter.createLedger(digestType, "testPasswd".getBytes());
+            long ledgerId = writeLh.getId();
+            int numOfEntries = 5;
+            for (int i = 0; i < numOfEntries; i++) {
+                writeLh.addEntry(("foobar" + i).getBytes());
+            }
+
+            try (BookKeeper bkReader = new BookKeeper(clientConfiguration);
+                LedgerHandle rlh = bkReader.openLedgerNoRecovery(ledgerId, digestType, "testPasswd".getBytes());) {
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                Assert.assertFalse(writeLh.isClosed());
+
+                // with readUnconfirmedEntries we are able to read all of the entries
+                Enumeration<LedgerEntry> entries = rlh.readUnconfirmedEntries(0, numOfEntries - 1);
+                int entryId = 0;
+                while (entries.hasMoreElements()) {
+                    LedgerEntry entry = entries.nextElement();
+                    String entryString = new String(entry.getEntry());
+                    Assert.assertTrue("Expected entry String: " + ("foobar" + entryId)
+                        + " actual entry String: " + entryString,
+                        entryString.equals("foobar" + entryId));
+                    entryId++;
+                }
+            }
+
+            try (BookKeeper bkReader = new BookKeeper(clientConfiguration);
+                LedgerHandle rlh = bkReader.openLedgerNoRecovery(ledgerId, digestType, "testPasswd".getBytes());) {
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                Assert.assertFalse(writeLh.isClosed());
+
+                // without readUnconfirmedEntries we are not able to read all of the entries
+                try {
+                    rlh.readEntries(0, numOfEntries - 1);
+                    fail("shoud not be able to read up to "+ (numOfEntries - 1) + " with readEntries");
+                } catch (BKException.BKReadException expected) {
+                }
+
+                // read all entries within the 0..LastAddConfirmed range with readEntries
+                assertEquals(rlh.getLastAddConfirmed() + 1,
+                    Collections.list(rlh.readEntries(0, rlh.getLastAddConfirmed())).size());
+
+                // assert local LAC does not change after reads
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                // read all entries within the 0..LastAddConfirmed range with readUnconfirmedEntries
+                assertEquals(rlh.getLastAddConfirmed() + 1,
+                    Collections.list(rlh.readUnconfirmedEntries(0, rlh.getLastAddConfirmed())).size());
+
+                // assert local LAC does not change after reads
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                // read all entries within the LastAddConfirmed..numOfEntries - 1 range with readUnconfirmedEntries
+                assertEquals(numOfEntries - rlh.getLastAddConfirmed(),
+                    Collections.list(rlh.readUnconfirmedEntries(rlh.getLastAddConfirmed(), numOfEntries - 1)).size());
+
+                // assert local LAC does not change after reads
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                try {
+                    // read all entries within the LastAddConfirmed..numOfEntries range  with readUnconfirmedEntries
+                    // this is an error, we are going outside the range of existing entries
+                    rlh.readUnconfirmedEntries(rlh.getLastAddConfirmed(), numOfEntries);
+                    fail("the read tried to access data for unexisting entry id "+numOfEntries);
+                } catch (BKException.BKNoSuchEntryException expected) {
+                    // expecting a BKNoSuchEntryException, as the entry does not exist on bookies
+                }
+
+                try {
+                    // read all entries within the LastAddConfirmed..numOfEntries range with readEntries
+                    // this is an error, we are going outside the range of existing entries
+                    rlh.readEntries(rlh.getLastAddConfirmed(), numOfEntries);
+                    fail("the read tries to access data for unexisting entry id "+numOfEntries);
+                } catch (BKException.BKReadException expected) {
+                    // expecting a BKReadException, as the client rejected the request to access entries
+                    // after local LastAddConfirmed
+                }
+
+            }
+
+            // ensure that after restarting every bookie entries are not lost
+            // even entries after the LastAddConfirmed
+            restartBookies();
+
+            try (BookKeeper bkReader = new BookKeeper(clientConfiguration);
+                LedgerHandle rlh = bkReader.openLedgerNoRecovery(ledgerId, digestType, "testPasswd".getBytes());) {
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                Assert.assertFalse(writeLh.isClosed());
+
+                // with readUnconfirmedEntries we are able to read all of the entries
+                Enumeration<LedgerEntry> entries = rlh.readUnconfirmedEntries(0, numOfEntries - 1);
+                int entryId = 0;
+                while (entries.hasMoreElements()) {
+                    LedgerEntry entry = entries.nextElement();
+                    String entryString = new String(entry.getEntry());
+                    Assert.assertTrue("Expected entry String: " + ("foobar" + entryId)
+                        + " actual entry String: " + entryString,
+                        entryString.equals("foobar" + entryId));
+                    entryId++;
+                }
+            }
+
+            try (BookKeeper bkReader = new BookKeeper(clientConfiguration);
+                LedgerHandle rlh = bkReader.openLedgerNoRecovery(ledgerId, digestType, "testPasswd".getBytes());) {
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                Assert.assertFalse(writeLh.isClosed());
+
+                // without readUnconfirmedEntries we are not able to read all of the entries
+                try {
+                    rlh.readEntries(0, numOfEntries - 1);
+                    fail("shoud not be able to read up to "+ (numOfEntries - 1) + " with readEntries");
+                } catch (BKException.BKReadException expected) {
+                }
+
+                // read all entries within the 0..LastAddConfirmed range with readEntries
+                assertEquals(rlh.getLastAddConfirmed() + 1,
+                    Collections.list(rlh.readEntries(0, rlh.getLastAddConfirmed())).size());
+
+                // assert local LAC does not change after reads
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                // read all entries within the 0..LastAddConfirmed range with readUnconfirmedEntries
+                assertEquals(rlh.getLastAddConfirmed() + 1,
+                    Collections.list(rlh.readUnconfirmedEntries(0, rlh.getLastAddConfirmed())).size());
+
+                // assert local LAC does not change after reads
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                // read all entries within the LastAddConfirmed..numOfEntries - 1 range with readUnconfirmedEntries
+                assertEquals(numOfEntries - rlh.getLastAddConfirmed(),
+                    Collections.list(rlh.readUnconfirmedEntries(rlh.getLastAddConfirmed(), numOfEntries - 1)).size());
+
+                // assert local LAC does not change after reads
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+                try {
+                    // read all entries within the LastAddConfirmed..numOfEntries range  with readUnconfirmedEntries
+                    // this is an error, we are going outside the range of existing entries
+                    rlh.readUnconfirmedEntries(rlh.getLastAddConfirmed(), numOfEntries);
+                    fail("the read tried to access data for unexisting entry id "+numOfEntries);
+                } catch (BKException.BKNoSuchEntryException expected) {
+                    // expecting a BKNoSuchEntryException, as the entry does not exist on bookies
+                }
+
+                try {
+                    // read all entries within the LastAddConfirmed..numOfEntries range with readEntries
+                    // this is an error, we are going outside the range of existing entries
+                    rlh.readEntries(rlh.getLastAddConfirmed(), numOfEntries);
+                    fail("the read tries to access data for unexisting entry id "+numOfEntries);
+                } catch (BKException.BKReadException expected) {
+                    // expecting a BKReadException, as the client rejected the request to access entries
+                    // after local LastAddConfirmed
+                }
+
+            }
+
+            // open ledger with fencing, this will repair the ledger and make the last entry readable
+            try (BookKeeper bkReader = new BookKeeper(clientConfiguration);
+                LedgerHandle rlh = bkReader.openLedger(ledgerId, digestType, "testPasswd".getBytes());) {
+                Assert.assertTrue(
+                    "Expected LAC of rlh: " + (numOfEntries - 1) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                    (rlh.getLastAddConfirmed() == (numOfEntries - 1)));
+
+                Assert.assertFalse(writeLh.isClosed());
+
+                // without readUnconfirmedEntries we are not able to read all of the entries
+                Enumeration<LedgerEntry> entries = rlh.readEntries(0, numOfEntries - 1);
+                int entryId = 0;
+                while (entries.hasMoreElements()) {
+                    LedgerEntry entry = entries.nextElement();
+                    String entryString = new String(entry.getEntry());
+                    Assert.assertTrue("Expected entry String: " + ("foobar" + entryId)
+                        + " actual entry String: " + entryString,
+                        entryString.equals("foobar" + entryId));
+                    entryId++;
+                }
+            }
+
+            try {
+                writeLh.close();
+                fail("should not be able to close the first LedgerHandler as a recovery has been performed");
+            } catch (BKException.BKMetadataVersionException expected) {
+            }
+
+        }
+    }
 }


### PR DESCRIPTION
This patch introduces a new client-side configuration option to allow reads outside the boundary of the local LastAddConfirmed value.