### PR TITLE
Issue-376 Skip getSysFileDescriptor if JournalRemovePagesFromCache=false

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -214,7 +214,9 @@ class JournalChannel implements Closeable {
                 LOG.error("Bookie journal file can seek to position :", e);
             }
         }
-        this.fd = NativeIO.getSysFileDescriptor(randomAccessFile.getFD());
+        if (fRemoveFromPageCache) {
+            this.fd = NativeIO.getSysFileDescriptor(randomAccessFile.getFD());
+        }
     }
 
     int getFormatVersion() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -216,6 +216,8 @@ class JournalChannel implements Closeable {
         }
         if (fRemoveFromPageCache) {
             this.fd = NativeIO.getSysFileDescriptor(randomAccessFile.getFD());
+        } else {
+            this.fd = -1;
         }
     }
 


### PR DESCRIPTION
Skip illegal reflective calls if not needed, this way the Bookie will run on Java9 cleanly

We need to access internals of FileDescriptor class only if JournalRemovePagesFromCache=true.
This change will allow to run the bookie on Java9 just by using JournalRemovePagesFromCache=false.

see #376 