### PR TITLE
Issue 383: mvn release:branch fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,9 +141,9 @@
           <source>1.8</source>
           <target>1.8</target>
           <compilerArguments>
-            <Werror />
-            <Xlint:deprecation />
-            <Xlint:unchecked />
+            <compilerArg>Werror</compilerArg>
+            <compilerArg>Xlint:deprecation</compilerArg>
+            <compilerArg>Xlint:unchecked</compilerArg>
 	  </compilerArguments>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -141,9 +141,9 @@
           <source>1.8</source>
           <target>1.8</target>
           <compilerArgs>
-            <compilerArg>Werror</compilerArg>
-            <compilerArg>Xlint:deprecation</compilerArg>
-            <compilerArg>Xlint:unchecked</compilerArg>
+            <compilerArg>-Werror</compilerArg>
+            <compilerArg>-Xlint:deprecation</compilerArg>
+            <compilerArg>-Xlint:unchecked</compilerArg>
 	  </compilerArgs>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -140,11 +140,11 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
-          <compilerArguments>
+          <compilerArgs>
             <compilerArg>Werror</compilerArg>
             <compilerArg>Xlint:deprecation</compilerArg>
             <compilerArg>Xlint:unchecked</compilerArg>
-	  </compilerArguments>
+	  </compilerArgs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Descriptions of the changes in this PR:

- change `compilerArguments` to `compilerArgs`
- use `compilerArg` for configuring the arguments for compilation.