### PR TITLE
Address the problem on merging #183

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -142,6 +142,7 @@ class BookieNettyServer {
         } else {
             bindAddress = bookieAddress.getSocketAddress();
         }
+        listenOn(bindAddress, bookieAddress);
     }
 
     public BookieNettyServer setRequestProcessor(RequestProcessor processor) {
@@ -374,7 +375,6 @@ class BookieNettyServer {
     }
 
     void start() throws InterruptedException {
-        listenOn(bindAddress, bookieAddress);
         isRunning.set(true);
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

listenOn should be running in constructing netty server. because we use binding to prevent two bookies start at the same time. #183 