### PR TITLE
Issue 258: BookieInitializationTest.testRegNodeExistsAfterSessionTimeOut failed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -125,7 +125,7 @@ public class IndexPersistenceMgr {
                         throw new Bookie.NoLedgerException(ledger);
                     }
                     // We don't have a ledger index file on disk, so create it.
-                    lf = getNewLedgerIndexFile(ledger, null, true);
+                    lf = getNewLedgerIndexFile(ledger, null);
                     createdNewFile = true;
                 }
             }
@@ -176,38 +176,7 @@ public class IndexPersistenceMgr {
      */
     private File getNewLedgerIndexFile(Long ledger, File excludedDir)
                     throws NoWritableLedgerDirException {
-        return getNewLedgerIndexFile(ledger, excludedDir, false);
-    }
-
-    /**
-     * Get a new index file for a ledger in a lazy way.
-     *
-     + <p>If fallback is false, this function will throw exception when there are no writable dirs.
-     + If fallback is true and there's no writable dirs, it will ignore the error and pick any dir.
-     + Set fallback to true is useful when we want to delay disk check and just get the File pointer, e.g. fence ledger
-     *
-     * @param ledger
-     *          Ledger id.
-     * @param excludedDir
-     *          The ledger directory to exclude.
-     * @param fallback
-     *          If fallback is false, the function will throw exception when there are no writable dirs;
-     *          If it is true and there's no writable dirs, it will ignore the error and pick any dir.
-     * @return new index file object.
-     * @throws NoWritableLedgerDirException if there is no writable dir available.
-     */
-    private File getNewLedgerIndexFile(Long ledger, File excludedDir, boolean fallback)
-                    throws NoWritableLedgerDirException {
-        File dir = null;
-        try {
-            dir = ledgerDirsManager.pickRandomWritableDirForNewIndexFile(excludedDir);
-        } catch (NoWritableLedgerDirException e) {
-            if (fallback) {
-                dir = ledgerDirsManager.pickRandomDir(excludedDir);
-            } else {
-                throw e;
-            }
-        }
+        File dir = ledgerDirsManager.pickRandomWritableDirForNewIndexFile(excludedDir);
         String ledgerName = getLedgerName(ledger);
         return new File(dir, ledgerName);
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Construct new zookeeper client to ensure the tests get new zookeeper session.

(this change is based on 77c7721 )