### PR TITLE
BOOKKEEPER-1087: Ledger Recovery (part 2) - Add a parallel reading request in PendingReadOp

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1466,7 +1466,8 @@ public class LedgerHandle implements AutoCloseable {
         if (wasInRecovery) {
             // if metadata is already in recover, dont try to write again,
             // just do the recovery from the starting point
-            new LedgerRecoveryOp(LedgerHandle.this, cb).initiate();
+            new LedgerRecoveryOp(LedgerHandle.this, cb)
+                    .parallelRead(bk.getConf().getEnableParallelRecoveryRead()).initiate();
             return;
         }
 
@@ -1492,7 +1493,8 @@ public class LedgerHandle implements AutoCloseable {
                         }
                     });
                 } else if (rc == BKException.Code.OK) {
-                    new LedgerRecoveryOp(LedgerHandle.this, cb).initiate();
+                    new LedgerRecoveryOp(LedgerHandle.this, cb)
+                            .parallelRead(bk.getConf().getEnableParallelRecoveryRead()).initiate();
                 } else {
                     LOG.error("Error writing ledger config " + rc + " of ledger " + ledgerId);
                     cb.operationComplete(rc, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -49,6 +49,7 @@ class LedgerRecoveryOp implements ReadCallback, AddCallback {
     long entryToRead;
     // keep a copy of metadata for recovery.
     LedgerMetadata metadataForRecovery;
+    boolean parallelRead = false;
 
     GenericCallback<Void> cb;
 
@@ -73,6 +74,11 @@ class LedgerRecoveryOp implements ReadCallback, AddCallback {
         callbackDone = new AtomicBoolean(false);
         this.cb = cb;
         this.lh = lh;
+    }
+
+    LedgerRecoveryOp parallelRead(boolean enabled) {
+        this.parallelRead = enabled;
+        return this;
     }
 
     public void initiate() {
@@ -110,7 +116,7 @@ class LedgerRecoveryOp implements ReadCallback, AddCallback {
         if (!callbackDone.get()) {
             entryToRead++;
             try {
-                new RecoveryReadOp(lh, lh.bk.scheduler, entryToRead, entryToRead, this, null).initiate();
+                new RecoveryReadOp(lh, lh.bk.scheduler, entryToRead, entryToRead, this, null).parallelRead(parallelRead).initiate();
             } catch (InterruptedException e) {
                 readComplete(BKException.Code.InterruptedException, lh, null, null);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -213,7 +213,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
 
         int numPendings;
 
-        ParallelReadRequest(ArrayList<InetSocketAddress> ensemble, long lId, long eId) {
+        ParallelReadRequest(ArrayList<BookieSocketAddress> ensemble, long lId, long eId) {
             super(ensemble, lId, eId);
             numPendings = writeSet.size();
         }
@@ -221,7 +221,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
         @Override
         void read() {
             for (int bookieIndex : writeSet) {
-                InetSocketAddress to = ensemble.get(bookieIndex);
+                BookieSocketAddress to = ensemble.get(bookieIndex);
                 try {
                     sendReadTo(to, this);
                 } catch (InterruptedException ie) {
@@ -234,7 +234,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
         }
 
         @Override
-        synchronized void logErrorAndReattemptRead(InetSocketAddress host, String errMsg, int rc) {
+        synchronized void logErrorAndReattemptRead(BookieSocketAddress host, String errMsg, int rc) {
             super.logErrorAndReattemptRead(host, errMsg, rc);
             --numPendings;
             // if received all responses or this entry doesn't meet quorum write, complete the request.
@@ -249,7 +249,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
         }
 
         @Override
-        InetSocketAddress maybeSendSpeculativeRead(Set<InetSocketAddress> heardFromHosts) {
+        BookieSocketAddress maybeSendSpeculativeRead(Set<BookieSocketAddress> heardFromHosts) {
             // no speculative read
             return null;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -71,6 +71,8 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
     OpStatsLogger readOpLogger;
 
     final int maxMissedReadsAllowed;
+    boolean parallelRead = false;
+    final AtomicBoolean complete = new AtomicBoolean(false);
 
     abstract class LedgerEntryRequest extends LedgerEntry {
 
@@ -124,6 +126,22 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
                 return true;
             } else {
                 buffer.release();
+                return false;
+            }
+        }
+
+        /**
+         * Fail the request with given result code <i>rc</i>.
+         *
+         * @param rc
+         *          result code to fail the request.
+         * @return true if we managed to fail the entry; otherwise return false if it already failed or completed.
+         */
+        boolean fail(int rc) {
+            if (complete.compareAndSet(false, true)) {
+                submitCallback(rc);
+                return true;
+            } else {
                 return false;
             }
         }
@@ -188,6 +206,52 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
         @Override
         public String toString() {
             return String.format("L%d-E%d", ledgerId, entryId);
+        }
+    }
+
+    class ParallelReadRequest extends LedgerEntryRequest {
+
+        int numPendings;
+
+        ParallelReadRequest(ArrayList<InetSocketAddress> ensemble, long lId, long eId) {
+            super(ensemble, lId, eId);
+            numPendings = writeSet.size();
+        }
+
+        @Override
+        void read() {
+            for (int bookieIndex : writeSet) {
+                InetSocketAddress to = ensemble.get(bookieIndex);
+                try {
+                    sendReadTo(to, this);
+                } catch (InterruptedException ie) {
+                    LOG.error("Interrupted reading entry {} : ", this, ie);
+                    Thread.currentThread().interrupt();
+                    fail(BKException.Code.InterruptedException);
+                    return;
+                }
+            }
+        }
+
+        @Override
+        synchronized void logErrorAndReattemptRead(InetSocketAddress host, String errMsg, int rc) {
+            super.logErrorAndReattemptRead(host, errMsg, rc);
+            --numPendings;
+            // if received all responses or this entry doesn't meet quorum write, complete the request.
+            if (numMissedEntryReads > maxMissedReadsAllowed || numPendings == 0) {
+                if (BKException.Code.BookieHandleNotAvailableException == firstError &&
+                    numMissedEntryReads > maxMissedReadsAllowed) {
+                    firstError = BKException.Code.NoSuchEntryException;
+                }
+
+                fail(firstError);
+            }
+        }
+
+        @Override
+        InetSocketAddress maybeSendSpeculativeRead(Set<InetSocketAddress> heardFromHosts) {
+            // no speculative read
+            return null;
         }
     }
 
@@ -280,7 +344,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
                     firstError = BKException.Code.NoSuchEntryException;
                 }
 
-                submitCallback(firstError);
+                fail(firstError);
                 return null;
             }
 
@@ -296,7 +360,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
             } catch (InterruptedException ie) {
                 LOG.error("Interrupted reading entry " + this, ie);
                 Thread.currentThread().interrupt();
-                submitCallback(BKException.Code.ReadException);
+                fail(BKException.Code.InterruptedException);
                 return null;
             }
         }
@@ -347,12 +411,17 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
         }
     }
 
+    PendingReadOp parallelRead(boolean enabled) {
+        this.parallelRead = enabled;
+        return this;
+    }
+
     public void initiate() throws InterruptedException {
         long nextEnsembleChange = startEntryId, i = startEntryId;
         this.requestTimeNanos = MathUtils.nowInNano();
         ArrayList<BookieSocketAddress> ensemble = null;
 
-        if (speculativeReadTimeout > 0) {
+        if (speculativeReadTimeout > 0 && !parallelRead) {
             Runnable readTask = new Runnable() {
                 public void run() {
                     int x = 0;
@@ -388,7 +457,12 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
                 ensemble = getLedgerMetadata().getEnsemble(i);
                 nextEnsembleChange = getLedgerMetadata().getNextEnsembleChange(i);
             }
-            LedgerEntryRequest entry = new SequenceReadRequest(ensemble, lh.ledgerId, i);
+            LedgerEntryRequest entry;
+            if (parallelRead) {
+                entry = new ParallelReadRequest(ensemble, lh.ledgerId, i);
+            } else {
+                entry = new SequenceReadRequest(ensemble, lh.ledgerId, i);
+            }
             seq.add(entry);
             i++;
 
@@ -441,6 +515,11 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
     private void submitCallback(int code) {
         if (cb == null) {
             // Callback had already been triggered before
+            return;
+        }
+
+        // ensure callback once
+        if (!complete.compareAndSet(false, true)) {
             return;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -72,24 +72,129 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
 
     final int maxMissedReadsAllowed;
 
-    class LedgerEntryRequest extends LedgerEntry {
-        final static int NOT_FOUND = -1;
-        int nextReplicaIndexToReadFrom = 0;
-        AtomicBoolean complete = new AtomicBoolean(false);
+    abstract class LedgerEntryRequest extends LedgerEntry {
+
+        final AtomicBoolean complete = new AtomicBoolean(false);
 
         int firstError = BKException.Code.OK;
         int numMissedEntryReads = 0;
 
         final ArrayList<BookieSocketAddress> ensemble;
         final List<Integer> writeSet;
-        final BitSet sentReplicas;
-        final BitSet erroredReplicas;
 
         LedgerEntryRequest(ArrayList<BookieSocketAddress> ensemble, long lId, long eId) {
             super(lId, eId);
 
             this.ensemble = ensemble;
             this.writeSet = lh.distributionSchedule.getWriteSet(entryId);
+        }
+
+        /**
+         * Execute the read request.
+         */
+        abstract void read();
+
+        /**
+         * Complete the read request from <i>host</i>.
+         *
+         * @param host
+         *          host that respond the read
+         * @param buffer
+         *          the data buffer
+         * @return return true if we managed to complete the entry;
+         *         otherwise return false if the read entry is not complete or it is already completed before
+         */
+        boolean complete(InetSocketAddress host, final ChannelBuffer buffer) {
+            ChannelBufferInputStream is;
+            try {
+                is = lh.macManager.verifyDigestAndReturnData(entryId, buffer);
+            } catch (BKDigestMatchException e) {
+                logErrorAndReattemptRead(host, "Mac mismatch", BKException.Code.DigestMatchException);
+                return false;
+            }
+
+            if (!complete.getAndSet(true)) {
+                entryDataStream = is;
+
+                /*
+                 * The length is a long and it is the last field of the metadata of an entry.
+                 * Consequently, we have to subtract 8 from METADATA_LENGTH to get the length.
+                 */
+                length = buffer.getLong(DigestManager.METADATA_LENGTH - 8);
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * Log error <i>errMsg</i> and reattempt read from <i>host</i>.
+         *
+         * @param host
+         *          host that just respond
+         * @param errMsg
+         *          error msg to log
+         * @param rc
+         *          read result code
+         */
+        void logErrorAndReattemptRead(InetSocketAddress host, String errMsg, int rc) {
+            if (BKException.Code.OK == firstError ||
+                BKException.Code.NoSuchEntryException == firstError ||
+                BKException.Code.NoSuchLedgerExistsException == firstError) {
+                firstError = rc;
+            } else if (BKException.Code.BookieHandleNotAvailableException == firstError &&
+                       BKException.Code.NoSuchEntryException != rc &&
+                       BKException.Code.NoSuchLedgerExistsException != rc) {
+                // if other exception rather than NoSuchEntryException is returned
+                // we need to update firstError to indicate that it might be a valid read but just failed.
+                firstError = rc;
+            }
+            if (BKException.Code.NoSuchEntryException == rc ||
+                BKException.Code.NoSuchLedgerExistsException == rc) {
+                ++numMissedEntryReads;
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(errMsg + " while reading entry: " + entryId + " ledgerId: " + lh.ledgerId + " from bookie: "
+                        + host);
+            }
+        }
+
+        /**
+         * Send to next replica speculatively, if required and possible.
+         * This returns the host we may have sent to for unit testing.
+         *
+         * @param heardFromHosts
+         *      the set of hosts that we already received responses.
+         * @return host we sent to if we sent. null otherwise.
+         */
+        abstract InetSocketAddress maybeSendSpeculativeRead(Set<InetSocketAddress> heardFromHosts);
+
+        /**
+         * Whether the read request completed.
+         *
+         * @return true if the read request is completed.
+         */
+        boolean isComplete() {
+            return complete.get();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("L%d-E%d", ledgerId, entryId);
+        }
+    }
+
+    class SequenceReadRequest extends LedgerEntryRequest {
+        final static int NOT_FOUND = -1;
+        int nextReplicaIndexToReadFrom = 0;
+
+        final BitSet sentReplicas;
+        final BitSet erroredReplicas;
+
+        SequenceReadRequest(ArrayList<InetSocketAddress> ensemble, long lId, long eId) {
+            super(ensemble, lId, eId);
+
             this.sentReplicas = new BitSet(lh.getLedgerMetadata().getWriteQuorumSize());
             this.erroredReplicas = new BitSet(lh.getLedgerMetadata().getWriteQuorumSize());
         }
@@ -133,6 +238,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
          * This returns the host we may have sent to for unit testing.
          * @return host we sent to if we sent. null otherwise.
          */
+        @Override
         synchronized BookieSocketAddress maybeSendSpeculativeRead(Set<BookieSocketAddress> heardFromHosts) {
             if (nextReplicaIndexToReadFrom >= getLedgerMetadata().getWriteQuorumSize()) {
                 return null;
@@ -149,6 +255,11 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
             } else {
                 return null;
             }
+        }
+
+        @Override
+        void read() {
+            sendNextRead();
         }
 
         synchronized BookieSocketAddress sendNextRead() {
@@ -184,28 +295,9 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
             }
         }
 
+        @Override
         synchronized void logErrorAndReattemptRead(BookieSocketAddress host, String errMsg, int rc) {
-            if (BKException.Code.OK == firstError ||
-                BKException.Code.NoSuchEntryException == firstError ||
-                BKException.Code.NoSuchLedgerExistsException == firstError) {
-                firstError = rc;
-            } else if (BKException.Code.BookieHandleNotAvailableException == firstError &&
-                       BKException.Code.NoSuchEntryException != rc &&
-                       BKException.Code.NoSuchLedgerExistsException != rc) {
-                // if other exception rather than NoSuchEntryException or NoSuchLedgerExistsException is
-                // returned we need to update firstError to indicate that it might be a valid read but just
-                // failed.
-                firstError = rc;
-            }
-            if (BKException.Code.NoSuchEntryException == rc ||
-                BKException.Code.NoSuchLedgerExistsException == rc) {
-                ++numMissedEntryReads;
-                LOG.debug("No such entry found on bookie.  L{} E{} bookie: {}",
-                        new Object[] { lh.ledgerId, entryId, host });
-            } else {
-                LOG.debug(errMsg + " while reading L{} E{} from bookie: {}",
-                          new Object[] { lh.ledgerId, entryId, host });
-            }
+            super.logErrorAndReattemptRead(host, errMsg, rc);
 
             int replica = getReplicaIndex(host);
             if (replica == NOT_FOUND) {
@@ -217,41 +309,6 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
             if (!readsOutstanding()) {
                 sendNextRead();
             }
-        }
-
-        // return true if we managed to complete the entry
-        // return false if the read entry is not complete or it is already completed before
-        boolean complete(BookieSocketAddress host, final ByteBuf buffer) {
-            ByteBuf content;
-            try {
-                content = lh.macManager.verifyDigestAndReturnData(entryId, buffer);
-            } catch (BKDigestMatchException e) {
-                logErrorAndReattemptRead(host, "Mac mismatch", BKException.Code.DigestMatchException);
-                buffer.release();
-                return false;
-            }
-
-            if (!complete.getAndSet(true)) {
-                /*
-                 * The length is a long and it is the last field of the metadata of an entry.
-                 * Consequently, we have to subtract 8 from METADATA_LENGTH to get the length.
-                 */
-                length = buffer.getLong(DigestManager.METADATA_LENGTH - 8);
-                data = content;
-                return true;
-            } else {
-                buffer.release();
-                return false;
-            }
-        }
-
-        boolean isComplete() {
-            return complete.get();
-        }
-
-        @Override
-        public String toString() {
-            return String.format("L%d-E%d", ledgerId, entryId);
         }
     }
 
@@ -325,11 +382,11 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
                 ensemble = getLedgerMetadata().getEnsemble(i);
                 nextEnsembleChange = getLedgerMetadata().getNextEnsembleChange(i);
             }
-            LedgerEntryRequest entry = new LedgerEntryRequest(ensemble, lh.ledgerId, i);
+            LedgerEntryRequest entry = new SequenceReadRequest(ensemble, lh.ledgerId, i);
             seq.add(entry);
             i++;
 
-            entry.sendNextRead();
+            entry.read();
         } while (i <= endEntryId);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -62,6 +62,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     // Read Parameters
     protected final static String READ_TIMEOUT = "readTimeout";
     protected final static String SPECULATIVE_READ_TIMEOUT = "speculativeReadTimeout";
+    protected final static String ENABLE_PARALLEL_RECOVERY_READ = "enableParallelRecoveryRead";
     // Timeout Setting
     protected final static String ADD_ENTRY_TIMEOUT_SEC = "addEntryTimeoutSec";
     protected final static String ADD_ENTRY_QUORUM_TIMEOUT_SEC = "addEntryQuorumTimeoutSec";
@@ -793,6 +794,27 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
+     * Whether to enable parallel reading in recovery read.
+     *
+     * @return true if enable parallel reading in recovery read. otherwise, return false.
+     */
+    public boolean getEnableParallelRecoveryRead() {
+        return getBoolean(ENABLE_PARALLEL_RECOVERY_READ, false);
+    }
+
+    /**
+     * Enable/Disable parallel reading in recovery read.
+     *
+     * @param enabled
+     *          flag to enable/disable parallel reading in recovery read.
+     * @return client configuration.
+     */
+    public ClientConfiguration setEnableParallelRecoveryRead(boolean enabled) {
+        setProperty(ENABLE_PARALLEL_RECOVERY_READ, enabled);
+        return this;
+    }
+
+    /**
      * Get Ensemble Placement Policy Class.
      *
      * @return ensemble placement policy class.
@@ -1096,5 +1118,4 @@ public class ClientConfiguration extends AbstractConfiguration {
     public String getClientRole() {
         return getString(CLIENT_ROLE, CLIENT_ROLE_STANDARD);
     }
-
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
@@ -1,0 +1,271 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Unit tests for parallel reading
+ */
+public class TestParallelRead extends BookKeeperClusterTestCase {
+
+    static Logger LOG = LoggerFactory.getLogger(TestParallelRead.class);
+
+    final DigestType digestType;
+    final byte[] passwd = "parallel-read".getBytes();
+
+    public TestParallelRead() {
+        super(6);
+        this.digestType = DigestType.CRC32;
+    }
+
+    long getLedgerToRead(int ensemble, int writeQuorum, int ackQuorum, int numEntries)
+            throws Exception {
+        LedgerHandle lh = bkc.createLedger(ensemble, writeQuorum, ackQuorum, digestType, passwd);
+        for (int i = 0; i < numEntries; i++) {
+            lh.addEntry(("" + i).getBytes());
+        }
+        lh.close();
+        return lh.getId();
+    }
+
+    static class LatchCallback implements ReadCallback {
+
+        final CountDownLatch l = new CountDownLatch(1);
+        int rc = -0x1314;
+        Enumeration<LedgerEntry> entries;
+
+        Enumeration<LedgerEntry> getEntries() {
+            return entries;
+        }
+
+        int getRc() {
+            return rc;
+        }
+
+        @Override
+        public void readComplete(int rc, LedgerHandle lh, Enumeration<LedgerEntry> seq, Object ctx) {
+            this.rc = rc;
+            this.entries = seq;
+            l.countDown();
+        }
+
+        void expectSuccess() throws Exception {
+            l.await();
+            assertTrue(BKException.Code.OK == rc);
+        }
+
+        void expectFail() throws Exception {
+            l.await();
+            assertFalse(BKException.Code.OK == rc);
+        }
+
+    }
+
+    @Test(timeout = 60000)
+    public void testNormalParallelRead() throws Exception {
+        int numEntries = 10;
+
+        long id = getLedgerToRead(5, 2, 2, numEntries);
+        LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
+
+        // read single entry
+        for (int i = 0; i < numEntries; i++) {
+            LatchCallback latch = new LatchCallback();
+            PendingReadOp readOp =
+                    new PendingReadOp(lh, lh.bk.scheduler, i, i, latch, null);
+            readOp.parallelRead(true).initiate();
+            latch.expectSuccess();
+            Enumeration<LedgerEntry> entries = latch.getEntries();
+            assertNotNull(entries);
+            assertTrue(entries.hasMoreElements());
+            LedgerEntry entry = entries.nextElement();
+            assertNotNull(entry);
+            assertEquals(i, Integer.parseInt(new String(entry.getEntry())));
+            assertFalse(entries.hasMoreElements());
+        }
+
+        // read multiple entries
+        LatchCallback latch = new LatchCallback();
+        PendingReadOp readOp =
+                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, latch, null);
+        readOp.parallelRead(true).initiate();
+        latch.expectSuccess();
+        Enumeration<LedgerEntry> entries = latch.getEntries();
+        assertNotNull(entries);
+
+        int numReads = 0;
+        while (entries.hasMoreElements()) {
+            LedgerEntry entry = entries.nextElement();
+            assertNotNull(entry);
+            assertEquals(numReads, Integer.parseInt(new String(entry.getEntry())));
+            ++numReads;
+        }
+        assertEquals(numEntries, numReads);
+
+        lh.close();
+    }
+
+    @Test(timeout = 60000)
+    public void testParallelReadMissingEntries() throws Exception {
+        int numEntries = 10;
+
+        long id = getLedgerToRead(5, 2, 2, numEntries);
+        LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
+
+        // read single entry
+        LatchCallback latch = new LatchCallback();
+        PendingReadOp readOp =
+                new PendingReadOp(lh, lh.bk.scheduler, 11, 11, latch, null);
+        readOp.parallelRead(true).initiate();
+        latch.expectFail();
+        assertEquals(BKException.Code.NoSuchEntryException, latch.getRc());
+
+        // read multiple entries
+        latch = new LatchCallback();
+        readOp = new PendingReadOp(lh, lh.bk.scheduler, 8, 11, latch, null);
+        readOp.parallelRead(true).initiate();
+        latch.expectFail();
+        assertEquals(BKException.Code.NoSuchEntryException, latch.getRc());
+
+        lh.close();
+    }
+
+    @Test(timeout = 60000)
+    public void testFailParallelReadMissingEntryImmediately() throws Exception {
+        int numEntries = 1;
+
+        long id = getLedgerToRead(5, 5, 3, numEntries);
+
+        ClientConfiguration newConf = new ClientConfiguration()
+                .setReadTimeout(30000);
+        newConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        BookKeeper newBk = new BookKeeper(newConf);
+
+        LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
+
+        ArrayList<InetSocketAddress> ensemble =
+                lh.getLedgerMetadata().getEnsemble(10);
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        // sleep two bookie
+        sleepBookie(ensemble.get(0), latch1);
+        sleepBookie(ensemble.get(1), latch2);
+
+        LatchCallback latchCallback = new LatchCallback();
+        PendingReadOp readOp =
+                new PendingReadOp(lh, lh.bk.scheduler, 10, 10, latchCallback, null);
+        readOp.parallelRead(true).initiate();
+        // would fail immediately if found missing entries don't cover ack quorum
+        latchCallback.expectFail();
+        assertEquals(BKException.Code.NoSuchEntryException, latchCallback.getRc());
+        latch1.countDown();
+        latch2.countDown();
+
+        lh.close();
+        newBk.close();
+    }
+
+    @Test(timeout = 60000)
+    public void testParallelReadWithFailedBookies() throws Exception {
+        int numEntries = 10;
+
+        long id = getLedgerToRead(5, 3, 3, numEntries);
+
+        ClientConfiguration newConf = new ClientConfiguration()
+                .setReadTimeout(30000);
+        newConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        BookKeeper newBk = new BookKeeper(newConf);
+
+        LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
+
+        ArrayList<InetSocketAddress> ensemble =
+                lh.getLedgerMetadata().getEnsemble(5);
+        // kill two bookies
+        killBookie(ensemble.get(0));
+        killBookie(ensemble.get(1));
+
+        // read multiple entries
+        LatchCallback latch = new LatchCallback();
+        PendingReadOp readOp =
+                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, latch, null);
+        readOp.parallelRead(true).initiate();
+        latch.expectSuccess();
+        Enumeration<LedgerEntry> entries = latch.getEntries();
+        assertNotNull(entries);
+
+        int numReads = 0;
+        while (entries.hasMoreElements()) {
+            LedgerEntry entry = entries.nextElement();
+            assertNotNull(entry);
+            assertEquals(numReads, Integer.parseInt(new String(entry.getEntry())));
+            ++numReads;
+        }
+        assertEquals(numEntries, numReads);
+
+        lh.close();
+        newBk.close();
+    }
+
+    @Test(timeout = 60000)
+    public void testParallelReadFailureWithFailedBookies() throws Exception {
+        int numEntries = 10;
+
+        long id = getLedgerToRead(5, 3, 3, numEntries);
+
+        ClientConfiguration newConf = new ClientConfiguration()
+                .setReadTimeout(30000);
+        newConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        BookKeeper newBk = new BookKeeper(newConf);
+
+        LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
+
+        ArrayList<InetSocketAddress> ensemble =
+                lh.getLedgerMetadata().getEnsemble(5);
+        // kill two bookies
+        killBookie(ensemble.get(0));
+        killBookie(ensemble.get(1));
+        killBookie(ensemble.get(2));
+
+        // read multiple entries
+        LatchCallback latch = new LatchCallback();
+        PendingReadOp readOp =
+                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, latch, null);
+        readOp.parallelRead(true).initiate();
+        latch.expectFail();
+        assertEquals(BKException.Code.BookieHandleNotAvailableException, latch.getRc());
+
+        lh.close();
+        newBk.close();
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
@@ -20,15 +20,20 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.concurrent.CountDownLatch;
@@ -167,13 +172,13 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         long id = getLedgerToRead(5, 5, 3, numEntries);
 
         ClientConfiguration newConf = new ClientConfiguration()
-                .setReadTimeout(30000);
+            .setReadEntryTimeout(30000);
         newConf.setZkServers(zkUtil.getZooKeeperConnectString());
         BookKeeper newBk = new BookKeeper(newConf);
 
         LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
 
-        ArrayList<InetSocketAddress> ensemble =
+        ArrayList<BookieSocketAddress> ensemble =
                 lh.getLedgerMetadata().getEnsemble(10);
         CountDownLatch latch1 = new CountDownLatch(1);
         CountDownLatch latch2 = new CountDownLatch(1);
@@ -202,13 +207,13 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         long id = getLedgerToRead(5, 3, 3, numEntries);
 
         ClientConfiguration newConf = new ClientConfiguration()
-                .setReadTimeout(30000);
+            .setReadEntryTimeout(30000);
         newConf.setZkServers(zkUtil.getZooKeeperConnectString());
         BookKeeper newBk = new BookKeeper(newConf);
 
         LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
 
-        ArrayList<InetSocketAddress> ensemble =
+        ArrayList<BookieSocketAddress> ensemble =
                 lh.getLedgerMetadata().getEnsemble(5);
         // kill two bookies
         killBookie(ensemble.get(0));
@@ -243,13 +248,13 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         long id = getLedgerToRead(5, 3, 3, numEntries);
 
         ClientConfiguration newConf = new ClientConfiguration()
-                .setReadTimeout(30000);
+            .setReadEntryTimeout(30000);
         newConf.setZkServers(zkUtil.getZooKeeperConnectString());
         BookKeeper newBk = new BookKeeper(newConf);
 
         LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
 
-        ArrayList<InetSocketAddress> ensemble =
+        ArrayList<BookieSocketAddress> ensemble =
                 lh.getLedgerMetadata().getEnsemble(5);
         // kill two bookies
         killBookie(ensemble.get(0));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
@@ -298,7 +298,7 @@ public class TestSpeculativeRead extends BaseTestCase {
 
             // if we've already heard from all hosts,
             // we only send the initial read
-            req0 = op.new LedgerEntryRequest(ensemble, l.getId(), 0);
+            req0 = op.new SequenceReadRequest(ensemble, l.getId(), 0);
             assertTrue("Should have sent to first",
                        req0.maybeSendSpeculativeRead(allHosts).equals(ensemble.get(0)));
             assertNull("Should not have sent another",
@@ -306,7 +306,7 @@ public class TestSpeculativeRead extends BaseTestCase {
 
             // if we have heard from some hosts, but not one we have sent to
             // send again
-            req2 = op.new LedgerEntryRequest(ensemble, l.getId(), 2);
+            req2 = op.new SequenceReadRequest(ensemble, l.getId(), 2);
             assertTrue("Should have sent to third",
                        req2.maybeSendSpeculativeRead(noHost).equals(ensemble.get(2)));
             assertTrue("Should have sent to first",
@@ -314,7 +314,7 @@ public class TestSpeculativeRead extends BaseTestCase {
 
             // if we have heard from some hosts, which includes one we sent to
             // do not read again
-            req4 = op.new LedgerEntryRequest(ensemble, l.getId(), 4);
+            req4 = op.new SequenceReadRequest(ensemble, l.getId(), 4);
             assertTrue("Should have sent to second",
                        req4.maybeSendSpeculativeRead(noHost).equals(ensemble.get(1)));
             assertNull("Should not have sent another",


### PR DESCRIPTION
THIS CHANGE IS BASED ON #176 (you can review f0fb89c)

bookkeeper recovery improvement (part-2): add a parallel reading request in PendingReadOp

- add a parallel reading request in PendingReadOp
- allow PendingReadOp to configure whether to do parallel reading or not
- add flag in ClientConfiguration to allow configuring whether to do parallel reading in LedgerRecoveryOp or not.
