### PR TITLE
Issue 225: Remove Parameterized from CompactionTest 

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionByBytesTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionByBytesTest.java
@@ -1,0 +1,27 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+public class CompactionByBytesTest extends CompactionTest {
+    public CompactionByBytesTest() {
+        super(true);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionByEntriesTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionByEntriesTest.java
@@ -1,0 +1,27 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+public class CompactionByEntriesTest extends CompactionTest {
+    public CompactionByEntriesTest() {
+        super(false);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -32,14 +32,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Arrays;
-import java.util.Collection;
 
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
 import org.apache.bookkeeper.bookie.GarbageCollectorThread.CompactionScannerFactory;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
-import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.LedgerMetadata;
@@ -61,9 +58,6 @@ import org.apache.zookeeper.AsyncCallback;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,29 +65,22 @@ import static org.junit.Assert.*;
 /**
  * This class tests the entry log compaction functionality.
  */
-@RunWith(Parameterized.class)
-public class CompactionTest extends BookKeeperClusterTestCase {
-    @Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {{true}, {false}});
-    }
-
-    private boolean isThrottleByBytes;
+public abstract class CompactionTest extends BookKeeperClusterTestCase {
 
     private final static Logger LOG = LoggerFactory.getLogger(CompactionTest.class);
-    DigestType digestType;
 
     static int ENTRY_SIZE = 1024;
     static int NUM_BOOKIES = 1;
 
-    int numEntries;
-    int gcWaitTime;
-    double minorCompactionThreshold;
-    double majorCompactionThreshold;
-    long minorCompactionInterval;
-    long majorCompactionInterval;
-
-    String msg;
+    private final boolean isThrottleByBytes;
+    private final DigestType digestType;
+    private final int numEntries;
+    private final int gcWaitTime;
+    private final double minorCompactionThreshold;
+    private final double majorCompactionThreshold;
+    private final long minorCompactionInterval;
+    private final long majorCompactionInterval;
+    private final String msg;
 
     public CompactionTest(boolean isByBytes) {
         super(NUM_BOOKIES);


### PR DESCRIPTION
Descriptions of the changes in this PR:

- Split the CompactionTest into two, one is by bytes, while the other one is by entries.