### PR TITLE
BOOKKEEPER-1090: Use LOG.isDebugEnabled() to avoid unexpected allocations

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -734,7 +734,9 @@ public class Bookie extends BookieCriticalThread {
                 long ledgerId = recBuff.getLong();
                 long entryId = recBuff.getLong();
                 try {
-                    LOG.debug("Replay journal - ledger id : {}, entry id : {}.", ledgerId, entryId);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Replay journal - ledger id : {}, entry id : {}.", ledgerId, entryId);
+                    }
                     if (entryId == METAENTRY_ID_LEDGER_KEY) {
                         if (journalVersion >= JournalChannel.V3) {
                             int masterKeyLen = recBuff.getInt();
@@ -771,7 +773,9 @@ public class Bookie extends BookieCriticalThread {
                         handle.addEntry(Unpooled.wrappedBuffer(recBuff));
                     }
                 } catch (NoLedgerException nsle) {
-                    LOG.debug("Skip replaying entries of ledger {} since it was deleted.", ledgerId);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Skip replaying entries of ledger {} since it was deleted.", ledgerId);
+                    }
                 } catch (BookieException be) {
                     throw new IOException(be);
                 }
@@ -788,8 +792,10 @@ public class Bookie extends BookieCriticalThread {
     @Override
     synchronized public void start() {
         setDaemon(true);
-        LOG.debug("I'm starting a bookie with journal directories {}",
-                  journalDirectories.stream().map(File::getName).collect(Collectors.joining(", ")));
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("I'm starting a bookie with journal directories {}",
+                    journalDirectories.stream().map(File::getName).collect(Collectors.joining(", ")));
+        }
         //Start DiskChecker thread
         ledgerDirsManager.start();
         if (indexDirsManager != ledgerDirsManager) {
@@ -1453,7 +1459,9 @@ public class Bookie extends BookieCriticalThread {
             bb.flip();
 
             FutureWriteCallback fwc = new FutureWriteCallback();
-            LOG.debug("record fenced state for ledger {} in journal.", ledgerId);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("record fenced state for ledger {} in journal.", ledgerId);
+            }
             getJournal(ledgerId).logAddEntry(bb, fwc, null);
             return fwc.getResult();
         } else {
@@ -1469,7 +1477,9 @@ public class Bookie extends BookieCriticalThread {
         int entrySize = 0;
         try {
             LedgerDescriptor handle = handles.getReadOnlyHandle(ledgerId);
-            LOG.trace("Reading {}@{}", entryId, ledgerId);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Reading {}@{}", entryId, ledgerId);
+            }
             ByteBuf entry = handle.readEntry(entryId);
             readBytes.add(entry.readableBytes());
             success = true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1217,8 +1217,8 @@ public class BookieShell implements Tool {
             return opts;
         }
     }
-    
-    
+
+
     /**
      * Command to print help message
      */
@@ -1479,7 +1479,9 @@ public class BookieShell implements Tool {
                         oldCookie.getValue().deleteFromZooKeeper(zk, conf, oldCookie.getVersion());
                         return 0;
                     } catch (KeeperException.NoNodeException nne) {
-                        LOG.debug("Ignoring, cookie will be written to zookeeper");
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Ignoring, cookie will be written to zookeeper");
+                        }
                     }
                 } else {
                     // writes newcookie to local dirs
@@ -1877,7 +1879,9 @@ public class BookieShell implements Tool {
             indexDirectories = Bookie.getCurrentDirectories(bkConf.getIndexDirs());
         }
         formatter = EntryFormatter.newEntryFormatter(bkConf, ENTRY_FORMATTER_CLASS);
-        LOG.debug("Using entry formatter {}", formatter.getClass().getName());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Using entry formatter {}", formatter.getClass().getName());
+        }
         pageSize = bkConf.getPageSize();
         entriesPerPage = pageSize / 8;
     }
@@ -1918,8 +1922,8 @@ public class BookieShell implements Tool {
     /**
      * Returns the sorted list of the files in the given folders with the given file extensions.
      * Sorting is done on the basis of CreationTime if the CreationTime is not available or if they are equal
-     * then sorting is done by LastModifiedTime  
-     * @param folderNames - array of folders which we need to look recursively for files with given extensions  
+     * then sorting is done by LastModifiedTime
+     * @param folderNames - array of folders which we need to look recursively for files with given extensions
      * @param extensions - the file extensions, which we are interested in
      * @return sorted list of files
      */
@@ -1947,11 +1951,11 @@ public class BookieShell implements Tool {
                 FileTime file1CreationTime = file1Attributes.creationTime();
                 FileTime file2CreationTime = file2Attributes.creationTime();
                 int compareValue = file1CreationTime.compareTo(file2CreationTime);
-                /* 
+                /*
                  * please check https://docs.oracle.com/javase/7/docs/api/java/nio/file/attribute/BasicFileAttributes.html#creationTime()
                  * So not all file system implementation store creation time, in that case creationTime()
-                 * method may return FileTime representing the epoch (1970-01-01T00:00:00Z). So in that case 
-                 * it would be better to compare lastModifiedTime 
+                 * method may return FileTime representing the epoch (1970-01-01T00:00:00Z). So in that case
+                 * it would be better to compare lastModifiedTime
                  */
                 if (compareValue == 0) {
                     FileTime file1LastModifiedTime = file1Attributes.lastModifiedTime();
@@ -1959,7 +1963,7 @@ public class BookieShell implements Tool {
                     compareValue = file1LastModifiedTime.compareTo(file2LastModifiedTime);
                 }
                 return compareValue;
-            } catch (IOException e) {                
+            } catch (IOException e) {
                 return 0;
             }
         }
@@ -2177,7 +2181,7 @@ public class BookieShell implements Tool {
 
     /**
      * Scan over an entry log file for a particular entry
-     * 
+     *
      * @param logId
      *          Entry Log File id.
      * @param ledgerId
@@ -2218,7 +2222,7 @@ public class BookieShell implements Tool {
 
     /**
      * Scan over an entry log file for entries in the given position range
-     * 
+     *
      * @param logId
      *          Entry Log File id.
      * @param rangeStartPos
@@ -2273,7 +2277,7 @@ public class BookieShell implements Tool {
                     + "or greater than the current log filesize.");
         }
     }
-    
+
     /**
      * Scan a journal file
      *
@@ -2311,10 +2315,10 @@ public class BookieShell implements Tool {
 
     /**
      * Format the entry into a readable format.
-     * 
-     * @param entry 
+     *
+     * @param entry
      *          ledgerentry to print
-     * @param printMsg 
+     * @param printMsg
      *          Whether printing the message body
      */
     private void formatEntry(LedgerEntry entry, boolean printMsg) {
@@ -2327,7 +2331,7 @@ public class BookieShell implements Tool {
             formatter.formatEntry(entry.getEntry());
         }
     }
-    
+
     /**
      * Format the message into a readable format.
      *

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -749,7 +749,9 @@ public class EntryLogger {
         if (logChannel != null) {
             logChannel.flush(true);
             bytesWrittenSinceLastFlush = 0;
-            LOG.debug("Flush and sync current entry logger {}.", logChannel.getLogId());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Flush and sync current entry logger {}.", logChannel.getLogId());
+            }
         }
     }
 
@@ -781,7 +783,7 @@ public class EntryLogger {
         long pos = logChannel.position();
         logChannel.write(entry);
         logChannel.registerWrittenEntry(ledger, entrySize);
-        
+
         incrementBytesWrittenAndMaybeFlush(4L + entrySize);
 
         return (logChannel.getLogId() << 32L) | pos;
@@ -1111,7 +1113,9 @@ public class EntryLogger {
             }
         });
 
-        LOG.debug("Retrieved entry log meta data entryLogId: {}, meta: {}", entryLogId, meta);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Retrieved entry log meta data entryLogId: {}, meta: {}", entryLogId, meta);
+        }
         return meta;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -120,7 +120,9 @@ class FileInfo {
     public ByteBuf getExplicitLac() {
         ByteBuf retLac = null;
         synchronized(this) {
-            LOG.debug("fileInfo:GetLac: {}", explicitLac);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("fileInfo:GetLac: {}", explicitLac);
+            }
             if (explicitLac != null) {
                 retLac = Unpooled.buffer(explicitLac.capacity());
                 explicitLac.rewind();//copy from the beginning
@@ -145,7 +147,9 @@ class FileInfo {
             long explicitLacValue = explicitLac.getLong();
             setLastAddConfirmed(explicitLacValue);
             explicitLac.rewind();
-            LOG.debug("fileInfo:SetLac: {}", explicitLac);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("fileInfo:SetLac: {}", explicitLac);
+            }
         }
     }
 
@@ -244,7 +248,9 @@ class FileInfo {
      */
     synchronized public boolean setFenced() throws IOException {
         checkOpen(false);
-        LOG.debug("Try to set fenced state in file info {} : state bits {}.", lf, stateBits);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Try to set fenced state in file info {} : state bits {}.", lf, stateBits);
+        }
         if ((stateBits & STATE_FENCED_BIT) != STATE_FENCED_BIT) {
             // not fenced yet
             stateBits |= STATE_FENCED_BIT;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -169,7 +169,9 @@ public class GarbageCollectorThread extends SafeRunnable {
 
         void flush() throws IOException {
             if (offsets.isEmpty()) {
-                LOG.debug("Skipping entry log flushing, as there are no offset!");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Skipping entry log flushing, as there are no offset!");
+                }
                 return;
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexInMemPageMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexInMemPageMgr.java
@@ -251,7 +251,9 @@ class IndexInMemPageMgr {
                     }
 
                     if (null == lep) {
-                        LOG.debug("Did not find eligible page in the first pass");
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Did not find eligible page in the first pass");
+                        }
                         return null;
                     }
                 }
@@ -511,7 +513,9 @@ class IndexInMemPageMgr {
         indexPersistenceManager.flushLedgerHeader(ledger);
 
         if (null == firstEntryList || firstEntryList.size() == 0) {
-            LOG.debug("Nothing to flush for ledger {}.", ledger);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Nothing to flush for ledger {}.", ledger);
+            }
             // nothing to do
             return;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -150,8 +150,10 @@ public class IndexPersistenceMgr {
             fi = oldFi;
         } else {
             if (createdNewFile) {
-                // Else, we won and the active ledger manager should know about this.
-                LOG.debug("New ledger index file created for ledgerId: {}", ledger);
+                // Else, we won and the active ledger manager should know about this
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("New ledger index file created for ledgerId: {}", ledger);
+                }
                 activeLedgers.put(ledger, true);
             }
             // Evict cached items from the file info cache if necessary

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -171,7 +171,9 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
             // which is safe since records before lastMark have been
             // persisted to disk (both index & entry logger)
             lastMark.getCurMark().writeLogMark(bb);
-            LOG.debug("RollLog to persist last marked log : {}", lastMark.getCurMark());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("RollLog to persist last marked log : {}", lastMark.getCurMark());
+            }
             List<File> writableLedgerDirs = ledgerDirsManager
                     .getWritableLedgerDirs();
             for (File dir : writableLedgerDirs) {
@@ -566,7 +568,9 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
         this.removePagesFromCache = conf.getJournalRemovePagesFromCache();
         // read last log mark
         lastLogMark.readLog();
-        LOG.debug("Last Log Mark : {}", lastLogMark.getCurMark());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Last Log Mark : {}", lastLogMark.getCurMark());
+        }
 
         // Expose Stats
         journalAddEntryStats = statsLogger.getOpStatsLogger(JOURNAL_ADD_ENTRY);
@@ -740,7 +744,10 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
                 throw new IOException("Recovery log " + markedLog.getLogFileId() + " is missing");
             }
         }
-        LOG.debug("Try to relay journal logs : {}", logs);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Try to relay journal logs : {}", logs);
+        }
         // TODO: When reading in the journal logs that need to be synced, we
         // should use BufferedChannels instead to minimize the amount of
         // system calls done.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
