### PR TITLE
Issue 397: [CI] publish-website job failed when mvn:release bump version to 4.6.0-SNAPSHOT

### DIFF
--- a/site/scripts/javadoc-gen.sh
+++ b/site/scripts/javadoc-gen.sh
@@ -5,6 +5,6 @@ source scripts/common.sh
 (
   rm -rf $JAVADOC_GEN_DIR $JAVADOC_DEST_DIR
   cd $ROOT_DIR
-  mvn compile javadoc:aggregate
+  mvn clean install javadoc:aggregate -DskipTests
   mv $JAVADOC_GEN_DIR $JAVADOC_DEST_DIR
 )


### PR DESCRIPTION
Descriptions of the changes in this PR:

Use `mvn install` rather than `mvn compile`