### PR TITLE
Issue 198: TestBackwardCompat.testCompat410 often fails due to io.netty.util.IllegalReferenceCountException

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -283,7 +283,7 @@ public class BookieProtoEncoding {
                 BookkeeperProtocol.AuthMessage am = builder.build();
                 return new BookieProtocol.AuthResponse(version, am);
             default:
-                return buffer;
+                throw new IllegalStateException("Received unknown response : op code = " + opCode);
             }
         }
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Problem:

in TestBackwardCompat#testCompact400, the test is to verify the current client can't talk to a 4.0.0 server.

The 4.5.0 client is sending a protobuf encoded request to 4.0.0 server. The 4.0.0 server will interpret the 4.5.0 protobuf encoded request, but it will realize this is bad request and sending v2 protocol encoded response. because the request is a bad request, 4.0.0 server sent a response back with unknown op code.

In current v2 ResponseEnDecoder (listed as below), when it doesn't know the op code, it will return the buffer to the channel. this might cause the misbehavior in the channel pipeline to decrement reference count.

Solution:

throw exception in the EnDeCoder when receiving unknown op code. so the netty can close the connection, error out the pending requests and cleaning up the resources.

