### PR TITLE
Flip apache baseurl from `/test/content` to `/`

### DIFF
--- a/site/_config.apache.yml
+++ b/site/_config.apache.yml
@@ -1,2 +1,2 @@
-baseurl: /test/content/
+baseurl: /
 destination: generated_site/content


### PR DESCRIPTION
Descriptions of the changes in this PR:

INFRA is cutting the bookkeeper website from CMS to git. we need to flip '/test/content' to '/'.