### PR TITLE
Issue 207: change the HashSet to BitSet to handle duplicated bookies on reading entries

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSequenceRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSequenceRead.java
@@ -1,0 +1,94 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Test reading an entry from replicas in sequence way.
+ */
+public class TestSequenceRead extends BookKeeperClusterTestCase {
+
+    static final Logger logger = LoggerFactory.getLogger(TestSequenceRead.class);
+
+    final DigestType digestType;
+    final byte[] passwd = "sequence-read".getBytes();
+
+    public TestSequenceRead() {
+        super(5);
+        this.digestType = DigestType.CRC32;
+    }
+
+    private LedgerHandle createLedgerWithDuplicatedBookies() throws Exception {
+        final LedgerHandle lh = bkc.createLedger(3, 3, 3, digestType, passwd);
+        // introduce duplicated bookies in an ensemble.
+        SortedMap<Long, ArrayList<BookieSocketAddress>> ensembles = lh.getLedgerMetadata().getEnsembles();
+        SortedMap<Long, ArrayList<BookieSocketAddress>> newEnsembles = new TreeMap<Long, ArrayList<BookieSocketAddress>>();
+        for (Map.Entry<Long, ArrayList<BookieSocketAddress>> entry : ensembles.entrySet()) {
+            ArrayList<BookieSocketAddress> newList = new ArrayList<BookieSocketAddress>(entry.getValue().size());
+            BookieSocketAddress firstBookie = entry.getValue().get(0);
+            for (BookieSocketAddress ignored : entry.getValue()) {
+                newList.add(firstBookie);
+            }
+            newEnsembles.put(entry.getKey(), newList);
+        }
+        lh.getLedgerMetadata().setEnsembles(newEnsembles);
+        // update the ledger metadata with duplicated bookies
+        final CountDownLatch latch = new CountDownLatch(1);
+        bkc.getLedgerManager().writeLedgerMetadata(lh.getId(), lh.getLedgerMetadata(), new BookkeeperInternalCallbacks.GenericCallback<Void>() {
+            @Override
+            public void operationComplete(int rc, Void result) {
+                if (BKException.Code.OK == rc) {
+                    latch.countDown();
+                } else {
+                    logger.error("Error on writing ledger metadata for ledger {} : ", lh.getId(), BKException.getMessage(rc));
+                }
+            }
+        });
+        latch.await();
+        logger.info("Update ledger metadata with duplicated bookies for ledger {}.", lh.getId());
+        return lh;
+    }
+
+    @Test(timeout = 60000)
+    public void testSequenceReadOnDuplicatedBookies() throws Exception {
+        final LedgerHandle lh = createLedgerWithDuplicatedBookies();
+
+        // should be able to open the ledger even it has duplicated bookies
+        final LedgerHandle readLh = bkc.openLedger(lh.getId(), digestType, passwd);
+        assertEquals(LedgerHandle.INVALID_ENTRY_ID, readLh.getLastAddConfirmed());
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.client;
-
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,19 +18,20 @@ package org.apache.bookkeeper.client;
  * under the License.
  *
  */
+package org.apache.bookkeeper.client;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
-import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BaseTestCase;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -286,10 +285,13 @@ public class TestSpeculativeRead extends BaseTestCase {
         LedgerHandle l = bkspec.openLedger(id, digestType, passwd);
 
         ArrayList<BookieSocketAddress> ensemble = l.getLedgerMetadata().getEnsembles().get(0L);
-        Set<BookieSocketAddress> allHosts = new HashSet<BookieSocketAddress>(ensemble);
-        Set<BookieSocketAddress> noHost = new HashSet<BookieSocketAddress>();
-        Set<BookieSocketAddress> secondHostOnly = new HashSet<BookieSocketAddress>();
-        secondHostOnly.add(ensemble.get(1));
+        BitSet allHosts = new BitSet(ensemble.size());
+        for (int i = 0; i < ensemble.size(); i++) {
+            allHosts.set(i, true);
+        }
+        BitSet noHost = new BitSet(ensemble.size());
+        BitSet secondHostOnly = new BitSet(ensemble.size());
+        secondHostOnly.set(1, true);
         PendingReadOp.LedgerEntryRequest req0 = null, req2 = null, req4 = null;
         try {
             LatchCallback latch0 = new LatchCallback();


### PR DESCRIPTION
Descriptions of the changes in this PR:

Problem:

If there happens to have duplicated bookies in same ledger (it happened before when ensemble change still has problem), the read doesn't work as expected. It hang forever.

Solution:

Change the HashSet to BitSet to use bookieIndex rather than InetSocketAddress to track the heardfrom bookies set.

---
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

- [x] Make sure the PR title is formatted like:
    `<Issue #>: Description of pull request`
    `e.g. Issue 123: Description ...`
- [x] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
- [x] Replace `<Issue #>` in the title with the actual Issue number, if there is one.

---
