### PR TITLE
BOOKKEEPER-1051: Fast shutdown for GarbageCollectorThread

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -487,11 +487,9 @@ public class GarbageCollectorThread extends SafeRunnable {
             // Wait till the thread stops compacting
             Thread.sleep(100);
         }
-        gcExecutor.shutdown();
-        if (gcExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
-            LOG.warn("GC executor did not shut down in 60 seconds. Killing");
-            gcExecutor.shutdownNow();
-        }
+
+        // Interrupt GC executor thread
+        gcExecutor.shutdownNow();
     }
 
     /**


### PR DESCRIPTION
Several unit tests are taking very long time to complete (eg: `BookieLedgerIndexTest` taking ~10 minutes). 
The reason is that these tests are playing with the ZK quorum shutting it down and after the test succeeds, the shutdown phase is taking long time, since we try to do graceful shutdown with 1min wait time.
I think is better to interrupt immediately the garbage collector thread when shutting down the bookie.