### PR TITLE
BOOKKEEPER-1103: Fix LedgerMetadataCreateTest random id loop

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerMetadataCreationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerMetadataCreationTest.java
@@ -76,8 +76,8 @@ public class LedgerMetadataCreationTest extends LedgerManagerTestCase {
                     long ledgerId = -1;
                     try {
                         if (randomLedgerId) {
-                            ledgerId = Math.abs(rand.nextLong());
                             do {
+                                ledgerId = Math.abs(rand.nextLong());
                                 if (!baseClientConf.getLedgerManagerFactoryClass()
                                         .equals(LongHierarchicalLedgerManagerFactory.class)) {
                                     /*


### PR DESCRIPTION
The previous version would loop indefinitely upon collision.

Signed-off-by: Samuel Just <sjust@salesforce.com>