### PR TITLE
BOOKKEEPER-1058: Ignore already deleted ledger on replication audit

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/BookieLedgerIndexer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/BookieLedgerIndexer.java
@@ -71,7 +71,7 @@ public class BookieLedgerIndexer {
                     final AsyncCallback.VoidCallback iterCallback) {
                 GenericCallback<LedgerMetadata> genericCallback = new GenericCallback<LedgerMetadata>() {
                     @Override
-                    public void operationComplete(final int rc,
+                    public void operationComplete(int rc,
                             LedgerMetadata ledgerMetadata) {
                         if (rc == BKException.Code.OK) {
                             for (Map.Entry<Long, ArrayList<BookieSocketAddress>> ensemble : ledgerMetadata
@@ -83,6 +83,10 @@ public class BookieLedgerIndexer {
                                               ledgerId);
                                 }
                             }
+                        } else if (rc == BKException.Code.NoSuchLedgerExistsException) {
+                            LOG.info("Ignoring replication of already deleted ledger {}",
+                                    ledgerId);
+                            rc = BKException.Code.OK;
                         } else {
                             LOG.warn("Unable to read the ledger:" + ledgerId
                                     + " information");


### PR DESCRIPTION
Replication auditor should skip ledgers that were deleted since the auditing was started.
