### PR TITLE
Issue 351: Apache rat check failed on master

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -342,6 +342,7 @@
             <exclude>certs/keyStoreClientPassword.txt</exclude>
             <exclude>certs/keyStoreServerPassword.txt</exclude>
             <exclude>certs/trustStorePassword.txt</exclude>
+            <exclude>src/test/resources/cacerts</exclude>
             <exclude>src/test/resources/keyStoreClientPassword.txt</exclude>
             <exclude>src/test/resources/keyStoreServerPassword.txt</exclude>
             <exclude>src/test/resources/trustStorePassword.txt</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,6 @@
             <exclude>**/.project</exclude>
             <exclude>**/.settings/*</exclude>
             <exclude>site/**</exclude>
-            <exclude>**/cacerts</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,7 @@
             <exclude>**/.project</exclude>
             <exclude>**/.settings/*</exclude>
             <exclude>site/**</exclude>
+            <exclude>**/cacerts</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Descriptions of the changes in this PR:

This fix on #352 was adding the exclusion rule in wrong location. this fix is to address that.