### PR TITLE
BOOKKEEPER-1047: Add missing error code in ZK setData return path

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -398,7 +398,7 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
                     metadata.setVersion(zv.setZnodeVersion(stat.getVersion()));
                     cb.operationComplete(BKException.Code.OK, null);
                 } else {
-                    LOG.warn("Conditional update ledger metadata failed: ", KeeperException.Code.get(rc));
+                    LOG.warn("Conditional update ledger metadata failed: {}", KeeperException.Code.get(rc));
                     cb.operationComplete(BKException.Code.ZKException, null);
                 }
             }


### PR DESCRIPTION
The log warning is not printing the error code returned by ZooKeeper
