### PR TITLE
BOOKKEEPER-1096: recursive znode delete

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -68,6 +68,7 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         super(numBookies);
         activeLedgers = new SnapshotMap<Long, Boolean>();
         baseConf.setLedgerManagerFactoryClass(lmFactoryCls);
+        baseClientConf.setLedgerManagerFactoryClass(lmFactoryCls);
     }
 
     public LedgerManager getLedgerManager() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerMetadataCreationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerMetadataCreationTest.java
@@ -1,0 +1,172 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.meta;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Random;
+import java.util.Set;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.Assume;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LedgerMetadataCreationTest extends LedgerManagerTestCase {
+    static final Logger LOG = LoggerFactory.getLogger(LedgerMetadataCreationTest.class);
+
+    public LedgerMetadataCreationTest(Class<? extends LedgerManagerFactory> lmFactoryCls) {
+        super(lmFactoryCls, 4);
+        baseConf.setGcWaitTime(100000);
+    }
+
+    @Test(timeout = 60000)
+    public void testLedgerCreationAndDeletionWithRandomLedgerIds() throws Exception {
+        testExecution(true);
+    }
+
+    @Test(timeout = 60000)
+    public void testLedgerCreationAndDeletion() throws Exception{
+        testExecution(false);
+    }
+    
+    public void testExecution(boolean randomLedgerId) throws Exception {
+        Set<Long> createRequestsLedgerIds = ConcurrentHashMap.newKeySet();
+        ConcurrentLinkedDeque<Long> existingLedgerIds = new ConcurrentLinkedDeque<Long>();
+
+        Vector<Long> failedCreates = new Vector<Long>();
+        Vector<Long> failedDeletes = new Vector<Long>();
+        BookKeeper bookKeeper = new BookKeeper(baseClientConf);
+
+        ExecutorService executor = Executors.newFixedThreadPool(300);
+        Random rand = new Random();
+        int numberOfOperations = 20000;
+        for (int i = 0; i < numberOfOperations; i++) {
+            int iteration = i;
+            if (rand.nextBoolean() || existingLedgerIds.isEmpty()) {
+                executor.submit(() -> {
+                    long ledgerId = -1;
+                    try {
+                        if (randomLedgerId) {
+                            ledgerId = Math.abs(rand.nextLong());
+                            do {
+                                if (!baseClientConf.getLedgerManagerFactoryClass()
+                                        .equals(LongHierarchicalLedgerManagerFactory.class)) {
+                                    /*
+                                     * since LongHierarchicalLedgerManager
+                                     * supports ledgerIds of decimal length upto
+                                     * 19 digits but other LedgerManagers only
+                                     * upto 10 decimals
+                                     */
+                                    ledgerId %= 9999999999L;
+                                }
+                            } while (!createRequestsLedgerIds.add(ledgerId));
+                        } else {
+                            ledgerId = iteration;
+                        }
+                        bookKeeper.createLedgerAdv(ledgerId, 3, 2, 2, DigestType.CRC32, "passwd".getBytes(), null);
+                        existingLedgerIds.add(ledgerId);
+                    } catch (Exception e) {
+                        LOG.error("Got Exception while creating Ledger with ledgerId " + ledgerId, e);
+                        failedCreates.add(ledgerId);
+                    }
+                });
+            } else {
+                executor.submit(() -> {
+                    Long ledgerId = null;
+                    if (rand.nextBoolean()) {
+                        ledgerId = existingLedgerIds.pollFirst();
+                    } else {
+                        ledgerId = existingLedgerIds.pollLast();
+                    }
+                    if (ledgerId == null) {
+                        return;
+                    }
+                    try {
+                        bookKeeper.deleteLedger(ledgerId);
+                    } catch (Exception e) {
+                        LOG.error("Got Exception while deleting Ledger with ledgerId " + ledgerId, e);
+                        failedDeletes.add(ledgerId);
+                    }
+                });
+            }
+        }
+        executor.shutdown();
+        assertTrue("All the ledger create/delete operations should have'been completed",
+                executor.awaitTermination(30, TimeUnit.SECONDS));
+        assertTrue("There should be no failed creates. But there are " + failedCreates.size() + " failedCreates",
+                failedCreates.isEmpty());
+        assertTrue("There should be no failed deletes. But there are " + failedDeletes.size() + " failedDeletes",
+                failedDeletes.isEmpty());
+        bookKeeper.close();
+    }
+    
+    @Test(timeout = 60000)
+    public void testParentNodeDeletion() throws Exception {
+        /*
+         * run this testcase only for HierarchicalLedgerManager and
+         * LongHierarchicalLedgerManager, since we do recursive zNode deletes
+         * only for HierarchicalLedgerManager
+         */
+        Assume.assumeTrue((baseClientConf.getLedgerManagerFactoryClass().equals(HierarchicalLedgerManagerFactory.class)
+                || baseClientConf.getLedgerManagerFactoryClass().equals(LongHierarchicalLedgerManagerFactory.class)));
+
+        ZooKeeper zkc = new ZooKeeper(zkUtil.getZooKeeperConnectString(), 10000, null);
+        BookKeeper bookKeeper = new BookKeeper(baseClientConf);
+        bookKeeper.createLedgerAdv(1, 3, 2, 2, DigestType.CRC32, "passwd".getBytes(), null);
+        String ledgersRootPath = baseClientConf.getZkLedgersRootPath();
+        String parentZnodePath;
+        if (baseClientConf.getLedgerManagerFactoryClass().equals(HierarchicalLedgerManagerFactory.class)) {
+            /*
+             * in HierarchicalLedgerManager (ledgersRootPath)/00/0000/L0001
+             * would be the path of the znode for ledger - 1. So when ledger - 1
+             * is deleted, (ledgersRootPath)/00 should also be deleted since
+             * there are no other children znodes
+             */
+            parentZnodePath = ledgersRootPath + "/00";
+
+        } else {
+            /*
+             * in LongHierarchicalLedgerManager
+             * (ledgersRootPath)/000/0000/0000/0000/L0001 would be the path of
+             * the znode for ledger - 1. So when ledger - 1 is deleted,
+             * (ledgersRootPath)/000 should also be deleted since there are no
+             * other children znodes
+             */
+            parentZnodePath = ledgersRootPath + "/000";
+        }
+        assertTrue(parentZnodePath + " zNode should exist", null != zkc.exists(parentZnodePath, false));
+        bookKeeper.deleteLedger(1);
+        assertTrue(parentZnodePath + " zNode should not exist anymore", null == zkc.exists(parentZnodePath, false));
+        bookKeeper.close();
+        zkc.close();
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestZkUtils.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestZkUtils.java
@@ -1,0 +1,87 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.util;
+
+import java.io.IOException;
+
+import org.apache.bookkeeper.test.ZooKeeperUtil;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import junit.framework.TestCase;
+
+public class TestZkUtils extends TestCase {
+
+    static final Logger logger = LoggerFactory.getLogger(TestZkUtils.class);
+
+    // ZooKeeper related variables
+    protected ZooKeeperUtil zkUtil = new ZooKeeperUtil();
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        logger.info("Setting up test {}.", getName());
+        zkUtil.startServer();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        zkUtil.killServer();
+        logger.info("Teared down test {}.", getName());
+    }
+
+    @Test(timeout = 60000)
+    public void testAsyncCreateAndDeleteFullPathOptimistic() throws IOException, KeeperException, InterruptedException {
+        ZooKeeper zkc = new ZooKeeper(zkUtil.getZooKeeperConnectString(), 10000, null);
+        /*
+         * "/ledgers/available" is already created in ZooKeeperUtil.startServer
+         */
+        String ledgerZnodePath = new String("/ledgers/000/000/000/001");
+        ZkUtils.createFullPathOptimistic(zkc, ledgerZnodePath, "data".getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        assertTrue(ledgerZnodePath + " zNode should exist", null != zkc.exists(ledgerZnodePath, false));
+
+        ledgerZnodePath = new String("/ledgers/000/000/000/002");
+        ZkUtils.createFullPathOptimistic(zkc, ledgerZnodePath, "data".getBytes(), Ids.OPEN_ACL_UNSAFE,
+                CreateMode.PERSISTENT);
+        assertTrue(ledgerZnodePath + " zNode should exist", null != zkc.exists(ledgerZnodePath, false));
+
+        ZkUtils.deleteFullPathOptimistic(zkc, ledgerZnodePath, -1);
+        assertTrue(ledgerZnodePath + " zNode should not exist, since it is deleted",
+                null == zkc.exists(ledgerZnodePath, false));
+
+        ledgerZnodePath = new String("/ledgers/000/000/000/001");
+        assertTrue(ledgerZnodePath + " zNode should exist", null != zkc.exists(ledgerZnodePath, false));
+        ZkUtils.deleteFullPathOptimistic(zkc, ledgerZnodePath, -1);
+        assertTrue(ledgerZnodePath + " zNode should not exist, since it is deleted",
+                null == zkc.exists(ledgerZnodePath, false));
+        assertTrue("/ledgers/000" + " zNode should not exist, since it should be deleted recursively",
+                null == zkc.exists(ledgerZnodePath, false));
+    }
+}


### PR DESCRIPTION
When ledger is deleted, along with leaf node
all the eligible branch nodes should be
deleted in ZooKeeper.