### PR TITLE
BOOKKEEPER-1052: Print autorecovery enabled or not in bookie shell

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1295,9 +1295,8 @@ public class BookieShell implements Tool {
             boolean disable = cmdLine.hasOption("d");
             boolean enable = cmdLine.hasOption("e");
 
-            if ((!disable && !enable)
-                || (enable && disable)) {
-                LOG.error("One and only one of -enable and -disable must be specified");
+            if (enable && disable) {
+                LOG.error("Only one of -enable and -disable can be specified");
                 printUsage();
                 return 1;
             }
@@ -1309,7 +1308,10 @@ public class BookieShell implements Tool {
                         .build();
                 LedgerManagerFactory mFactory = LedgerManagerFactory.newLedgerManagerFactory(bkConf, zk);
                 LedgerUnderreplicationManager underreplicationManager = mFactory.newLedgerUnderreplicationManager();
-                if (enable) {
+                if (!enable && !disable) {
+                    boolean enabled = underreplicationManager.isLedgerReplicationEnabled();
+                    System.out.println("Autorecovery is " + (enabled ? "enabled." : "disabled."));
+                } else if (enable) {
                     if (underreplicationManager.isLedgerReplicationEnabled()) {
                         LOG.warn("Autorecovery already enabled. Doing nothing");
                     } else {


### PR DESCRIPTION
Print the current status of auto-recovery, whether it's enabled or disabled.
