### PR TITLE
Issue 267: Bookie should serve in read only mode during shutting down.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -1279,15 +1279,18 @@ public class Bookie extends BookieCriticalThread {
                 // mark bookie as in shutting down progress
                 shuttingdown = true;
 
-                // Shutdown the state service
-                stateService.shutdown();
+                // turn bookie to read only during shutting down process
+                LOG.info("Turning bookie to read only during shut down");
+                this.readOnly.set(true);
+
+                // Shutdown Sync thread
+                syncThread.shutdown();
 
                 // Shutdown journals
                 for (Journal journal : journals) {
                     journal.shutdown();
                 }
                 this.join();
-                syncThread.shutdown();
 
                 // Shutdown the EntryLogger which has the GarbageCollector Thread running
                 ledgerStorage.shutdown();
@@ -1305,6 +1308,9 @@ public class Bookie extends BookieCriticalThread {
                 if (indexDirsManager != ledgerDirsManager) {
                     idxMonitor.shutdown();
                 }
+                
+                // Shutdown the state service
+                stateService.shutdown();
             }
             // Shutdown the ZK client
             if (zk != null) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -202,13 +202,16 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         // shut down gc thread, which depends on zookeeper client
         // also compaction will write entries again to entry log file
         LOG.info("Shutting down InterleavedLedgerStorage");
+        LOG.info("Shutting down GC thread");
         gcThread.shutdown();
+        LOG.info("Shutting down entry logger");
         entryLogger.shutdown();
         try {
             ledgerCache.close();
         } catch (IOException e) {
             LOG.error("Error while closing the ledger cache", e);
         }
+        LOG.info("Complete shutting down Ledger Storage");
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -998,6 +998,7 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
             running = false;
             this.interrupt();
             this.join();
+            LOG.info("Finished Shutting down Journal thread");
         } catch (InterruptedException ie) {
             LOG.warn("Interrupted during shutting down journal : ", ie);
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Set the bookie in readonly mode during shutting down. (contributed by @yzang)
