### PR TITLE
Issue #372: Allow to configure advertised address in bookies

### DIFF
--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -56,8 +56,9 @@ journalDirectory=/tmp/bk-txn
 # If not set, the bookie will listen on all interfaces.
 # listeningInterface=eth0
 
-# Configure a specific hostname or IP address that the bookie
-# should use to advertise itself to clients
+# Configure a specific hostname or IP address that the bookie should use to advertise itself to
+# clients. If not set, bookie will advertised its own IP address or hostname, depending on the
+# listeningInterface and `seHostNameAsBookieID settings.
 # advertisedAddress=
 
 # Whether the bookie allowed to use a loopback interface as its primary

--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -56,6 +56,10 @@ journalDirectory=/tmp/bk-txn
 # If not set, the bookie will listen on all interfaces.
 # listeningInterface=eth0
 
+# Configure a specific hostname or IP address that the bookie
+# should use to advertise itself to clients
+# advertisedAddress=
+
 # Whether the bookie allowed to use a loopback interface as its primary
 # interface(i.e. the interface it uses to establish its identity)?
 # By default, loopback interfaces are not allowed as the primary

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -586,6 +586,10 @@ public class Bookie extends BookieCriticalThread {
         if (conf.getUseHostNameAsBookieID()) {
             hostAddress = inetAddr.getAddress().getCanonicalHostName();
         }
+
+        if (conf.getAdvertisedAddress() != null && conf.getAdvertisedAddress().trim().length() > 0) {
+            hostAddress = conf.getAdvertisedAddress().trim();
+        }
         BookieSocketAddress addr =
                 new BookieSocketAddress(hostAddress, conf.getBookiePort());
         if (addr.getSocketAddress().getAddress().isLoopbackAddress()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -572,6 +572,13 @@ public class Bookie extends BookieCriticalThread {
      */
     public static BookieSocketAddress getBookieAddress(ServerConfiguration conf)
             throws UnknownHostException {
+        // Advertised address takes precedence over the listening interface and the
+        // useHostNameAsBookieID settings
+        if (conf.getAdvertisedAddress() != null && conf.getAdvertisedAddress().trim().length() > 0) {
+            String hostAddress = conf.getAdvertisedAddress().trim();
+            return new BookieSocketAddress(hostAddress, conf.getBookiePort());
+        }
+
         String iface = conf.getListeningInterface();
         if (iface == null) {
             iface = "default";
@@ -587,9 +594,6 @@ public class Bookie extends BookieCriticalThread {
             hostAddress = inetAddr.getAddress().getCanonicalHostName();
         }
 
-        if (conf.getAdvertisedAddress() != null && conf.getAdvertisedAddress().trim().length() > 0) {
-            hostAddress = conf.getAdvertisedAddress().trim();
-        }
         BookieSocketAddress addr =
                 new BookieSocketAddress(hostAddress, conf.getBookiePort());
         if (addr.getSocketAddress().getAddress().isLoopbackAddress()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -82,6 +82,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     protected final static String BOOKIE_PORT = "bookiePort";
     protected final static String LISTENING_INTERFACE = "listeningInterface";
     protected final static String ALLOW_LOOPBACK = "allowLoopback";
+    protected final static String ADVERTISED_ADDRESS = "advertisedAddress";
     protected final static String ALLOW_EPHEMERAL_PORTS = "allowEphemeralPorts";
 
     protected final static String JOURNAL_DIR = "journalDirectory";
@@ -575,6 +576,35 @@ public class ServerConfiguration extends AbstractConfiguration {
      */
     public ServerConfiguration setAllowLoopback(boolean allow) {
         this.setProperty(ALLOW_LOOPBACK, allow);
+        return this;
+    }
+
+    /**
+     * Get the configured advertised address for the bookie.
+     *
+     * @see #setAdvertisedAddress(String)
+     * @return the configure address to be advertised
+     */
+    public String getAdvertisedAddress() {
+        return this.getString(ADVERTISED_ADDRESS, null);
+    }
+
+    /**
+     * Configure the bookie to advertise a specific address.
+     *
+     * By default, a bookie will advertise either its own IP or hostname,
+     * depending on the {@link getUseHostNameAsBookieID()} setting.
+     *
+     * When the advertised is set to a non-empty string, the bookie will
+     * register and advertise using this address.
+     *
+     * @see #getAdvertisedAddress()
+     * @param allow
+     *            whether to allow loopback interfaces
+     * @return server configuration
+     */
+    public ServerConfiguration setAdvertisedAddress(String advertisedAddress) {
+        this.setProperty(ADVERTISED_ADDRESS, advertisedAddress);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -582,6 +582,10 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Get the configured advertised address for the bookie.
      *
+     * If present, this setting will take precedence over the
+     * {@link #setListeningInterface(String)} and
+     * {@link #setUseHostNameAsBookieID(boolean)}.
+     *
      * @see #setAdvertisedAddress(String)
      * @return the configure address to be advertised
      */
@@ -597,6 +601,10 @@ public class ServerConfiguration extends AbstractConfiguration {
      *
      * When the advertised is set to a non-empty string, the bookie will
      * register and advertise using this address.
+     *
+     * If present, this setting will take precedence over the
+     * {@link #setListeningInterface(String)} and
+     * {@link #setUseHostNameAsBookieID(boolean)}.
      *
      * @see #getAdvertisedAddress()
      * @param allow

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/AdvertisedAddressTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/AdvertisedAddressTest.java
@@ -1,0 +1,100 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.test.PortManager;
+import org.apache.bookkeeper.util.IOUtils;
+import org.junit.Test;
+
+public class AdvertisedAddressTest extends BookKeeperClusterTestCase {
+    final int bookiePort = PortManager.nextFreePort();
+
+    public AdvertisedAddressTest() {
+        super(0);
+    }
+
+    private String newDirectory(boolean createCurDir) throws IOException {
+        File d = IOUtils.createTempDir("cookie", "tmpdir");
+        if (createCurDir) {
+            new File(d, "current").mkdirs();
+        }
+        tmpDirs.add(d);
+        return d.getPath();
+    }
+
+    /**
+     * Test starting bookie with clean state.
+     */
+    @Test(timeout = 60000)
+    public void testSetAdvertisedAddress() throws Exception {
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+                .setZkServers(zkUtil.getZooKeeperConnectString()).setJournalDirName(newDirectory(false))
+                .setLedgerDirNames(new String[] { newDirectory(false) }).setBookiePort(bookiePort);
+
+        conf.setAdvertisedAddress("10.0.0.1");
+        assertEquals("10.0.0.1", conf.getAdvertisedAddress());
+
+        BookieSocketAddress bkAddress = new BookieSocketAddress("10.0.0.1", bookiePort);
+        assertEquals(bkAddress, Bookie.getBookieAddress(conf));
+
+        Bookie b = new Bookie(conf);
+        b.start();
+
+        BookKeeperAdmin bka = new BookKeeperAdmin(baseClientConf);
+        Collection<BookieSocketAddress> bookies = bka.getAvailableBookies();
+
+        assertEquals(1, bookies.size());
+        BookieSocketAddress address = bookies.iterator().next();
+        assertEquals(bkAddress, address);
+
+        b.shutdown();
+        bka.close();
+    }
+
+    /**
+     * When advertised address is specified, it should override the use
+     */
+    @Test(timeout = 60000)
+    public void testBothUseHostnameAndAdvertisedAddress() throws Exception {
+        ServerConfiguration conf = new ServerConfiguration().setBookiePort(bookiePort);
+
+        conf.setAdvertisedAddress("10.0.0.1");
+        conf.setUseHostNameAsBookieID(true);
+
+        assertEquals("10.0.0.1", conf.getAdvertisedAddress());
+
+        BookieSocketAddress bkAddress = new BookieSocketAddress("10.0.0.1", bookiePort);
+        assertEquals(bkAddress, Bookie.getBookieAddress(conf));
+    }
+
+}

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -26,6 +26,12 @@ groups:
   - param: listeningInterface
     description: The network interface that the bookie should listen on. If not set, the bookie will listen on all interfaces.
     default: eth0
+  - param: advertisedAddress
+    description: |
+      Configure a specific hostname or IP address that the bookie should use to advertise itself to
+      clients. If not set, bookie will advertised its own IP address or hostname, depending on the
+      `listeningInterface` and `useHostNameAsBookieID` settings.
+    default: eth0
   - param: allowLoopback
     description: |
       Whether the bookie is allowed to use a loopback interface as its primary


### PR DESCRIPTION
Add option to configure advertised address for bookies. 

Reasons for this are outlined in #372 
