### PR TITLE
Fix zkCli issue

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -59,7 +59,7 @@ echo "wait for zookeeper"
 until /opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server ${BK_zkServers} ls /; do sleep 5; done
 
 echo "create the zk root dir for bookkeeper"
-/opt/zk/bin/zkCli.sh -server ${BK_zkServers} create ${BK_CLUSTER_ROOT_PATH}
+/opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server ${BK_zkServers} create ${BK_CLUSTER_ROOT_PATH}
 
 echo "format zk metadata"
 echo "please ignore the failure, if it has already been formatted, "


### PR DESCRIPTION
Descriptions of the changes in this PR:
/opt/zk/bin/zkCli.sh was leaked to replace by /opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain and cause:

/opt/bookkeeper/entrypoint.sh: line 61: /opt/zk/bin/zkCli.sh: No such file or directory