### PR TITLE
BOOKKEEPER-1050: Cache journalFormatVersionToWrite when starting Journal

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -792,7 +792,8 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
         ByteBuffer lenBuff = ByteBuffer.allocate(4);
         ByteBuffer paddingBuff = ByteBuffer.allocate(2 * conf.getJournalAlignmentSize());
         ZeroBuffer.put(paddingBuff);
-        int journalFormatVersionToWrite = conf.getJournalFormatVersionToWrite();
+        final int journalFormatVersionToWrite = conf.getJournalFormatVersionToWrite();
+        final int journalAlignmentSize = conf.getJournalAlignmentSize();
         JournalChannel logFile = null;
         forceWriteThread.start();
         Stopwatch journalCreationWatcher = new Stopwatch();
@@ -821,7 +822,7 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
                                         logId,
                                         journalPreAllocSize,
                                         journalWriteBufferSize,
-                                        conf.getJournalAlignmentSize(),
+                                        journalAlignmentSize,
                                         removePagesFromCache,
                                         journalFormatVersionToWrite);
                     journalCreationStats.registerSuccessfulEvent(
@@ -887,7 +888,7 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
                         // toFlush is non null and not empty so should be safe to access getFirst
                         if (shouldFlush) {
                             if (journalFormatVersionToWrite >= JournalChannel.V5) {
-                                writePaddingBytes(logFile, paddingBuff, conf.getJournalAlignmentSize());
+                                writePaddingBytes(logFile, paddingBuff, journalAlignmentSize);
                             }
                             journalFlushWatcher.reset().start();
                             bc.flush(false);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -792,6 +792,7 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
         ByteBuffer lenBuff = ByteBuffer.allocate(4);
         ByteBuffer paddingBuff = ByteBuffer.allocate(2 * conf.getJournalAlignmentSize());
         ZeroBuffer.put(paddingBuff);
+        int journalFormatVersionToWrite = conf.getJournalFormatVersionToWrite();
         JournalChannel logFile = null;
         forceWriteThread.start();
         Stopwatch journalCreationWatcher = new Stopwatch();
@@ -822,7 +823,7 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
                                         journalWriteBufferSize,
                                         conf.getJournalAlignmentSize(),
                                         removePagesFromCache,
-                                        conf.getJournalFormatVersionToWrite());
+                                        journalFormatVersionToWrite);
                     journalCreationStats.registerSuccessfulEvent(
                             journalCreationWatcher.stop().elapsedTime(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
 
@@ -885,7 +886,7 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
 
                         // toFlush is non null and not empty so should be safe to access getFirst
                         if (shouldFlush) {
-                            if (conf.getJournalFormatVersionToWrite() >= JournalChannel.V5) {
+                            if (journalFormatVersionToWrite >= JournalChannel.V5) {
                                 writePaddingBytes(logFile, paddingBuff, conf.getJournalAlignmentSize());
                             }
                             journalFlushWatcher.reset().start();


### PR DESCRIPTION
Reading the journal version format from `ServiceConfiguration` each time is inefficient.
`ServiceConfiguration` is based on Java properties which is based on a String to object hashtable. Each read implies acquiring a mutex and converting from object to int.