### PR TITLE
BOOKKEEPER-1063: Use executure.execute() instead of submit() to avoid…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -338,7 +338,7 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
 
                 // Notify the waiters that the force write succeeded
                 for (QueueEntry e : this.forceWriteWaiters) {
-                    cbThreadPool.submit(e);
+                    cbThreadPool.execute(e);
                 }
 
                 return this.forceWriteWaiters.size();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -175,7 +175,7 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
         //
         // The only exception for the size limitation is if a file grows to be more than hard limit 2GB,
         // we have to force rolling log, which it might cause slight performance effects
-        scheduler.submit(new Runnable() {
+        scheduler.execute(new Runnable() {
             @Override
             public void run() {
                 try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManager.java
@@ -32,9 +32,9 @@ import org.apache.zookeeper.ZooKeeper;
  * HierarchicalLedgerManager makes use of both LongHierarchicalLedgerManager and LegacyHierarchicalLedgerManager
  * to extend the 31-bit ledger id range of the LegacyHierarchicalLedgerManager to that of the LongHierarchicalLedgerManager
  * while remaining backwards-compatible with the legacy manager.
- * 
- * In order to achieve backwards-compatibility, the HierarchicalLedgerManager forwards requests relating to ledger IDs which 
- * are < Integer.MAX_INT to the LegacyHierarchicalLedgerManager. The new 5-part directory structure will not appear until a 
+ *
+ * In order to achieve backwards-compatibility, the HierarchicalLedgerManager forwards requests relating to ledger IDs which
+ * are < Integer.MAX_INT to the LegacyHierarchicalLedgerManager. The new 5-part directory structure will not appear until a
  * ledger with an ID >= Integer.MAX_INT is created.
  *
  * @see LongHierarchicalLedgerManager

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/OrderedSafeExecutor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/OrderedSafeExecutor.java
@@ -20,18 +20,14 @@ package org.apache.bookkeeper.util;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.Random;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
@@ -166,7 +162,6 @@ public class OrderedSafeExecutor {
      * @param warnTimeMicroSec
      *            - log long task exec warning after this interval
      */
-    @SuppressWarnings("unchecked")
     private OrderedSafeExecutor(String baseName, int numThreads, ThreadFactory threadFactory,
                                 StatsLogger statsLogger, boolean traceTaskExecution,
                                 long warnTimeMicroSec) {
@@ -281,7 +276,7 @@ public class OrderedSafeExecutor {
      * schedules a one time action to execute
      */
     public void submit(SafeRunnable r) {
-        chooseThread().submit(timedRunnable(r));
+        chooseThread().execute(timedRunnable(r));
     }
 
     /**
@@ -290,12 +285,12 @@ public class OrderedSafeExecutor {
      * @param r
      */
     public void submitOrdered(Object orderingKey, SafeRunnable r) {
-        chooseThread(orderingKey).submit(timedRunnable(r));
+        chooseThread(orderingKey).execute(timedRunnable(r));
     }
 
     /**
      * Creates and executes a one-shot action that becomes enabled after the given delay.
-     * 
+     *
      * @param command - the SafeRunnable to execute
      * @param delay - the time from now to delay execution
      * @param unit - the time unit of the delay parameter
@@ -307,8 +302,8 @@ public class OrderedSafeExecutor {
 
     /**
      * Creates and executes a one-shot action that becomes enabled after the given delay.
-     * 
-     * @param orderingKey - the key used for ordering 
+     *
+     * @param orderingKey - the key used for ordering
      * @param command - the SafeRunnable to execute
      * @param delay - the time from now to delay execution
      * @param unit - the time unit of the delay parameter
@@ -318,35 +313,35 @@ public class OrderedSafeExecutor {
         return chooseThread(orderingKey).schedule(command, delay, unit);
     }
 
-    /** 
+    /**
      * Creates and executes a periodic action that becomes enabled first after
-     * the given initial delay, and subsequently with the given period; 
-     * 
+     * the given initial delay, and subsequently with the given period;
+     *
      * For more details check scheduleAtFixedRate in interface ScheduledExecutorService
-     * 
+     *
      * @param command - the SafeRunnable to execute
      * @param initialDelay - the time to delay first execution
      * @param period - the period between successive executions
      * @param unit - the time unit of the initialDelay and period parameters
-     * @return a ScheduledFuture representing pending completion of the task, and whose get() 
+     * @return a ScheduledFuture representing pending completion of the task, and whose get()
      * method will throw an exception upon cancellation
      */
     public ScheduledFuture<?> scheduleAtFixedRate(SafeRunnable command, long initialDelay, long period, TimeUnit unit) {
         return chooseThread().scheduleAtFixedRate(command, initialDelay, period, unit);
     }
 
-    /** 
+    /**
      * Creates and executes a periodic action that becomes enabled first after
-     * the given initial delay, and subsequently with the given period; 
-     * 
+     * the given initial delay, and subsequently with the given period;
+     *
      * For more details check scheduleAtFixedRate in interface ScheduledExecutorService
-     * 
+     *
      * @param orderingKey - the key used for ordering
      * @param command - the SafeRunnable to execute
      * @param initialDelay - the time to delay first execution
      * @param period - the period between successive executions
      * @param unit - the time unit of the initialDelay and period parameters
-     * @return a ScheduledFuture representing pending completion of the task, and whose get() method 
+     * @return a ScheduledFuture representing pending completion of the task, and whose get() method
      * will throw an exception upon cancellation
      */
     public ScheduledFuture<?> scheduleAtFixedRateOrdered(Object orderingKey, SafeRunnable command, long initialDelay,
@@ -355,16 +350,16 @@ public class OrderedSafeExecutor {
     }
 
     /**
-     * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently 
+     * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently
      * with the given delay between the termination of one execution and the commencement of the next.
-     * 
+     *
      * For more details check scheduleWithFixedDelay in interface ScheduledExecutorService
-     * 
+     *
      * @param command - the SafeRunnable to execute
      * @param initialDelay - the time to delay first execution
      * @param delay - the delay between the termination of one execution and the commencement of the next
      * @param unit - the time unit of the initialDelay and delay parameters
-     * @return a ScheduledFuture representing pending completion of the task, and whose get() method 
+     * @return a ScheduledFuture representing pending completion of the task, and whose get() method
      * will throw an exception upon cancellation
      */
     public ScheduledFuture<?> scheduleWithFixedDelay(SafeRunnable command, long initialDelay, long delay,
@@ -373,17 +368,17 @@ public class OrderedSafeExecutor {
     }
 
     /**
-     * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently 
+     * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently
      * with the given delay between the termination of one execution and the commencement of the next.
-     * 
+     *
      * For more details check scheduleWithFixedDelay in interface ScheduledExecutorService
-     * 
+     *
      * @param orderingKey - the key used for ordering
      * @param command - the SafeRunnable to execute
      * @param initialDelay - the time to delay first execution
      * @param delay - the delay between the termination of one execution and the commencement of the next
      * @param unit - the time unit of the initialDelay and delay parameters
-     * @return a ScheduledFuture representing pending completion of the task, and whose get() method 
+     * @return a ScheduledFuture representing pending completion of the task, and whose get() method
      * will throw an exception upon cancellation
      */
     public ScheduledFuture<?> scheduleWithFixedDelayOrdered(Object orderingKey, SafeRunnable command, long initialDelay,
@@ -397,7 +392,7 @@ public class OrderedSafeExecutor {
      * @param r
      */
     public void submitOrdered(long orderingKey, SafeRunnable r) {
-        chooseThread(orderingKey).submit(r);
+        chooseThread(orderingKey).execute(r);
     }
 
     /**
@@ -406,7 +401,7 @@ public class OrderedSafeExecutor {
      * @param r
      */
     public void submitOrdered(int orderingKey, SafeRunnable r) {
-        chooseThread(orderingKey).submit(r);
+        chooseThread(orderingKey).execute(r);
     }
 
     private long getThreadID(long orderingKey) {


### PR DESCRIPTION
… creation of unused FutureTask

When submitting tasks to an executor, if the `FutureTask` object is not being used we should use `execute()` instead of `submit()` in order to avoid the task object allocation.
