### PR TITLE
BOOKKEEPER-1084: Make variables finale if necessary

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerEntry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerEntry.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.client;
-
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,6 +18,7 @@ package org.apache.bookkeeper.client;
  * under the License.
  *
  */
+package org.apache.bookkeeper.client;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -31,7 +30,6 @@ import java.io.InputStream;
  * the entry content.
  *
  */
-
 public class LedgerEntry {
     long ledgerId;
     long entryId;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
-    private final static Logger LOG = LoggerFactory.getLogger(PendingReadOp.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PendingReadOp.class);
 
     final int speculativeReadTimeout;
     final private ScheduledExecutorService scheduler;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -88,7 +88,6 @@ import org.apache.bookkeeper.proto.BookkeeperProtocol.Response;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse;
-
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/streaming/LedgerInputStream.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/streaming/LedgerInputStream.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 public class LedgerInputStream extends InputStream {
     private final static Logger LOG = LoggerFactory.getLogger(LedgerInputStream.class);
-    private LedgerHandle lh;
+    private final LedgerHandle lh;
     private ByteBuffer bytebuff;
     byte[] bbytes;
     long lastEntry = 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/streaming/LedgerOutputStream.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/streaming/LedgerOutputStream.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LedgerOutputStream extends OutputStream {
     private final static Logger LOG = LoggerFactory.getLogger(LedgerOutputStream.class);
-    private LedgerHandle lh;
+    private final LedgerHandle lh;
     private ByteBuffer bytebuff;
     byte[] bbytes;
     int defaultSize = 1024 * 1024; // 1MB default size

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LoopbackClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LoopbackClient.java
@@ -39,13 +39,11 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class tests BookieClient. It just sends the a new entry to itself.
- *
- *
- *
  */
-
 class LoopbackClient implements WriteCallback {
-    private final static Logger LOG = LoggerFactory.getLogger(LoopbackClient.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoopbackClient.class);
+
     BookieClient client;
     static int recvTimeout = 2000;
     long begin = 0;
@@ -81,6 +79,7 @@ class LoopbackClient implements WriteCallback {
         client.addEntry(addr, ledgerId, passwd, entry, Unpooled.wrappedBuffer(data), cb, ctx, BookieProtocol.FLAG_NONE);
     }
 
+    @Override
     public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx) {
         Counter counter = (Counter) ctx;
         counter.increment();


### PR DESCRIPTION
not all logger in bookkeeper & hedwig are static. some class like PendnigReadOp and LedgerEntry would have lots of objects, it might be bad. so this task is to make logger as a static variable if it didn't.

with benefit, cleaning up the imports when touching that file.

RB_ID=141138