### PR TITLE
BOOKKEEPER-1048: Use ByteBuf in LedgerStorage interface

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryKeyValue.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryKeyValue.java
@@ -19,6 +19,9 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -82,8 +85,8 @@ public class EntryKeyValue extends EntryKey {
     *
     * @return the value
     */
-    public ByteBuffer getValueAsByteBuffer() {
-        return ByteBuffer.wrap(getBuffer(), getOffset(), getLength());
+    public ByteBuf getValueAsByteBuffer() {
+        return Unpooled.wrappedBuffer(getBuffer(), getOffset(), getLength());
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTable.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTable.java
@@ -251,7 +251,7 @@ public class EntryMemTable {
                         ledger = kv.getLedgerId();
                         if (ledgerGC != ledger) {
                             try {
-                                flusher.process(ledger, kv.getEntryId(), kv.getValueAsByteBuffer());
+                                flusher.process(ledger, kv.getEntryId(), kv.getValueAsByteBuffer().nioBuffer());
                             } catch (NoLedgerException exception) {
                                 ledgerGC = ledger;
                             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import io.netty.buffer.ByteBuf;
+
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LEDGER_CACHE_NUM_EVICTED_LEDGERS;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.NUM_OPEN_LEDGERS;
 
@@ -389,7 +391,7 @@ public class IndexPersistenceMgr {
         }
     }
 
-    void setExplicitLac(long ledgerId, ByteBuffer lac) throws IOException {
+    void setExplicitLac(long ledgerId, ByteBuf lac) throws IOException {
         FileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
@@ -402,7 +404,7 @@ public class IndexPersistenceMgr {
         }
     }
 
-    public ByteBuffer getExplicitLac(long ledgerId) {
+    public ByteBuf getExplicitLac(long ledgerId) {
         FileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -21,6 +21,9 @@
 
 package org.apache.bookkeeper.bookie;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -36,6 +39,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Stopwatch;
+
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
@@ -272,14 +276,14 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
      * Journal Entry to Record
      */
     private class QueueEntry implements Runnable {
-        ByteBuffer entry;
+        ByteBuf entry;
         long ledgerId;
         long entryId;
         WriteCallback cb;
         Object ctx;
         long enqueueTime;
 
-        QueueEntry(ByteBuffer entry, long ledgerId, long entryId,
+        QueueEntry(ByteBuf entry, long ledgerId, long entryId,
                    WriteCallback cb, Object ctx, long enqueueTime) {
             this.entry = entry.duplicate();
             this.cb = cb;
@@ -750,14 +754,20 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
         }
     }
 
+    public void logAddEntry(ByteBuffer entry, WriteCallback cb, Object ctx) {
+        logAddEntry(Unpooled.wrappedBuffer(entry), cb, ctx);
+    }
+
     /**
      * record an add entry operation in journal
      */
-    public void logAddEntry(ByteBuffer entry, WriteCallback cb, Object ctx) {
-        long ledgerId = entry.getLong();
-        long entryId = entry.getLong();
-        entry.rewind();
+    public void logAddEntry(ByteBuf entry, WriteCallback cb, Object ctx) {
+        long ledgerId = entry.getLong(entry.readerIndex() + 0);
+        long entryId = entry.getLong(entry.readerIndex() + 8);
         journalQueueSize.inc();
+
+        //Retain entry until it gets written to journal
+        entry.retain();
         queue.add(new QueueEntry(entry, ledgerId, entryId, cb, ctx, MathUtils.nowInNano()));
     }
 
@@ -927,24 +937,25 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
                     continue;
                 }
 
-                journalWriteBytes.add(qe.entry.remaining());
+                journalWriteBytes.add(qe.entry.readableBytes());
                 journalQueueSize.dec();
 
-                batchSize += (4 + qe.entry.remaining());
+                batchSize += (4 + qe.entry.readableBytes());
 
                 lenBuff.clear();
-                lenBuff.putInt(qe.entry.remaining());
+                lenBuff.putInt(qe.entry.readableBytes());
                 lenBuff.flip();
 
                 // preAlloc based on size
-                logFile.preAllocIfNeeded(4 + qe.entry.remaining());
+                logFile.preAllocIfNeeded(4 + qe.entry.readableBytes());
 
                 //
                 // we should be doing the following, but then we run out of
                 // direct byte buffers
                 // logFile.write(new ByteBuffer[] { lenBuff, qe.entry });
                 bc.write(lenBuff);
-                bc.write(qe.entry);
+                bc.write(qe.entry.nioBuffer());
+                qe.entry.release();
 
                 toFlush.add(qe);
                 qe = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
@@ -25,6 +25,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * This class maps a ledger entry number into a location (entrylogid, offset) in
  * an entry log file. It does user level caching to more efficiently manage disk
@@ -51,6 +53,6 @@ interface LedgerCache extends Closeable {
     void deleteLedger(long ledgerId) throws IOException;
 
     LedgerCacheBean getJMXBean();
-    void setExplicitLac(long ledgerId, ByteBuffer lac) throws IOException;
-    ByteBuffer getExplicitLac(long ledgerId);
+    void setExplicitLac(long ledgerId, ByteBuf lac) throws IOException;
+    ByteBuf getExplicitLac(long ledgerId);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
@@ -31,6 +31,8 @@ import org.apache.bookkeeper.util.SnapshotMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * Implementation of LedgerCache interface.
  * This class serves two purposes.
@@ -137,11 +139,11 @@ public class LedgerCacheImpl implements LedgerCache {
         return indexPersistenceManager.isFenced(ledgerId);
     }
 
-    public void setExplicitLac(long ledgerId, ByteBuffer lac) throws IOException {
+    public void setExplicitLac(long ledgerId, ByteBuf lac) throws IOException {
         indexPersistenceManager.setExplicitLac(ledgerId, lac);
     }
 
-    public ByteBuffer getExplicitLac(long ledgerId) {
+    public ByteBuf getExplicitLac(long ledgerId) {
         return indexPersistenceManager.getExplicitLac(ledgerId);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
@@ -21,12 +21,9 @@
 
 package org.apache.bookkeeper.bookie;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
+import io.netty.buffer.ByteBuf;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.IOException;
 
 /**
  * Implements a ledger inside a bookie. In particular, it implements operations
@@ -57,12 +54,12 @@ public abstract class LedgerDescriptor {
     abstract boolean setFenced() throws IOException;
     abstract boolean isFenced() throws IOException;
 
-    abstract long addEntry(ByteBuffer entry) throws IOException;
-    abstract ByteBuffer readEntry(long entryId) throws IOException;
+    abstract long addEntry(ByteBuf entry) throws IOException;
+    abstract ByteBuf readEntry(long entryId) throws IOException;
 
     abstract long getLastAddConfirmed() throws IOException;
 
-    abstract void setExplicitLac(ByteBuffer entry) throws IOException;
+    abstract void setExplicitLac(ByteBuf entry) throws IOException;
 
-    abstract  ByteBuffer getExplicitLac();
+    abstract  ByteBuf getExplicitLac();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -21,8 +21,10 @@
 
 package org.apache.bookkeeper.bookie;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import org.slf4j.Logger;
@@ -69,28 +71,27 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
     }
 
     @Override
-    void setExplicitLac(ByteBuffer lac) throws IOException {
+    void setExplicitLac(ByteBuf lac) throws IOException {
         ledgerStorage.setExplicitlac(ledgerId, lac);
     }
 
     @Override
-    ByteBuffer getExplicitLac() {
+    ByteBuf getExplicitLac() {
         return ledgerStorage.getExplicitLac(ledgerId);
     }
-    @Override
-    long addEntry(ByteBuffer entry) throws IOException {
-        long ledgerId = entry.getLong();
+
+    long addEntry(ByteBuf entry) throws IOException {
+        long ledgerId = entry.getLong(entry.readerIndex());
 
         if (ledgerId != this.ledgerId) {
             throw new IOException("Entry for ledger " + ledgerId + " was sent to " + this.ledgerId);
         }
-        entry.rewind();
 
         return ledgerStorage.addEntry(entry);
     }
 
     @Override
-    ByteBuffer readEntry(long entryId) throws IOException {
+    ByteBuf readEntry(long entryId) throws IOException {
         return ledgerStorage.getEntry(ledgerId, entryId);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorReadOnlyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorReadOnlyImpl.java
@@ -21,8 +21,9 @@
 
 package org.apache.bookkeeper.bookie;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
-import java.nio.ByteBuffer;
 /**
  * Implements a ledger inside a bookie. In particular, it implements operations
  * to write entries to a ledger and read entries from a ledger.
@@ -39,7 +40,7 @@ public class LedgerDescriptorReadOnlyImpl extends LedgerDescriptorImpl {
     }
 
     @Override
-    long addEntry(ByteBuffer entry) throws IOException {
+    long addEntry(ByteBuf entry) throws IOException {
         assert false;
         throw new IOException("Invalid action on read only descriptor");
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -21,13 +21,13 @@
 
 package org.apache.bookkeeper.bookie;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;
-
 import org.apache.bookkeeper.jmx.BKMBeanInfo;
 import org.apache.bookkeeper.meta.LedgerManager;
 
@@ -101,12 +101,12 @@ public interface LedgerStorage {
      * Add an entry to the storage.
      * @return the entry id of the entry added
      */
-    long addEntry(ByteBuffer entry) throws IOException;
+    long addEntry(ByteBuf entry) throws IOException;
 
     /**
      * Read an entry from storage
      */
-    ByteBuffer getEntry(long ledgerId, long entryId) throws IOException;
+    ByteBuf getEntry(long ledgerId, long entryId) throws IOException;
 
     /**
      * Get last add confirmed.
@@ -162,7 +162,7 @@ public interface LedgerStorage {
      */
     BKMBeanInfo getJMXBean();
 
-    void setExplicitlac(long ledgerId, ByteBuffer lac) throws IOException;
+    void setExplicitlac(long ledgerId, ByteBuf lac) throws IOException;
 
-    ByteBuffer getExplicitLac(long ledgerId);
+    ByteBuf getExplicitLac(long ledgerId);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -20,6 +20,8 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Executors;
@@ -27,6 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
@@ -93,12 +96,12 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
     }
 
     @Override
-    public long addEntry(ByteBuffer entry) throws IOException {
-        long ledgerId = entry.getLong();
-        long entryId = entry.getLong();
-        long lac = entry.getLong();
-        entry.rewind();
-        memTable.addEntry(ledgerId, entryId, entry, this);
+    public long addEntry(ByteBuf entry) throws IOException {
+        long ledgerId = entry.getLong(entry.readerIndex() + 0);
+        long entryId = entry.getLong(entry.readerIndex() + 8);
+        long lac = entry.getLong(entry.readerIndex() + 16);
+
+        memTable.addEntry(ledgerId, entryId, entry.nioBuffer(), this);
         ledgerCache.updateLastAddConfirmed(ledgerId, lac);
         return entryId;
     }
@@ -108,7 +111,7 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
      * @param ledgerId
      * @return
      */
-    private ByteBuffer getLastEntryId(long ledgerId) throws IOException {
+    private ByteBuf getLastEntryId(long ledgerId) throws IOException {
         EntryKeyValue kv = memTable.getLastEntry(ledgerId);
         if (null != kv) {
             return kv.getValueAsByteBuffer();
@@ -118,11 +121,11 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
     }
 
     @Override
-    public ByteBuffer getEntry(long ledgerId, long entryId) throws IOException {
+    public ByteBuf getEntry(long ledgerId, long entryId) throws IOException {
         if (entryId == BookieProtocol.LAST_ADD_CONFIRMED) {
             return getLastEntryId(ledgerId);
         }
-        ByteBuffer buffToRet;
+        ByteBuf buffToRet;
         try {
             buffToRet = super.getEntry(ledgerId, entryId);
         } catch (Bookie.NoEntryException nee) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -22,8 +22,7 @@ package org.apache.bookkeeper.proto;
  */
 
 import io.netty.buffer.ByteBuf;
-
-import java.nio.ByteBuffer;
+import io.netty.buffer.Unpooled;
 
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
 
@@ -262,10 +261,6 @@ public interface BookieProtocol {
             return data;
         }
 
-        ByteBuffer getDataAsByteBuffer() {
-            return data.nioBuffer().slice();
-        }
-
         boolean isRecoveryAdd() {
             return (flags & FLAG_RECOVERY_ADD) == FLAG_RECOVERY_ADD;
         }
@@ -351,7 +346,7 @@ public interface BookieProtocol {
 
         ReadResponse(byte protocolVersion, int errorCode, long ledgerId, long entryId) {
             super(protocolVersion, READENTRY, errorCode, ledgerId, entryId);
-            this.data = null;
+            this.data = Unpooled.EMPTY_BUFFER;
         }
 
         ReadResponse(byte protocolVersion, int errorCode, long ledgerId, long entryId, ByteBuf data) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ResponseBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ResponseBuilder.java
@@ -20,9 +20,7 @@
  */
 package org.apache.bookkeeper.proto;
 
-import io.netty.buffer.Unpooled;
-
-import java.nio.ByteBuffer;
+import io.netty.buffer.ByteBuf;
 
 class ResponseBuilder {
     static BookieProtocol.Response buildErrorResponse(int errorCode, BookieProtocol.Request r) {
@@ -41,8 +39,8 @@ class ResponseBuilder {
                                               r.getEntryId());
     }
 
-    static BookieProtocol.Response buildReadResponse(ByteBuffer data, BookieProtocol.Request r) {
+    static BookieProtocol.Response buildReadResponse(ByteBuf data, BookieProtocol.Request r) {
         return new BookieProtocol.ReadResponse(r.getProtocolVersion(), BookieProtocol.EOK,
-                r.getLedgerId(), r.getEntryId(), Unpooled.wrappedBuffer(data));
+                r.getLedgerId(), r.getEntryId(), data);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -62,11 +62,9 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
         int rc = BookieProtocol.EOK;
         try {
             if (add.isRecoveryAdd()) {
-                requestProcessor.bookie.recoveryAddEntry(add.getDataAsByteBuffer(),
-                                                         this, channel, add.getMasterKey());
+                requestProcessor.bookie.recoveryAddEntry(add.getData(), this, channel, add.getMasterKey());
             } else {
-                requestProcessor.bookie.addEntry(add.getDataAsByteBuffer(),
-                                                 this, channel, add.getMasterKey());
+                requestProcessor.bookie.addEntry(add.getData(), this, channel, add.getMasterKey());
             }
         } catch (IOException e) {
             LOG.error("Error writing " + add, e);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
@@ -20,10 +20,11 @@
  */
 package org.apache.bookkeeper.proto;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.bookie.BookieException;
@@ -102,7 +103,7 @@ class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
         };
         StatusCode status = null;
         byte[] masterKey = addRequest.getMasterKey().toByteArray();
-        ByteBuffer entryToAdd = addRequest.getBody().asReadOnlyByteBuffer();
+        ByteBuf entryToAdd = Unpooled.wrappedBuffer(addRequest.getBody().asReadOnlyByteBuffer());
         try {
             if (addRequest.hasFlag() && addRequest.getFlag().equals(AddRequest.Flag.RECOVERY_ADD)) {
                 requestProcessor.bookie.recoveryAddEntry(entryToAdd, wcb, channel, masterKey);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -34,6 +34,7 @@ import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 
 class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
@@ -69,7 +70,7 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
         byte[] masterKey = writeLacRequest.getMasterKey().toByteArray();
 
         try {
-            requestProcessor.bookie.setExplicitLac(lacToAdd, channel, masterKey);
+            requestProcessor.bookie.setExplicitLac(Unpooled.wrappedBuffer(lacToAdd), channel, masterKey);
             status = StatusCode.EOK;
         } catch (IOException e) {
             logger.error("Error saving lac for ledger:{}",

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.junit.After;
+
 import static org.junit.Assert.*;
 
 public class BookieJournalTest {
@@ -620,15 +621,15 @@ public class BookieJournalTest {
         b.readEntry(1, 99);
 
         // still able to read last entry, but it's junk
-        ByteBuffer buf = b.readEntry(1, 100);
-        assertEquals("Ledger Id is wrong", buf.getLong(), 1);
-        assertEquals("Entry Id is wrong", buf.getLong(), 100);
-        assertEquals("Last confirmed is wrong", buf.getLong(), 99);
-        assertEquals("Length is wrong", buf.getLong(), 100*1024);
-        buf.getLong(); // skip checksum
+        ByteBuf buf = b.readEntry(1, 100);
+        assertEquals("Ledger Id is wrong", buf.readLong(), 1);
+        assertEquals("Entry Id is wrong", buf.readLong(), 100);
+        assertEquals("Last confirmed is wrong", buf.readLong(), 99);
+        assertEquals("Length is wrong", buf.readLong(), 100*1024);
+        buf.readLong(); // skip checksum
         boolean allX = true;
         for (int i = 0; i < 1024; i++) {
-            byte x = buf.get();
+            byte x = buf.readByte();
             allX = allX && x == (byte)'X';
         }
         assertFalse("Some of buffer should have been zeroed", allX);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -20,9 +20,11 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,6 +53,7 @@ import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.TestUtils;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.zookeeper.AsyncCallback;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -571,14 +574,13 @@ public class CompactionTest extends BookKeeperClusterTestCase {
         storage.gcThread.doCompactEntryLogs(threshold);
     }
 
-    private ByteBuffer genEntry(long ledger, long entry, int size) {
-        ByteBuffer bb = ByteBuffer.wrap(new byte[size]);
-        bb.putLong(ledger);
-        bb.putLong(entry);
-        while (bb.hasRemaining()) {
-            bb.put((byte)0xFF);
+    private ByteBuf genEntry(long ledger, long entry, int size) {
+        ByteBuf bb = Unpooled.buffer(size);
+        bb.writeLong(ledger);
+        bb.writeLong(entry);
+        while (bb.isWritable()) {
+            bb.writeByte((byte)0xFF);
         }
-        bb.flip();
         return bb;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
@@ -20,10 +20,10 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Callable;
@@ -35,17 +35,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.LedgerDirsListener;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
-
 import org.apache.bookkeeper.jmx.BKMBeanInfo;
-
+import org.apache.bookkeeper.meta.LedgerManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.junit.Test;
 import org.junit.Before;
 import org.junit.After;
@@ -314,12 +311,12 @@ public class TestSyncThread {
         }
 
         @Override
-        public long addEntry(ByteBuffer entry) throws IOException {
+        public long addEntry(ByteBuf entry) throws IOException {
             return 1L;
         }
 
         @Override
-        public ByteBuffer getEntry(long ledgerId, long entryId)
+        public ByteBuf getEntry(long ledgerId, long entryId)
                 throws IOException {
             return null;
         }
@@ -334,11 +331,11 @@ public class TestSyncThread {
         }
 
         @Override
-        public void setExplicitlac(long ledgerId, ByteBuffer lac) {
+        public void setExplicitlac(long ledgerId, ByteBuf lac) {
         }
 
         @Override
-        public ByteBuffer getExplicitLac(long ledgerId) {
+        public ByteBuf getExplicitLac(long ledgerId) {
             return null;
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
@@ -39,6 +39,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.SettableFuture;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Enumeration;
@@ -72,7 +75,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
         Bookie delayBookie = new Bookie(conf) {
                 @Override
-                public void recoveryAddEntry(ByteBuffer entry, WriteCallback cb,
+                public void recoveryAddEntry(ByteBuf entry, WriteCallback cb,
                                              Object ctx, byte[] masterKey)
                         throws IOException, BookieException {
                     try {
@@ -86,7 +89,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
                 }
 
                 @Override
-                public void addEntry(ByteBuffer entry, WriteCallback cb,
+                public void addEntry(ByteBuf entry, WriteCallback cb,
                                      Object ctx, byte[] masterKey)
                         throws IOException, BookieException {
                     try {
@@ -100,7 +103,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
                 }
 
                 @Override
-                public ByteBuffer readEntry(long ledgerId, long entryId)
+                public ByteBuf readEntry(long ledgerId, long entryId)
                         throws IOException, NoLedgerException {
                     try {
                         Thread.sleep(5000);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -194,7 +196,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
             throws Exception {
         Bookie sBookie = new Bookie(conf) {
             @Override
-            public void addEntry(ByteBuffer entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void addEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 try {
                     latch.await();
@@ -204,7 +206,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
             }
 
             @Override
-            public void recoveryAddEntry(ByteBuffer entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void recoveryAddEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 throw new IOException("Dead bookie for recovery adds.");
             }
@@ -218,7 +220,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
     private void startDeadBookie(ServerConfiguration conf, final CountDownLatch latch) throws Exception {
         Bookie dBookie = new Bookie(conf) {
             @Override
-            public void addEntry(ByteBuffer entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void addEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 try {
                     latch.await();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
@@ -21,6 +21,8 @@ package org.apache.bookkeeper.client;
  *
  */
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
@@ -186,7 +188,7 @@ public class LedgerRecoveryTest extends BaseTestCase {
 
         Bookie fakeBookie = new Bookie(conf) {
             @Override
-            public void addEntry(ByteBuffer entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void addEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 // drop request to simulate a slow and failed bookie
             }
@@ -245,7 +247,7 @@ public class LedgerRecoveryTest extends BaseTestCase {
         ServerConfiguration conf = newServerConfiguration();
         Bookie deadBookie1 = new Bookie(conf) {
             @Override
-            public void recoveryAddEntry(ByteBuffer entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void recoveryAddEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 // drop request to simulate a slow and failed bookie
                 throw new IOException("Couldn't write for some reason");
@@ -326,7 +328,7 @@ public class LedgerRecoveryTest extends BaseTestCase {
         ServerConfiguration conf = newServerConfiguration();
         Bookie deadBookie1 = new Bookie(conf) {
             @Override
-            public void recoveryAddEntry(ByteBuffer entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void recoveryAddEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 // drop request to simulate a slow and failed bookie
                 throw new IOException("Couldn't write for some reason");
@@ -410,7 +412,7 @@ public class LedgerRecoveryTest extends BaseTestCase {
     private void startDeadBookie(ServerConfiguration conf) throws Exception {
         Bookie rBookie = new Bookie(conf) {
             @Override
-            public void recoveryAddEntry(ByteBuffer entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void recoveryAddEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 // drop request to simulate a dead bookie
                 throw new IOException("Couldn't write entries for some reason");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -21,14 +21,16 @@
 
 package org.apache.bookkeeper.meta;
 
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -336,11 +338,11 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         }
 
         @Override
-        public void setExplicitlac(long ledgerId, ByteBuffer lac) throws IOException {
+        public void setExplicitlac(long ledgerId, ByteBuf lac) throws IOException {
         }
 
         @Override
-        public ByteBuffer getExplicitLac(long ledgerId) {
+        public ByteBuf getExplicitLac(long ledgerId) {
             return null;
         }
 
@@ -369,12 +371,12 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         }
 
         @Override
-        public long addEntry(ByteBuffer entry) throws IOException {
+        public long addEntry(ByteBuf entry) throws IOException {
             return 0;
         }
 
         @Override
-        public ByteBuffer getEntry(long ledgerId, long entryId) throws IOException {
+        public ByteBuf getEntry(long ledgerId, long entryId) throws IOException {
             return null;
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -22,7 +22,6 @@
 package org.apache.bookkeeper.meta;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -35,7 +34,6 @@ import org.apache.bookkeeper.bookie.CompactableLedgerStorage;
 import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.EntryLogger;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
-import org.apache.bookkeeper.bookie.LedgerStorage.LedgerDeletionListener;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.jmx.BKMBeanInfo;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -48,6 +46,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * Test case to run over serveral ledger managers
@@ -153,12 +153,12 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         }
 
         @Override
-        public long addEntry(ByteBuffer entry) throws IOException {
+        public long addEntry(ByteBuf entry) throws IOException {
             return 0;
         }
 
         @Override
-        public ByteBuffer getEntry(long ledgerId, long entryId) throws IOException {
+        public ByteBuf getEntry(long ledgerId, long entryId) throws IOException {
             return null;
         }
 
@@ -213,13 +213,13 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         }
 
         @Override
-        public void setExplicitlac(long ledgerId, ByteBuffer lac) throws IOException {
+        public void setExplicitlac(long ledgerId, ByteBuf lac) throws IOException {
             // TODO Auto-generated method stub
 
         }
 
         @Override
-        public ByteBuffer getExplicitLac(long ledgerId) {
+        public ByteBuf getExplicitLac(long ledgerId) {
             // TODO Auto-generated method stub
             return null;
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -235,7 +235,7 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
 
         Bookie delayBookie = new Bookie(conf) {
             @Override
-            public ByteBuffer readEntry(long ledgerId, long entryId)
+            public ByteBuf readEntry(long ledgerId, long entryId)
                     throws IOException, NoLedgerException {
                 try {
                     Thread.sleep(3000);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
@@ -40,6 +40,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
@@ -251,7 +253,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
 
         Bookie deadBookie = new Bookie(conf) {
             @Override
-            public ByteBuffer readEntry(long ledgerId, long entryId)
+            public ByteBuf readEntry(long ledgerId, long entryId)
                     throws IOException, NoLedgerException {
                 // we want to disable during checking
                 numReads.incrementAndGet();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
@@ -21,6 +21,9 @@
 
 package org.apache.bookkeeper.test;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -148,12 +151,12 @@ public class ConcurrentLedgerTest {
         long start = System.currentTimeMillis();
         for(int i = 1; i <= totalwrites/ledgers; i++) {
             for(int j = 1; j <= ledgers; j++) {
-                ByteBuffer entry = bookie.readEntry(j, i);
+                ByteBuf entry = bookie.readEntry(j, i);
                 // skip the ledger id and the entry id
-                entry.getLong();
-                entry.getLong();
-                assertEquals(j + "@" + i, j+2, entry.getLong());
-                assertEquals(j + "@" + i, i+3, entry.getLong());
+                entry.readLong();
+                entry.readLong();
+                assertEquals(j + "@" + i, j+2, entry.readLong());
+                assertEquals(j + "@" + i, i+3, entry.readLong());
             }
         }
         long finish = System.currentTimeMillis();
@@ -184,7 +187,7 @@ public class ConcurrentLedgerTest {
                 bytes.position(0);
                 bytes.limit(bytes.capacity());
                 throttle.acquire();
-                bookie.addEntry(bytes, cb, counter, zeros);
+                bookie.addEntry(Unpooled.wrappedBuffer(bytes), cb, counter, zeros);
             }
         }
         long finish = System.currentTimeMillis();


### PR DESCRIPTION
To pass ref-counted buffer from Netty directly to the storage and the Journal, we need to have LedgerStorage to accept ByteBuf instead of ByteBuffer


#### Note

This commit is on top of BOOKKEEPER-1048 / #138. Once that gets merged, I will rebase. Posting now to get Jenkins run. Please review last commit f53f772f79d0a334edc0f05e66edb7cc645b1ffa in this PR for now.

