### PR TITLE
BOOKKEEPER-1042 Deploy SNAPSHOTS of master to public Apache Repository

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server-compat400</artifactId>
-      <version>4.0.0</version>
+      <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server-compat410</artifactId>
-      <version>4.1.0</version>
+      <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -175,7 +175,7 @@
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server-compat420</artifactId>
-      <version>4.2.0</version>
+      <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/compat-deps/bookkeeper-server-compat-4.0.0/pom.xml
+++ b/compat-deps/bookkeeper-server-compat-4.0.0/pom.xml
@@ -25,7 +25,6 @@
   </parent>
   <groupId>org.apache.bookkeeper</groupId>
   <artifactId>bookkeeper-server-compat400</artifactId>
-  <version>4.0.0</version>
   <name>bookkeeper-server-compat400</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/compat-deps/bookkeeper-server-compat-4.1.0/pom.xml
+++ b/compat-deps/bookkeeper-server-compat-4.1.0/pom.xml
@@ -25,7 +25,6 @@
   </parent>
   <groupId>org.apache.bookkeeper</groupId>
   <artifactId>bookkeeper-server-compat410</artifactId>
-  <version>4.1.0</version>
   <name>bookkeeper-server-compat410</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/compat-deps/bookkeeper-server-compat-4.2.0/pom.xml
+++ b/compat-deps/bookkeeper-server-compat-4.2.0/pom.xml
@@ -25,7 +25,6 @@
   </parent>
   <groupId>org.apache.bookkeeper</groupId>
   <artifactId>bookkeeper-server-compat420</artifactId>
-  <version>4.2.0</version>
   <name>bookkeeper-server-compat420</name>
   <url>http://maven.apache.org</url>
   <properties>


### PR DESCRIPTION
Make all pom.xml files have a -SNAPSHOT version.

Currently we have the 'compats' subprojects which have a strange versioning scheme.
Actual versioning scheme for that poms will clash will other versions of the project, because they are fixed and do not depend on the common parent pom.

Changing the version will make the build more reproducible and it is a prerequisite for the deployment of -SNAPSHOT version to the official Apache Snapshots Repository 