@@ -117,7 +117,9 @@ public class LedgerCacheImpl implements LedgerCache {
      */
     @Override
     public void deleteLedger(long ledgerId) throws IOException {
-        LOG.debug("Deleting ledgerId: {}", ledgerId);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Deleting ledgerId: {}", ledgerId);
+        }
 
         indexPageManager.removePagesForLedger(ledgerId);
         indexPersistenceManager.removeLedger(ledgerId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -74,7 +74,9 @@ class SyncThread {
             .setNameFormat("SyncThread-" + conf.getBookiePort() + "-%d");
         this.executor = Executors.newSingleThreadScheduledExecutor(tfb.build());
         flushInterval = conf.getFlushInterval();
-        LOG.debug("Flush Interval : {}", flushInterval);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Flush Interval : {}", flushInterval);
+        }
     }
 
     void start() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -72,7 +72,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * BookKeeper client. We assume there is one single writer to a ledger at any
@@ -385,7 +384,9 @@ public class BookKeeper implements AutoCloseable {
         this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
         this.ledgerIdGenerator = ledgerManagerFactory.newLedgerIdGenerator();
         this.explicitLacInterval = conf.getExplictLacInterval();
-        LOG.debug("Explicit LAC Interval : {}", this.explicitLacInterval);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Explicit LAC Interval : {}", this.explicitLacInterval);
+        }
 
         scheduleBookieHealthCheckIfEnabled();
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -312,7 +312,7 @@ public class BookKeeperAdmin implements AutoCloseable {
     /**
      * Read entries from a ledger synchronously. If the lastEntry is -1, it will read all the entries in the ledger from
      * the firstEntry.
-     * 
+     *
      * @param ledgerId
      * @param firstEntry
      * @param lastEntry
@@ -670,7 +670,9 @@ public class BookKeeperAdmin implements AutoCloseable {
      */
     private void recoverLedger(final BookieSocketAddress bookieSrc, final long lId,
             final AsyncCallback.VoidCallback ledgerIterCb, final List<BookieSocketAddress> availableBookies) {
-        LOG.debug("Recovering ledger : {}", lId);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Recovering ledger : {}", lId);
+        }
 
         asyncOpenLedgerNoRecovery(lId, new OpenCallback() {
             @Override
@@ -941,13 +943,15 @@ public class BookKeeperAdmin implements AutoCloseable {
             bkc = new BookKeeper(conf, zkc);
             // Format all ledger metadata layout
             bkc.ledgerManagerFactory.format(conf, zkc);
-            
+
             // Clear underreplicated ledgers
             try {
                 ZKUtil.deleteRecursive(zkc, ZkLedgerUnderreplicationManager.getBasePath(conf.getZkLedgersRootPath())
                         + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH);
             } catch (KeeperException.NoNodeException e) {
-                LOG.debug("underreplicated ledgers root path node not exists in zookeeper to delete");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("underreplicated ledgers root path node not exists in zookeeper to delete");
+                }
             }
 
             // Clear underreplicatedledger locks
@@ -955,15 +959,19 @@ public class BookKeeperAdmin implements AutoCloseable {
                 ZKUtil.deleteRecursive(zkc, ZkLedgerUnderreplicationManager.getBasePath(conf.getZkLedgersRootPath())
                         + '/' + BookKeeperConstants.UNDER_REPLICATION_LOCK);
             } catch (KeeperException.NoNodeException e) {
-                LOG.debug("underreplicatedledger locks node not exists in zookeeper to delete");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("underreplicatedledger locks node not exists in zookeeper to delete");
+                }
             }
-            
+
             // Clear the cookies
             try {
                 ZKUtil.deleteRecursive(zkc, conf.getZkLedgersRootPath()
                         + "/cookies");
             } catch (KeeperException.NoNodeException e) {
-                LOG.debug("cookies node not exists in zookeeper to delete");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("cookies node not exists in zookeeper to delete");
+                }
             }
 
             // Clear the INSTANCEID
@@ -971,7 +979,9 @@ public class BookKeeperAdmin implements AutoCloseable {
                 zkc.delete(conf.getZkLedgersRootPath() + "/"
                         + BookKeeperConstants.INSTANCEID, -1);
             } catch (KeeperException.NoNodeException e) {
-                LOG.debug("INSTANCEID not exists in zookeeper to delete");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("INSTANCEID not exists in zookeeper to delete");
+                }
             }
 
             // create INSTANCEID

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
@@ -91,7 +91,9 @@ public class BookieInfoReader {
         scheduler.scheduleAtFixedRate(new Runnable() {
             @Override
             public void run() {
-                LOG.debug("Running periodic BookieInfo scan");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Running periodic BookieInfo scan");
+                }
                 getReadWriteBookieInfo(null);
             }
         }, 0, conf.getGetBookieInfoIntervalSeconds(), TimeUnit.SECONDS);
@@ -128,7 +130,9 @@ public class BookieInfoReader {
             if (newBookiesList != null) {
                 refreshBookieList.set(true);
             }
-            LOG.debug("Exiting due to running instance");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Exiting due to running instance");
+            }
             return;
         }
         Collection<BookieSocketAddress> deadBookies = null, joinedBookies=null;
