### PR TITLE
Issue-308 LocalBookKeeper.java rethrow Exception in case of failed boot

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -298,9 +298,9 @@ public class LocalBookKeeper {
                 throw ie;
             }
         } catch (Exception e) {
-                LOG.error("Failed to run {} bookies : zk ensemble = '{}:{}'",
-                    new Object[] { numBookies, zkHost, zkPort, e });
-                throw e;
+            LOG.error("Failed to run {} bookies : zk ensemble = '{}:{}'",
+                new Object[] { numBookies, zkHost, zkPort, e });
+            throw e;
         } finally {
             if (stopOnExit) {
                 cleanupDirectories(bkTmpDirs);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -297,9 +297,6 @@ public class LocalBookKeeper {
                 }
                 throw ie;
             }
-        } catch (Exception e) {
-            LOG.error("Failed to run {} bookies : zk ensemble = '{}:{}'",
-                new Object[] { numBookies, zkHost, zkPort, e });
         } finally {
             if (stopOnExit) {
                 cleanupDirectories(bkTmpDirs);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -297,6 +297,10 @@ public class LocalBookKeeper {
                 }
                 throw ie;
             }
+        } catch (Exception e) {
+                LOG.error("Failed to run {} bookies : zk ensemble = '{}:{}'",
+                    new Object[] { numBookies, zkHost, zkPort, e });
+                throw e;
         } finally {
             if (stopOnExit) {
                 cleanupDirectories(bkTmpDirs);


### PR DESCRIPTION
Do not swallow generic Exceptions during the boot of LocalBookKeeper and let the caller handle errors