### PR TITLE
BOOKKEEPER-759: Delay Ensemble Change & Disable Ensemble Change

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
@@ -114,6 +114,7 @@ public abstract class BKException extends Exception {
      *
      */
     public interface Code {
+        int UNINITIALIZED = 1;
         int OK = 0;
         int ReadException = -1;
         int QuorumException = -2;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -45,6 +45,7 @@ import org.apache.bookkeeper.client.AsyncCallback.OpenCallback;
 import org.apache.bookkeeper.client.AsyncCallback.IsClosedCallback;
 import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.feature.Feature;
 import org.apache.bookkeeper.feature.FeatureProvider;
 import org.apache.bookkeeper.feature.SettableFeatureProvider;
 import org.apache.bookkeeper.meta.CleanupLedgerManager;
@@ -122,7 +123,10 @@ public class BookKeeper implements AutoCloseable {
     final HashedWheelTimer requestTimer;
     final boolean ownTimer;
     final FeatureProvider featureProvider;
-    ScheduledExecutorService bookieInfoScheduler;
+    final ScheduledExecutorService bookieInfoScheduler;
+
+    // Features
+    final Feature disableEnsembleChangeFeature;
 
     // Ledger manager responsible for how to store ledger meta data
     final LedgerManagerFactory ledgerManagerFactory;
@@ -135,6 +139,7 @@ public class BookKeeper implements AutoCloseable {
 
     final ClientConfiguration conf;
     final int explicitLacInterval;
+    final boolean delayEnsembleChange;
 
     // Close State
     boolean closed = false;
@@ -296,6 +301,7 @@ public class BookKeeper implements AutoCloseable {
                        FeatureProvider featureProvider)
             throws IOException, InterruptedException, KeeperException {
         this.conf = conf;
+        this.delayEnsembleChange = conf.getDelayEnsembleChange();
 
         // initialize zookeeper client
         if (zkc == null) {
@@ -341,6 +347,9 @@ public class BookKeeper implements AutoCloseable {
         } else {
             this.featureProvider = featureProvider;
         }
+        
+        // get features
+        this.disableEnsembleChangeFeature = this.featureProvider.getFeature(conf.getDisableEnsembleChangeFeatureName());
 
         // initialize scheduler
         ThreadFactoryBuilder tfb = new ThreadFactoryBuilder().setNameFormat(
@@ -378,6 +387,7 @@ public class BookKeeper implements AutoCloseable {
             this.bookieInfoReader.start();
         } else {
             LOG.info("Weighted ledger placement is not enabled");
+            this.bookieInfoScheduler = null;
             this.bookieInfoReader = new BookieInfoReader(this, conf, null);
             this.bookieWatcher.readBookiesBlocking();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -20,9 +20,8 @@
  */
 package org.apache.bookkeeper.client;
 
-import static com.google.common.base.Charsets.UTF_8;
-
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.RateLimiter;
 import io.netty.buffer.ByteBuf;
@@ -89,6 +88,7 @@ public class LedgerHandle implements AutoCloseable {
     final static public long INVALID_ENTRY_ID = BookieProtocol.INVALID_ENTRY_ID;
 
     final AtomicInteger blockAddCompletions = new AtomicInteger(0);
+    final AtomicInteger numEnsembleChanges = new AtomicInteger(0);
     Queue<PendingAddOp> pendingAddOps;
     ExplicitLacFlushPolicy explicitLacFlushPolicy;
 
@@ -183,8 +183,12 @@ public class LedgerHandle implements AutoCloseable {
      *
      * @return the last confirmed entry id or {@link #INVALID_ENTRY_ID INVALID_ENTRY_ID} if no entry has been confirmed
      */
-    public long getLastAddConfirmed() {
+    public synchronized long getLastAddConfirmed() {
         return lastAddConfirmed;
+    }
+
+    synchronized void setLastAddConfirmed(long lac) {
+        this.lastAddConfirmed = lac;
     }
 
     /**
@@ -425,8 +429,8 @@ public class LedgerHandle implements AutoCloseable {
                                 @Override
                                 public void safeOperationComplete(int newrc, LedgerMetadata newMeta) {
                                     if (newrc != BKException.Code.OK) {
-                                        LOG.error("Error reading new metadata from ledger " + ledgerId
-                                                  + " when closing, code=" + newrc);
+                                        LOG.error("Error reading new metadata from ledger {} when closing, code={}",
+                                                ledgerId, newrc);
                                         cb.closeComplete(rc, LedgerHandle.this, ctx);
                                     } else {
                                         metadata.setState(prevState);
@@ -442,13 +446,13 @@ public class LedgerHandle implements AutoCloseable {
                                             metadata.setEnsembles(newMeta.getEnsembles());
                                             metadata.setVersion(newMeta.version);
                                             metadata.setLength(length);
-                                            metadata.close(lastAddConfirmed);
+                                            metadata.close(getLastAddConfirmed());
                                             writeLedgerConfig(new CloseCb());
                                             return;
                                         } else {
                                             metadata.setLength(length);
-                                            metadata.close(lastAddConfirmed);
-                                            LOG.warn("Conditional update ledger metadata for ledger " + ledgerId + " failed.");
+                                            metadata.close(getLastAddConfirmed());
+                                            LOG.warn("Conditional update ledger metadata for ledger {} failed.", ledgerId);
                                             cb.closeComplete(rc, LedgerHandle.this, ctx);
                                         }
                                     }
@@ -460,7 +464,7 @@ public class LedgerHandle implements AutoCloseable {
                                 }
                             });
                         } else if (rc != BKException.Code.OK) {
-                            LOG.error("Error update ledger metadata for ledger " + ledgerId + " : " + rc);
+                            LOG.error("Error update ledger metadata for ledger {} : {}", ledgerId, rc);
                             cb.closeComplete(rc, LedgerHandle.this, ctx);
                         } else {
                             cb.closeComplete(BKException.Code.OK, LedgerHandle.this, ctx);
@@ -1184,70 +1188,89 @@ public class LedgerHandle implements AutoCloseable {
 
     }
 
-    ArrayList<BookieSocketAddress> replaceBookieInMetadata(final BookieSocketAddress addr, final int bookieIndex)
+    EnsembleInfo replaceBookieInMetadata(final Map<Integer, BookieSocketAddress> failedBookies,
+                                         int ensembleChangeIdx)
             throws BKException.BKNotEnoughBookiesException {
-        BookieSocketAddress newBookie;
-        LOG.info("Handling failure of bookie: {} index: {}", addr, bookieIndex);
         final ArrayList<BookieSocketAddress> newEnsemble = new ArrayList<BookieSocketAddress>();
-        final long newEnsembleStartEntry = lastAddConfirmed + 1;
-
-        // avoid parallel ensemble changes to same ensemble.
+        final long newEnsembleStartEntry = getLastAddConfirmed() + 1;
+        final HashSet<Integer> replacedBookies = new HashSet<Integer>();
         synchronized (metadata) {
             newEnsemble.addAll(metadata.currentEnsemble);
-            newBookie = bk.bookieWatcher.replaceBookie(metadata.getEnsembleSize(),
-                    metadata.getWriteQuorumSize(),
-                    metadata.getAckQuorumSize(),
-                    metadata.getCustomMetadata(),
-                    newEnsemble,
-                    bookieIndex, new HashSet<>(Arrays.asList(addr)));
-
-
-            newEnsemble.set(bookieIndex, newBookie);
-
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Changing ensemble from: " + metadata.currentEnsemble
-                        + " to: " + newEnsemble + " for ledger: " + ledgerId
-                        + " starting at entry: " + (lastAddConfirmed + 1));
+            for (Map.Entry<Integer, BookieSocketAddress> entry : failedBookies.entrySet()) {
+                int idx = entry.getKey();
+                BookieSocketAddress addr = entry.getValue();
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("[EnsembleChange-L{}-{}] : replacing bookie: {} index: {}",
+                        new Object[]{getId(), ensembleChangeIdx, addr, idx});
+                }
+                if (!newEnsemble.get(idx).equals(addr)) {
+                    // ensemble has already changed, failure of this addr is immaterial
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Write did not succeed to {}, bookieIndex {}, but we have already fixed it.",
+                                  addr, idx);
+                    }
+                    continue;
+                }
+                try {
+                    BookieSocketAddress newBookie = bk.bookieWatcher.replaceBookie(
+                        metadata.getEnsembleSize(),
+                        metadata.getWriteQuorumSize(),
+                        metadata.getAckQuorumSize(),
+                        metadata.getCustomMetadata(),
+                        newEnsemble,
+                        idx,
+                        new HashSet<BookieSocketAddress>(failedBookies.values()));
+                    newEnsemble.set(idx, newBookie);
+                    replacedBookies.add(idx);
+                } catch (BKException.BKNotEnoughBookiesException e) {
+                    // if there is no bookie replaced, we throw not enough bookie exception
+                    if (replacedBookies.size() <= 0) {
+                        throw e;
+                    } else {
+                        break;
+                    }
+                }
             }
-
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("[EnsembleChange-L{}-{}] : changing ensemble from: {} to: {} starting at entry: {}," +
+                    " failed bookies: {}, replaced bookies: {}",
+                      new Object[] { ledgerId, ensembleChangeIdx, metadata.currentEnsemble, newEnsemble,
+                              (getLastAddConfirmed() + 1), failedBookies, replacedBookies });
+            }
             metadata.addEnsemble(newEnsembleStartEntry, newEnsemble);
         }
-        return newEnsemble;
+        return new EnsembleInfo(newEnsemble, failedBookies, replacedBookies);
     }
 
-    void handleBookieFailure(final BookieSocketAddress addr, final int bookieIndex) {
-        // If this is the first failure,
-        // try to submit completed pendingAddOps before this failure.
-        if (0 == blockAddCompletions.get()) {
-            sendAddSuccessCallbacks();
+    void handleBookieFailure(final Map<Integer, BookieSocketAddress> failedBookies) {
+        int curBlockAddCompletions = blockAddCompletions.incrementAndGet();
+
+        if (bk.disableEnsembleChangeFeature.isAvailable()) {
+            blockAddCompletions.decrementAndGet();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ensemble change is disabled. Retry sending to failed bookies {} for ledger {}.",
+                    failedBookies, ledgerId);
+            }
+            unsetSuccessAndSendWriteRequest(failedBookies.keySet());
+            return;
         }
 
-        blockAddCompletions.incrementAndGet();
+        int curNumEnsembleChanges = numEnsembleChanges.incrementAndGet();
 
         synchronized (metadata) {
-            if (!metadata.currentEnsemble.get(bookieIndex).equals(addr)) {
-                // ensemble has already changed, failure of this addr is immaterial
-                LOG.warn("Write did not succeed to {}, bookieIndex {}, but we have already fixed it.",
-                         addr, bookieIndex);
-                blockAddCompletions.decrementAndGet();
-
-                // Try to submit completed pendingAddOps, pending by this fix.
-                if (0 == blockAddCompletions.get()) {
-                    sendAddSuccessCallbacks();
-                }
-
-                return;
-            }
-
             try {
-                ArrayList<BookieSocketAddress> newEnsemble = replaceBookieInMetadata(addr, bookieIndex);
-
-                EnsembleInfo ensembleInfo = new EnsembleInfo(newEnsemble, bookieIndex,
-                                                             addr);
-                writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo));
+                EnsembleInfo ensembleInfo = replaceBookieInMetadata(failedBookies, curNumEnsembleChanges);
+                if (ensembleInfo.replacedBookies.isEmpty()) {
+                    blockAddCompletions.decrementAndGet();
+                    return;
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("[EnsembleChange-L{}-{}] : writing new ensemble info = {}, block add completions = {}",
+                        new Object[]{getId(), curNumEnsembleChanges, ensembleInfo, curBlockAddCompletions});
+                }
+                writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions, curNumEnsembleChanges));
             } catch (BKException.BKNotEnoughBookiesException e) {
-                LOG.error("Could not get additional bookie to "
-                          + "remake ensemble, closing ledger: " + ledgerId);
+                LOG.error("Could not get additional bookie to remake ensemble, closing ledger: {}", ledgerId);
                 handleUnrecoverableErrorDuringAdd(e.getCode());
                 return;
             }
@@ -1255,16 +1278,26 @@ public class LedgerHandle implements AutoCloseable {
     }
 
     // Contains newly reformed ensemble, bookieIndex, failedBookieAddress
-    private static final class EnsembleInfo {
+    static final class EnsembleInfo {
         private final ArrayList<BookieSocketAddress> newEnsemble;
-        private final int bookieIndex;
-        private final BookieSocketAddress addr;
+        private final Map<Integer, BookieSocketAddress> failedBookies;
+        final Set<Integer> replacedBookies;
 
-        public EnsembleInfo(ArrayList<BookieSocketAddress> newEnsemble, int bookieIndex,
-                            BookieSocketAddress addr) {
+        public EnsembleInfo(ArrayList<BookieSocketAddress> newEnsemble,
+                            Map<Integer, BookieSocketAddress> failedBookies,
+                            Set<Integer> replacedBookies) {
             this.newEnsemble = newEnsemble;
-            this.bookieIndex = bookieIndex;
-            this.addr = addr;
+            this.failedBookies = failedBookies;
+            this.replacedBookies = replacedBookies;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Ensemble Info : failed bookies = ").append(failedBookies)
+                    .append(", replaced bookies = ").append(replacedBookies)
+                    .append(", new ensemble = ").append(newEnsemble);
+            return sb.toString();
         }
     }
 
@@ -1275,10 +1308,16 @@ public class LedgerHandle implements AutoCloseable {
      */
     private final class ChangeEnsembleCb extends OrderedSafeGenericCallback<Void> {
         private final EnsembleInfo ensembleInfo;
+        private final int curBlockAddCompletions;
+        private final int ensembleChangeIdx;
 
-        ChangeEnsembleCb(EnsembleInfo ensembleInfo) {
+        ChangeEnsembleCb(EnsembleInfo ensembleInfo,
+                         int curBlockAddCompletions,
+                         int ensembleChangeIdx) {
             super(bk.mainWorkerPool, ledgerId);
             this.ensembleInfo = ensembleInfo;
+            this.curBlockAddCompletions = curBlockAddCompletions;
+            this.ensembleChangeIdx = ensembleChangeIdx;
         }
 
         @Override
@@ -1287,30 +1326,39 @@ public class LedgerHandle implements AutoCloseable {
                 // We changed the ensemble, but got a version exception. We
                 // should still consider this as an ensemble change
                 ensembleChangeCounter.inc();
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.info("[EnsembleChange-L{}-{}] : encountered version conflicts, re-read ledger metadata.",
+                        getId(), ensembleChangeIdx);
+                }
+
                 rereadMetadata(new ReReadLedgerMetadataCb(rc,
-                                       ensembleInfo));
+                                       ensembleInfo, curBlockAddCompletions, ensembleChangeIdx));
                 return;
             } else if (rc != BKException.Code.OK) {
-                LOG.error("Could not persist ledger metadata while "
-                          + "changing ensemble to: "
-                          + ensembleInfo.newEnsemble
-                          + " , closing ledger");
+                LOG.error("[EnsembleChange-L{}-{}] : could not persist ledger metadata : info = {}, closing ledger : {}.",
+                        new Object[] { getId(), ensembleChangeIdx, ensembleInfo, rc });
                 handleUnrecoverableErrorDuringAdd(rc);
                 return;
             }
-            blockAddCompletions.decrementAndGet();
+            int newBlockAddCompletions = blockAddCompletions.decrementAndGet();
+
+            if (LOG.isDebugEnabled()) {
+                LOG.info("[EnsembleChange-L{}-{}] : completed ensemble change, block add completion {} => {}",
+                    new Object[]{getId(), ensembleChangeIdx, curBlockAddCompletions, newBlockAddCompletions});
+            }
 
             // We've successfully changed an ensemble
             ensembleChangeCounter.inc();
             // the failed bookie has been replaced
-            unsetSuccessAndSendWriteRequest(ensembleInfo.bookieIndex);
+            unsetSuccessAndSendWriteRequest(ensembleInfo.replacedBookies);
         }
 
         @Override
         public String toString() {
             return String.format("ChangeEnsemble(%d)", ledgerId);
         }
-    };
+    }
 
     /**
      * Callback which is reading the ledgerMetadata present in zk. This will try
@@ -1319,29 +1367,32 @@ public class LedgerHandle implements AutoCloseable {
     private final class ReReadLedgerMetadataCb extends OrderedSafeGenericCallback<LedgerMetadata> {
         private final int rc;
         private final EnsembleInfo ensembleInfo;
+        private final int curBlockAddCompletions;
+        private final int ensembleChangeIdx;
 
-        ReReadLedgerMetadataCb(int rc, EnsembleInfo ensembleInfo) {
+        ReReadLedgerMetadataCb(int rc,
+                               EnsembleInfo ensembleInfo,
+                               int curBlockAddCompletions,
+                               int ensembleChangeIdx) {
             super(bk.mainWorkerPool, ledgerId);
             this.rc = rc;
             this.ensembleInfo = ensembleInfo;
+            this.curBlockAddCompletions = curBlockAddCompletions;
+            this.ensembleChangeIdx = ensembleChangeIdx;
         }
 
         @Override
         public void safeOperationComplete(int newrc, LedgerMetadata newMeta) {
             if (newrc != BKException.Code.OK) {
-                LOG.error("Error reading new metadata from ledger "
-                        + "after changing ensemble, code=" + newrc);
+                LOG.error("[EnsembleChange-L{}-{}] : error re-reading metadata to address ensemble change conflicts," +
+                        " code=", new Object[] { ledgerId, ensembleChangeIdx, newrc });
                 handleUnrecoverableErrorDuringAdd(rc);
             } else {
                 if (!resolveConflict(newMeta)) {
-                    LOG.error("Could not resolve ledger metadata conflict "
-                            + "while changing ensemble to: "
-                            + ensembleInfo.newEnsemble
-                            + ", old meta data is \n"
-                            + new String(metadata.serialize(), UTF_8)
-                            + "\n, new meta data is \n"
-                            + new String(newMeta.serialize(), UTF_8)
-                            + "\n ,closing ledger");
+                    LOG.error("[EnsembleChange-L{}-{}] : could not resolve ledger metadata conflict" +
+                            " while changing ensemble to: {}, local meta data is \n {} \n," +
+                            " zk meta data is \n {} \n, closing ledger",
+                            new Object[] { ledgerId, ensembleChangeIdx, ensembleInfo.newEnsemble, metadata, newMeta });
                     handleUnrecoverableErrorDuringAdd(rc);
                 }
             }
@@ -1362,8 +1413,17 @@ public class LedgerHandle implements AutoCloseable {
          * </p>
          */
         private boolean resolveConflict(LedgerMetadata newMeta) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("[EnsembleChange-L{}-{}] : resolving conflicts - local metadata = \n {} \n," +
+                    " zk metadata = \n {} \n", new Object[]{ledgerId, ensembleChangeIdx, metadata, newMeta});
+            }
             // make sure the ledger isn't closed by other ones.
             if (metadata.getState() != newMeta.getState()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.info("[EnsembleChange-L{}-{}] : resolving conflicts but state changed," +
+                            " local metadata = \n {} \n, zk metadata = \n {} \n",
+                        new Object[]{ledgerId, ensembleChangeIdx, metadata, newMeta});
+                }
                 return false;
             }
 
@@ -1375,6 +1435,11 @@ public class LedgerHandle implements AutoCloseable {
             //           than the metadata changed by recovery.
             int diff = newMeta.getEnsembles().size() - metadata.getEnsembles().size();
             if (0 != diff) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("[EnsembleChange-L{}-{}] : resolving conflicts but ensembles have {} differences," +
+                            " local metadata = \n {} \n, zk metadata = \n {} \n",
+                        new Object[]{ledgerId, ensembleChangeIdx, diff, metadata, newMeta});
+                }
                 if (-1 == diff) {
                     // Case 1: metadata is changed by other ones (e.g. Recovery)
                     return updateMetadataIfPossible(newMeta);
@@ -1389,45 +1454,76 @@ public class LedgerHandle implements AutoCloseable {
             // the ensemble change of the failed bookie is failed due to metadata conflicts. so try to
             // update the ensemble change metadata again. Otherwise, it means that the ensemble change
             // is already succeed, unset the success and re-adding entries.
-            if (newMeta.currentEnsemble.get(ensembleInfo.bookieIndex).equals(
-                    ensembleInfo.addr)) {
+            if (!areFailedBookiesReplaced(newMeta, ensembleInfo)) {
                 // If the in-memory data doesn't contains the failed bookie, it means the ensemble change
                 // didn't finish, so try to resolve conflicts with the metadata read from zookeeper and
                 // update ensemble changed metadata again.
-                if (!metadata.currentEnsemble.get(ensembleInfo.bookieIndex)
-                        .equals(ensembleInfo.addr)) {
+                if (areFailedBookiesReplaced(metadata, ensembleInfo)) {
                     return updateMetadataIfPossible(newMeta);
                 }
             } else {
                 ensembleChangeCounter.inc();
                 // We've successfully changed an ensemble
                 // the failed bookie has been replaced
-                blockAddCompletions.decrementAndGet();
-                unsetSuccessAndSendWriteRequest(ensembleInfo.bookieIndex);
+                int newBlockAddCompletions = blockAddCompletions.decrementAndGet();
+                unsetSuccessAndSendWriteRequest(ensembleInfo.replacedBookies);
+                if (LOG.isDebugEnabled()) {
+                    LOG.info("[EnsembleChange-L{}-{}] : resolved conflicts, block add complectiosn {} => {}.",
+                        new Object[]{ledgerId, ensembleChangeIdx, curBlockAddCompletions, newBlockAddCompletions});
+                }
             }
             return true;
+        }
+
+        /**
+         * Check whether all the failed bookies are replaced.
+         *
+         * @param newMeta
+         *          new ledger metadata
+         * @param ensembleInfo
+         *          ensemble info used for ensemble change.
+         * @return true if all failed bookies are replaced, false otherwise
+         */
+        private boolean areFailedBookiesReplaced(LedgerMetadata newMeta, EnsembleInfo ensembleInfo) {
+            boolean replaced = true;
+            for (Integer replacedBookieIdx : ensembleInfo.replacedBookies) {
+                BookieSocketAddress failedBookieAddr = ensembleInfo.failedBookies.get(replacedBookieIdx);
+                BookieSocketAddress replacedBookieAddr = newMeta.currentEnsemble.get(replacedBookieIdx);
+                replaced &= !Objects.equal(replacedBookieAddr, failedBookieAddr);
+            }
+            return replaced;
         }
 
         private boolean updateMetadataIfPossible(LedgerMetadata newMeta) {
             // if the local metadata is newer than zookeeper metadata, it means that metadata is updated
             // again when it was trying re-reading the metatada, re-kick the reread again
             if (metadata.isNewerThan(newMeta)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("[EnsembleChange-L{}-{}] : reread metadata because local metadata is newer.",
+                        new Object[]{ledgerId, ensembleChangeIdx});
+                }
                 rereadMetadata(this);
                 return true;
             }
             // make sure the metadata doesn't changed by other ones.
             if (metadata.isConflictWith(newMeta)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("[EnsembleChange-L{}-{}] : metadata is conflicted, local metadata = \n {} \n," +
+                        " zk metadata = \n {} \n", new Object[]{ledgerId, ensembleChangeIdx, metadata, newMeta});
+                }
                 return false;
             }
-            LOG.info("Resolve ledger metadata conflict while changing ensemble to: {},"
-                    + " old meta data is \n {} \n, new meta data is \n {}.", new Object[] {
-                    ensembleInfo.newEnsemble, metadata, newMeta });
+            if (LOG.isDebugEnabled()) {
+                LOG.info("[EnsembleChange-L{}-{}] : resolved ledger metadata conflict and writing to zookeeper,"
+                        + " local meta data is \n {} \n, zk meta data is \n {}.",
+                    new Object[]{ledgerId, ensembleChangeIdx, metadata, newMeta});
+            }
             // update znode version
             metadata.setVersion(newMeta.getVersion());
             // merge ensemble infos from new meta except last ensemble
             // since they might be modified by recovery tool.
             metadata.mergeEnsembles(newMeta.getEnsembles());
-            writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo));
+            writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions, ensembleChangeIdx));
             return true;
         }
 
@@ -1435,11 +1531,13 @@ public class LedgerHandle implements AutoCloseable {
         public String toString() {
             return String.format("ReReadLedgerMetadata(%d)", ledgerId);
         }
-    };
+    }
 
-    void unsetSuccessAndSendWriteRequest(final int bookieIndex) {
+    void unsetSuccessAndSendWriteRequest(final Set<Integer> bookies) {
         for (PendingAddOp pendingAddOp : pendingAddOps) {
-            pendingAddOp.unsetSuccessAndSendWriteRequest(bookieIndex);
+            for (Integer bookieIndex: bookies) {
+                pendingAddOp.unsetSuccessAndSendWriteRequest(bookieIndex);
+            }
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
@@ -75,6 +75,10 @@ class PendingReadLacOp implements ReadLacCallback {
     public void readLacComplete(int rc, long ledgerId, final ByteBuf lacBuffer, final ByteBuf lastEntryBuffer,
             Object ctx) {
         int bookieIndex = (Integer) ctx;
+
+        // add the response to coverage set
+        coverageSet.addBookie(bookieIndex, rc);
+
         numResponsesPending--;
         boolean heardValidResponse = false;
 
@@ -127,7 +131,7 @@ class PendingReadLacOp implements ReadLacCallback {
 
         // We don't consider a success until we have coverage set responses.
         if (heardValidResponse
-                && coverageSet.addBookieAndCheckCovered(bookieIndex)
+                && coverageSet.checkCovered()
                 && !completed) {
             completed = true;
             if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
@@ -98,7 +98,7 @@ class PendingWriteLacOp implements WriteLacCallback {
         receivedResponseSet.remove(bookieIndex);
 
         if (rc == BKException.Code.OK) {
-            if (ackSet.addBookieAndCheck(bookieIndex) && !completed) {
+            if (ackSet.completeBookieAndCheck(bookieIndex) && !completed) {
                 completed = true;
                 cb.addLacComplete(rc, lh, ctx);
                 return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
@@ -80,6 +80,9 @@ class ReadLastConfirmedOp implements ReadEntryCallback {
             final ByteBuf buffer, final Object ctx) {
         int bookieIndex = (Integer) ctx;
 
+        // add the response to coverage set
+        coverageSet.addBookie(bookieIndex, rc);
+
         numResponsesPending--;
         boolean heardValidResponse = false;
         if (rc == BKException.Code.OK) {
@@ -116,7 +119,7 @@ class ReadLastConfirmedOp implements ReadEntryCallback {
 
         // other return codes dont count as valid responses
         if (heardValidResponse
-            && coverageSet.addBookieAndCheckCovered(bookieIndex)
+            && coverageSet.checkCovered()
             && !completed) {
             completed = true;
             if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -18,6 +18,7 @@
 package org.apache.bookkeeper.conf;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static org.apache.bookkeeper.util.BookKeeperConstants.FEATURE_DISABLE_ENSEMBLE_CHANGE;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +65,8 @@ public class ClientConfiguration extends AbstractConfiguration {
     protected final static String SPECULATIVE_READ_TIMEOUT = "speculativeReadTimeout";
     protected final static String ENABLE_PARALLEL_RECOVERY_READ = "enableParallelRecoveryRead";
     protected final static String RECOVERY_READ_BATCH_SIZE = "recoveryReadBatchSize";
+    // Add Parameters
+    protected final static String DELAY_ENSEMBLE_CHANGE = "delayEnsembleChange";
     // Timeout Setting
     protected final static String ADD_ENTRY_TIMEOUT_SEC = "addEntryTimeoutSec";
     protected final static String ADD_ENTRY_QUORUM_TIMEOUT_SEC = "addEntryQuorumTimeoutSec";
@@ -97,6 +100,9 @@ public class ClientConfiguration extends AbstractConfiguration {
     // Stats
     protected final static String ENABLE_TASK_EXECUTION_STATS = "enableTaskExecutionStats";
     protected final static String TASK_EXECUTION_WARN_TIME_MICROS = "taskExecutionWarnTimeMicros";
+    
+    // Names of dynamic features
+    protected final static String DISABLE_ENSEMBLE_CHANGE_FEATURE_NAME = "disableEnsembleChangeFeatureName";
 
     // Role of the client
     protected final static String CLIENT_ROLE = "clientRole";
@@ -1141,4 +1147,50 @@ public class ClientConfiguration extends AbstractConfiguration {
         return getString(CLIENT_ROLE, CLIENT_ROLE_STANDARD);
     }
 
+    /**
+     * Whether to delay ensemble change or not?
+     *
+     * @return true if to delay ensemble change, otherwise false.
+     */
+    public boolean getDelayEnsembleChange() {
+        return getBoolean(DELAY_ENSEMBLE_CHANGE, false);
+    }
+
+    /**
+     * Enable/Disable delaying ensemble change.
+     * <p>
+     * If set to true, ensemble change only happens when it can't meet
+     * ack quorum requirement. If set to false, ensemble change happens
+     * immediately when it received a failed write.
+     * </p>
+     *
+     * @param enabled
+     *          flag to enable/disable delaying ensemble change.
+     * @return client configuration.
+     */
+    public ClientConfiguration setDelayEnsembleChange(boolean enabled) {
+        setProperty(DELAY_ENSEMBLE_CHANGE, enabled);
+        return this;
+    }
+
+    /**
+     * Get the name of the dynamic feature that disables ensemble change
+     *
+     * @return name of the dynamic feature that disables ensemble change
+     */
+    public String getDisableEnsembleChangeFeatureName() {
+        return getString(DISABLE_ENSEMBLE_CHANGE_FEATURE_NAME, FEATURE_DISABLE_ENSEMBLE_CHANGE);
+    }
+
+    /**
+     * Set the name of the dynamic feature that disables ensemble change
+     *
+     * @param disableEnsembleChangeFeatureName
+     *          name of the dynamic feature that disables ensemble change
+     * @return client configuration.
+     */
+    public ClientConfiguration setDisableEnsembleChangeFeatureName(String disableEnsembleChangeFeatureName) {
+        setProperty(DISABLE_ENSEMBLE_CHANGE_FEATURE_NAME, disableEnsembleChangeFeatureName);
+        return this;
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1775,6 +1775,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             case EFENCED:
                 rcToRet = BKException.Code.LedgerFencedException;
                 break;
+            case EREADONLY:
+                rcToRet = BKException.Code.WriteOnReadOnlyBookieException;
+                break;
             default:
                 break;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/BookKeeperConstants.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/BookKeeperConstants.java
@@ -52,4 +52,5 @@ public class BookKeeperConstants {
     public static final long MAX_LOG_SIZE_LIMIT = 1 * 1024 * 1024 * 1024;
 
     public static final String FEATURE_REPP_DISABLE_DURABILITY_ENFORCEMENT = "repp_disable_durability_enforcement";
+    public static final String FEATURE_DISABLE_ENSEMBLE_CHANGE = "disable_ensemble_change";
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
@@ -43,10 +43,10 @@ public class RoundRobinDistributionScheduleTest {
         assertEquals("Write set is wrong size", wSet.size(), 3);
 
         DistributionSchedule.AckSet ackSet = schedule.getAckSet();
-        assertFalse("Shouldn't ack yet", ackSet.addBookieAndCheck(wSet.get(0)));
-        assertFalse("Shouldn't ack yet", ackSet.addBookieAndCheck(wSet.get(0)));
-        assertTrue("Should ack after 2 unique", ackSet.addBookieAndCheck(wSet.get(2)));
-        assertTrue("Should still be acking", ackSet.addBookieAndCheck(wSet.get(1)));
+        assertFalse("Shouldn't ack yet", ackSet.completeBookieAndCheck(wSet.get(0)));
+        assertFalse("Shouldn't ack yet", ackSet.completeBookieAndCheck(wSet.get(0)));
+        assertTrue("Should ack after 2 unique", ackSet.completeBookieAndCheck(wSet.get(2)));
+        assertTrue("Should still be acking", ackSet.completeBookieAndCheck(wSet.get(1)));
     }
 
     /**
@@ -113,10 +113,10 @@ public class RoundRobinDistributionScheduleTest {
         int errors = 0;
         for (Set<Integer> subset : subsets) {
             DistributionSchedule.QuorumCoverageSet covSet = schedule.getCoverageSet();
-            boolean covSetSays = false;
             for (Integer i : subset) {
-                covSetSays = covSet.addBookieAndCheckCovered(i);
+                covSet.addBookie(i, BKException.Code.OK);
             }
+            boolean covSetSays = covSet.checkCovered();
 
             boolean[] nodesAvailable = buildAvailable(ensemble, subset);
             boolean canGetAck = canGetAckQuorum(ensemble, writeQuorum, ackQuorum, nodesAvailable);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
@@ -1,0 +1,417 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
+
+    final static Logger logger = LoggerFactory.getLogger(TestDelayEnsembleChange.class);
+
+    final DigestType digestType;
+    final byte[] testPasswd = "".getBytes();
+
+    public TestDelayEnsembleChange() {
+        super(5);
+        this.digestType = DigestType.CRC32;
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        baseClientConf.setDelayEnsembleChange(true);
+        super.setUp();
+    }
+
+    private static class VerificationCallback implements ReadEntryCallback {
+        final CountDownLatch latch;
+        final AtomicLong numSuccess;
+        final AtomicLong numMissing;
+        final AtomicLong numFailure;
+
+        VerificationCallback(int numRequests) {
+            latch = new CountDownLatch(numRequests);
+            numSuccess = new AtomicLong(0L);
+            numMissing = new AtomicLong(0L);
+            numFailure = new AtomicLong(0L);
+        }
+
+        @Override
+        public void readEntryComplete(int rc, long ledgerId, long entryId, ByteBuf buffer, Object ctx) {
+            if (rc == BKException.Code.OK) {
+                numSuccess.incrementAndGet();
+            } else if (rc == BKException.Code.NoSuchEntryException || rc == BKException.Code.NoSuchLedgerExistsException) {
+                logger.error("Missed entry({}, {}) from host {}.", new Object[] { ledgerId, entryId, ctx });
+                numMissing.incrementAndGet();
+            } else {
+                logger.error("Failed to get entry({}, {}) from host {} : {}",
+                             new Object[] { ledgerId, entryId, ctx, rc });
+                numFailure.incrementAndGet();
+            }
+            latch.countDown();
+        }
+    }
+
+    private void verifyEntries(LedgerHandle lh, long startEntry, long untilEntry,
+                               long expectedSuccess, long expectedMissing) throws Exception {
+        LedgerMetadata md = lh.getLedgerMetadata();
+
+        for (long eid = startEntry; eid < untilEntry; eid++) {
+            ArrayList<BookieSocketAddress> addresses = md.getEnsemble(eid);
+            VerificationCallback callback = new VerificationCallback(addresses.size());
+            for (BookieSocketAddress addr : addresses) {
+                bkc.bookieClient.readEntry(addr, lh.getId(), eid, callback, addr);
+            }
+            callback.latch.await();
+            assertEquals(expectedSuccess, callback.numSuccess.get());
+            assertEquals(expectedMissing, callback.numMissing.get());
+            assertEquals(0, callback.numFailure.get());
+        }
+    }
+
+    private void verifyEntriesRange(LedgerHandle lh, long startEntry, long untilEntry,
+                                    long expectedSuccess, long expectedMissing) throws Exception {
+        LedgerMetadata md = lh.getLedgerMetadata();
+
+        for (long eid = startEntry; eid < untilEntry; eid++) {
+            ArrayList<BookieSocketAddress> addresses = md.getEnsemble(eid);
+            VerificationCallback callback = new VerificationCallback(addresses.size());
+            for (BookieSocketAddress addr : addresses) {
+                bkc.bookieClient.readEntry(addr, lh.getId(), eid, callback, addr);
+            }
+            callback.latch.await();
+            assertTrue(expectedSuccess >= callback.numSuccess.get());
+            assertTrue(expectedMissing <= callback.numMissing.get());
+            assertEquals(0, callback.numFailure.get());
+        }
+    }
+
+    @Test(timeout = 60000)
+    public void testNotChangeEnsembleIfNotBrokenAckQuorum() throws Exception {
+        LedgerHandle lh = bkc.createLedger(5, 5, 3, digestType, testPasswd);
+
+        byte[] data = "foobar".getBytes();
+
+        int numEntries = 10;
+        for (int i = 0; i < numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // kill two bookies, but we still have 3 bookies for the ack quorum.
+        ServerConfiguration conf0 = killBookie(lh.getLedgerMetadata().currentEnsemble.get(0));
+        ServerConfiguration conf1 = killBookie(lh.getLedgerMetadata().currentEnsemble.get(1));
+
+        for (int i = numEntries; i < 2 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
+                     1, lh.getLedgerMetadata().getEnsembles().size());
+
+        bsConfs.add(conf0);
+        bs.add(startBookie(conf0));
+        bsConfs.add(conf1);
+        bs.add(startBookie(conf1));
+
+        for (int i = 2 * numEntries; i < 3 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
+                     1, lh.getLedgerMetadata().getEnsembles().size());
+
+        // check entries
+        verifyEntries(lh, 0, numEntries, 5, 0);
+        verifyEntries(lh, numEntries, 2 * numEntries, 3, 2);
+        verifyEntries(lh, 2 * numEntries, 3 * numEntries, 5, 0);
+    }
+
+    @Test(timeout = 60000)
+    public void testChangeEnsembleIfBrokenAckQuorum() throws Exception {
+        startNewBookie();
+        startNewBookie();
+        startNewBookie();
+
+        LedgerHandle lh = bkc.createLedger(5, 5, 3, digestType, testPasswd);
+
+        byte[] data = "foobar".getBytes();
+
+        int numEntries = 5;
+        for (int i = 0; i < numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        logger.info("Kill bookie 0 and write {} entries.", numEntries);
+
+        // kill two bookies, but we still have 3 bookies for the ack quorum.
+        ServerConfiguration conf0 = killBookie(lh.getLedgerMetadata().currentEnsemble.get(0));
+
+        for (int i = numEntries; i < 2 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
+                     1, lh.getLedgerMetadata().getEnsembles().size());
+
+        logger.info("Kill bookie 1 and write another {} entries.", numEntries);
+
+        ServerConfiguration conf1 = killBookie(lh.getLedgerMetadata().currentEnsemble.get(1));
+
+        for (int i = 2 * numEntries; i < 3 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
+                     1, lh.getLedgerMetadata().getEnsembles().size());
+
+        logger.info("Kill bookie 2 and write another {} entries.", numEntries);
+
+        ServerConfiguration conf2 = killBookie(lh.getLedgerMetadata().currentEnsemble.get(2));
+
+        for (int i = 3 * numEntries; i < 4 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensemble change should kill in
+        assertEquals("There should be ensemble change if ack quorum couldn't be formed.",
+                     2, lh.getLedgerMetadata().getEnsembles().size());
+
+        ArrayList<BookieSocketAddress> firstFragment = lh.getLedgerMetadata().getEnsemble(0);
+        ArrayList<BookieSocketAddress> secondFragment = lh.getLedgerMetadata().getEnsemble(3 * numEntries);
+        assertFalse(firstFragment.get(0).equals(secondFragment.get(0)));
+        assertFalse(firstFragment.get(1).equals(secondFragment.get(1)));
+        assertFalse(firstFragment.get(2).equals(secondFragment.get(2)));
+        assertEquals(firstFragment.get(3), secondFragment.get(3));
+        assertEquals(firstFragment.get(4), secondFragment.get(4));
+
+        bsConfs.add(conf0);
+        bs.add(startBookie(conf0));
+        bsConfs.add(conf1);
+        bs.add(startBookie(conf1));
+        bsConfs.add(conf2);
+        bs.add(startBookie(conf2));
+
+        for (int i = 4 * numEntries; i < 5 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
+                     2, lh.getLedgerMetadata().getEnsembles().size());
+
+        // check entries
+        verifyEntries(lh, 0, numEntries, 5, 0);
+        verifyEntries(lh, numEntries, 2 * numEntries, 4, 1);
+        verifyEntries(lh, 2 * numEntries, 3 * numEntries, 3, 2);
+        verifyEntries(lh, 3 * numEntries, 4 * numEntries, 5, 0);
+        verifyEntries(lh, 4 * numEntries, 5 * numEntries, 5, 0);
+    }
+
+    @Test(timeout = 60000)
+    public void testEnsembleChangeWithNotEnoughBookies() throws Exception {
+        startNewBookie();
+
+        LedgerHandle lh = bkc.createLedger(5, 5, 3, digestType, testPasswd);
+
+        byte[] data = "foobar".getBytes();
+
+        int numEntries = 10;
+        for (int i = 0; i < numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        logger.info("Killed 3 bookies and add {} more entries : {}", numEntries, lh.getLedgerMetadata());
+
+        // kill three bookies, but we only have 2 new bookies for ensemble change.
+        ServerConfiguration conf0 = killBookie(lh.getLedgerMetadata().currentEnsemble.get(0));
+        ServerConfiguration conf1 = killBookie(lh.getLedgerMetadata().currentEnsemble.get(1));
+        ServerConfiguration conf2 = killBookie(lh.getLedgerMetadata().currentEnsemble.get(2));
+
+        for (int i = numEntries; i < 2 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        logger.info("Ledger metadata after killed bookies : {}", lh.getLedgerMetadata());
+
+        // ensure there is ensemble changed
+        assertEquals("There should be ensemble change if ack quorum is broken.",
+                     2, lh.getLedgerMetadata().getEnsembles().size());
+
+        bsConfs.add(conf0);
+        bs.add(startBookie(conf0));
+        bsConfs.add(conf1);
+        bs.add(startBookie(conf1));
+        bsConfs.add(conf2);
+        bs.add(startBookie(conf2));
+
+        for (int i = 2 * numEntries; i < 3 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("There should be no ensemble change after adding failed bookies back.",
+                     2, lh.getLedgerMetadata().getEnsembles().size());
+
+        // check entries
+        verifyEntries(lh, 0, numEntries, 5, 0);
+        verifyEntries(lh, numEntries, 2 * numEntries, 3, 2);
+        verifyEntries(lh, 2 * numEntries, 3 * numEntries, 5, 0);
+    }
+
+    @Test(timeout = 60000)
+    public void testEnsembleChangeWithMoreBookieFailures() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            startNewBookie();
+        }
+
+        LedgerHandle lh = bkc.createLedger(5, 5, 3, digestType, testPasswd);
+
+        byte[] data = "foobar".getBytes();
+
+        int numEntries = 10;
+        for (int i = 0; i < numEntries; i++) {
+            logger.info("Add entry {}", i);
+            lh.addEntry(data);
+        }
+
+        logger.info("Killed 5 bookies and add {} more entries : {}", numEntries, lh.getLedgerMetadata());
+
+        // kill 5 bookies to introduce more bookie failure
+        List<ServerConfiguration> confs = new ArrayList<ServerConfiguration>(5);
+        for (int i = 0; i < 5; i++) {
+            confs.add(killBookie(lh.getLedgerMetadata().currentEnsemble.get(i)));
+        }
+
+        for (int i = numEntries; i < 2 * numEntries; i++) {
+            logger.info("Add entry {}", i);
+            lh.addEntry(data);
+        }
+
+        logger.info("Ledger metadata after killed bookies : {}", lh.getLedgerMetadata());
+
+        // ensure there is no ensemble changed
+        assertEquals("There should be ensemble change if breaking ack quorum.",
+                     2, lh.getLedgerMetadata().getEnsembles().size());
+
+        for (ServerConfiguration conf : confs) {
+            bsConfs.add(conf);
+            bs.add(startBookie(conf));
+        }
+
+        for (int i = 2 * numEntries; i < 3 * numEntries; i++) {
+            logger.info("Add entry {}", i);
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("There should not be ensemble changed if delaying ensemble change is enabled.",
+                     2, lh.getLedgerMetadata().getEnsembles().size());
+
+        // check entries
+        verifyEntries(lh, 0, numEntries, 5, 0);
+        verifyEntriesRange(lh, numEntries, 2 * numEntries, 5, 0);
+        verifyEntries(lh, 2 * numEntries, 3 * numEntries, 5, 0);
+    }
+
+    @Test(timeout = 60000)
+    public void testChangeEnsembleIfBookieReadOnly() throws Exception {
+        LedgerHandle lh = bkc.createLedger(3, 3, 2, digestType, testPasswd);
+
+        byte[] data = "foobar".getBytes();
+
+        int numEntries = 10;
+        for (int i = 0; i < numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // kill two bookies, but we still have 3 bookies for the ack quorum.
+        setBookieToReadOnly(lh.getLedgerMetadata().currentEnsemble.get(0));
+
+        for (int i = numEntries; i < 2 * numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("The ensemble should change when a bookie is readonly even if we delay ensemble change.",
+            2, lh.getLedgerMetadata().getEnsembles().size());
+
+    }
+
+    @Test(timeout = 60000)
+    public void testChangeEnsembleSecondBookieReadOnly() throws Exception {
+        LedgerHandle lh = bkc.createLedger(3, 3, 2, digestType, testPasswd);
+
+        byte[] data = "foobar".getBytes();
+
+        int numEntries = 10;
+        for (int i = 0; i < numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        BookieSocketAddress failedBookie = lh.getLedgerMetadata().currentEnsemble.get(0);
+        BookieSocketAddress readOnlyBookie = lh.getLedgerMetadata().currentEnsemble.get(1);
+        ServerConfiguration conf0 = killBookie(failedBookie);
+
+        for (int i = 0; i < numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        assertEquals("There should be ensemble change if delaying ensemble change is enabled.",
+            1, lh.getLedgerMetadata().getEnsembles().size());
+
+        // kill two bookies, but we still have 3 bookies for the ack quorum.
+        setBookieToReadOnly(readOnlyBookie);
+
+        for (int i = 0; i < numEntries; i++) {
+            lh.addEntry(data);
+        }
+
+        // ensure there is no ensemble changed
+        assertEquals("The ensemble should change when a bookie is readonly even if we delay ensemble change.",
+            2, lh.getLedgerMetadata().getEnsembles().size());
+        assertEquals(3, lh.getLedgerMetadata().currentEnsemble.size());
+        assertFalse(lh.getLedgerMetadata().currentEnsemble.contains(failedBookie));
+        assertFalse(lh.getLedgerMetadata().currentEnsemble.contains(readOnlyBookie));
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
@@ -1,0 +1,277 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.feature.SettableFeature;
+import org.apache.bookkeeper.feature.SettableFeatureProvider;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.apache.bookkeeper.util.BookKeeperConstants.*;
+import static org.junit.Assert.*;
+
+/**
+ * Test Case on Disabling Ensemble Change Feature
+ */
+public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
+
+    static final Logger logger = LoggerFactory.getLogger(TestDisableEnsembleChange.class);
+
+    public TestDisableEnsembleChange() {
+        super(4);
+    }
+
+    @Test(timeout = 60000)
+    public void testDisableEnsembleChange() throws Exception {
+        disableEnsembleChangeTest(true);
+    }
+
+    @Test(timeout = 60000)
+    public void testDisableEnsembleChangeNotEnoughBookies() throws Exception {
+        disableEnsembleChangeTest(false);
+    }
+
+    void disableEnsembleChangeTest(boolean startNewBookie) throws Exception {
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setZkServers(zkUtil.getZooKeeperConnectString())
+            .setDelayEnsembleChange(false)
+            .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE);
+
+        SettableFeatureProvider featureProvider = new SettableFeatureProvider("test", 0);
+        BookKeeper bkc = BookKeeper.forConfig(conf)
+                .featureProvider(featureProvider)
+                .build();
+
+        SettableFeature disableEnsembleChangeFeature = featureProvider.getFeature(FEATURE_DISABLE_ENSEMBLE_CHANGE);
+        disableEnsembleChangeFeature.set(true);
+
+        final byte[] password = new byte[0];
+        final LedgerHandle lh = bkc.createLedger(4, 3, 2, BookKeeper.DigestType.CRC32, password);
+        final AtomicBoolean finished = new AtomicBoolean(false);
+        final AtomicBoolean failTest = new AtomicBoolean(false);
+        final byte[] entry = "test-disable-ensemble-change".getBytes(UTF_8);
+
+        assertEquals(1, lh.getLedgerMetadata().getEnsembles().size());
+        ArrayList<BookieSocketAddress> ensembleBeforeFailure =
+                new ArrayList<BookieSocketAddress>(lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue());
+
+        final RateLimiter rateLimiter = RateLimiter.create(10);
+
+        Thread addThread = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    while (!finished.get()) {
+                        rateLimiter.acquire();
+                        lh.addEntry(entry);
+                    }
+                } catch (Exception e) {
+                    logger.error("Exception on adding entry : ", e);
+                    failTest.set(true);
+                }
+            }
+        };
+        addThread.start();
+        Thread.sleep(2000);
+        killBookie(0);
+        Thread.sleep(2000);
+        finished.set(true);
+        addThread.join();
+
+        assertFalse("Should not fail adding entries facing one bookie failure when disable ensemble change",
+                failTest.get());
+
+        // check the ensemble after failure
+        assertEquals("No new ensemble should be added when disable ensemble change.",
+                1, lh.getLedgerMetadata().getEnsembles().size());
+        ArrayList<BookieSocketAddress> ensembleAfterFailure =
+                new ArrayList<BookieSocketAddress>(lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue());
+        assertArrayEquals(ensembleBeforeFailure.toArray(new BookieSocketAddress[ensembleBeforeFailure.size()]),
+                ensembleAfterFailure.toArray(new BookieSocketAddress[ensembleAfterFailure.size()]));
+
+        // enable ensemble change
+        disableEnsembleChangeFeature.set(false);
+        if (startNewBookie) {
+            startNewBookie();
+        }
+
+        // reset add thread
+        finished.set(false);
+        final CountDownLatch failLatch = new CountDownLatch(1);
+
+        addThread = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    while (!finished.get()) {
+                        lh.addEntry(entry);
+                    }
+                } catch (Exception e) {
+                    logger.error("Exception on adding entry : ", e);
+                    failLatch.countDown();
+                    failTest.set(true);
+                }
+            }
+        };
+        addThread.start();
+        failLatch.await(4000, TimeUnit.MILLISECONDS);
+        finished.set(true);
+        addThread.join();
+
+        if (startNewBookie) {
+            assertFalse("Should not fail adding entries when enable ensemble change again.",
+                    failTest.get());
+            assertFalse("Ledger should be closed when enable ensemble change again.",
+                    lh.getLedgerMetadata().isClosed());
+            assertEquals("New ensemble should be added when enable ensemble change again.",
+                    2, lh.getLedgerMetadata().getEnsembles().size());
+        } else {
+            assertTrue("Should fail adding entries when enable ensemble change again.",
+                    failTest.get());
+            assertTrue("Ledger should be closed when enable ensemble change again.",
+                    lh.getLedgerMetadata().isClosed());
+        }
+    }
+
+    @Test(timeout=20000)
+    public void testRetryFailureBookie() throws Exception {
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setZkServers(zkUtil.getZooKeeperConnectString())
+            .setDelayEnsembleChange(false)
+            .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE);
+
+        SettableFeatureProvider featureProvider = new SettableFeatureProvider("test", 0);
+        BookKeeper bkc = BookKeeper.forConfig(conf)
+                .featureProvider(featureProvider)
+                .build();
+
+        SettableFeature disableEnsembleChangeFeature = featureProvider.getFeature(FEATURE_DISABLE_ENSEMBLE_CHANGE);
+        disableEnsembleChangeFeature.set(true);
+
+        LedgerHandle lh = bkc.createLedger(4, 4, 4, BookKeeper.DigestType.CRC32, new byte[] {});
+        byte[] entry = "testRetryFailureBookie".getBytes();
+        for (int i=0; i<10; i++) {
+            lh.addEntry(entry);
+        }
+        // kill a bookie
+        ServerConfiguration killedConf = killBookie(0);
+
+        final AtomicInteger res = new AtomicInteger(0xdeadbeef);
+        final CountDownLatch addLatch = new CountDownLatch(1);
+        AsyncCallback.AddCallback cb = new AsyncCallback.AddCallback() {
+            @Override
+                public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {
+                    logger.info("Add entry {} completed : rc {}.", entryId, rc);
+                    res.set(rc);
+                    addLatch.countDown();
+                }
+        };
+        lh.asyncAddEntry(entry, cb, null);
+        assertFalse("Add entry operation should not complete.",
+                addLatch.await(1000, TimeUnit.MILLISECONDS));
+        assertEquals(res.get(), 0xdeadbeef);
+        // start the original bookie
+        bsConfs.add(killedConf);
+        bs.add(startBookie(killedConf));
+        assertTrue("Add entry operation should complete at this point.",
+                addLatch.await(1000, TimeUnit.MILLISECONDS));
+        assertEquals(res.get(), BKException.Code.OK);
+    }
+
+    @Test(timeout=20000)
+    public void testRetrySlowBookie() throws Exception {
+        final int readTimeout = 2;
+
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setZkServers(zkUtil.getZooKeeperConnectString())
+            .setReadEntryTimeout(readTimeout)
+            .setAddEntryTimeout(readTimeout)
+            .setDelayEnsembleChange(false)
+            .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE);
+
+
+        SettableFeatureProvider featureProvider = new SettableFeatureProvider("test", 0);
+        BookKeeper bkc = BookKeeper.forConfig(conf)
+                .featureProvider(featureProvider)
+                .build();
+
+        SettableFeature disableEnsembleChangeFeature = featureProvider.getFeature(FEATURE_DISABLE_ENSEMBLE_CHANGE);
+        disableEnsembleChangeFeature.set(true);
+
+        LedgerHandle lh = bkc.createLedger(4, 4, 4, BookKeeper.DigestType.CRC32, new byte[] {});
+        byte[] entry = "testRetryFailureBookie".getBytes();
+        for (int i=0; i<10; i++) {
+            lh.addEntry(entry);
+        }
+
+        List<BookieSocketAddress> curEns = lh.getLedgerMetadata().currentEnsemble;
+
+        final CountDownLatch wakeupLatch = new CountDownLatch(1);
+        final CountDownLatch suspendLatch = new CountDownLatch(1);
+        sleepBookie(curEns.get(2), wakeupLatch, suspendLatch);
+
+        suspendLatch.await();
+
+        final AtomicInteger res = new AtomicInteger(0xdeadbeef);
+        final CountDownLatch addLatch = new CountDownLatch(1);
+        AsyncCallback.AddCallback cb = new AsyncCallback.AddCallback() {
+            @Override
+                public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {
+                    logger.info("Add entry {} completed : rc {}.", entryId, rc);
+                    res.set(rc);
+                    addLatch.countDown();
+                }
+        };
+        lh.asyncAddEntry(entry, cb, null);
+        assertFalse("Add entry operation should not complete.",
+                addLatch.await(1000, TimeUnit.MILLISECONDS));
+        assertEquals(res.get(), 0xdeadbeef);
+        // wait until read timeout
+        assertFalse("Add entry operation should not complete even timeout.",
+                addLatch.await(readTimeout, TimeUnit.SECONDS));
+        assertEquals(res.get(), 0xdeadbeef);
+        // wait one more read timeout, to ensure we resend multiple retries
+        // to ensure it works correctly
+        assertFalse("Add entry operation should not complete even timeout.",
+                addLatch.await(readTimeout, TimeUnit.SECONDS));
+        assertEquals(res.get(), 0xdeadbeef);
+        // wakeup the sleep bookie
+        wakeupLatch.countDown();
+        assertTrue("Add entry operation should complete at this point.",
+                addLatch.await(1000, TimeUnit.MILLISECONDS));
+        assertEquals(res.get(), BKException.Code.OK);
+    }
+
+}

--- a/bookkeeper-server/src/test/resources/log4j.properties
+++ b/bookkeeper-server/src/test/resources/log4j.properties
@@ -42,12 +42,17 @@ log4j.appender.CONSOLE.Threshold=INFO
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n
 
+#disable zookeeper logging
+log4j.logger.org.apache.zookeeper=OFF
+log4j.logger.org.apache.bookkeeper.bookie=INFO
+log4j.logger.org.apache.bookkeeper.meta=INFO
+
 #
 # Add ROLLINGFILE to rootLogger to get log file output
 #    Log DEBUG level and above messages to a log file
 log4j.appender.ROLLINGFILE=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.ROLLINGFILE.Threshold=DEBUG
-log4j.appender.ROLLINGFILE.File=bookkeeper-server.log
+log4j.appender.ROLLINGFILE.File=target/bookkeeper-server.log
 log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

This pull request contains the changes around ensemble change.

- Delay Ensemble Change: Provide a flag to allow delay ensemble change. if that is set to change, will not do ensemble change until it breaks ack quorum requirements.
- Disable Ensemble Change: Provide a runtime feature flag to allow disabling ensemble change. The ensemble change behavior can be disabled on-the-fly via the FeatureProvider.

---
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

- [x] Make sure the PR title is formatted like:
    `<Issue #>: Description of pull request`
    `e.g. Issue 123: Description ...`
- [x] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
- [x] Replace `<Issue #>` in the title with the actual Issue number, if there is one.

---