@@ -137,7 +141,9 @@ public class BookieInfoReader {
                 if (this.bookies == null) {
                     joinedBookies = this.bookies = bk.bookieWatcher.getBookies();
                 } else if (refreshBookieList.get()) {
-                    LOG.debug("Refreshing bookie list");
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Refreshing bookie list");
+                    }
                     newBookiesList = bk.bookieWatcher.getBookies();
                     refreshBookieList.set(false);
                 } else {
@@ -169,7 +175,9 @@ public class BookieInfoReader {
         BookieClient bkc = bk.getBookieClient();
         totalSent.set(0);
         completedCnt.set(0);
-        LOG.debug("Getting bookie info for: {}", joinedBookies);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Getting bookie info for: {}", joinedBookies);
+        }
         for (BookieSocketAddress b : joinedBookies) {
             bkc.getBookieInfo(b, GET_BOOKIE_INFO_REQUEST_FLAGS,
                     new GetBookieInfoCallback() {
@@ -181,7 +189,9 @@ public class BookieInfoReader {
                                 // create a new one only if the key was missing
                                 bookieInfoMap.putIfAbsent(b, new BookieInfo());
                             } else {
-                                LOG.debug("Bookie Info for bookie {} is {}", b, bInfo);
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("Bookie Info for bookie {} is {}", b, bInfo);
+                                }
                                 bookieInfoMap.put(b, bInfo);
                             }
                             if (completedCnt.incrementAndGet() == totalSent.get()) {
@@ -214,7 +224,9 @@ public class BookieInfoReader {
 
     void onExit() {
         if (isQueued.get()) {
-            LOG.debug("Scheduling a queued task");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Scheduling a queued task");
+            }
             submitTask(null);
         }
         isQueued.set(false);
@@ -243,7 +255,9 @@ public class BookieInfoReader {
                             if (rc != BKException.Code.OK) {
                                 LOG.error("Reading bookie info from bookie {} failed due to error: {}.", b, rc);
                             } else {
-                                LOG.debug("Free disk space on bookie {} is {}.", b, bInfo.getFreeDiskSpace());
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("Free disk space on bookie {} is {}.", b, bInfo.getFreeDiskSpace());
+                                }
                                 map.put(b, bInfo);
                             }
                             if (totalCompleted.incrementAndGet() == totalSent.get()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ExplicitLacFlushPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ExplicitLacFlushPolicy.java
@@ -59,7 +59,9 @@ interface ExplicitLacFlushPolicy {
         ExplicitLacFlushPolicyImpl(LedgerHandle lh) {
             this.lh = lh;
             scheduleExplictLacFlush();
-            LOG.debug("Scheduled Explicit Last Add Confirmed Update");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Scheduled Explicit Last Add Confirmed Update");
+            }
         }
 
         private long getExplicitLac() {
@@ -87,20 +89,25 @@ interface ExplicitLacFlushPolicy {
                     // Piggyback, so no need to send an explicit LAC update to
                     // bookies.
                     if (getExplicitLac() < getPiggyBackedLac()) {
-                        LOG.debug("ledgerid: {}", lh.getId());
-                        LOG.debug("explicitLac:{} piggybackLac:{}", getExplicitLac(),
-                                getPiggyBackedLac());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("ledgerid: {}", lh.getId());
+                            LOG.debug("explicitLac:{} piggybackLac:{}", getExplicitLac(), getPiggyBackedLac());
+                        }
                         setExplicitLac(getPiggyBackedLac());
                         return;
                     }
 
                     if (lh.getLastAddConfirmed() > getExplicitLac()) {
                         // Send Explicit LAC
-                        LOG.debug("ledgerid: {}", lh.getId());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("ledgerid: {}", lh.getId());
+                        }
                         asyncExplicitLacFlush(lh.getLastAddConfirmed());
                         setExplicitLac(lh.getLastAddConfirmed());
-                        LOG.debug("After sending explict LAC lac: {}  explicitLac:{}", lh.getLastAddConfirmed(),
-                                getExplicitLac());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("After sending explict LAC lac: {}  explicitLac:{}", lh.getLastAddConfirmed(),
+                                    getExplicitLac());
+                        }
                     }
                 }
 
@@ -126,7 +133,9 @@ interface ExplicitLacFlushPolicy {
             final PendingWriteLacOp op = new PendingWriteLacOp(lh, cb, null);
             op.setLac(explicitLac);
             try {
-                LOG.debug("Sending Explicit LAC: {}", explicitLac);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Sending Explicit LAC: {}", explicitLac);
+                }
                 lh.bk.mainWorkerPool.submit(new SafeRunnable() {
                     @Override
                     public void safeRun() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -284,7 +284,9 @@ public class LedgerHandle implements AutoCloseable {
     }
 
     void writeLedgerConfig(GenericCallback<Void> writeCb) {
-        LOG.debug("Writing metadata to ledger manager: {}, {}", this.ledgerId, metadata.getVersion());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Writing metadata to ledger manager: {}, {}", this.ledgerId, metadata.getVersion());
+        }
 
         bk.getLedgerManager().writeLedgerMetadata(ledgerId, metadata, writeCb);
     }
@@ -331,7 +333,9 @@ public class LedgerHandle implements AutoCloseable {
         try {
             doAsyncCloseInternal(cb, ctx, rc);
         } catch (RejectedExecutionException re) {
-            LOG.debug("Failed to close ledger {} : ", ledgerId, re);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Failed to close ledger {} : ", ledgerId, re);
+            }
             errorOutPendingAdds(bk.getReturnRc(rc));
             cb.closeComplete(bk.getReturnRc(BKException.Code.InterruptedException), this, ctx);
         }
@@ -639,7 +643,9 @@ public class LedgerHandle implements AutoCloseable {
      */
     public long addEntry(byte[] data, int offset, int length)
             throws InterruptedException, BKException {
-        LOG.debug("Adding entry {}", data);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Adding entry {}", data);
+        }
 
         CompletableFuture<Long> counter = new CompletableFuture<>();
 
@@ -1156,12 +1162,17 @@ public class LedgerHandle implements AutoCloseable {
         while ((pendingAddOp = pendingAddOps.peek()) != null
                && blockAddCompletions.get() == 0) {
             if (!pendingAddOp.completed) {
-                LOG.debug("pending add not completed: {}", pendingAddOp);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("pending add not completed: {}", pendingAddOp);
+                }
                 return;
             }
             // Check if it is the next entry in the sequence.
             if (pendingAddOp.entryId != 0 && pendingAddOp.entryId != lastAddConfirmed + 1) {
-                LOG.debug("Head of the queue entryId: {} is not lac: {} + 1", pendingAddOp.entryId, lastAddConfirmed);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Head of the queue entryId: {} is not lac: {} + 1", pendingAddOp.entryId,
+                            lastAddConfirmed);
+                }
                 return;
             }
 
@@ -1537,7 +1548,9 @@ public class LedgerHandle implements AutoCloseable {
             if (rc != BKException.Code.OK) {
                 LOG.warn("LastAddConfirmedUpdate failed: {} ", BKException.getMessage(rc));
             } else {
-                LOG.debug("Callback LAC Updated for: {} ", lh.getId());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Callback LAC Updated for: {} ", lh.getId());
+                }
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -92,7 +92,9 @@ public class LedgerHandleAdv extends LedgerHandle {
     @Override
     public long addEntry(final long entryId, byte[] data, int offset, int length) throws InterruptedException,
             BKException {
-        LOG.debug("Adding entry {}", data);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Adding entry {}", data);
+        }
 
         CompletableFuture<Long> counter = new CompletableFuture<>();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -172,11 +172,11 @@ public class LedgerMetadata {
 
     /**
      * Get the creation timestamp of the ledger
-     * @return 
+     * @return
      */
     public long getCtime() {
         return ctime;
-    }        
+    }
 
     public int getAckQuorumSize() {
         return ackQuorumSize;
@@ -259,7 +259,7 @@ public class LedgerMetadata {
      * place
      *
      * @param entryId
-     * @return the entry id of the next ensemble change (-1 if no further ensemble changes) 
+     * @return the entry id of the next ensemble change (-1 if no further ensemble changes)
      */
     long getNextEnsembleChange(long entryId) {
         SortedMap<Long, ArrayList<BookieSocketAddress>> tailMap = ensembles.tailMap(entryId + 1);
@@ -317,7 +317,9 @@ public class LedgerMetadata {
         StringBuilder s = new StringBuilder();
         s.append(VERSION_KEY).append(tSplitter).append(CURRENT_METADATA_FORMAT_VERSION).append(lSplitter);
         s.append(TextFormat.printToString(builder.build()));
-        LOG.debug("Serialized config: {}", s);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Serialized config: {}", s);
+        }
         return s.toString().getBytes(UTF_8);
     }
 
@@ -340,7 +342,9 @@ public class LedgerMetadata {
             s.append(lSplitter).append(getLastEntryId()).append(tSplitter).append(closed);
         }
 
-        LOG.debug("Serialized config: {}", s);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Serialized config: {}", s);
+        }
 
         return s.toString().getBytes(UTF_8);
     }
@@ -364,7 +368,9 @@ public class LedgerMetadata {
 
         String config = new String(bytes, UTF_8);
 
-        LOG.debug("Parsing Config: {}", config);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Parsing Config: {}", config);
+        }
         BufferedReader reader = new BufferedReader(new StringReader(config));
         String versionLine = reader.readLine();
         if (versionLine == null) {
@@ -404,12 +410,12 @@ public class LedgerMetadata {
 
         TextFormat.merge((CharSequence) CharBuffer.wrap(configBuffer), builder);
         LedgerMetadataFormat data = builder.build();
-        lc.writeQuorumSize = data.getQuorumSize();        
+        lc.writeQuorumSize = data.getQuorumSize();
         if (data.hasCtime()) {
             lc.ctime = data.getCtime();
         } else if (msCtime.isPresent()) {
             lc.ctime = msCtime.get();
-        }        
+        }
         if (data.hasAckQuorumSize()) {
             lc.ackQuorumSize = data.getAckQuorumSize();
         } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -128,7 +128,9 @@ class LedgerRecoveryOp implements ReadCallback, AddCallback {
                         cb.operationComplete(rc, null);
                     } else {
                         cb.operationComplete(BKException.Code.OK, null);
-                        LOG.debug("After closing length is: {}", lh.getLength());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("After closing length is: {}", lh.getLength());
+                        }
                     }
                 }
             }, null, BKException.Code.LedgerClosedException);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -238,7 +238,9 @@ class PendingAddOp implements WriteCallback, TimerTask {
         if (ackSet.addBookieAndCheck(bookieIndex) && !completed) {
             completed = true;
 
-            LOG.debug("Complete (lid:{}, eid:{}).", ledgerId, entryId);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Complete (lid:{}, eid:{}).", ledgerId, entryId);
+            }
             // when completed an entry, try to send success add callbacks in order
             lh.sendAddSuccessCallbacks();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
@@ -130,8 +130,9 @@ class PendingReadLacOp implements ReadLacCallback {
                 && coverageSet.addBookieAndCheckCovered(bookieIndex)
                 && !completed) {
             completed = true;
-            LOG.debug("Read LAC complete with enough validResponse for ledger: {} LAC: {}",
-                    ledgerId, maxLac);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Read LAC complete with enough validResponse for ledger: {} LAC: {}", ledgerId, maxLac);
+            }
             cb.getLacComplete(BKException.Code.OK, maxLac);
             return;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -362,15 +362,18 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
                                 // Subsequent speculative read will not materialize anyway
                                 cancelSpeculativeTask(false);
                             } else {
-                                LOG.debug("Send speculative read for {}. Hosts heard are {}.",
-                                          r, heardFromHosts);
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("Send speculative read for {}. Hosts heard are {}.", r, heardFromHosts);
+                                }
                                 ++x;
                             }
                         }
                     }
                     if (x > 0) {
-                        LOG.debug("Send {} speculative reads for ledger {} ({}, {}). Hosts heard are {}.",
-                                  new Object[] { x, lh.getId(), startEntryId, endEntryId, heardFromHosts });
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Send {} speculative reads for ledger {} ({}, {}). Hosts heard are {}.",
+                                    new Object[] { x, lh.getId(), startEntryId, endEntryId, heardFromHosts });
+                        }
                     }
                 }
             };
