### PR TITLE
Issue 252: Enable four-letter-words zookeeper commands in localbookie

### DIFF
--- a/bookkeeper-server/bin/bookkeeper
+++ b/bookkeeper-server/bin/bookkeeper
@@ -209,7 +209,7 @@ elif [ $COMMAND == "autorecovery" ]; then
 elif [ $COMMAND == "localbookie" ]; then
   NUMBER=$1
   shift
-  exec $JAVA $OPTS $JMX_ARGS org.apache.bookkeeper.util.LocalBookKeeper $NUMBER $BOOKIE_CONF $@
+  exec $JAVA $OPTS $JMX_ARGS -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.util.LocalBookKeeper $NUMBER $BOOKIE_CONF $@
 elif [ $COMMAND == "upgrade" ]; then
   exec $JAVA $OPTS org.apache.bookkeeper.bookie.FileSystemUpgrade --conf $BOOKIE_CONF $@
 elif [ $COMMAND == "shell" ]; then


### PR DESCRIPTION
Descriptions of the changes in this PR:

Enable four-letter-words zookeeper commands in localbookie