### PR TITLE
BOOKKEEPER-1104: Fix testWithDiskFullAndAbilityToCreateNewIndexFile

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -468,7 +468,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
 
         long usableSpace = tmpDir.getUsableSpace();
         long totalSpace = tmpDir.getTotalSpace();
-        conf.setDiskUsageThreshold((1.0f - ((float) usableSpace / (float) totalSpace)) * 0.999f)
+        conf.setDiskUsageThreshold(0.001f)
                 .setDiskUsageWarnThreshold(0.0f).setReadOnlyModeEnabled(true).setIsForceGCAllowWhenNoSpace(true)
                 .setMinUsableSizeForIndexFileCreation(Long.MAX_VALUE);
         server = new BookieServer(conf);


### PR DESCRIPTION
The usage threshhold was chosen to be very close to the actual disk
usage at test time.  This made the test unnecessarily fragile in the
case that there other things concurrently using the disk.  Since we
aren't really testing that here, simply set the threshhold to be really
low.

Signed-off-by: Samuel Just <sjust@salesforce.com>