### PR TITLE
BOOKKEEPER-1068: Expose ByteBuf in LedgerEntry to avoid data copy

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DigestManager.java
@@ -19,7 +19,6 @@ package org.apache.bookkeeper.client;
  */
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 
@@ -83,22 +82,18 @@ abstract class DigestManager {
      * @param data
      * @return
      */
-
-    public ByteBuf computeDigestAndPackageForSending(long entryId, long lastAddConfirmed, long length, byte[] data,
-            int doffset, int dlength) {
+    public ByteBuf computeDigestAndPackageForSending(long entryId, long lastAddConfirmed, long length, ByteBuf data) {
         ByteBuf headersBuffer = PooledByteBufAllocator.DEFAULT.buffer(METADATA_LENGTH + macCodeLength);
         headersBuffer.writeLong(ledgerId);
         headersBuffer.writeLong(entryId);
         headersBuffer.writeLong(lastAddConfirmed);
         headersBuffer.writeLong(length);
 
-        ByteBuf dataBuffer = Unpooled.wrappedBuffer(data, doffset, dlength);
-
         update(headersBuffer);
-        update(dataBuffer);
+        update(data);
         populateValueAndReset(headersBuffer);
 
-        return DoubleByteBuf.get(headersBuffer, dataBuffer);
+        return DoubleByteBuf.get(headersBuffer, data);
     }
 
     /**
@@ -212,11 +207,11 @@ abstract class DigestManager {
      * @return
      * @throws BKDigestMatchException
      */
-    ByteBufInputStream verifyDigestAndReturnData(long entryId, ByteBuf dataReceived)
+    ByteBuf verifyDigestAndReturnData(long entryId, ByteBuf dataReceived)
             throws BKDigestMatchException {
         verifyDigest(entryId, dataReceived);
         dataReceived.readerIndex(METADATA_LENGTH + macCodeLength);
-        return new ByteBufInputStream(dataReceived);
+        return dataReceived;
     }
 
     static class RecoveryData {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerEntry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerEntry.java
@@ -21,13 +21,10 @@ package org.apache.bookkeeper.client;
  *
  */
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 
-import java.io.IOException;
 import java.io.InputStream;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Ledger entry. Its a simple tuple containing the ledger id, the entry-id, and
@@ -36,12 +33,10 @@ import org.slf4j.LoggerFactory;
  */
 
 public class LedgerEntry {
-    private final static Logger LOG = LoggerFactory.getLogger(LedgerEntry.class);
-
     long ledgerId;
     long entryId;
     long length;
-    ByteBufInputStream entryDataStream;
+    ByteBuf data;
 
     LedgerEntry(long lId, long eId) {
         this.ledgerId = lId;
@@ -61,23 +56,23 @@ public class LedgerEntry {
     }
 
     public byte[] getEntry() {
-        try {
-            // In general, you can't rely on the available() method of an input
-            // stream, but ChannelBufferInputStream is backed by a byte[] so it
-            // accurately knows the # bytes available
-            byte[] ret = new byte[entryDataStream.available()];
-            entryDataStream.readFully(ret);
-            return ret;
-        } catch (IOException e) {
-            // The channelbufferinput stream doesnt really throw the
-            // ioexceptions, it just has to be in the signature because
-            // InputStream says so. Hence this code, should never be reached.
-            LOG.error("Unexpected IOException while reading from channel buffer", e);
-            return new byte[0];
-        }
+        byte[] entry = new byte[data.readableBytes()];
+        data.readBytes(entry);
+        data.release();
+        return entry;
     }
 
     public InputStream getEntryInputStream() {
-        return entryDataStream;
+        return new ByteBufInputStream(data);
+    }
+
+    /**
+     * Return the internal buffer that contains the entry payload.
+     * <p>
+     *
+     * Note: It is responsibility of the caller to ensure to release the buffer after usage.
+     */
+    public ByteBuf getEntryBuffer() {
+        return data;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -20,6 +20,7 @@
 package org.apache.bookkeeper.client;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -284,7 +285,7 @@ public class LedgerFragmentReplicator {
                 ByteBuf toSend = lh.getDigestManager()
                         .computeDigestAndPackageForSending(entryId,
                                 lh.getLastAddConfirmed(), entry.getLength(),
-                                data, 0, data.length);
+                                Unpooled.wrappedBuffer(data, 0, data.length));
                 bkc.getBookieClient().addEntry(newBookie, lh.getId(),
                         lh.getLedgerKey(), entryId, toSend,
                         new WriteCallback() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.client;
 
 import static com.google.common.base.Charsets.UTF_8;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
@@ -708,8 +709,21 @@ public class LedgerHandle implements AutoCloseable {
      */
     public void asyncAddEntry(final byte[] data, final int offset, final int length,
                               final AddCallback cb, final Object ctx) {
+        if (offset < 0 || length < 0
+                || (offset + length) > data.length) {
+            throw new ArrayIndexOutOfBoundsException(
+                    "Invalid values for offset("+offset
+                    +") or length("+length+")");
+        }
+
         PendingAddOp op = new PendingAddOp(LedgerHandle.this, cb, ctx);
-        doAsyncAddEntry(op, data, offset, length, cb, ctx);
+        doAsyncAddEntry(op, Unpooled.wrappedBuffer(data, offset, length), cb, ctx);
+    }
+
+    public void asyncAddEntry(ByteBuf data, final AddCallback cb, final Object ctx) {
+        data.retain();
+        PendingAddOp op = new PendingAddOp(LedgerHandle.this, cb, ctx);
+        doAsyncAddEntry(op, data, cb, ctx);
     }
 
     /**
@@ -751,19 +765,10 @@ public class LedgerHandle implements AutoCloseable {
     void asyncRecoveryAddEntry(final byte[] data, final int offset, final int length,
                                final AddCallback cb, final Object ctx) {
         PendingAddOp op = new PendingAddOp(LedgerHandle.this, cb, ctx).enableRecoveryAdd();
-        doAsyncAddEntry(op, data, offset, length, cb, ctx);
+        doAsyncAddEntry(op, Unpooled.wrappedBuffer(data, offset, length), cb, ctx);
     }
 
-    void doAsyncAddEntry(final PendingAddOp op, final byte[] data, final int offset, final int length,
-                         final AddCallback cb, final Object ctx) {
-
-        if (offset < 0 || length < 0
-                || (offset + length) > data.length) {
-            throw new ArrayIndexOutOfBoundsException(
-                    "Invalid values for offset(" +offset
-                    +") or length("+length+")");
-        }
-
+    protected void doAsyncAddEntry(final PendingAddOp op, final ByteBuf data, final AddCallback cb, final Object ctx) {
         if (throttler != null) {
             throttler.acquire();
         }
@@ -781,7 +786,7 @@ public class LedgerHandle implements AutoCloseable {
                 currentLength = 0;
             } else {
                 entryId = ++lastAddPushed;
-                currentLength = addToLength(length);
+                currentLength = addToLength(data.readableBytes());
                 op.setEntryId(entryId);
                 pendingAddOps.add(op);
             }
@@ -815,9 +820,9 @@ public class LedgerHandle implements AutoCloseable {
                 @Override
                 public void safeRun() {
                     ByteBuf toSend = macManager.computeDigestAndPackageForSending(entryId, lastAddConfirmed,
-                            currentLength, data, offset, length);
+                            currentLength, data);
                     try {
-                        op.initiate(toSend, length);
+                        op.initiate(toSend, data.readableBytes());
                     } finally {
                         toSend.release();
                     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ClientUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ClientUtil.java
@@ -18,6 +18,7 @@
 package org.apache.bookkeeper.client;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 public class ClientUtil {
     public static ByteBuf generatePacket(long ledgerId, long entryId, long lastAddConfirmed,
@@ -29,7 +30,7 @@ public class ClientUtil {
                                                long length, byte[] data, int offset, int len) {
         CRC32DigestManager dm = new CRC32DigestManager(ledgerId);
         return dm.computeDigestAndPackageForSending(entryId, lastAddConfirmed, length,
-                                                    data, offset, len);
+                                                    Unpooled.wrappedBuffer(data, offset, len));
     }
 
     /** Returns that whether ledger is in open state */


### PR DESCRIPTION
To avoid copying the entries payloads when writing/reading on a ledger and having to allocate a lot of `byte[]` on the JVM heap, we need to accept Netty ByteBuf buffer.

By passing a ByteBuf, an application can use a pooled buffer, pointing to direct memory, to the `LedgerHandle.addEntry()` and have the same buffer forwarded on the connection sockets to the bookies.

The same thing on the read side, `LedgerEntry` exposes an additional `getEntryBuffer()` method that can be used to get the underlying buffer and possibly forward that to some other connection, with zero-copy behavior (excluding getting data in-out of the kernel).