### PR TITLE
Fix ByteBuf refcount release

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -318,6 +318,7 @@ public class LedgerFragmentReplicator {
                                         null);
                             }
                         }, null, BookieProtocol.FLAG_RECOVERY_ADD);
+                toSend.release();
             }
         }, null);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -155,9 +155,8 @@ public class BookieProtoEncoding {
                 // Read ledger and entry id without advancing the reader index
                 ledgerId = packet.getLong(packet.readerIndex());
                 entryId = packet.getLong(packet.readerIndex() + 8);
-                return new BookieProtocol.AddRequest(version, ledgerId, entryId, flags, masterKey, packet.retain());
+                return new BookieProtocol.AddRequest(version, ledgerId, entryId, flags, masterKey, packet);
             }
-
             case BookieProtocol.READENTRY:
                 ledgerId = packet.readLong();
                 entryId = packet.readLong();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -570,7 +570,6 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         final Channel c = channel;
         if (c == null) {
             errorOutAddKey(completionKey);
-            toSend.release();
             return;
         }
         try {


### PR DESCRIPTION
- Release ByteBuf in Replicator
- Do not release refcnt in PCBC upon addEntry error
- Remove unnecessary ByteBuf refcnt retain in Bookie protocol (V2) request encoding

Descriptions of the changes in this PR:

Addressing test failure - TestBackwardCompat.testCompat410 often fails due to io.netty.util.IllegalReferenceCountException (#198)

---
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

- [ ] Make sure the PR title is formatted like:
    `<Issue #>: Description of pull request`
    `e.g. Issue 123: Description ...`
- [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
- [ ] Replace `<Issue #>` in the title with the actual Issue number, if there is one.

---
