### PR TITLE
Issue 381: update old releases url to achives

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -7,7 +7,6 @@ bk_version: "4.5.0"
 baseurl: /
 destination: local-generated
 twitter_url: https://twitter.com/asfbookkeeper
-archived_releases_url: //bookkeeper.apache.org/docs/r
 
 livereload: true
 

--- a/site/_data/cli/shell.yaml
+++ b/site/_data/cli/shell.yaml
@@ -53,11 +53,11 @@ commands:
   description: List the bookies, which are running as either readwrite or readonly mode.
   options:
   - flag: -readwrite
-  description: Print readwrite bookies
+    description: Print readwrite bookies
   - flag: -readonly
-  description: Print readonly bookies
+    description: Print readonly bookies
   - flag: -hostnames
-  description: Also print hostname of the bookie
+    description: Also print hostname of the bookie
 - name: listfilesondisc
   description: List the files in JournalDirectory/LedgerDirectories/IndexDirectories.
   options:
@@ -119,13 +119,12 @@ commands:
     description: End Position
 - name: recover
   description: Recover the ledger data for failed bookie.
-  argument: [-deleteCookie] <bookieSrc> [bookieDest]
+  argument: <bookieSrc> [<bookieDest>]
   options:
   - flag: -deleteCookie
     description: Delete cookie node for the bookie.
 - name: simpletest
   description: Simple test to create a ledger and write entries to it.
-  argument: [-ensemble N] [-writeQuorum N] [-ackQuorum N] [-numEntries N]
   options:
   - flag: -ensemble N
     description: Ensemble size (default 3)
@@ -148,10 +147,10 @@ commands:
   - flag: -bookieId <hostname|ip>
     description: Bookie Id
   - flag: -updatespersec N
-    description: Number of ledgers updating per second (default: 5 per sec)
+    description: Number of ledgers updating per second (default 5 per sec)
   - flag: -limit N
-    description: Maximum number of ledgers to update (default: no limit)
+    description: Maximum number of ledgers to update (default no limit)
   - flag: -verbose
-    description: Print status of the ledger updation (default: false)
+    description: Print status of the ledger updation (default false)
   - flag: -printprogress N
-    description: Print messages on every configured seconds if verbose turned on (default: 10 secs)
+    description: Print messages on every configured seconds if verbose turned on (default 10 secs)

--- a/site/_includes/navbar.html
+++ b/site/_includes/navbar.html
@@ -46,7 +46,7 @@
           </a>
           <hr class="dropdown-divider">
           {% for version in site.archived_versions %}
-          <a class="navbar-item" href="{{ site.archived_releases_url }}{{version}}">
+          <a class="navbar-item" href="{{ site.baseurl }}archives/docs/r{{version}}">
             Release {{version}}
             {% if version == site.stable_release %}<span class="tag is-success">Stable</span>{% endif %}
           </a>

--- a/site/scripts/publish-website.sh
+++ b/site/scripts/publish-website.sh
@@ -29,17 +29,20 @@ echo "ORIGIN_REPO: $ORIGIN_REPO"
 (
   cd $APACHE_GENERATED_DIR
 
-  git init
+  rm -rf $TMP_DIR
+  mkdir -p $TMP_DIR
+  cd $TMP_DIR
+
+  # clone the remote repo
+  git clone "https://$ORIGIN_REPO" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
-
-  git remote add upstream "https://$ORIGIN_REPO"
-  git fetch upstream
-  git reset upstream/asf-site
-
-  touch .
+  # copy the apache generated dir
+  cp -r $APACHE_GENERATED_DIR/* $TMP_DIR/content
 
   git add -A .
   git commit -m "Updated site at revision $REVISION"
-  git push -q upstream HEAD:asf-site
+  git push -q origin HEAD:asf-site
+
+  rm -rf $TMP_DIR
 )

--- a/site/scripts/staging-website.sh
+++ b/site/scripts/staging-website.sh
@@ -29,20 +29,17 @@ echo "GENERATE SITE DIR: $LOCAL_GENERATED_DIR"
 (
   rm -rf $TMP_DIR
   mkdir -p $TMP_DIR
-  cp -r $LOCAL_GENERATED_DIR $TMP_DIR/docs
+
   cd $TMP_DIR
 
-  git init
-
-  git remote add upstream "https://$STAGING_REPO"
-  git fetch upstream
-  git reset upstream/master
-
-  touch .
+  # clone the remote repo
+  git clone "https://$STAGING_REPO" .
+  # copy the local generated dir
+  cp -r $LOCAL_GENERATED_DIR/* $TMP_DIR/docs/*
 
   git add -A .
   git commit -m "Updated site at revision $REVISION"
-  git push -q upstream HEAD:master
+  git push -q origin HEAD:master
 
   rm -rf $TMP_DIR
 )

--- a/site/scripts/staging-website.sh
+++ b/site/scripts/staging-website.sh
@@ -35,7 +35,7 @@ echo "GENERATE SITE DIR: $LOCAL_GENERATED_DIR"
   # clone the remote repo
   git clone "https://$STAGING_REPO" .
   # copy the local generated dir
-  cp -r $LOCAL_GENERATED_DIR/* $TMP_DIR/docs/*
+  cp -r $LOCAL_GENERATED_DIR/* $TMP_DIR/docs/
 
   git add -A .
   git commit -m "Updated site at revision $REVISION"


### PR DESCRIPTION
Descriptions of the changes in this PR:

- the cms content has been copied from cms to asf-site branch under /content/archives. it is available under http://bookkeeper.apache.org/test/content/archives/
- update the release url from 'bookkeeper.apache.org/docs/rx.y.z' to '{{ site.baseurl }}achives/rx.y.z'

scripts:

- update the scripts to use clone and copy to avoid trash everything in remote. this would prevent overwrite `archives` directory.

content:

- fix syntax error in `shell.yaml` to be able to build website