### PR TITLE
Issue-316 BookKeeperTest#testReadEntryReleaseByteBufs is failing

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -823,12 +823,12 @@ public class BookKeeperTest extends BaseTestCase {
                     try {
                         entry.getEntry();
                         fail("entry data accessed twice");
-                    } catch (IllegalStateException ok){
+                    } catch (NullPointerException ok){
                     }
                     try {
                         entry.getEntryInputStream();
                         fail("entry data accessed twice");
-                    } catch (IllegalStateException ok){
+                    } catch (NullPointerException ok){
                     }
                 }
             }


### PR DESCRIPTION
Change the assertion in BookKeeperTest#testReadEntryReleaseByteBufs: expect a NullPointerException instead of a IllegalStateException