### PR TITLE
Issue 351: Apache rat check failed on master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,7 @@
             <exclude>**/.project</exclude>
             <exclude>**/.settings/*</exclude>
             <exclude>site/**</exclude>
+            <exclude>**/cacerts</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Descriptions of the changes in this PR:

Excludes cacerts from apache-rat check