@@ -378,8 +381,10 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
                 speculativeTask = scheduler.scheduleWithFixedDelay(readTask,
                         speculativeReadTimeout, speculativeReadTimeout, TimeUnit.MILLISECONDS);
             } catch (RejectedExecutionException re) {
-                LOG.debug("Failed to schedule speculative reads for ledger {} ({}, {}) : ",
-                    new Object[] { lh.getId(), startEntryId, endEntryId, re });
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Failed to schedule speculative reads for ledger {} ({}, {}) : ", lh.getId(),
+                            startEntryId, endEntryId, re);
+                }
             }
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
@@ -119,8 +119,10 @@ class ReadLastConfirmedOp implements ReadEntryCallback {
             && coverageSet.addBookieAndCheckCovered(bookieIndex)
             && !completed) {
             completed = true;
-            LOG.debug("Read Complete with enough validResponses for ledger: {}, entry: {}",
-                ledgerId, entryId);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Read Complete with enough validResponses for ledger: {}, entry: {}",
+                        ledgerId, entryId);
+            }
 
             cb.readLastConfirmedDataComplete(BKException.Code.OK, maxRecoveredData);
             return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
@@ -124,8 +124,10 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
             try {
                 if (!metadata.currentEnsemble.get(bookieIndex).equals(addr)) {
                     // ensemble has already changed, failure of this addr is immaterial
-                    LOG.debug("Write did not succeed to {}, bookieIndex {},"
-                              +" but we have already fixed it.", addr, bookieIndex);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Write did not succeed to {}, bookieIndex {},"
+                                +" but we have already fixed it.", addr, bookieIndex);
+                    }
                     blockAddCompletions.decrementAndGet();
                     return;
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -176,9 +176,11 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
                             int maxAllowedSum) {
                 if (remainingRacksOrRegions.isEmpty() || (subsetSize <= 0)) {
                     if (maxAllowedSum < 0) {
-                        LOG.trace("CHECK FAILED: RacksOrRegions Included {} Remaining {}, subsetSize {}, maxAllowedSum {}", new Object[]{
-                            includedRacksOrRegions, remainingRacksOrRegions, subsetSize, maxAllowedSum
-                        });
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace(
+                                    "CHECK FAILED: RacksOrRegions Included {} Remaining {}, subsetSize {}, maxAllowedSum {}",
+                                    includedRacksOrRegions, remainingRacksOrRegions, subsetSize, maxAllowedSum);
+                        }
                     }
                     return (maxAllowedSum >= 0);
                 }
@@ -191,9 +193,11 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
                     }
 
                     if (currentAllocation > maxAllowedSum) {
-                        LOG.trace("CHECK FAILED: RacksOrRegions Included {} Candidate {}, subsetSize {}, maxAllowedSum {}", new Object[]{
-                            includedRacksOrRegions, rackOrRegion, subsetSize, maxAllowedSum
-                        });
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace(
+                                    "CHECK FAILED: RacksOrRegions Included {} Candidate {}, subsetSize {}, maxAllowedSum {}",
+                                    includedRacksOrRegions, rackOrRegion, subsetSize, maxAllowedSum);
+                        }
                         return false;
                     } else {
                         Set<String> remainingElements = new HashSet<String>(remainingRacksOrRegions);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/WeightedRandomSelection.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/WeightedRandomSelection.java
@@ -100,7 +100,9 @@ public class WeightedRandomSelection<T> {
         medianWeight = median/(double)totalWeight;
         minWeight = (double)min/totalWeight;
 
-        LOG.debug("Updating weights map. MediaWeight: " + medianWeight + " MinWeight: " + minWeight);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Updating weights map. MediaWeight: " + medianWeight + " MinWeight: " + minWeight);
+        }
 
         double maxWeight = maxProbabilityMultiplier*medianWeight;
         Map<T, Double> weightMap = new HashMap<T, Double>();
@@ -113,7 +115,10 @@ public class WeightedRandomSelection<T> {
             }
             if (maxWeight > 0 && weightedProbability > maxWeight) {
                 weightedProbability=maxWeight;
-                LOG.debug("Capping the probability to " + weightedProbability + " for " + e.getKey() + " Value: " + e.getValue());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Capping the probability to " + weightedProbability + " for " + e.getKey() + " Value: "
+                            + e.getValue());
+                }
             }
             weightMap.put(e.getKey(), weightedProbability);
         }
@@ -125,8 +130,10 @@ public class WeightedRandomSelection<T> {
         Double key=0.0;
         for (Map.Entry<T, Double> e : weightMap.entrySet()) {
             tmpCummulativeMap.put(key, e.getKey());
-            LOG.debug("Key: " + e.getKey() + " Value: " + e.getValue()
-                    + " AssignedKey: " + key + " AssignedWeight: " + e.getValue());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Key: " + e.getKey() + " Value: " + e.getValue() + " AssignedKey: " + key
+                        + " AssignedWeight: " + e.getValue());
+            }
             key += e.getValue();
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -38,7 +38,6 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.LedgerMetadataLis
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.MultiCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.Processor;
 import org.apache.bookkeeper.util.BookKeeperConstants;
-import org.apache.bookkeeper.util.StringUtils;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.zookeeper.AsyncCallback;
@@ -51,7 +50,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -90,10 +88,14 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
         @Override
         public void run() {
             if (null != listeners.get(ledgerId)) {
-                LOG.debug("Re-read ledger metadata for {}.", ledgerId);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Re-read ledger metadata for {}.", ledgerId);
+                }
                 readLedgerMetadata(ledgerId, this, AbstractZkLedgerManager.this);
             } else {
-                LOG.debug("Ledger metadata listener for ledger {} is already removed.", ledgerId);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Ledger metadata listener for ledger {} is already removed.", ledgerId);
+                }
             }
         }
 
@@ -102,7 +104,9 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
             if (BKException.Code.OK == rc) {
                 final Set<LedgerMetadataListener> listenerSet = listeners.get(ledgerId);
                 if (null != listenerSet) {
-                    LOG.debug("Ledger metadata is changed for {} : {}.", ledgerId, result);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Ledger metadata is changed for {} : {}.", ledgerId, result);
+                    }
                     scheduler.submit(new Runnable() {
                         @Override
                         public void run() {
@@ -118,8 +122,10 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
                 // the ledger is removed, do nothing
                 Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
                 if (null != listenerSet) {
-                    LOG.debug("Removed ledger metadata listener set on ledger {} as its ledger is deleted : {}",
-                            ledgerId, listenerSet.size());
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Removed ledger metadata listener set on ledger {} as its ledger is deleted : {}",
+                                ledgerId, listenerSet.size());
+                    }
                 }
             } else {
                 LOG.warn("Failed on read ledger metadata of ledger {} : {}", ledgerId, rc);
@@ -144,7 +150,9 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
                 "ZkLedgerManagerScheduler-%d");
         this.scheduler = Executors
                 .newSingleThreadScheduledExecutor(tfb.build());
-        LOG.debug("Using AbstractZkLedgerManager with root path : {}", ledgerRootPath);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Using AbstractZkLedgerManager with root path : {}", ledgerRootPath);
+        }
     }
 
     /**
@@ -217,7 +225,9 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
             new ReadLedgerMetadataTask(ledgerId).run();
             break;
         default:
-            LOG.debug("Received event {} on {}.", event.getType(), event.getPath());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Received event {} on {}.", event.getType(), event.getPath());
+            }
             break;
         }
     }
@@ -284,11 +294,15 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
                     // removed listener on ledgerId
                     Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
                     if (null != listenerSet) {
-                        LOG.debug("Remove registered ledger metadata listeners on ledger {} after ledger is deleted.",
-                                ledgerId, listenerSet);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Remove registered ledger metadata listeners on ledger {} after ledger is deleted.",
+                                    ledgerId, listenerSet);
+                        }
                     } else {
-                        LOG.debug("No ledger metadata listeners to remove from ledger {} when it's being deleted.",
-                                ledgerId);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("No ledger metadata listeners to remove from ledger {} when it's being deleted.",
+                                    ledgerId);
+                        }
                     }
                     bkRc = BKException.Code.OK;
                 } else {
@@ -326,7 +340,9 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
         if (listenerSet != null) {
             synchronized (listenerSet) {
                 if (listenerSet.remove(listener)) {
-                    LOG.debug("Unregistered ledger metadata listener {} on ledger {}.", listener, ledgerId);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Unregistered ledger metadata listener {} on ledger {}.", listener, ledgerId);
+                    }
                 }
                 if (listenerSet.isEmpty()) {
                     listeners.remove(ledgerId, listenerSet);
@@ -444,7 +460,9 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
                 }
 
                 Set<Long> zkActiveLedgers = ledgerListToSet(ledgerNodes, path);
-                LOG.debug("Processing ledgers: {}", zkActiveLedgers);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Processing ledgers: {}", zkActiveLedgers);
+                }
 
                 // no ledgers found, return directly
                 if (zkActiveLedgers.size() == 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerLayout.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerLayout.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 class LedgerLayout {
     static final Logger LOG = LoggerFactory.getLogger(LedgerLayout.class);
 
-   
+
     // version of compability layout version
     public static final int LAYOUT_MIN_COMPAT_VERSION = 1;
     // version of ledger layout metadata
@@ -65,7 +65,7 @@ class LedgerLayout {
             } catch (KeeperException.NoNodeException nne) {
                 return null;
             }
-            
+
             return layout;
         } catch (InterruptedException ie) {
             throw new IOException(ie);
@@ -169,7 +169,9 @@ class LedgerLayout {
           new StringBuilder().append(layoutFormatVersion).append(lSplitter)
               .append(managerFactoryCls).append(splitter).append(managerVersion).toString();
 
-        LOG.debug("Serialized layout info: {}", s);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Serialized layout info: {}", s);
+        }
         return s.getBytes("UTF-8");
     }
 
@@ -186,8 +188,9 @@ class LedgerLayout {
      */
     private static LedgerLayout parseLayout(byte[] bytes) throws IOException {
         String layout = new String(bytes, "UTF-8");
-
-        LOG.debug("Parsing Layout: {}", layout);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Parsing Layout: {}", layout);
+        }
 
         String lines[] = layout.split(lSplitter);
 
