### PR TITLE
Issue#243 - asyncAddEntry fails with NPE with LedgerHandlerAdv

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -720,8 +720,7 @@ public class LedgerHandle implements AutoCloseable {
      * @param ctx
      *            some control object
      */
-    public void asyncAddEntry(final long entryId, final byte[] data, final AddCallback cb, final Object ctx)
-            throws BKException {
+    public void asyncAddEntry(final long entryId, final byte[] data, final AddCallback cb, final Object ctx) {
         LOG.error("To use this feature Ledger must be created with createLedgerAdv() interface.");
         cb.addComplete(BKException.Code.IllegalOpException, LedgerHandle.this, entryId, ctx);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -121,7 +121,7 @@ public class LedgerHandleAdv extends LedgerHandle {
      *            some control object
      */
     @Override
-    public void asyncAddEntry(long entryId, byte[] data, AddCallback cb, Object ctx) throws BKException {
+    public void asyncAddEntry(long entryId, byte[] data, AddCallback cb, Object ctx) {
         asyncAddEntry(entryId, data, 0, data.length, cb, ctx);
     }
 
@@ -165,6 +165,11 @@ public class LedgerHandleAdv extends LedgerHandle {
      */
     @Override
     protected void doAsyncAddEntry(final PendingAddOp op, final ByteBuf data, final AddCallback cb, final Object ctx) {
+        if (op.entryId < 0 ) {
+            super.doAsyncAddEntry(op, data, cb, ctx);
+            return;
+        }
+
         if (throttler != null) {
             throttler.acquire();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -165,7 +165,9 @@ public class LedgerHandleAdv extends LedgerHandle {
      */
     @Override
     protected void doAsyncAddEntry(final PendingAddOp op, final ByteBuf data, final AddCallback cb, final Object ctx) {
-        if (op.entryId < 0 ) {
+        if (op.entryId == LedgerHandle.INVALID_ENTRY_ID) {
+            // if entryId has not been set we need to fallback to normal LedgerHandle doAsyncAddEntry
+            // and assign a new entryId
             super.doAsyncAddEntry(op, data, cb, ctx);
             return;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -165,13 +165,6 @@ public class LedgerHandleAdv extends LedgerHandle {
      */
     @Override
     protected void doAsyncAddEntry(final PendingAddOp op, final ByteBuf data, final AddCallback cb, final Object ctx) {
-        if (op.entryId == LedgerHandle.INVALID_ENTRY_ID) {
-            // if entryId has not been set we need to fallback to normal LedgerHandle doAsyncAddEntry
-            // and assign a new entryId
-            super.doAsyncAddEntry(op, data, cb, ctx);
-            return;
-        }
-
         if (throttler != null) {
             throttler.acquire();
         }
@@ -230,6 +223,23 @@ public class LedgerHandleAdv extends LedgerHandle {
             cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
                     LedgerHandleAdv.this, op.getEntryId(), ctx);
         }
+    }
+
+    /**
+     * LedgerHandleAdv will not allow addEntry without providing an entryId
+     */
+    @Override
+    public void asyncAddEntry(ByteBuf data, AddCallback cb, Object ctx) {
+        cb.addComplete(BKException.Code.IllegalOpException, this, LedgerHandle.INVALID_ENTRY_ID, ctx);
+    }
+
+    /**
+     * LedgerHandleAdv will not allow addEntry without providing an entryId
+     */
+    @Override
+    public void asyncAddEntry(final byte[] data, final int offset, final int length,
+                              final AddCallback cb, final Object ctx) {
+        cb.addComplete(BKException.Code.IllegalOpException, this, LedgerHandle.INVALID_ENTRY_ID, ctx);
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -211,7 +211,7 @@ public class BookieWriteLedgerTest extends
         }
 
         try {
-            CompletableFuture done = new CompletableFuture();
+            CompletableFuture<Object> done = new CompletableFuture<>();
             lh.asyncAddEntry(Unpooled.wrappedBuffer(entry.array()),
                 (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
                 SynchCallbackUtils.finish(rc, null, done);
@@ -224,7 +224,7 @@ public class BookieWriteLedgerTest extends
         }
 
         try {
-            CompletableFuture done = new CompletableFuture();
+            CompletableFuture<Object> done = new CompletableFuture<>();
             lh.asyncAddEntry(entry.array(),
                 (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
                 SynchCallbackUtils.finish(rc, null, done);
@@ -237,7 +237,7 @@ public class BookieWriteLedgerTest extends
         }
 
         try {
-            CompletableFuture done = new CompletableFuture();
+            CompletableFuture<Object> done = new CompletableFuture<>();
             lh.asyncAddEntry(entry.array(),0, 4,
                 (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
                 SynchCallbackUtils.finish(rc, null, done);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.meta.LongHierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.MultiLedgerManagerMultiDigestTestCase;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -174,6 +175,27 @@ public class BookieWriteLedgerTest extends
             lh.addEntry(i, entry.array());
         }
 
+        readEntries(lh, entries1);
+        lh.close();
+    }
+
+    /**
+     * Verify that LedgerHandleAdv can handle asynchAddEntry without the entryId
+     *
+     * @throws Exception
+     */
+    @Test(timeout = 60000)
+    public void testAsynchAddEntryLedgerCreateAdv() throws Exception {
+        // Create a ledger
+        lh = bkc.createLedgerAdv(5, 3, 2, digestType, ledgerPassword);
+        for (int i = 0; i < numEntriesToWrite; i++) {
+            ByteBuffer entry = ByteBuffer.allocate(4);
+            entry.putInt(rng.nextInt(maxInt));
+            entry.position(0);
+
+            entries1.add(entry.array());
+            lh.addEntry(entry.array());
+        }
         readEntries(lh, entries1);
         lh.close();
     }


### PR DESCRIPTION
Fix asyncAddEntry on LedgerHandleAdv and clean up the asyncAddEntry API, drops BKException which is never thrown in asynch functions