### PR TITLE
BOOKKEEPER-1057: Do not log error message after read failure in PendingReadOp

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -389,8 +389,10 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
                     break;
                 }
             }
-            LOG.error("Read of ledger entry failed: L{} E{}-E{}, Heard from {}. First unread entry is {}",
-                    new Object[] { lh.getId(), startEntryId, endEntryId, heardFromHosts, firstUnread });
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Read of ledger entry failed: L{} E{}-E{}, Heard from {}. First unread entry is {}",
+                        new Object[] { lh.getId(), startEntryId, endEntryId, heardFromHosts, firstUnread });
+            }
             readOpLogger.registerFailedEvent(latencyNanos, TimeUnit.NANOSECONDS);
         } else {
             readOpLogger.registerSuccessfulEvent(latencyNanos, TimeUnit.NANOSECONDS);


### PR DESCRIPTION
In PendingReadOp, there is an error message that is printed each time a read on a specific bookie is failing:

```java
LOG.error("Read of ledger entry failed: L{} E{}-E{}, Heard from {}. First unread entry is {}",
    new Object[] { lh.getId(), startEntryId, endEntryId, heardFromHosts, firstUnread });
```

This message is getting printed each time a ledger is recovered and there is no error, since the ledger recovery logic is to keep reading and incrementing the entryId until a NoEntry error is received.

This log message should be set at debug level.