@@ -195,7 +198,7 @@ class LedgerLayout {
             int layoutFormatVersion = Integer.parseInt(lines[0]);
             if (LAYOUT_FORMAT_VERSION < layoutFormatVersion ||
                 LAYOUT_MIN_COMPAT_VERSION > layoutFormatVersion) {
-                throw new IOException("Metadata version not compatible. Expected " 
+                throw new IOException("Metadata version not compatible. Expected "
                         + LAYOUT_FORMAT_VERSION + ", but got " + layoutFormatVersion);
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
@@ -138,7 +138,9 @@ public abstract class LedgerManagerFactory {
             return lmFactory
                     .initialize(conf, zk, lmFactory.getCurrentVersion());
         }
-        LOG.debug("read ledger layout {}", layout);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("read ledger layout {}", layout);
+        }
 
         // there is existing layout, we need to look into the layout.
         // handle pre V2 layout
@@ -242,7 +244,7 @@ public abstract class LedgerManagerFactory {
 
     /**
      * Format the ledger metadata for LedgerManager
-     * 
+     *
      * @param conf
      *            Configuration instance
      * @param zk
@@ -250,18 +252,18 @@ public abstract class LedgerManagerFactory {
      */
     public void format(final AbstractConfiguration conf, final ZooKeeper zk)
             throws InterruptedException, KeeperException, IOException {
-        
+
         Class<? extends LedgerManagerFactory> factoryClass;
         try {
             factoryClass = conf.getLedgerManagerFactoryClass();
         } catch (ConfigurationException e) {
             throw new IOException("Failed to get ledger manager factory class from configuration : ", e);
         }
-       
+
         LedgerLayout layout = LedgerLayout.readLayout(zk,
                 conf.getZkLedgersRootPath());
         layout.delete(zk, conf.getZkLedgersRootPath());
-        // Create new layout information again.        
+        // Create new layout information again.
         createNewLMFactory(conf, zk, factoryClass);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongZkLedgerIdGenerator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongZkLedgerIdGenerator.java
@@ -82,7 +82,7 @@ public class LongZkLedgerIdGenerator implements LedgerIdGenerator {
         this.shortIdGen = shortIdGen;
         highOrderDirectories = new ArrayList<String>();
         ledgerIdGenPathStatus = HighOrderLedgerIdGenPathStatus.UNKNOWN;
-        this.zkAcls = zkAcls; 
+        this.zkAcls = zkAcls;
     }
 
     private void generateLongLedgerIdLowBits(final String ledgerPrefix, long highBits, final GenericCallback<Long> cb) throws KeeperException, InterruptedException, IOException {
@@ -130,13 +130,17 @@ public class LongZkLedgerIdGenerator implements LedgerIdGenerator {
 
     private void createHOBPathAndGenerateId(String ledgerPrefix, int hob, final GenericCallback<Long> cb) throws KeeperException, InterruptedException, IOException {
         try {
-            LOG.debug("Creating HOB path: {}", ledgerPrefix + formatHalfId(hob));
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating HOB path: {}", ledgerPrefix + formatHalfId(hob));
+            }
             zk.create(ledgerPrefix + formatHalfId(hob), new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         }
         catch(KeeperException.NodeExistsException e) {
             // It's fine if we lost a race to create the node (NodeExistsException).
             // All other exceptions should continue unwinding.
-            LOG.debug("Tried to create High-order-bits node, but it already existed!", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Tried to create High-order-bits node, but it already existed!", e);
+            }
         }
         // We just created a new HOB directory. Invalidate the directory cache
         invalidateDirectoryCache();
@@ -210,13 +214,17 @@ public class LongZkLedgerIdGenerator implements LedgerIdGenerator {
 
             for(int i = 0; i < highOrderDirs.length - 3; i++) {
                 String path = ledgerPrefix + formatHalfId(((Long)highOrderDirs[i]).intValue());
-                LOG.debug("DELETING HIGH ORDER DIR: {}", path);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("DELETING HIGH ORDER DIR: {}", path);
+                }
                 try {
                     zk.delete(path, 0);
                 }
                 catch (KeeperException e) {
                     // We don't care if we fail. Just warn about it.
-                    LOG.debug("Failed to delete {}", path);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Failed to delete {}", path);
+                    }
                 }
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
@@ -215,10 +215,14 @@ public class MSLedgerManagerFactory extends LedgerManagerFactory {
             @Override
             public void run() {
                 if (null != listeners.get(ledgerId)) {
-                    LOG.debug("Re-read ledger metadata for {}.", ledgerId);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Re-read ledger metadata for {}.", ledgerId);
+                    }
                     readLedgerMetadata(ledgerId, ReadLedgerMetadataTask.this);
                 } else {
-                    LOG.debug("Ledger metadata listener for ledger {} is already removed.", ledgerId);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Ledger metadata listener for ledger {} is already removed.", ledgerId);
+                    }
                 }
             }
 
@@ -227,7 +231,9 @@ public class MSLedgerManagerFactory extends LedgerManagerFactory {
                 if (BKException.Code.OK == rc) {
                     final Set<LedgerMetadataListener> listenerSet = listeners.get(ledgerId);
                     if (null != listenerSet) {
-                        LOG.debug("Ledger metadata is changed for {} : {}.", ledgerId, result);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Ledger metadata is changed for {} : {}.", ledgerId, result);
+                        }
                         scheduler.submit(new Runnable() {
                             @Override
                             public void run() {
@@ -243,8 +249,10 @@ public class MSLedgerManagerFactory extends LedgerManagerFactory {
                     // the ledger is removed, do nothing
                     Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
                     if (null != listenerSet) {
-                        LOG.debug("Removed ledger metadata listener set on ledger {} as its ledger is deleted : {}",
-                                ledgerId, listenerSet.size());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Removed ledger metadata listener set on ledger {} as its ledger is deleted : {}",
+                                    ledgerId, listenerSet.size());
+                        }
                     }
                 } else {
                     LOG.warn("Failed on read ledger metadata of ledger {} : {}", ledgerId, rc);
@@ -360,7 +368,9 @@ public class MSLedgerManagerFactory extends LedgerManagerFactory {
                         ledgerCb.operationComplete(BKException.Code.MetaStoreException, null);
                         return;
                     }
-                    LOG.debug("Create ledger {} with version {} successfully.", lid, version);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Create ledger {} with version {} successfully.", lid, version);
+                    }
                     // update version
                     metadata.setVersion(version);
                     ledgerCb.operationComplete(BKException.Code.OK, null);
@@ -430,7 +440,9 @@ public class MSLedgerManagerFactory extends LedgerManagerFactory {
                 final GenericCallback<Void> cb) {
             Value data = new Value().setField(META_FIELD, metadata.serialize());
 
-            LOG.debug("Writing ledger {} metadata, version {}", new Object[] { ledgerId, metadata.getVersion() });
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Writing ledger {} metadata, version {}", new Object[] { ledgerId, metadata.getVersion() });
+            }
 
             final String key = ledgerId2Key(ledgerId);
             MetastoreCallback<Version> msCallback = new MetastoreCallback<Version>() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerIdGenerator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerIdGenerator.java
@@ -113,7 +113,9 @@ public class ZkLedgerIdGenerator implements LedgerIdGenerator {
                                     LOG.warn("Exception during deleting znode for id generation : ",
                                             KeeperException.create(KeeperException.Code.get(rc), path));
                                 } else {
-                                    LOG.debug("Deleting znode for id generation : {}", idPathName);
+                                    if (LOG.isDebugEnabled()) {
+                                        LOG.debug("Deleting znode for id generation : {}", idPathName);
+                                    }
                                 }
                             }
                         }, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
@@ -240,7 +240,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
     @Override
     public void markLedgerUnderreplicated(long ledgerId, String missingReplica)
             throws ReplicationException.UnavailableException {
-        LOG.debug("markLedgerUnderreplicated(ledgerId={}, missingReplica={})", ledgerId, missingReplica);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("markLedgerUnderreplicated(ledgerId={}, missingReplica={})", ledgerId, missingReplica);
+        }
         try {
             List<ACL> zkAcls = ZkUtils.getACLs(conf);
             String znode = getUrLedgerZnode(ledgerId);
@@ -289,7 +291,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
 
     @Override
     public void markLedgerReplicated(long ledgerId) throws ReplicationException.UnavailableException {
-        LOG.debug("markLedgerReplicated(ledgerId={})", ledgerId);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("markLedgerReplicated(ledgerId={})", ledgerId);
+        }
         try {
             Lock l = heldLocks.get(ledgerId);
             if (l != null) {
@@ -405,7 +409,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
 
                     Stat stat = zkc.exists(parent + "/" + tryChild, false);
                     if (stat == null) {
-                        LOG.debug("{}/{} doesn't exist", parent, tryChild);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("{}/{} doesn't exist", parent, tryChild);
+                        }
                         children.remove(tryChild);
                         continue;
                     }
@@ -449,7 +455,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
 
     @Override
     public long pollLedgerToRereplicate() throws ReplicationException.UnavailableException {
-        LOG.debug("pollLedgerToRereplicate()");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("pollLedgerToRereplicate()");
+        }
         try {
             Watcher w = new Watcher() {
                     public void process(WatchedEvent e) { // do nothing
@@ -466,7 +474,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
 
     @Override
     public long getLedgerToRereplicate() throws ReplicationException.UnavailableException {
-        LOG.debug("getLedgerToRereplicate()");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("getLedgerToRereplicate()");
+        }
         try {
             while (true) {
                 waitIfLedgerReplicationDisabled();
@@ -508,7 +518,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
 
     @Override
     public void releaseUnderreplicatedLedger(long ledgerId) throws ReplicationException.UnavailableException {
-        LOG.debug("releaseLedger(ledgerId={})", ledgerId);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("releaseLedger(ledgerId={})", ledgerId);
+        }
         try {
             Lock l = heldLocks.remove(ledgerId);
             if (l != null) {
@@ -527,7 +539,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
 
     @Override
     public void close() throws ReplicationException.UnavailableException {
-        LOG.debug("close()");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("close()");
+        }
         try {
             for (Map.Entry<Long, Lock> e : heldLocks.entrySet()) {
                 zkc.delete(e.getValue().getLockZNode(), -1);
@@ -547,7 +561,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
     public void disableLedgerReplication()
             throws ReplicationException.UnavailableException {
         List<ACL> zkAcls = ZkUtils.getACLs(conf);
-        LOG.debug("disableLedegerReplication()");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("disableLedegerReplication()");
+        }
         try {
             String znode = basePath + '/' + BookKeeperConstants.DISABLE_NODE;
             zkc.create(znode, "".getBytes(UTF_8), zkAcls, CreateMode.PERSISTENT);
@@ -570,7 +586,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
     @Override
     public void enableLedgerReplication()
             throws ReplicationException.UnavailableException {
-        LOG.debug("enableLedegerReplication()");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("enableLedegerReplication()");
+        }
         try {
             zkc.delete(basePath + '/' + BookKeeperConstants.DISABLE_NODE, -1);
             LOG.info("Resuming automatic ledger re-replication");
@@ -592,7 +610,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
     @Override
     public boolean isLedgerReplicationEnabled()
             throws ReplicationException.UnavailableException {
-        LOG.debug("isLedgerReplicationEnabled()");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("isLedgerReplicationEnabled()");
+        }
         try {
             if (null != zkc.exists(basePath + '/'
                     + BookKeeperConstants.DISABLE_NODE, false)) {
@@ -614,7 +634,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
     @Override
     public void notifyLedgerReplicationEnabled(final GenericCallback<Void> cb)
             throws ReplicationException.UnavailableException {
-        LOG.debug("notifyLedgerReplicationEnabled()");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("notifyLedgerReplicationEnabled()");
+        }
         Watcher w = new Watcher() {
             public void process(WatchedEvent e) {
                 if (e.getType() == Watcher.Event.EventType.NodeDeleted) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
@@ -222,7 +222,9 @@ class AuthHandler {
                     authenticated = true;
                     LOG.info("Authentication success on server side");
                 } else {
-                    LOG.debug("Authentication failed on server side");
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Authentication failed on server side");
+                    }
                 }
             }
         }
@@ -386,7 +388,9 @@ class AuthHandler {
                     }
                 } else {
                     authenticationError(ctx, rc);
-                    LOG.debug("Authentication failed on server side");
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Authentication failed on server side");
+                    }
                 }
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -106,7 +106,7 @@ public class BookieServer {
 
     protected Bookie newBookie(ServerConfiguration conf)
         throws IOException, KeeperException, InterruptedException, BookieException {
-        return conf.isForceReadOnlyBookie() ? 
+        return conf.isForceReadOnlyBookie() ?
                 new ReadOnlyBookie(conf, statsLogger.scope(BOOKIE_SCOPE)) :
                 new Bookie(conf, statsLogger.scope(BOOKIE_SCOPE));
     }
@@ -143,7 +143,9 @@ public class BookieServer {
      */
     @VisibleForTesting
     public void suspendProcessing() {
-        LOG.debug("Suspending bookie server, port is {}", conf.getBookiePort());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Suspending bookie server, port is {}", conf.getBookiePort());
+        }
         nettyServer.suspendProcessing();
     }
 
@@ -152,7 +154,9 @@ public class BookieServer {
      */
     @VisibleForTesting
     public void resumeProcessing() {
-        LOG.debug("Resuming bookie server, port is {}", conf.getBookiePort());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Resuming bookie server, port is {}", conf.getBookiePort());
+        }
         nettyServer.resumeProcessing();
     }
 
@@ -294,7 +298,7 @@ public class BookieServer {
                 throw new IllegalArgumentException();
             }
 
-            ServerConfiguration conf = new ServerConfiguration();            
+            ServerConfiguration conf = new ServerConfiguration();
 
             if (cmdLine.hasOption('c')) {
                 String confFile = cmdLine.getOptionValue("c");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetBookieInfoProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetBookieInfoProcessorV3.java
@@ -55,7 +55,9 @@ public class GetBookieInfoProcessorV3 extends PacketProcessorBaseV3 implements R
             return getBookieInfoResponse.build();
         }
 
-        LOG.debug("Received new getBookieInfo request: {}", request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Received new getBookieInfo request: {}", request);
+        }
         StatusCode status = StatusCode.EOK;
         long freeDiskSpace = 0L, totalDiskSpace = 0L;
         if ((requested & GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE) != 0) {
@@ -66,7 +68,10 @@ public class GetBookieInfoProcessorV3 extends PacketProcessorBaseV3 implements R
             totalDiskSpace = requestProcessor.bookie.getTotalDiskSpace();
             getBookieInfoResponse.setTotalDiskCapacity(totalDiskSpace);
         }
-        LOG.debug("FreeDiskSpace info is " + freeDiskSpace + " totalDiskSpace is: " + totalDiskSpace);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("FreeDiskSpace info is " + freeDiskSpace + " totalDiskSpace is: " + totalDiskSpace);
+        }
         getBookieInfoResponse.setStatus(status);
         requestProcessor.getBookieInfoStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),
                 TimeUnit.NANOSECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -288,7 +288,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
     }
 
     protected ChannelFuture connect() {
-        LOG.debug("Connecting to bookie: {}", addr);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Connecting to bookie: {}", addr);
+        }
 
         // Set up the ClientBootStrap so we can create a new Channel connection to the bookie.
         Bootstrap bootstrap = new Bootstrap();
@@ -348,7 +350,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         future.addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
-                LOG.debug("Channel connected ({}) {}", future.isSuccess(), future.channel());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Channel connected ({}) {}", future.isSuccess(), future.channel());
+                }
                 int rc;
                 Queue<GenericCallback<PerChannelBookieClient>> oldPendingOps;
 
@@ -366,8 +370,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                         rc = BKException.Code.BookieHandleNotAvailableException;
                         channel = null;
                     } else if (future.isSuccess() && state == ConnectionState.CONNECTED) {
-                        LOG.debug("Already connected with another channel({}), so close the new channel({})",
-                                channel, future.channel());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Already connected with another channel({}), so close the new channel({})",
+                                    channel, future.channel());
+                        }
                         closeChannel(future.channel());
                         return; // pendingOps should have been completed when other channel connected
                     } else {
@@ -702,8 +708,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
                     if (future.isSuccess()) {
-                        LOG.debug("Succssfully wrote request {} to {}",
-                                readLacRequest, c.remoteAddress());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Succssfully wrote request {} to {}", readLacRequest, c.remoteAddress());
+                        }
                     } else {
                         if (!(future.cause() instanceof ClosedChannelException)) {
                             LOG.warn("Writing readLac(lid = {}) to channel {} failed : ",
@@ -888,7 +895,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
     }
 
     private ChannelFuture closeChannel(Channel c) {
-        LOG.debug("Closing channel {}", c);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Closing channel {}", c);
+        }
         return c.close();
     }
 
@@ -897,7 +906,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
     }
 
     void errorOutReadKey(final CompletionKey key, final int rc) {
-        LOG.debug("Removing completion key: {}", key);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Removing completion key: {}", key);
+        }
         final ReadCompletion readCompletion = (ReadCompletion)completionObjects.remove(key);
         if (null == readCompletion) {
             return;
@@ -911,8 +922,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                     bAddress = c.remoteAddress().toString();
                 }
 
-                LOG.debug("Could not write request for reading entry: {} ledger-id: {} bookie: {} rc: {}",
-                        new Object[]{ readCompletion.entryId, readCompletion.ledgerId, bAddress, rc });
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Could not write request for reading entry: {} ledger-id: {} bookie: {} rc: {}",
+                            new Object[] { readCompletion.entryId, readCompletion.ledgerId, bAddress, rc });
+                }
 
                 readCompletion.cb.readEntryComplete(rc, readCompletion.ledgerId, readCompletion.entryId,
                                                     null, readCompletion.ctx);
@@ -930,7 +943,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
     }
 
     void errorOutWriteLacKey(final CompletionKey key, final int rc) {
-        LOG.debug("Removing completion key: {}", key);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Removing completion key: {}", key);
+        }
         final WriteLacCompletion writeLacCompletion = (WriteLacCompletion)completionObjects.remove(key);
         if (null == writeLacCompletion) {
             return;
@@ -943,8 +958,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                 if (c != null) {
                     bAddress = c.remoteAddress().toString();
                 }
-                LOG.debug("Could not write request writeLac for ledgerId: {} bookie: {}",
-                          new Object[] { writeLacCompletion.ledgerId, bAddress});
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Could not write request writeLac for ledgerId: {} bookie: {}",
+                            writeLacCompletion.ledgerId, bAddress);
+                }
                 writeLacCompletion.cb.writeLacComplete(rc, writeLacCompletion.ledgerId, addr, writeLacCompletion.ctx);
             }
         });
@@ -955,7 +972,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
     }
 
     void errorOutReadLacKey(final CompletionKey key, final int rc) {
-        LOG.debug("Removing completion key: {}", key);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Removing completion key: {}", key);
+        }
         final ReadLacCompletion readLacCompletion = (ReadLacCompletion)completionObjects.remove(key);
         if (null == readLacCompletion) {
             return;
@@ -968,8 +987,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                 if (c != null) {
                     bAddress = c.remoteAddress().toString();
                 }
-                LOG.debug("Could not write request readLac for ledgerId: {} bookie: {}",
-                          new Object[] { readLacCompletion.ledgerId, bAddress});
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Could not write request readLac for ledgerId: {} bookie: {}", readLacCompletion.ledgerId,
+                            bAddress);
+                }
                 readLacCompletion.cb.readLacComplete(rc, readLacCompletion.ledgerId, null, null, readLacCompletion.ctx);
             }
         });
@@ -992,12 +1013,17 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                 if (c != null && c.remoteAddress() != null) {
                     bAddress = c.remoteAddress().toString();
                 }
-                LOG.debug("Could not write request for adding entry: {} ledger-id: {} bookie: {} rc: {}",
-                          new Object[] { addCompletion.entryId, addCompletion.ledgerId, bAddress, rc });
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Could not write request for adding entry: {} ledger-id: {} bookie: {} rc: {}",
+                            new Object[] { addCompletion.entryId, addCompletion.ledgerId, bAddress, rc });
+                }
 
                 addCompletion.cb.writeComplete(rc, addCompletion.ledgerId, addCompletion.entryId,
                                                addr, addCompletion.ctx);
