### PR TITLE
BOOKKEEPER-1100: Add Http Server for Bookkeeper

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -217,11 +217,68 @@
       <version>${netty.version}</version>
     </dependency>
     <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-minikdc</artifactId>
-        <version>2.7.3</version>
-        <scope>test</scope>
-    </dependency>          
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minikdc</artifactId>
+      <version>2.7.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>3.4.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.8.4</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20160810</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>twitter-server_2.11</artifactId>
+      <version>1.29.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -23,6 +23,9 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.Beta;
 
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.TwitterHttpServer;
+import org.apache.bookkeeper.http.VertxHttpServer;
 import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.bookkeeper.util.BookKeeperConstants;
@@ -142,6 +145,12 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     // Bookie auth provider factory class name
     protected final static String BOOKIE_AUTH_PROVIDER_FACTORY_CLASS = "bookieAuthProviderFactoryClass";
+
+    // Http Server parameters
+    protected final static String HTTP_SERVER_ENABLED = "httpServerEnabled";
+    protected final static String HTTP_SERVER_PORT = "httpServerPort";
+    protected final static String HTTP_SERVER_CLASS = "httpServerClass";
+
 
     /**
      * Construct a default configuration object
@@ -1937,6 +1946,74 @@ public class ServerConfiguration extends AbstractConfiguration {
     @Override
     public ServerConfiguration setNettyMaxFrameSizeBytes(int maxSize) {
         super.setNettyMaxFrameSizeBytes(maxSize);
+        return this;
+    }
+
+    /**
+     * Sets that whether the http server can start along with auto-recovery service
+     *
+     * @param enabled
+     *            - true if need to start http server with auto-recovery
+     * @return ServerConfiguration
+     */
+    public ServerConfiguration setHttpServerEnabled(boolean enabled) {
+        setProperty(HTTP_SERVER_ENABLED, enabled);
+        return this;
+    }
+
+    /**
+     * Get whether the http server start with auto-recovery service or not
+     *
+     * @return true - if http server should start with auto-recovery service
+     */
+    public boolean isHttpServerEnabled() {
+        return getBoolean(HTTP_SERVER_ENABLED, true);
+    }
+
+    /**
+     * Set Http server port listening on
+     *
+     * @param port
+     *          Port to listen on
+     * @return server configuration
+     */
+    public ServerConfiguration setHttpServerPort(int port) {
+        setProperty(HTTP_SERVER_PORT, port);
+        return this;
+    }
+
+    /**
+     * Get the http server port
+     *
+     * @return http server port
+     */
+    public int getHttpServerPort() {
+        return getInt(HTTP_SERVER_PORT, 8080);
+    }
+
+    /**
+     * Get Http server Class.
+     *
+     * @return Http server class.
+     */
+    public Class<? extends HttpServer> getHttpServer()
+        throws ConfigurationException {
+        return ReflectionUtils.getClass(this, HTTP_SERVER_CLASS ,
+            VertxHttpServer.class,
+            HttpServer.class,
+            defaultLoader);
+    }
+
+    /**
+     * Set Http server Class.
+     *
+     * @param httpClass
+     *          Http server Class.
+     *
+     * @return server configuration
+     */
+    public ServerConfiguration setHttpServer(Class<? extends HttpServer> httpClass) {
+        setProperty(HTTP_SERVER_CLASS, httpClass.getName());
         return this;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -1967,7 +1967,7 @@ public class ServerConfiguration extends AbstractConfiguration {
      * @return true - if http server should start with auto-recovery service
      */
     public boolean isHttpServerEnabled() {
-        return getBoolean(HTTP_SERVER_ENABLED, true);
+        return getBoolean(HTTP_SERVER_ENABLED, false);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
@@ -1,0 +1,66 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http;
+
+public interface HttpServer {
+
+    static final String HEARTBEAT             = "/heartbeat";
+    static final String SERVER_CONFIG         = "/api/config/serverConfig";
+    static final String BOOKIE_STATUS         = "/api/bookie/bookieStatus";
+
+    static enum StatusCode {
+        OK(200),
+        REDIRECT(302),
+        NOT_FOUND(404),
+        INTERNAL_ERROR(500);
+
+        private int value;
+
+        StatusCode(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    /**
+     * Initialize the HTTP server with the given options
+     */
+    void initialize(ServerOptions serverOptions);
+
+    /**
+     * Start the HTTP server
+     */
+    void startServer();
+
+    /**
+     * Stop the HTTP server
+     */
+    void stopServer();
+
+    /**
+     * Check whether the HTTP is still running
+     */
+    boolean isRunning();
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/ServerLoader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/ServerLoader.java
@@ -1,0 +1,43 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.util.ReflectionUtils;
+import org.apache.commons.configuration.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ServerLoader {
+
+    static final Logger LOG = LoggerFactory.getLogger(ServerLoader.class);
+
+    public static HttpServer loadHttpServer(ServerConfiguration conf) {
+        try {
+            Class<? extends HttpServer> httpClass = conf.getHttpServer();
+            return ReflectionUtils.newInstance(httpClass);
+        } catch (ConfigurationException e) {
+            LOG.error("Failed to load HttpServer class");
+        }
+        return null;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/ServerOptions.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/ServerOptions.java
@@ -1,0 +1,70 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.replication.AutoRecoveryMain;
+
+public class ServerOptions {
+    // Default port: 8080
+    private int port = 8080;
+    private ServerConfiguration serverConf;
+    private AutoRecoveryMain autoRecovery;
+    private BookieServer bookieServer;
+
+    public int getPort() {
+        return port;
+    }
+
+    public ServerOptions setPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public AutoRecoveryMain getAutoRecovery() {
+        return autoRecovery;
+    }
+
+    public ServerOptions setAutoRecovery(AutoRecoveryMain autoRecovery) {
+        this.autoRecovery = autoRecovery;
+        return this;
+    }
+
+    public ServerConfiguration getServerConf() {
+        return serverConf;
+    }
+
+    public ServerOptions setServerConf(ServerConfiguration serverConf) {
+        this.serverConf = serverConf;
+        return this;
+    }
+
+    public BookieServer getBookieServer() {
+        return bookieServer;
+    }
+
+    public ServerOptions setBookieServer(BookieServer bookieServer) {
+        this.bookieServer = bookieServer;
+        return this;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/TwitterHttpServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/TwitterHttpServer.java
@@ -1,0 +1,98 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http;
+
+import java.net.InetSocketAddress;
+
+import org.apache.bookkeeper.http.handler.AbstractHandlerFactory;
+import org.apache.bookkeeper.http.handler.TwitterHandlerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.twitter.finagle.Http;
+import com.twitter.finagle.ListeningServer;
+import com.twitter.finagle.Service;
+import com.twitter.finagle.http.HttpMuxer;
+import com.twitter.finagle.http.Request;
+import com.twitter.finagle.http.Response;
+import com.twitter.server.AbstractTwitterServer;
+
+public class TwitterHttpServer extends AbstractTwitterServer implements HttpServer {
+
+    private final Logger LOG = LoggerFactory.getLogger(TwitterHttpServer.class);
+
+    private ListeningServer server;
+    private boolean isRunning;
+    private ServerOptions serverOptions;
+
+    public TwitterHttpServer() {
+        this.serverOptions = new ServerOptions();
+    }
+
+    @Override
+    public void initialize(ServerOptions serverOptions) {
+        this.serverOptions = serverOptions;
+    }
+
+    @Override
+    public void startServer() {
+        try {
+            this.main();
+            LOG.info("HTTP server started successfully");
+        } catch (Throwable throwable) {
+            LOG.error("Failed to start http server", throwable);
+        }
+    }
+
+    @Override
+    public void stopServer() {
+        if (server != null) {
+            server.close();
+            isRunning = false;
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return isRunning;
+    }
+
+    @Override
+    public void main() throws Throwable {
+        int port = serverOptions.getPort();
+        LOG.info("Starting Twitter HTTP server on port {}", port);
+        AbstractHandlerFactory<Service<Request, Response>> handlerFactory = new TwitterHandlerFactory(serverOptions);
+        HttpMuxer muxer = new HttpMuxer()
+            .withHandler(HEARTBEAT, handlerFactory.newHeartbeatHandler())
+            .withHandler(SERVER_CONFIG, handlerFactory.newConfigurationHandler())
+            .withHandler(BOOKIE_STATUS, handlerFactory.newBookieStatusHandler());
+        InetSocketAddress addr = new InetSocketAddress(port);
+        server = Http.server().serve(addr, muxer);
+        isRunning = true;
+    }
+
+    @Override
+    public void onExit() {
+        stopServer();
+    }
+
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/VertxHttpServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/VertxHttpServer.java
@@ -1,0 +1,109 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.bookkeeper.http.handler.AbstractHandlerFactory;
+import org.apache.bookkeeper.http.handler.VertxHandlerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class VertxHttpServer implements HttpServer {
+
+    private final Logger LOG = LoggerFactory.getLogger(VertxHttpServer.class);
+
+    private Vertx vertx;
+    private boolean isRunning;
+    private ServerOptions serverOptions;
+
+    public VertxHttpServer() {
+        this.serverOptions = new ServerOptions();
+        this.vertx = Vertx.vertx();
+    }
+
+    @Override
+    public void initialize(ServerOptions serverOptions) {
+        this.serverOptions = serverOptions;
+    }
+
+    @Override
+    public void startServer() {
+        int port = serverOptions.getPort();
+        CompletableFuture<AsyncResult> future = new CompletableFuture<>();
+        AbstractHandlerFactory<Handler<RoutingContext>> handlerFactory = new VertxHandlerFactory(serverOptions);
+        Router router = Router.router(vertx);
+        router.get(HEARTBEAT).handler(handlerFactory.newHeartbeatHandler());
+        router.get(SERVER_CONFIG).handler(handlerFactory.newConfigurationHandler());
+        router.get(BOOKIE_STATUS).handler(handlerFactory.newBookieStatusHandler());
+        vertx.deployVerticle(new AbstractVerticle() {
+            @Override
+            public void start() throws Exception {
+                LOG.info("Starting Vertx HTTP server on port {}", port);
+                vertx.createHttpServer().requestHandler(router::accept).listen(port, asyncResult -> {
+                    isRunning = true;
+                    future.complete(asyncResult);
+                });
+            }
+        });
+        try {
+            AsyncResult asyncResult = future.get();
+            if (asyncResult.succeeded()) {
+                LOG.info("Http server started successfully");
+            } else {
+                LOG.error("Failed to start http server on port {}", port, asyncResult.cause());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            LOG.error("Failed to start http server on port {}", port, e);
+        }
+    }
+
+    @Override
+    public void stopServer() {
+        CountDownLatch shutdownLatch = new CountDownLatch(1);
+        Vertx vertx = Vertx.vertx();
+        vertx.close(asyncResult -> {
+            isRunning = false;
+            shutdownLatch.countDown();
+            LOG.info("HTTP server is shutdown");
+        });
+        try {
+            shutdownLatch.await();
+        } catch (InterruptedException e) {
+            LOG.error("Interrupted while shutting down http server");
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return isRunning;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/handler/AbstractHandlerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/handler/AbstractHandlerFactory.java
@@ -1,0 +1,76 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http.handler;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.http.ServerOptions;
+import org.apache.bookkeeper.http.service.BookieStatusService;
+import org.apache.bookkeeper.http.service.ConfigService;
+import org.apache.bookkeeper.http.service.HeartbeatService;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.replication.AutoRecoveryMain;
+
+public abstract class AbstractHandlerFactory<Handler> {
+
+    private AutoRecoveryMain autoRecovery;
+    private ServerConfiguration serverConfiguration;
+    private BookieServer bookieServer;
+
+    public AbstractHandlerFactory(ServerOptions serverOptions) {
+        this.autoRecovery = serverOptions.getAutoRecovery();
+        this.serverConfiguration = serverOptions.getServerConf();
+        this.bookieServer = serverOptions.getBookieServer();
+    }
+
+    /**
+     * Create a handler for heartbeat service
+     */
+    public abstract Handler newHeartbeatHandler();
+
+    /**
+     * Create a handler for configuration service
+     */
+    public abstract Handler newConfigurationHandler();
+
+    /**
+     * Create a handler for bookie status service
+     */
+    public abstract Handler newBookieStatusHandler();
+
+    HeartbeatService getHeartbeatService() {
+        return new HeartbeatService();
+    }
+
+    ConfigService getConfigService() {
+        if (serverConfiguration == null) {
+            return null;
+        }
+        return new ConfigService(serverConfiguration);
+    }
+
+    BookieStatusService getBookieStatusService() {
+        if (bookieServer == null || bookieServer.getBookie() == null) {
+            return null;
+        }
+        return new BookieStatusService(bookieServer.getBookie());
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/handler/TwitterHandlerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/handler/TwitterHandlerFactory.java
@@ -1,0 +1,91 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http.handler;
+
+import org.apache.bookkeeper.http.HttpServer.StatusCode;
+import org.apache.bookkeeper.http.ServerOptions;
+import org.apache.bookkeeper.http.service.BookieStatusService;
+import org.apache.bookkeeper.http.service.ConfigService;
+import org.apache.bookkeeper.http.service.HeartbeatService;
+
+import com.twitter.finagle.Service;
+import com.twitter.finagle.http.Request;
+import com.twitter.finagle.http.Response;
+import com.twitter.util.Future;
+
+
+public class TwitterHandlerFactory extends AbstractHandlerFactory<Service<Request, Response>> {
+    public TwitterHandlerFactory(ServerOptions serverOptions) {
+        super(serverOptions);
+    }
+
+    @Override
+    public Service<Request, Response> newHeartbeatHandler() {
+        return new Service<Request, Response>() {
+            @Override
+            public Future<Response> apply(Request request) {
+                Response response = Response.apply();
+                HeartbeatService service = getHeartbeatService();
+                response.setContentString(service.getHeartbeat());
+                return Future.value(response);
+            }
+        };
+    }
+
+    @Override
+    public Service<Request, Response> newConfigurationHandler() {
+        return new Service<Request, Response>() {
+            @Override
+            public Future<Response> apply(Request request) {
+                Response response = Response.apply();
+                ConfigService service = getConfigService();
+                if (service == null) {
+                    return handleServiceNotFound(response);
+                }
+                response.setContentString(service.getServerConfiguration());
+                return Future.value(response);
+            }
+        };
+    }
+
+    @Override
+    public Service<Request, Response> newBookieStatusHandler() {
+        return new Service<Request, Response>() {
+            @Override
+            public Future<Response> apply(Request request) {
+                Response response = Response.apply();
+                BookieStatusService service = getBookieStatusService();
+                if (request.method().toString().equals("GET") && service != null) {
+                    response.setContentString(service.getBookieStatus());
+                    return Future.value(response);
+                } else {
+                    return handleServiceNotFound(response);
+                }
+            }
+        };
+    }
+
+    private Future<Response> handleServiceNotFound(Response response) {
+        response.statusCode(StatusCode.NOT_FOUND.getValue());
+        return Future.value(response);
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/handler/VertxHandlerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/handler/VertxHandlerFactory.java
@@ -1,0 +1,88 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http.handler;
+
+import org.apache.bookkeeper.http.HttpServer.StatusCode;
+import org.apache.bookkeeper.http.ServerOptions;
+import org.apache.bookkeeper.http.service.BookieStatusService;
+import org.apache.bookkeeper.http.service.ConfigService;
+import org.apache.bookkeeper.http.service.HeartbeatService;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+public class VertxHandlerFactory extends AbstractHandlerFactory<Handler<RoutingContext>> {
+
+
+    public VertxHandlerFactory(ServerOptions serverOptions) {
+        super(serverOptions);
+    }
+
+    @Override
+    public Handler<RoutingContext> newHeartbeatHandler() {
+        return context -> {
+            HttpServerResponse response = context.response();
+            HeartbeatService service = getHeartbeatService();
+            response.end(service.getHeartbeat());
+        };
+    }
+
+    @Override
+    public Handler<RoutingContext> newConfigurationHandler() {
+        return context -> {
+            HttpServerResponse response = context.response();
+            ConfigService service = getConfigService();
+            if (service == null) {
+                handleServiceNotFound(response);
+                return;
+            }
+            String responseBody = service.getServerConfiguration();
+            response.end(responseBody);
+        };
+    }
+
+    @Override
+    public Handler<RoutingContext> newBookieStatusHandler() {
+        return context -> {
+            HttpServerResponse response = context.response();
+            HttpServerRequest request = context.request();
+            BookieStatusService service = getBookieStatusService();
+            if (request.method().equals(HttpMethod.GET) && service != null) {
+                String responseBody = service.getBookieStatus();
+                response.end(responseBody);
+            } else {
+                handleServiceNotFound(response);
+            }
+        };
+    }
+
+
+    private void handleServiceNotFound(HttpServerResponse response) {
+        response.setStatusCode(StatusCode.NOT_FOUND.getValue());
+        response.end();
+    }
+
+
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/service/BookieStatusService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/service/BookieStatusService.java
@@ -1,0 +1,44 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http.service;
+
+import org.apache.bookkeeper.bookie.Bookie;
+import org.json.JSONObject;
+
+public class BookieStatusService {
+
+    private Bookie bookie;
+
+    public BookieStatusService(Bookie bookie) {
+        this.bookie = bookie;
+    }
+
+    public String getBookieStatus() {
+        JSONObject response = new JSONObject();
+        if (bookie.isReadOnly()) {
+            response.put("bookie_status", "readonly");
+        } else {
+            response.put("bookie_status", "writable");
+        }
+        return response.toString(2);
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/service/ConfigService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/service/ConfigService.java
@@ -1,0 +1,51 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http.service;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.json.JSONObject;
+
+public class ConfigService {
+    private ServerConfiguration conf;
+
+    public ConfigService(ServerConfiguration conf) {
+        this.conf = conf;
+    }
+
+    public String getServerConfiguration(){
+        JSONObject response = new JSONObject();
+        JSONObject config = new JSONObject();
+        Iterator iterator = conf.getKeys();
+        while (iterator.hasNext()) {
+            String key = iterator.next().toString();
+            List values = conf.getList(key);
+            if (values.size() >= 0) {
+                config.put(key, values.get(0));
+            }
+        }
+        response.put("server_config", config);
+        return response.toString(2);
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/service/HeartbeatService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/service/HeartbeatService.java
@@ -1,0 +1,29 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http.service;
+
+public class HeartbeatService {
+
+    public String getHeartbeat() {
+        return "OK\n";
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/http/TestHttpServer.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/http/TestHttpServer.java
@@ -1,0 +1,161 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.test.PortManager;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+public class TestHttpServer extends BookKeeperClusterTestCase {
+
+    public TestHttpServer() {
+        super(1);
+    }
+
+    /**
+     * Test TwitterHttpServer
+     */
+    @Test(timeout = 60000)
+    public void testTwitterHttpServer() throws Exception {
+        baseConf.setHttpServer(TwitterHttpServer.class);
+        doTestHttpServer();
+    }
+
+    /**
+     * Test VertxHttpServer
+     */
+    @Test(timeout = 60000)
+    public void testVertxHttpServer() throws Exception {
+        baseConf.setHttpServer(VertxHttpServer.class);
+        doTestHttpServer();
+    }
+
+
+    private void doTestHttpServer() throws Exception {
+        int port = PortManager.nextFreePort();
+        ServerOptions serverOptions = new ServerOptions()
+            .setPort(port)
+            .setBookieServer(bs.get(0))
+            .setServerConf(baseConf);
+        HttpServer server = ServerLoader.loadHttpServer(baseConf);
+        // check reflection works
+        assertNotNull(server);
+        if(baseConf.getHttpServer() == TwitterHttpServer.class) {
+            assertTrue(server instanceof TwitterHttpServer);
+        } else {
+            assertTrue(server instanceof VertxHttpServer);
+        }
+
+        // start http server
+        server.initialize(serverOptions);
+        server.startServer();
+        assertTrue(server.isRunning());
+
+        // test heartbeat api
+        HttpResponse response = sendGet(getUrl(port, HttpServer.HEARTBEAT));
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.responseCode);
+        assertEquals("OK", response.responseBody);
+
+        // test config api
+        response = sendGet(getUrl(port, HttpServer.SERVER_CONFIG));
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.responseCode);
+        JSONObject jsonResponse = new JSONObject(response.responseBody);
+        JSONObject innerJson = jsonResponse.getJSONObject("server_config");
+        assertTrue(innerJson.length() > 0);
+
+        // test bookie status api when bookie is writable
+        response = sendGet(getUrl(port, HttpServer.BOOKIE_STATUS));
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.responseCode);
+        jsonResponse = new JSONObject(response.responseBody);
+        String bookieStatus = jsonResponse.getString("bookie_status");
+        assertEquals("writable", bookieStatus);
+
+        // test bookie status api when bookie is read only
+        bs.get(0).getBookie().doTransitionToReadOnlyMode();
+        response = sendGet(getUrl(port, HttpServer.BOOKIE_STATUS));
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.responseCode);
+        jsonResponse = new JSONObject(response.responseBody);
+        bookieStatus = jsonResponse.getString("bookie_status");
+        assertEquals("readonly", bookieStatus);
+
+        // stop http server
+        server.stopServer();
+        assertFalse(server.isRunning());
+    }
+
+    // HTTP GET request
+    private HttpResponse sendGet(String url) throws IOException {
+
+        URL obj = new URL(url);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+
+        // optional, default is GET
+        con.setRequestMethod("GET");
+
+        int responseCode = con.getResponseCode();
+        StringBuilder response = new StringBuilder();
+        BufferedReader in = null;
+        try {
+            in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            String inputLine;
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+        } catch (IOException e) {
+            // no-ops
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+        }
+
+        return new HttpResponse(responseCode, response.toString());
+    }
+
+    private String getUrl(int port, String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    private class HttpResponse {
+        private int responseCode;
+        private String responseBody;
+
+        public HttpResponse(int responseCode, String responseBody) {
+            this.responseCode = responseCode;
+            this.responseBody = responseBody;
+        }
+    }
+
+}


### PR DESCRIPTION
BOOKKEEPER-1100:

Provide a general interface for HttpServer, which can be easily implemented by different HTTP frameworks.

This change include two implementations of HttpServer, one is TwitterServer and another one is Vertx.

Provide a general AbstractHandlerFactory, which is able to create handlers to handler different http apis, and is able to be implemented for different HTTP frameworks.

Provide a service level classes, which include all the logics that http handlers will use.

Add test case for HttpServer

Descriptions of the changes in this PR:

xxxxxx

---
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

- [x] Make sure the PR title is formatted like:
    `<Issue #>: Description of pull request`
    `e.g. Issue 123: Description ...`
- [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
- [x] Replace `<Issue #>` in the title with the actual Issue number, if there is one.

---
