### PR TITLE
Issue 191: add template for ISSUE and PR

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@ Is this a question, feature request, or bug report?
 
 **QUESTION**
 
-Have you checked our documentation at http://bookkeeper.apache.org/ , If you could not find an answer there, please consider asking your question in our community forum at dev@bookkeeper.apache.org, as it would benefit other members of our community.
+Have you checked our documentation at http://bookkeeper.apache.org/ , If you could not find an answer there, please consider asking your question in our community forum at user@bookkeeper.apache.org, as it would benefit other members of our community.
 
 
 **FEATURE REQUEST**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+Is this a question, feature request, or bug report?
+
+**QUESTION**
+
+Have you checked our documentation at http://bookkeeper.apache.org/ , If you could not find an answer there, please consider asking your question in our community forum at dev@bookkeeper.apache.org, as it would benefit other members of our community.
+
+
+**FEATURE REQUEST**
+
+1. Please describe the feature you are requesting.
+
+2. Indicate the importance of this issue to you (blocker, must-have, should-have, nice-to-have). Are you currently using any workarounds to address this issue?
+
+3. Provide any additional detail on your proposed use case for this feature.
+
+4. If there are some sub-tasks using -[] for each subtask and create a corresponding issue to map to the sub task:
+- [ ] [sub-task1-issue-number](example_sub_issue1_link_here): sub-task1 discription here, 
+- [ ] [sub-task2-issue-number](example_sub_issue2_link_here): sub-task2 discription here,
+- ...
+
+
+**BUG REPORT**
+
+1. Please describe the issue you observed:
+
+- What did you do?
+
+- What did you expect to see?
+
+- What did you see instead?
+
+---------------------------------------------------------------------------------
+
+Please label the issue with proper labels. It would help us triage the issues.
+
+- "release/": please mark the issue with the release. 
+- "type/": please mark the issue with corresponding issue type.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Descriptions of the changes in this PR:
+
+xxxxxx
+
+---
+Be sure to do all of the following to help us incorporate your contribution
+quickly and easily:
+
+- [ ] Make sure the PR title is formatted like:
+    `<Issue #>: Description of pull request`
+    `e.g. Issue 123: Description ...`
+- [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
+- [ ] Replace `<Issue #>` in the title with the actual Issue number, if there is one.
+
+---

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <configuration>
           <excludes>
             <exclude>.git/**/*</exclude>
+            <exclude>.github/**/*</exclude>
             <exclude>**/target/**/*</exclude>
             <exclude>**/.svn/**/*</exclude>
             <exclude>CHANGES.txt</exclude>


### PR DESCRIPTION
Following BP-9, provide a template for ISSUE and PR.
When create issue, will use ISSUE template; while create PR will use PR template.