-                LOG.debug("Invoked callback method: {}", addCompletion.entryId);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Invoked callback method: {}", addCompletion.entryId);
+                }
             }
 
             @Override
@@ -1323,7 +1349,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         // The completion value should always be an instance of an WriteLacCompletion object when we reach here.
         WriteLacCompletion plc = (WriteLacCompletion)completionValue;
 
-        LOG.debug("Got response for writeLac request from bookie: " + addr + " for ledger: " + ledgerId + " rc: " + status);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Got response for writeLac request from bookie: " + addr + " for ledger: " + ledgerId + " rc: "
+                    + status);
+        }
 
         // convert to BKException code
         Integer rcToRet = statusCodeToExceptionCode(status);
@@ -1361,12 +1390,16 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         // The completion value should always be an instance of an WriteLacCompletion object when we reach here.
         ReadLacCompletion glac = (ReadLacCompletion)completionValue;
 
-        LOG.debug("Got response for readLac request from bookie: " + addr + " for ledger: " + ledgerId + " rc: " + status);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Got response for readLac request from bookie: " + addr + " for ledger: " + ledgerId + " rc: "
+                    + status);
+        }
         // convert to BKException code
         Integer rcToRet = statusCodeToExceptionCode(status);
         if (null == rcToRet) {
-            LOG.debug("readLac for ledger: " + ledgerId + " failed on bookie: " + addr
-                      + " with code:" + status);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("readLac for ledger: " + ledgerId + " failed on bookie: " + addr + " with code:" + status);
+            }
             rcToRet = BKException.Code.ReadException;
         }
         glac.cb.readLacComplete(rcToRet, ledgerId, lacBuffer.slice(), lastEntryBuffer.slice(), glac.ctx);
