### PR TITLE
Issue-196 Create Jenkins configuration using OpenStack Jenkins Job Builder

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -48,7 +48,7 @@ How do I create job ?
 
 Get an username and an "API Token" for your Jenkins configuration
 
-In order to test jenkins job configuration, run:
+In order to test jenkins job configuration, go to 'jenkins' directory and run:
 
 ```
    $ jenkins-jobs test bookkeeper-master-job-configuration.yaml

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,65 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+Instructions for build Jenkins bookkeeper-master job using Jenkins Job Builder
+
+
+Requirements:
+
+* Unix System
+* Jenkins Job Builder (see https://docs.openstack.org/infra/jenkins-job-builder/)
+
+
+The jenkins folder contains:
+
+ - bookkeeper-master-job-configuration.yaml   (Jenkins job definition)
+ - jenkins_jobs.ini   (Jenkins job builder configuration)
+
+
+Build and install latest version of jenkins-job-builder;
+
+```
+$ git clone https://git.openstack.org/openstack-infra/jenkins-job-builder
+```
+
+```
+$ python setup.py build
+```
+
+```
+$ python setup.py install --user
+```
+
+How do I create job ?
+
+Get an username and an "API Token" for your Jenkins configuration
+
+In order to test jenkins job configuration, run:
+
+```
+   $ jenkins-jobs test bookkeeper-master-job-configuration.yaml
+```
+
+This will print the XML configuration of the job which will be deployed to your Jenkins
+
+ In order to apply the configuration and create the job, run:
+
+```
+   $ jenkins-jobs --user USER --password API-TOKEN --conf jenkins_jobs.ini update bookkeeper-master-job-configuration.yaml
+```
+
+By default the job will be deployed to builds.apache.org, you can change the destination in jenkins_jobs.ini

--- a/jenkins/bookkeeper-master-job-configuration.yaml
+++ b/jenkins/bookkeeper-master-job-configuration.yaml
@@ -20,7 +20,7 @@
     name: repo
     scm:
     - git:
-        url: https://git-wip-us.apache.org/repos/asf/bookkeeper.git
+        url: https://github.com/apache/bookkeeper.git
         branches:
         - "*/master"
 - job:

--- a/jenkins/bookkeeper-master-job-configuration.yaml
+++ b/jenkins/bookkeeper-master-job-configuration.yaml
@@ -1,0 +1,60 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- scm:
+    name: repo
+    scm:
+    - git:
+        url: https://git-wip-us.apache.org/repos/asf/bookkeeper.git
+        branches:
+        - "*/master"
+- job:
+    name: bookkeeper-master
+    description: "Nightly build for BookKeeper master.\r\nThis job is built using jenkins-jobs build scripts committed on BookKeeper repo.\r\n\r\nNo not edit manually this job"
+    project-type: maven
+    jdk: "JDK 1.8 (latest)"
+    node: Hadoop
+    maven:
+      root-pom: pom.xml
+      goals: clean apache-rat:check package findbugs:check -Dmaven.test.failure.ignore=false deploy
+      incremental-build: true
+    reporters:
+    - email:
+        recipients: dev@bookkeeper.apache.org
+    triggers:
+    - timed: H 12 * * *
+    wrappers:
+    - timeout:
+        type: likely-stuck
+        write-description: true
+    scm:
+    - repo
+    properties:
+    - build-discarder:
+        days-to-keep: 14
+        num-to-keep: 5
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+    - throttle:
+        enabled: false
+        max-per-node: 0
+        max-total: 0
+        option: project
+    -  rebuild:
+        auto-rebuild: false
+        rebuild-disabled: false

--- a/jenkins/jenkins_jobs.ini
+++ b/jenkins/jenkins_jobs.ini
@@ -1,0 +1,28 @@
+
+;Licensed to the Apache Software Foundation (ASF) under one or more
+;contributor license agreements.  See the NOTICE file distributed with
+;this work for additional information regarding copyright ownership.
+;The ASF licenses this file to You under the Apache License, Version 2.0
+;(the "License"); you may not use this file except in compliance with
+;the License.  You may obtain a copy of the License at
+;    http://www.apache.org/licenses/LICENSE-2.0
+;Unless required by applicable law or agreed to in writing, software
+;distributed under the License is distributed on an "AS IS" BASIS,
+;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;See the License for the specific language governing permissions and
+;limitations under the License.
+
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.:scripts:~/git/
+recursive=False
+exclude=.*:manual:./development
+allow_duplicates=False
+
+[jenkins]
+url=https://builds.apache.org
+query_plugins_info=False
+
+
+


### PR DESCRIPTION
Descriptions of the changes in this PR:

Introduction of Jenkins Job Builder script, in order to have the configuration of Jenkins jobs directly stored in GIT repo.
This will enable reviews of Jenkins configuration
