### PR TITLE
Issue-237 Upgrade to ZooKeeper 3.5.3-BETA

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
@@ -47,6 +47,12 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.*;
 
 public class ZooKeeperUtil {
+
+    static {
+        // org.apache.zookeeper.test.ClientBase uses FourLetterWordMain, from 3.5.3 four letter words
+        // are disabled by default due to security reasons
+        System.setProperty("zookeeper.4lw.commands.whitelist", "*");
+    }
     static final Logger LOG = LoggerFactory.getLogger(ZooKeeperUtil.class);
 
     // ZooKeeper related variables

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <netty.version>4.1.10.Final</netty.version>
     <protobuf.version>2.6.1</protobuf.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <zookeeper.version>3.5.1-alpha</zookeeper.version>
+    <zookeeper.version>3.5.3-beta</zookeeper.version>
   </properties>
   <url>http://bookkeeper.apache.org</url>
   <build>


### PR DESCRIPTION
Descriptions of the changes in this PR:

Update ZooKeeper dependency from 3.5.1-alpha to 3.5.3-beta.
This will enable ZooKeeper over SSL

---
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

- [x ] Make sure the PR title is formatted like:
    `<Issue # or BOOKKEEPER-#>: Description of pull request`
    `e.g. Issue 123: Description ...`
    `e.g. BOOKKEEPER-1234: Description ...`
- [ x] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
- [ x] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.

---