@@ -1413,7 +1446,11 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                       new Object[] { addr, status });
             rcToRet = BKException.Code.ReadException;
         }
-        LOG.debug("Response received from bookie info read: freeDiskSpace=" +  freeDiskSpace + " totalDiskSpace:" + totalDiskCapacity);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Response received from bookie info read: freeDiskSpace=" + freeDiskSpace + " totalDiskSpace:"
+                    + totalDiskCapacity);
+        }
         rc.cb.getBookieInfoComplete(rcToRet, new BookieInfo(totalDiskCapacity, freeDiskSpace), rc.ctx);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -47,7 +47,9 @@ class ReadEntryProcessor extends PacketProcessorBase {
         assert (request instanceof BookieProtocol.ReadRequest);
         BookieProtocol.ReadRequest read = (BookieProtocol.ReadRequest) request;
 
-        LOG.debug("Received new read request: {}", request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Received new read request: {}", request);
+        }
         int errorCode = BookieProtocol.EIO;
         long startTimeNanos = MathUtils.nowInNano();
         ByteBuf data = null;
@@ -64,7 +66,9 @@ class ReadEntryProcessor extends PacketProcessorBase {
                 }
             }
             data = requestProcessor.bookie.readEntry(request.getLedgerId(), request.getEntryId());
-            LOG.debug("##### Read entry ##### {} -- ref-count: {}", data.readableBytes(), data.refCnt());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("##### Read entry ##### {} -- ref-count: {}", data.readableBytes(), data.refCnt());
+            }
             if (null != fenceResult) {
                 // TODO:
                 // currently we don't have readCallback to run in separated read
@@ -119,8 +123,9 @@ class ReadEntryProcessor extends PacketProcessorBase {
             errorCode = BookieProtocol.EUA;
         }
 
-        LOG.trace("Read entry rc = {} for {}",
-                new Object[] { errorCode, read });
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Read entry rc = {} for {}", new Object[] { errorCode, read });
+        }
         if (errorCode == BookieProtocol.EOK) {
             requestProcessor.readEntryStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),
                     TimeUnit.NANOSECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -64,7 +64,9 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
             return readResponse.build();
         }
 
-        LOG.debug("Received new read request: {}", request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Received new read request: {}", request);
+        }
         StatusCode status;
         ByteBuf entryBody = null;
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -566,7 +566,9 @@ public class Auditor implements BookiesListener {
                         numBookiesPerLedger.registerSuccessfulValue(lh.getNumBookies());
                         numLedgersChecked.inc();
                     } catch (BKException.BKNoSuchLedgerExistsException bknsle) {
-                        LOG.debug("Ledger was deleted before we could check it", bknsle);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Ledger was deleted before we could check it", bknsle);
+                        }
                         callback.processResult(BKException.Code.OK,
                                                null, null);
                         return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationEnableCb.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationEnableCb.java
