### PR TITLE
Issue 296: Bookie supports ephemeral port

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -82,6 +82,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     protected final static String BOOKIE_PORT = "bookiePort";
     protected final static String LISTENING_INTERFACE = "listeningInterface";
     protected final static String ALLOW_LOOPBACK = "allowLoopback";
+    protected final static String ALLOW_EPHEMERAL_PORTS = "allowEphemeralPorts";
 
     protected final static String JOURNAL_DIR = "journalDirectory";
     protected final static String JOURNAL_DIRS = "journalDirectories";
@@ -566,6 +567,31 @@ public class ServerConfiguration extends AbstractConfiguration {
      */
     public ServerConfiguration setAllowLoopback(boolean allow) {
         this.setProperty(ALLOW_LOOPBACK, allow);
+        return this;
+    }
+
+    /**
+     * Is the bookie allowed to use an ephemeral port (port 0) as its server port.
+     *
+     * <p>By default, an ephemeral port is not allowed. Using an ephemeral port
+     * as the service port usually indicates a configuration error. However, in unit
+     * tests, using ephemeral port will address port conflicts problem and allow
+     * running tests in parallel.
+     *
+     * @return whether is allowed to use an ephemeral port.
+     */
+    public boolean getAllowEphemeralPorts() {
+        return this.getBoolean(ALLOW_EPHEMERAL_PORTS, false);
+    }
+
+    /**
+     * Configure the bookie to allow using an ephemeral port.
+     *
+     * @param allow whether to allow using an ephemeral port.
+     * @return server configuration
+     */
+    public ServerConfiguration setAllowEphemeralPorts(boolean allow) {
+        this.setProperty(ALLOW_EPHEMERAL_PORTS, allow);
         return this;
     }
 
@@ -1931,6 +1957,9 @@ public class ServerConfiguration extends AbstractConfiguration {
         if (getEntryLogSizeLimit() > BookKeeperConstants.MAX_LOG_SIZE_LIMIT) {
             throw new ConfigurationException("Entry log file size should not be larger than "
                     + BookKeeperConstants.MAX_LOG_SIZE_LIMIT);
+        }
+        if (0 == getBookiePort() && !getAllowEphemeralPorts()) {
+            throw new ConfigurationException("Invalid port specified, using ephemeral ports accidentally?");
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -83,7 +83,7 @@ class BookieNettyServer {
     final ServerConfiguration conf;
     final EventLoopGroup eventLoopGroup;
     final EventLoopGroup jvmEventLoopGroup;
-    final RequestProcessor requestProcessor;
+    RequestProcessor requestProcessor;
     final AtomicBoolean isRunning = new AtomicBoolean(false);
     final AtomicBoolean isClosed = new AtomicBoolean(false);
     final Object suspensionLock = new Object();
@@ -140,6 +140,11 @@ class BookieNettyServer {
         listenOn(bindAddress, bookieAddress);
     }
 
+    public BookieNettyServer setRequestProcessor(RequestProcessor processor) {
+        this.requestProcessor = processor;
+        return this;
+    }
+
     boolean isRunning() {
         return isRunning.get();
     }
@@ -175,7 +180,8 @@ class BookieNettyServer {
         }
     }
 
-    private void listenOn(InetSocketAddress address, BookieSocketAddress bookieAddress) throws InterruptedException {
+    private void listenOn(InetSocketAddress address, BookieSocketAddress bookieAddress)
+            throws InterruptedException {
         if (!conf.isDisableServerSocketBind()) {
             ServerBootstrap bootstrap = new ServerBootstrap();
             bootstrap.childOption(ChannelOption.ALLOCATOR, new PooledByteBufAllocator(true));
@@ -219,7 +225,12 @@ class BookieNettyServer {
             });
 
             // Bind and start to accept incoming connections
-            bootstrap.bind(address.getAddress(), address.getPort()).sync();
+            Channel listen = bootstrap.bind(address.getAddress(), address.getPort()).sync().channel();
+            if (listen.localAddress() instanceof InetSocketAddress) {
+                if (conf.getBookiePort() == 0) {
+                    conf.setBookiePort(((InetSocketAddress) listen.localAddress()).getPort());
+                }
+            }
         }
 
         if (conf.isEnableLocalTransport()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -94,10 +94,11 @@ public class BookieServer {
             BookieException, UnavailableException, CompatibilityException {
         this.conf = conf;
         this.statsLogger = statsLogger;
+        this.nettyServer = new BookieNettyServer(this.conf, null);
         this.bookie = newBookie(conf);
         this.requestProcessor = new BookieRequestProcessor(conf, bookie,
                 statsLogger.scope(SERVER_SCOPE));
-        this.nettyServer = new BookieNettyServer(this.conf, requestProcessor);
+        this.nettyServer.setRequestProcessor(this.requestProcessor);
         isAutoRecoveryDaemonEnabled = conf.isAutoRecoveryDaemonEnabled();
         if (isAutoRecoveryDaemonEnabled) {
             this.autoRecoveryMain = new AutoRecoveryMain(conf, statsLogger.scope(REPLICATION_SCOPE));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
@@ -1,0 +1,31 @@
+package org.apache.bookkeeper.conf;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link ServerConfiguration}.
+ */
+public class TestServerConfiguration {
+
+    @Test
+    public void testEphemeralPortsAllowed() throws ConfigurationException {
+        ServerConfiguration conf = new ServerConfiguration();
+        conf.setAllowEphemeralPorts(true);
+        conf.setBookiePort(0);
+
+        conf.validate();
+        assertTrue(true);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testEphemeralPortsDisallowed() throws ConfigurationException {
+        ServerConfiguration conf = new ServerConfiguration();
+        conf.setAllowEphemeralPorts(false);
+        conf.setBookiePort(0);
+        conf.validate();
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
@@ -1,3 +1,24 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 package org.apache.bookkeeper.conf;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Descriptions of the changes in this PR:

- add a flag to allow/disable using ephemeral ports
- change the initialization sequence to support ephmeral port
- added two tests on verifying this behavior
