### PR TITLE
BOOKKEEPER-1045: Execute tests in different JVM processes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <configuration>
           <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true</argLine>
 	  <redirectTestOutputToFile>true</redirectTestOutputToFile>
-	  <forkMode>always</forkMode>
+	  <reuseForks>false</reuseForks>
 	  <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
         </configuration>
       </plugin>


### PR DESCRIPTION
The current Maven Surefire configuration is using:
```xml
<forkMode>always</forkMode>
```

This is a deprecated config and apparently it's not creating new processes for each test as intended.

Currently the tests are leaking a big number of files and threads due to several reasons:
 * Tests that instantiate bookies and call shutdown() without calling start() before are creating and initializing the ledger storage but not closing it, leaking threads and several fds
  * ZooKeeperClient sometimes doesn't shutdown the zk handle if the test completes too quickly, leaking sockets.
 * Several tests are passing bad config, so the bookie/client start gets exception (on purpose) and then doesn't clean up some partial objects.
 * ...

That make running the test suite to be dependent on ulimit of the machine.

Until we can fix (almost) all the test to do proper cleanup, we should make maven to run tests in separated processes.