@@ -38,19 +38,22 @@ public class ReplicationEnableCb implements GenericCallback<Void> {
     @Override
     public void operationComplete(int rc, Void result) {
         latch.countDown();
-        LOG.debug("Automatic ledger re-replication is enabled");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Automatic ledger re-replication is enabled");
+        }
     }
 
     /**
      * This is a blocking call and causes the current thread to wait until the
      * replication process is enabled
-     * 
+     *
      * @throws InterruptedException
      *             interrupted while waiting
      */
     public void await() throws InterruptedException {
-        LOG.debug("Automatic ledger re-replication is disabled. "
-                + "Hence waiting until its enabled!");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Automatic ledger re-replication is disabled. Hence waiting until its enabled!");
+        }
         latch.await();
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -224,10 +224,15 @@ public class ReplicationWorker implements Runnable {
 
     private boolean rereplicate(long ledgerIdToReplicate) throws InterruptedException, BKException,
             UnavailableException {
-        LOG.debug("Going to replicate the fragments of the ledger: {}", ledgerIdToReplicate);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Going to replicate the fragments of the ledger: {}", ledgerIdToReplicate);
+        }
         try (LedgerHandle lh = admin.openLedgerNoRecovery(ledgerIdToReplicate)) {
             Set<LedgerFragment> fragments = getUnderreplicatedFragments(lh);
-            LOG.debug("Founds fragments {} for replication from ledger: {}", fragments, ledgerIdToReplicate);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Founds fragments {} for replication from ledger: {}", fragments, ledgerIdToReplicate);
+            }
 
             boolean foundOpenFragments = false;
             long numFragsReplicated = 0;
@@ -237,8 +242,10 @@ public class ReplicationWorker implements Runnable {
                     continue;
                 } else if (isTargetBookieExistsInFragmentEnsemble(lh,
                         ledgerFragment)) {
-                    LOG.debug("Target Bookie[{}] found in the fragment ensemble: {}", targetBookie,
-                            ledgerFragment.getEnsemble());
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Target Bookie[{}] found in the fragment ensemble: {}", targetBookie,
+                                ledgerFragment.getEnsemble());
+                    }
                     continue;
                 }
                 try {
@@ -383,7 +390,9 @@ public class ReplicationWorker implements Runnable {
                     LOG.info("InterruptedException "
                             + "while replicating fragments", e);
                 } catch (BKNoSuchLedgerExistsException bknsle) {
-                    LOG.debug("Ledger was deleted, safe to continue", bknsle);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Ledger was deleted, safe to continue", bknsle);
+                    }
                 } catch (BKException e) {
                     LOG.error("BKException while fencing the ledger"
                             + " for rereplication of postponed ledgers", e);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLBookieAuthProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLBookieAuthProvider.java
@@ -40,7 +40,7 @@ public class SASLBookieAuthProvider implements BookieAuthProvider {
 
     private SaslServerState server;
     private final AuthCallbacks.GenericCallback<Void> completeCb;
-    
+
     SASLBookieAuthProvider(BookieConnectionPeer addr, AuthCallbacks.GenericCallback<Void> completeCb,
         ServerConfiguration serverConfiguration, Subject subject, Pattern allowedIdsPattern) {
         this.completeCb = completeCb;
@@ -64,7 +64,9 @@ public class SASLBookieAuthProvider implements BookieAuthProvider {
                 completeCb.operationComplete(BKException.Code.OK, null);
             }
         } catch (SaslException err) {
-            LOG.debug("SASL error", err);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("SASL error", err);
+            }
             completeCb.operationComplete(BKException.Code.UnauthorizedAccessException, null);
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLBookieAuthProviderFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLBookieAuthProviderFactory.java
@@ -112,7 +112,9 @@ public class SASLBookieAuthProviderFactory implements org.apache.bookkeeper.auth
             try {
                 ticketRefreshThread.join(10000);
             } catch (InterruptedException exit) {
-                LOG.debug("interrupted while waiting for TGT reresh thread to stop", exit);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("interrupted while waiting for TGT reresh thread to stop", exit);
+                }
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLClientAuthProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLClientAuthProvider.java
@@ -53,7 +53,9 @@ public class SASLClientAuthProvider implements ClientAuthProvider {
                 hostname = InetAddress.getLocalHost().getHostName();
             }
             client = new SaslClientState(hostname, subject);
-            LOG.debug("SASLClientAuthProvider Boot " + client + " for " + hostname);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("SASLClientAuthProvider Boot " + client + " for " + hostname);
+            }
         } catch (IOException error) {
             LOG.error("Error while booting SASL client", error);
             completeCb.operationComplete(BKException.Code.UnauthorizedAccessException, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLClientProviderFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLClientProviderFactory.java
@@ -113,7 +113,9 @@ public class SASLClientProviderFactory implements
             try {
                 ticketRefreshThread.join(10000);
             } catch (InterruptedException exit) {
-                LOG.debug("interrupted while waiting for TGT reresh thread to stop", exit);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("interrupted while waiting for TGT reresh thread to stop", exit);
+                }
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslClientState.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslClientState.java
@@ -53,7 +53,9 @@ public class SaslClientState {
             throw new SaslException("Cannot create JAAS Sujbect for SASL");
         }
         if (clientSubject.getPrincipals().isEmpty()) {
-            LOG.debug("Using JAAS/SASL/DIGEST-MD5 auth to connect to {}", serverPrincipal);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using JAAS/SASL/DIGEST-MD5 auth to connect to {}", serverPrincipal);
+            }
             String[] mechs = {"DIGEST-MD5"};
             username = (String) (clientSubject.getPublicCredentials().toArray()[0]);
             password = (String) (clientSubject.getPrivateCredentials().toArray()[0]);
@@ -67,7 +69,9 @@ public class SaslClientState {
             final String serviceName = serviceKerberosName.getServiceName();
             final String serviceHostname = serviceKerberosName.getHostName();
             final String clientPrincipalName = clientKerberosName.toString();
-            LOG.debug("Using JAAS/SASL/GSSAPI auth to connect to server Principal {}", serverPrincipal);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using JAAS/SASL/GSSAPI auth to connect to server Principal {}", serverPrincipal);
+            }
             try {
                 saslClient = Subject.doAs(clientSubject, new PrivilegedExceptionAction<SaslClient>() {
                     @Override
@@ -78,7 +82,9 @@ public class SaslClientState {
                     }
                 });
             } catch (PrivilegedActionException err) {
-                LOG.debug("GSSAPI client error", err.getCause());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("GSSAPI client error", err.getCause());
+                }
                 throw new SaslException("error while booting GSSAPI client", err.getCause());
             }
         }
@@ -103,7 +109,9 @@ public class SaslClientState {
                     });
                 return retval;
             } catch (PrivilegedActionException e) {
-                LOG.debug("SASL error", e.getCause());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("SASL error", e.getCause());
+                }
                 throw new SaslException("SASL/JAAS error", e.getCause());
             }
         } else {
@@ -172,7 +180,9 @@ public class SaslClientState {
             byte[] retval = saslClient.evaluateChallenge(saslTokenMessage);
             return retval;
         } catch (SaslException e) {
-            LOG.debug("saslResponse: Failed to respond to SASL server's token:", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("saslResponse: Failed to respond to SASL server's token:", e);
+            }
             return null;
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslServerState.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslServerState.java
@@ -70,7 +70,9 @@ public class SaslServerState {
             try {
                 final Object[] principals = subject.getPrincipals().toArray();
                 final Principal servicePrincipal = (Principal) principals[0];
-                LOG.debug("Authentication will use SASL/JAAS/Kerberos, servicePrincipal is {}", servicePrincipal);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Authentication will use SASL/JAAS/Kerberos, servicePrincipal is {}", servicePrincipal);
+                }
 
                 final String servicePrincipalNameAndHostname = servicePrincipal.getName();
                 int indexOf = servicePrincipalNameAndHostname.indexOf("/");
@@ -109,7 +111,9 @@ public class SaslServerState {
                 throw new SaslException("error on GSSAPI boot", e);
             }
         } else {
-            LOG.debug("Authentication will use SASL/JAAS/DIGEST-MD5");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Authentication will use SASL/JAAS/DIGEST-MD5");
+            }
             return Sasl.createSaslServer("DIGEST-MD5", SaslConstants.SASL_BOOKKEEPER_PROTOCOL,
                 SaslConstants.SASL_MD5_DUMMY_HOSTNAME, null, callbackHandler);
         }
@@ -199,7 +203,9 @@ public class SaslServerState {
         }
 
         private void handleRealmCallback(RealmCallback rc) {
-            LOG.debug("client supplied realm: " + rc.getDefaultText());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("client supplied realm: " + rc.getDefaultText());
+            }
             rc.setText(rc.getDefaultText());
         }
 
@@ -220,15 +226,19 @@ public class SaslServerState {
             }
             ac.setAuthorized(true);
 
-            LOG.debug("Successfully authenticated client: authenticationID=" + authenticationID
-                + ";  authorizationID=" + authorizationID + ".");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Successfully authenticated client: authenticationID=" + authenticationID
+                        + ";  authorizationID=" + authorizationID + ".");
+            }
 
             KerberosName kerberosName = new KerberosName(authenticationID);
             try {
                 StringBuilder userNameBuilder = new StringBuilder(kerberosName.getShortName());
                 userNameBuilder.append("/").append(kerberosName.getHostName());
                 userNameBuilder.append("@").append(kerberosName.getRealm());
-                LOG.debug("Setting authorizedID: " + userNameBuilder);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Setting authorizedID: " + userNameBuilder);
+                }
                 ac.setAuthorizedID(userNameBuilder.toString());
             } catch (IOException e) {
                 LOG.error("Failed to set name based on Kerberos authentication rules.");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/TGTRefreshThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/TGTRefreshThread.java
@@ -63,8 +63,10 @@ class TGTRefreshThread extends Thread {
         for (KerberosTicket ticket : tickets) {
             KerberosPrincipal server = ticket.getServer();
             if (server.getName().equals("krbtgt/" + server.getRealm() + "@" + server.getRealm())) {
-                LOG.debug("Client principal is \"" + ticket.getClient().getName() + "\".");
-                LOG.debug("Server principal is \"" + ticket.getServer().getName() + "\".");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Client principal is \"" + ticket.getClient().getName() + "\".");
+                    LOG.debug("Server principal is \"" + ticket.getServer().getName() + "\".");
+                }
                 return ticket;
             }
         }
@@ -178,7 +180,9 @@ class TGTRefreshThread extends Thread {
                 int retry = 1;
                 while (retry >= 0) {
                     try {
-                        LOG.debug("running ticket cache refresh command: {} {}", cmd, kinitArgs);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("running ticket cache refresh command: {} {}", cmd, kinitArgs);
+                        }
                         Shell.execCommand(cmd, kinitArgs);
                         break;
                     } catch (Exception e) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -95,7 +95,9 @@ public class LocalBookKeeper {
 
         boolean b = waitForServerUp(InetAddress.getLoopbackAddress().getHostAddress() + ":" + zookeeperPort,
           CONNECTION_TIMEOUT);
-        LOG.debug("ZooKeeper server up: {}", b);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("ZooKeeper server up: {}", b);
+        }
         return server;
     }
 
@@ -213,7 +215,7 @@ public class LocalBookKeeper {
             } else {
                 bsConfs[i].setBookiePort(initialPort + i);
             }
-            
+
             if (null == baseConf.getZkServers()) {
                 bsConfs[i].setZkServers(InetAddress.getLocalHost().getHostAddress() + ":"
                                   + ZooKeeperDefaultPort);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ZooKeeperWatcherBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ZooKeeperWatcherBase.java
@@ -112,15 +112,18 @@ public class ZooKeeperWatcherBase implements Watcher {
     public void process(WatchedEvent event) {
         // If event type is NONE, this is a connection status change
         if (event.getType() != EventType.None) {
-            LOG.debug("Received event: {}, path: {} from ZooKeeper server",
-                    event.getType(), event.getPath());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Received event: {}, path: {} from ZooKeeper server", event.getType(), event.getPath());
+            }
             getEventCounter(event.getType()).inc();
             // notify the child watchers
             notifyEvent(event);
             return;
         }
         getStateCounter(event.getState()).inc();
-        LOG.debug("Received {} from ZooKeeper server", event.getState());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Received {} from ZooKeeper server", event.getState());
+        }
         // TODO: Needs to handle AuthFailed, SaslAuthenticated events
         switch (event.getState()) {
         case SyncConnected:


### PR DESCRIPTION
Using `LOG.debug(...)` can lead to multiple unexpected memory allocation, even when the logger it's turned off.
For example, int and long parameter are boxed into Integer and Long objects and the var-arg parameters are using an `Object[]` to hold
them.
We should guard all usages of `LOG.debug()` with the `if (LOG.isDebugEnabled()` guard.