### PR TITLE
Issue 393: [CI] publish-website job will be marked as failure if it is an empty commit

### DIFF
--- a/site/scripts/publish-website.sh
+++ b/site/scripts/publish-website.sh
@@ -20,7 +20,6 @@
 
 # NOTE: this is the script used by CI to push to apache. If you are looking for
 #       staging the changes, try the `staging-website.sh` script.
-
 source scripts/common.sh
 
 ORIGIN_REPO=$(git remote show origin | grep 'Push  URL' | awk -F// '{print $NF}')
@@ -37,12 +36,12 @@ echo "ORIGIN_REPO: $ORIGIN_REPO"
   git clone "https://$ORIGIN_REPO" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
+  git checkout asf-site
   # copy the apache generated dir
-  cp -r $APACHE_GENERATED_DIR/* $TMP_DIR/content
+  cp -r $APACHE_GENERATED_DIR/content/* $TMP_DIR/content
 
   git add -A .
-  git commit -m "Updated site at revision $REVISION"
-  git push -q origin HEAD:asf-site
+  git diff-index --quiet HEAD || (git commit -m "Updated site at revision $REVISION" && git push -q origin HEAD:asf-site)
 
   rm -rf $TMP_DIR
 )


### PR DESCRIPTION
Descriptions of the changes in this PR:

- use `git diff-index` to checkout if there is any changes to commit or not
- port some changes from CI back to script.