### PR TITLE
Issue #377: Make Prometheus stats logger registration idempotent

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusCounter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusCounter.java
@@ -28,7 +28,8 @@ public class PrometheusCounter implements Counter {
     private final Gauge gauge;
 
     public PrometheusCounter(CollectorRegistry registry, String name) {
-        this.gauge = Gauge.build().name(Collector.sanitizeMetricName(name)).help("-").create().register(registry);
+        this.gauge = PrometheusUtil.safeRegister(registry,
+                Gauge.build().name(Collector.sanitizeMetricName(name)).help("-").create());
     }
 
     @Override

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusOpStatsLogger.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusOpStatsLogger.java
@@ -30,17 +30,18 @@ public class PrometheusOpStatsLogger implements OpStatsLogger {
     private final Summary.Child fail;
 
     public PrometheusOpStatsLogger(CollectorRegistry registry, String name) {
-        this.summary = Summary.build().name(name).help("-") //
-                .quantile(0.50, 0.01) //
-                .quantile(0.75, 0.01) //
-                .quantile(0.95, 0.01) //
-                .quantile(0.99, 0.01) //
-                .quantile(0.999, 0.01) //
-                .quantile(0.9999, 0.01) //
-                .quantile(1.0, 0.01) //
-                .maxAgeSeconds(60) //
-                .labelNames("success") //
-                .create().register(registry);
+        this.summary = PrometheusUtil.safeRegister(registry,
+                Summary.build().name(name).help("-") //
+                        .quantile(0.50, 0.01) //
+                        .quantile(0.75, 0.01) //
+                        .quantile(0.95, 0.01) //
+                        .quantile(0.99, 0.01) //
+                        .quantile(0.999, 0.01) //
+                        .quantile(0.9999, 0.01) //
+                        .quantile(1.0, 0.01) //
+                        .maxAgeSeconds(60) //
+                        .labelNames("success") //
+                        .create());
 
         this.success = summary.labels("true");
         this.fail = summary.labels("false");

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusStatsLogger.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusStatsLogger.java
@@ -45,8 +45,8 @@ public class PrometheusStatsLogger implements StatsLogger {
 
     @Override
     public <T extends Number> void registerGauge(String name, Gauge<T> gauge) {
-        io.prometheus.client.Gauge.build().name(completeName(name)).help("-").create()
-                .setChild(new io.prometheus.client.Gauge.Child() {
+        PrometheusUtil.safeRegister(registry, io.prometheus.client.Gauge.build().name(completeName(name)).help("-")
+                .create().setChild(new io.prometheus.client.Gauge.Child() {
                     @Override
                     public double get() {
                         Number value = null;
@@ -61,7 +61,7 @@ public class PrometheusStatsLogger implements StatsLogger {
                         }
                         return value.doubleValue();
                     }
-                }).register(registry);
+                }));
     }
 
     @Override

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusUtil.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusUtil.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.bookkeeper.stats;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Container for Prometheus utility methods.
+ *
+ */
+public class PrometheusUtil {
+
+    private static final Field collectorsMapField;
+    private static final Method collectorsNamesMethod;
+
+    static {
+        try {
+            collectorsMapField = CollectorRegistry.class.getDeclaredField("namesToCollectors");
+            collectorsMapField.setAccessible(true);
+
+            collectorsNamesMethod = CollectorRegistry.class.getDeclaredMethod("collectorNames", String.class);
+            collectorsNamesMethod.setAccessible(true);
+
+        } catch (NoSuchFieldException | SecurityException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Collector> T safeRegister(CollectorRegistry registry, T collector) {
+        try {
+            registry.register(collector);
+            return collector;
+        } catch (IllegalArgumentException e) {
+            // Collector is already registered. Return the existing instance
+            try {
+                Map<String, Collector> collectorsMap = (Map<String, Collector>) collectorsMapField.get(registry);
+                List<String> collectorNames = (List<String>) collectorsNamesMethod.invoke(registry, collector);
+                return (T) collectorsMap.get(collectorNames.get(0));
+
+            } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e1) {
+                throw new RuntimeException(e1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Make sure the metric are only registered once on Prometheus client lib.

Discusses in #377.