### PR TITLE
Issue-299 EnsemblePlacementPolicy in 4.5 is not compatible with 4.4 clients

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultEnsemblePlacementPolicy.java
@@ -61,7 +61,7 @@ public class DefaultEnsemblePlacementPolicy implements EnsemblePlacementPolicy {
     }
 
     @Override
-    public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize, int quorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Set<BookieSocketAddress> excludeBookies) throws BKNotEnoughBookiesException {
+    public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize, int quorumSize, Set<BookieSocketAddress> excludeBookies) throws BKNotEnoughBookiesException {
         ArrayList<BookieSocketAddress> newBookies = new ArrayList<BookieSocketAddress>(ensembleSize);
         if (ensembleSize <= 0) {
             return newBookies;
@@ -110,9 +110,9 @@ public class DefaultEnsemblePlacementPolicy implements EnsemblePlacementPolicy {
     }
 
     @Override
-    public BookieSocketAddress replaceBookie(int ensembleSize, int writeQuorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Collection<BookieSocketAddress> currentEnsemble, BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies) throws BKNotEnoughBookiesException {
-        excludeBookies.addAll(currentEnsemble);
-        ArrayList<BookieSocketAddress> addresses = newEnsemble(1, 1, 1, customMetadata, excludeBookies);
+    public BookieSocketAddress replaceBookie(BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies)
+        throws BKNotEnoughBookiesException {
+        ArrayList<BookieSocketAddress> addresses = newEnsemble(1, 1, excludeBookies);
         return addresses.get(0);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/GenericEnsemblePlacementPolicyTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/GenericEnsemblePlacementPolicyTest.java
@@ -132,9 +132,9 @@ public class GenericEnsemblePlacementPolicyTest extends BookKeeperClusterTestCas
                     lh.addEntry(value);
                 }
             }
-            assertEquals(2, customMetadataOnNewEnsembleStack.size());
+            assertEquals(1, customMetadataOnNewEnsembleStack.size());
             assertArrayEquals(value, customMetadataOnNewEnsembleStack.get(0).get(property));
-            // replaceBookie by default calls newEnsemble, so newEnsemble gets called twice
+            // replaceBookie by default calls legacy 4.4 newEnsemble
             assertArrayEquals(value, customMetadataOnNewEnsembleStack.get(0).get(property));
 
             assertEquals(1, customMetadataOnReplaceBookieStack.size());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LegacyCustomDefaultEnsemblePlacementPolicyTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LegacyCustomDefaultEnsemblePlacementPolicyTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test that policies which extended DefaultEnsemblePlacementPolicy of BookKeeper 4.4 work with current version
+ * @author enrico.olivelli
+ */
+public class LegacyCustomDefaultEnsemblePlacementPolicyTest extends BookKeeperClusterTestCase {
+
+    private BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
+    private static final String PASSWORD = "testPasswd";
+    private static final String property = "foo";
+    private static final byte[] value = "bar".getBytes(StandardCharsets.UTF_8);
+    private static AtomicBoolean legacyNewEnsembleMethodCalled = new AtomicBoolean(false);
+    private static AtomicBoolean legacyReplaceBookieMethodCalled = new AtomicBoolean(false);
+
+    public LegacyCustomDefaultEnsemblePlacementPolicyTest() {
+        super(0);
+        baseClientConf.setEnsemblePlacementPolicy(Custom44ClientEnsemblePlacementPolicy.class);
+    }
+
+    public static final class Custom44ClientEnsemblePlacementPolicy extends DefaultEnsemblePlacementPolicy {
+
+        @Override
+        public BookieSocketAddress replaceBookie(BookieSocketAddress bookieToReplace,
+            Set<BookieSocketAddress> excludeBookies) throws BKException.BKNotEnoughBookiesException {
+            legacyReplaceBookieMethodCalled.set(true);
+            return super.replaceBookie(bookieToReplace, excludeBookies);
+        }
+
+        @Override
+        public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize, int quorumSize, Set<BookieSocketAddress> excludeBookies) throws BKException.BKNotEnoughBookiesException {
+            legacyNewEnsembleMethodCalled.set(true);
+            return super.newEnsemble(ensembleSize, quorumSize, excludeBookies);
+        }
+
+    }
+
+    @Before
+    public void reset() {
+        legacyReplaceBookieMethodCalled.set(false);
+        legacyNewEnsembleMethodCalled.set(false);
+    }
+
+    @Test(timeout = 60000)
+    public void testNewEnsemble() throws Exception {
+        numBookies = 1;
+        startBKCluster();
+        try {
+            Map<String, byte[]> customMetadata = new HashMap<>();
+            customMetadata.put(property, value);
+            try (BookKeeper bk = new BookKeeper(baseClientConf, zkc)) {
+                bk.createLedger(1, 1, 1, digestType, PASSWORD.getBytes(), customMetadata);
+            }
+            Assert.assertTrue(legacyNewEnsembleMethodCalled.get());
+        } finally {
+            stopBKCluster();
+        }
+    }
+
+    @Test(timeout = 60000)
+    public void testReplaceBookie() throws Exception {
+        numBookies = 3;
+        startBKCluster();
+        try {
+            Map<String, byte[]> customMetadata = new HashMap<>();
+            customMetadata.put(property, value);
+            try (BookKeeper bk = new BookKeeper(baseClientConf, zkc)) {
+                try (LedgerHandle lh = bk.createLedger(2, 2, 2, digestType, PASSWORD.getBytes(), customMetadata)) {
+                    lh.addEntry(value);
+                    long lId = lh.getId();
+                    ArrayList<BookieSocketAddress> ensembleAtFirstEntry = lh.getLedgerMetadata().getEnsemble(lId);
+                    assertEquals(2, ensembleAtFirstEntry.size());
+                    killBookie(ensembleAtFirstEntry.get(0));
+                    lh.addEntry(value);
+                }
+            }
+            Assert.assertTrue(legacyReplaceBookieMethodCalled.get());
+        } finally {
+            stopBKCluster();
+        }
+    }
+
+}


### PR DESCRIPTION
Introduce overloaded methods in EnsemblePlacementPolicy in order to handle compatibility with 4.4 clients.
Modify DefaultEnsemblePlacementPolicy in order to let legacy EnsemblePlacementPolicy which extended DefaultEnsemblePlacementPolicy to work as expected

see issue #299 