### PR TITLE
BOOKKEEPER-1075: BK LedgerMetadata: more memory-efficient parsing of configs

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -393,8 +394,13 @@ public class LedgerMetadata {
             return parseVersion1Config(lc, reader);
         }
 
+        // remaining size is total minus the length of the version line and '\n'
+        char[] configBuffer = new char[config.length() - (versionLine.length() + 1)];
+        reader.read(configBuffer, 0, configBuffer.length);
+
         LedgerMetadataFormat.Builder builder = LedgerMetadataFormat.newBuilder();
-        TextFormat.merge(reader, builder);
+
+        TextFormat.merge((CharSequence) CharBuffer.wrap(configBuffer), builder);
         LedgerMetadataFormat data = builder.build();
         lc.writeQuorumSize = data.getQuorumSize();        
         if (data.hasCtime()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -396,7 +396,9 @@ public class LedgerMetadata {
 
         // remaining size is total minus the length of the version line and '\n'
         char[] configBuffer = new char[config.length() - (versionLine.length() + 1)];
-        reader.read(configBuffer, 0, configBuffer.length);
+        if (configBuffer.length != reader.read(configBuffer, 0, configBuffer.length)) {
+            throw new IOException("Invalid metadata buffer");
+        }
 
         LedgerMetadataFormat.Builder builder = LedgerMetadataFormat.newBuilder();
 


### PR DESCRIPTION
It is the contribution from Alex Yarmula

commit 9d9d7dd26235a9beda4421b7bed750fea1789076
Author: Alex Yarmula <ak@twitter.com>
Date: Wed Sep 23 05:57:30 2015 -0700

BK LedgerMetadata: more memory-efficient parsing of configs
Looking at the most prevalent client-side memory allocations, I noticed that we allocate 4KB every time we open a ledger. This is caused by allocating a 4KB buffer (in TextFormat.toStringBuilder) to account for the maximum possible Protobufs message, which is unnecessary in our case: we know the exact size of the metadata ( << 500 B) and don't need to allocate more.
TextFormat.merge(Readable, Message.Builder) is the current method we use. This changes to use TextFormat.merge(CharSequence, Message.Builder), which avoids the extra 4K allocation conversion + an extra StringBuilder.

RB_ID=745700