### PR TITLE
BOOKKEEPER-1056: Removed PacketHeader serialization/deserialization allocation

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -69,18 +69,8 @@ public interface BookieProtocol {
      * and just had an int representing the opCode as the 
      * first int. This handles that case also. 
      */
-    static class PacketHeader {
-        final byte version;
-        final byte opCode;
-        final short flags;
-
-        public PacketHeader(byte version, byte opCode, short flags) {
-            this.version = version;
-            this.opCode = opCode;
-            this.flags = flags;
-        }
-        
-        int toInt() {
+    final static class PacketHeader {
+        public static int toInt(byte version, byte opCode, short flags) {
             if (version == 0) {
                 return (int)opCode;
             } else {
@@ -90,29 +80,26 @@ public interface BookieProtocol {
             }
         }
 
-        static PacketHeader fromInt(int i) {
-            byte version = (byte)(i >> 24); 
-            byte opCode = 0;
-            short flags = 0;
+        public static byte getVersion(int packetHeader) {
+            return (byte)(packetHeader >> 24);
+        }
+
+        public static byte getOpCode(int packetHeader) {
+            int version = getVersion(packetHeader);
             if (version == 0) {
-                opCode = (byte)i;
+                return (byte) packetHeader;
             } else {
-                opCode = (byte)((i >> 16) & 0xFF);
-                flags = (short)(i & 0xFFFF);
+                return (byte)((packetHeader >> 16) & 0xFF);
             }
-            return new PacketHeader(version, opCode, flags);
         }
 
-        byte getVersion() {
-            return version;
-        }
-
-        byte getOpCode() {
-            return opCode;
-        }
-
-        short getFlags() {
-            return flags;
+        public static short getFlags(int packetHeader) {
+            byte version = (byte)(packetHeader >> 24);
+            if (version == 0) {
+                return 0;
+            } else {
+                return (short)(packetHeader & 0xFFFF);
+            }
         }
     }
 


### PR DESCRIPTION
When parsing the request packet header, use static methods to avoid creating a `PacketHeader` instance.
