### PR TITLE
BOOKKEEPER-1064: ConcurrentModificationException in AuditorLedgerCheckerTest

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -77,7 +78,7 @@ public class AuditorLedgerCheckerTest extends MultiLedgerManagerTestCase {
     private final String UNDERREPLICATED_PATH = baseClientConf
             .getZkLedgersRootPath()
             + "/underreplication/ledgers";
-    private HashMap<String, AuditorElector> auditorElectors = new HashMap<String, AuditorElector>();
+    private Map<String, AuditorElector> auditorElectors = new ConcurrentHashMap<>();
     private ZkLedgerUnderreplicationManager urLedgerMgr;
     private Set<Long> urLedgerList;
     private String electionPath;
@@ -316,7 +317,7 @@ public class AuditorLedgerCheckerTest extends MultiLedgerManagerTestCase {
 
         /*
          * Sample data format present in the under replicated ledger path
-         * 
+         *
          * {4=replica: "10.18.89.153:5002"}
          */
         assertTrue("Ledger is not marked as underreplicated:" + ledgerId, urLedgerList.contains(ledgerId));


### PR DESCRIPTION
As seen in:
https://builds.apache.org/job/bookkeeper-master-git-pullrequest/371/

The test is iterating over a hash map that gets updated by a different thread. The map needs to be concurrent.

```
java.util.ConcurrentModificationException
	at org.apache.bookkeeper.replication.AuditorLedgerCheckerTest.stopAuditorElectors(AuditorLedgerCheckerTest.java:130)
	at org.apache.bookkeeper.replication.AuditorLedgerCheckerTest.tearDown(AuditorLedgerCheckerTest.java:114)
```

All subsequent tests in the same class are failing because of the 1st test not cleaning up properly.