### PR TITLE
Issue 216: Remove useless and misleading '&= true'

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -370,17 +370,13 @@ public class Auditor implements BookiesListener {
             shutDownTask = false;
         } catch (BKException bke) {
             LOG.error("Exception getting bookie list", bke);
-            shutDownTask &= true;
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             LOG.error("Interrupted while watching available bookies ", ie);
-            shutDownTask &= true;
         } catch (BKAuditException bke) {
             LOG.error("Exception while watching available bookies", bke);
-            shutDownTask &= true;
         } catch (KeeperException ke) {
             LOG.error("Exception reading bookie list", ke);
-            shutDownTask &= true;
         }
         if (shutDownTask) {
             submitShutdownTask();


### PR DESCRIPTION
This is just a super minor issue, I stumbled upon it looking into https://github.com/apache/bookkeeper/pull/58...

Assignments like 'shutDownTask =& true' aren't useful at all. I presume that compiler could strip them out but the code is less readable. (Just note that 'x & true == x').

Removed useless assignments.