### PR TITLE
ISSUE #239: typo in class name SpeculativeRequestExecutor

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
@@ -59,12 +59,12 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
      * @param requestExecutor The executor is used to issue the actual speculative requests
      */
     @Override
-    public void initiateSpeculativeRequest(final ScheduledExecutorService scheduler, final SpeculativeRequestExectuor requestExecutor) {
+    public void initiateSpeculativeRequest(final ScheduledExecutorService scheduler, final SpeculativeRequestExecutor requestExecutor) {
         scheduleSpeculativeRead(scheduler, requestExecutor, firstSpeculativeRequestTimeout);
     }
 
     private void scheduleSpeculativeRead(final ScheduledExecutorService scheduler,
-                                         final SpeculativeRequestExectuor requestExecutor,
+                                         final SpeculativeRequestExecutor requestExecutor,
                                          final int speculativeRequestTimeout) {
         try {
             scheduler.schedule(new Runnable() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -77,7 +77,7 @@ class PendingReadOp implements Enumeration<LedgerEntry>, ReadEntryCallback {
     boolean parallelRead = false;
     final AtomicBoolean complete = new AtomicBoolean(false);
 
-    abstract class LedgerEntryRequest extends LedgerEntry implements SpeculativeRequestExectuor {
+    abstract class LedgerEntryRequest extends LedgerEntry implements SpeculativeRequestExecutor {
 
         final AtomicBoolean complete = new AtomicBoolean(false);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
@@ -39,7 +39,7 @@ import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEntryCallback, SpeculativeRequestExectuor {
+public class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEntryCallback, SpeculativeRequestExecutor {
     static final Logger LOG = LoggerFactory.getLogger(ReadLastConfirmedAndEntryOp.class);
 
     final private ScheduledExecutorService scheduler;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutionPolicy.java
@@ -30,5 +30,5 @@ public interface SpeculativeRequestExecutionPolicy {
      * @param scheduler The scheduler service to issue the speculative request
      * @param requestExectuor The executor is used to issue the actual speculative requests
      */
-    void initiateSpeculativeRequest(ScheduledExecutorService scheduler, SpeculativeRequestExectuor requestExectuor);
+    void initiateSpeculativeRequest(ScheduledExecutorService scheduler, SpeculativeRequestExecutor requestExectuor);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutor.java
@@ -22,7 +22,7 @@ package org.apache.bookkeeper.client;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-public interface SpeculativeRequestExectuor {
+public interface SpeculativeRequestExecutor {
 
     /**
      * Issues a speculative request and indicates if more speculative


### PR DESCRIPTION
Fix a simple typo in class name. It should be `SpeculativeRequestExecutor` instead of `SpeculativeRequestExectuor`.
