### PR TITLE
Issue 412: css and js files are broken in `archives` links

### DIFF
--- a/content/archives/bylaws.html
+++ b/content/archives/bylaws.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Apache BookKeeper Project Bylaws</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -213,6 +213,6 @@ minimum length of time that a vote must remain open, measured in business days. 
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/credits.html
+++ b/content/archives/credits.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Credits</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookieConfigParams.html
+++ b/content/archives/docs/master/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -177,6 +177,6 @@ longs. This parameter should <em>not</em> be modified unless you know what you'r
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookieRecovery.html
+++ b/content/archives/docs/master/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperConfig.html
+++ b/content/archives/docs/master/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperConfigParams.html
+++ b/content/archives/docs/master/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperInternals.html
+++ b/content/archives/docs/master/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperJMX.html
+++ b/content/archives/docs/master/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperLedgers2Logs.html
+++ b/content/archives/docs/master/bookkeeperLedgers2Logs.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - From Ledgers to Logs</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -167,6 +167,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperMetadata.html
+++ b/content/archives/docs/master/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperOverview.html
+++ b/content/archives/docs/master/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BookKeeper is to implement a write-ahead transaction log. A s
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperProgrammer.html
+++ b/content/archives/docs/master/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperStarted.html
+++ b/content/archives/docs/master/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperStream.html
+++ b/content/archives/docs/master/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/bookkeeperTutorial.html
+++ b/content/archives/docs/master/bookkeeperTutorial.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookkeeper Client tutorial</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -736,6 +736,6 @@ public class Dice extends LeaderSelectorListenerAdapter implements Closeable {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/doc.html
+++ b/content/archives/docs/master/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigBuild.html
+++ b/content/archives/docs/master/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigConsole.html
+++ b/content/archives/docs/master/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigDesign.html
+++ b/content/archives/docs/master/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigDocs.html
+++ b/content/archives/docs/master/hedwigDocs.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -142,6 +142,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigJMX.html
+++ b/content/archives/docs/master/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigMessageFilter.html
+++ b/content/archives/docs/master/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigMetadata.html
+++ b/content/archives/docs/master/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigParams.html
+++ b/content/archives/docs/master/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/hedwigUser.html
+++ b/content/archives/docs/master/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/index.html
+++ b/content/archives/docs/master/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -123,7 +123,7 @@
 
 <p><strong>Administrators</strong> will be more interested in the <a href="./bookkeeperConfig.html">BookKeeper Admin guide</a>. It describes the steps involved in setting up and maintaining a cluster. The available configuration parameters can be found <a href="./bookieConfigParams.html">here</a>. An important aspect of BookKeeper is how it deals with the failure of storage nodes. This is covered in <a href="./bookieRecovery.html">Bookie Recovery</a>.</p>
 
-<p><strong>Contributor</strong> documentation is less organized, <a href="./bookkeeperInternals.html">BookKeeper Internals</a> is a good place to start. From there you can check out our <a href="https://cwiki.apache.org/confluence/display/BOOKKEEPER/Index">wiki</a> and ask questions on our <a href="/lists.html">mailing lists</a> or <a href="/irc.html"><span class="caps">IRC</span></a>.</p>
+<p><strong>Contributor</strong> documentation is less organized, <a href="./bookkeeperInternals.html">BookKeeper Internals</a> is a good place to start. From there you can check out our <a href="https://cwiki.apache.org/confluence/display/BOOKKEEPER/Index">wiki</a> and ask questions on our <a href="/archives/lists.html">mailing lists</a> or <a href="/irc.html"><span class="caps">IRC</span></a>.</p>
 
 <p>Hedwig documentation can be found <a href="./hedwigDocs.html">here</a>.</p>
 
@@ -173,6 +173,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/master/metastore.html
+++ b/content/archives/docs/master/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/bookieRecovery.html
+++ b/content/archives/docs/r4.0.0/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -154,6 +154,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/bookkeeperConfig.html
+++ b/content/archives/docs/r4.0.0/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -168,6 +168,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.0.0/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -144,6 +144,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/bookkeeperInternals.html
+++ b/content/archives/docs/r4.0.0/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/bookkeeperOverview.html
+++ b/content/archives/docs/r4.0.0/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -304,6 +304,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.0.0/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/bookkeeperStarted.html
+++ b/content/archives/docs/r4.0.0/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -219,6 +219,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/bookkeeperStream.html
+++ b/content/archives/docs/r4.0.0/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/doc.html
+++ b/content/archives/docs/r4.0.0/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/hedwigBuild.html
+++ b/content/archives/docs/r4.0.0/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/hedwigDesign.html
+++ b/content/archives/docs/r4.0.0/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/hedwigUser.html
+++ b/content/archives/docs/r4.0.0/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/index.html
+++ b/content/archives/docs/r4.0.0/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -150,6 +150,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.0.0/releaseNotes.html
+++ b/content/archives/docs/r4.0.0/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -297,6 +297,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookieConfigParams.html
+++ b/content/archives/docs/r4.1.0/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -148,6 +148,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookieRecovery.html
+++ b/content/archives/docs/r4.1.0/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -154,6 +154,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookkeeperConfig.html
+++ b/content/archives/docs/r4.1.0/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -216,6 +216,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.1.0/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookkeeperInternals.html
+++ b/content/archives/docs/r4.1.0/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookkeeperJMX.html
+++ b/content/archives/docs/r4.1.0/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookkeeperOverview.html
+++ b/content/archives/docs/r4.1.0/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.1.0/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookkeeperStarted.html
+++ b/content/archives/docs/r4.1.0/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -219,6 +219,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/bookkeeperStream.html
+++ b/content/archives/docs/r4.1.0/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/doc.html
+++ b/content/archives/docs/r4.1.0/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/hedwigBuild.html
+++ b/content/archives/docs/r4.1.0/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/hedwigConsole.html
+++ b/content/archives/docs/r4.1.0/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/hedwigDesign.html
+++ b/content/archives/docs/r4.1.0/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/hedwigJMX.html
+++ b/content/archives/docs/r4.1.0/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/hedwigUser.html
+++ b/content/archives/docs/r4.1.0/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/index.html
+++ b/content/archives/docs/r4.1.0/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.1.0/releaseNotes.html
+++ b/content/archives/docs/r4.1.0/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -356,6 +356,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookieConfigParams.html
+++ b/content/archives/docs/r4.2.0/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -168,6 +168,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookieRecovery.html
+++ b/content/archives/docs/r4.2.0/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperConfig.html
+++ b/content/archives/docs/r4.2.0/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -274,6 +274,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.2.0/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperInternals.html
+++ b/content/archives/docs/r4.2.0/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperJMX.html
+++ b/content/archives/docs/r4.2.0/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.2.0/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperOverview.html
+++ b/content/archives/docs/r4.2.0/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.2.0/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperStarted.html
+++ b/content/archives/docs/r4.2.0/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/bookkeeperStream.html
+++ b/content/archives/docs/r4.2.0/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/doc.html
+++ b/content/archives/docs/r4.2.0/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/hedwigBuild.html
+++ b/content/archives/docs/r4.2.0/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/hedwigConsole.html
+++ b/content/archives/docs/r4.2.0/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/hedwigDesign.html
+++ b/content/archives/docs/r4.2.0/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/hedwigJMX.html
+++ b/content/archives/docs/r4.2.0/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/hedwigMessageFilter.html
+++ b/content/archives/docs/r4.2.0/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/hedwigMetadata.html
+++ b/content/archives/docs/r4.2.0/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/hedwigParams.html
+++ b/content/archives/docs/r4.2.0/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/hedwigUser.html
+++ b/content/archives/docs/r4.2.0/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/index.html
+++ b/content/archives/docs/r4.2.0/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -174,6 +174,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/metastore.html
+++ b/content/archives/docs/r4.2.0/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.0/releaseNotes.html
+++ b/content/archives/docs/r4.2.0/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -530,6 +530,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookieConfigParams.html
+++ b/content/archives/docs/r4.2.1/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -168,6 +168,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookieRecovery.html
+++ b/content/archives/docs/r4.2.1/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperConfig.html
+++ b/content/archives/docs/r4.2.1/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.2.1/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperInternals.html
+++ b/content/archives/docs/r4.2.1/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperJMX.html
+++ b/content/archives/docs/r4.2.1/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.2.1/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperOverview.html
+++ b/content/archives/docs/r4.2.1/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.2.1/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperStarted.html
+++ b/content/archives/docs/r4.2.1/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/bookkeeperStream.html
+++ b/content/archives/docs/r4.2.1/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/doc.html
+++ b/content/archives/docs/r4.2.1/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/hedwigBuild.html
+++ b/content/archives/docs/r4.2.1/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/hedwigConsole.html
+++ b/content/archives/docs/r4.2.1/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/hedwigDesign.html
+++ b/content/archives/docs/r4.2.1/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/hedwigJMX.html
+++ b/content/archives/docs/r4.2.1/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/hedwigMessageFilter.html
+++ b/content/archives/docs/r4.2.1/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/hedwigMetadata.html
+++ b/content/archives/docs/r4.2.1/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/hedwigParams.html
+++ b/content/archives/docs/r4.2.1/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/hedwigUser.html
+++ b/content/archives/docs/r4.2.1/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/index.html
+++ b/content/archives/docs/r4.2.1/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -174,6 +174,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/metastore.html
+++ b/content/archives/docs/r4.2.1/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.1/releaseNotes.html
+++ b/content/archives/docs/r4.2.1/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -144,6 +144,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookieConfigParams.html
+++ b/content/archives/docs/r4.2.2/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -168,6 +168,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookieRecovery.html
+++ b/content/archives/docs/r4.2.2/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperConfig.html
+++ b/content/archives/docs/r4.2.2/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.2.2/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperInternals.html
+++ b/content/archives/docs/r4.2.2/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperJMX.html
+++ b/content/archives/docs/r4.2.2/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.2.2/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperOverview.html
+++ b/content/archives/docs/r4.2.2/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.2.2/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperStarted.html
+++ b/content/archives/docs/r4.2.2/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/bookkeeperStream.html
+++ b/content/archives/docs/r4.2.2/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/doc.html
+++ b/content/archives/docs/r4.2.2/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/hedwigBuild.html
+++ b/content/archives/docs/r4.2.2/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/hedwigConsole.html
+++ b/content/archives/docs/r4.2.2/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/hedwigDesign.html
+++ b/content/archives/docs/r4.2.2/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/hedwigJMX.html
+++ b/content/archives/docs/r4.2.2/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/hedwigMessageFilter.html
+++ b/content/archives/docs/r4.2.2/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/hedwigMetadata.html
+++ b/content/archives/docs/r4.2.2/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/hedwigParams.html
+++ b/content/archives/docs/r4.2.2/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/hedwigUser.html
+++ b/content/archives/docs/r4.2.2/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/index.html
+++ b/content/archives/docs/r4.2.2/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -174,6 +174,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/metastore.html
+++ b/content/archives/docs/r4.2.2/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.2/releaseNotes.html
+++ b/content/archives/docs/r4.2.2/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -250,6 +250,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookieConfigParams.html
+++ b/content/archives/docs/r4.2.3/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -168,6 +168,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookieRecovery.html
+++ b/content/archives/docs/r4.2.3/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperConfig.html
+++ b/content/archives/docs/r4.2.3/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.2.3/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperInternals.html
+++ b/content/archives/docs/r4.2.3/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperJMX.html
+++ b/content/archives/docs/r4.2.3/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.2.3/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperOverview.html
+++ b/content/archives/docs/r4.2.3/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.2.3/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperStarted.html
+++ b/content/archives/docs/r4.2.3/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/bookkeeperStream.html
+++ b/content/archives/docs/r4.2.3/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/doc.html
+++ b/content/archives/docs/r4.2.3/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/hedwigBuild.html
+++ b/content/archives/docs/r4.2.3/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/hedwigConsole.html
+++ b/content/archives/docs/r4.2.3/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/hedwigDesign.html
+++ b/content/archives/docs/r4.2.3/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/hedwigJMX.html
+++ b/content/archives/docs/r4.2.3/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/hedwigMessageFilter.html
+++ b/content/archives/docs/r4.2.3/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/hedwigMetadata.html
+++ b/content/archives/docs/r4.2.3/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/hedwigParams.html
+++ b/content/archives/docs/r4.2.3/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/hedwigUser.html
+++ b/content/archives/docs/r4.2.3/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/index.html
+++ b/content/archives/docs/r4.2.3/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -174,6 +174,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/metastore.html
+++ b/content/archives/docs/r4.2.3/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.3/releaseNotes.html
+++ b/content/archives/docs/r4.2.3/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookieConfigParams.html
+++ b/content/archives/docs/r4.2.4/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -168,6 +168,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookieRecovery.html
+++ b/content/archives/docs/r4.2.4/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperConfig.html
+++ b/content/archives/docs/r4.2.4/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.2.4/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperInternals.html
+++ b/content/archives/docs/r4.2.4/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperJMX.html
+++ b/content/archives/docs/r4.2.4/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.2.4/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperOverview.html
+++ b/content/archives/docs/r4.2.4/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.2.4/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperStarted.html
+++ b/content/archives/docs/r4.2.4/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/bookkeeperStream.html
+++ b/content/archives/docs/r4.2.4/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/doc.html
+++ b/content/archives/docs/r4.2.4/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/hedwigBuild.html
+++ b/content/archives/docs/r4.2.4/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/hedwigConsole.html
+++ b/content/archives/docs/r4.2.4/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/hedwigDesign.html
+++ b/content/archives/docs/r4.2.4/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/hedwigJMX.html
+++ b/content/archives/docs/r4.2.4/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/hedwigMessageFilter.html
+++ b/content/archives/docs/r4.2.4/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/hedwigMetadata.html
+++ b/content/archives/docs/r4.2.4/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/hedwigParams.html
+++ b/content/archives/docs/r4.2.4/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/hedwigUser.html
+++ b/content/archives/docs/r4.2.4/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/index.html
+++ b/content/archives/docs/r4.2.4/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -174,6 +174,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/metastore.html
+++ b/content/archives/docs/r4.2.4/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.2.4/releaseNotes.html
+++ b/content/archives/docs/r4.2.4/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookieConfigParams.html
+++ b/content/archives/docs/r4.3.0/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -177,6 +177,6 @@ longs. This parameter should <em>not</em> be modified unless you know what you'r
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookieRecovery.html
+++ b/content/archives/docs/r4.3.0/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperConfig.html
+++ b/content/archives/docs/r4.3.0/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.3.0/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperInternals.html
+++ b/content/archives/docs/r4.3.0/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperJMX.html
+++ b/content/archives/docs/r4.3.0/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.3.0/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperOverview.html
+++ b/content/archives/docs/r4.3.0/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.3.0/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperStarted.html
+++ b/content/archives/docs/r4.3.0/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/bookkeeperStream.html
+++ b/content/archives/docs/r4.3.0/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/doc.html
+++ b/content/archives/docs/r4.3.0/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/hedwigBuild.html
+++ b/content/archives/docs/r4.3.0/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/hedwigConsole.html
+++ b/content/archives/docs/r4.3.0/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/hedwigDesign.html
+++ b/content/archives/docs/r4.3.0/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/hedwigJMX.html
+++ b/content/archives/docs/r4.3.0/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/hedwigMessageFilter.html
+++ b/content/archives/docs/r4.3.0/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/hedwigMetadata.html
+++ b/content/archives/docs/r4.3.0/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/hedwigParams.html
+++ b/content/archives/docs/r4.3.0/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/hedwigUser.html
+++ b/content/archives/docs/r4.3.0/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/index.html
+++ b/content/archives/docs/r4.3.0/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -174,6 +174,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/metastore.html
+++ b/content/archives/docs/r4.3.0/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.0/releaseNotes.html
+++ b/content/archives/docs/r4.3.0/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -493,6 +493,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookieConfigParams.html
+++ b/content/archives/docs/r4.3.1/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -177,6 +177,6 @@ longs. This parameter should <em>not</em> be modified unless you know what you'r
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookieRecovery.html
+++ b/content/archives/docs/r4.3.1/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperConfig.html
+++ b/content/archives/docs/r4.3.1/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.3.1/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperInternals.html
+++ b/content/archives/docs/r4.3.1/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperJMX.html
+++ b/content/archives/docs/r4.3.1/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.3.1/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperOverview.html
+++ b/content/archives/docs/r4.3.1/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.3.1/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperStarted.html
+++ b/content/archives/docs/r4.3.1/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/bookkeeperStream.html
+++ b/content/archives/docs/r4.3.1/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/doc.html
+++ b/content/archives/docs/r4.3.1/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/hedwigBuild.html
+++ b/content/archives/docs/r4.3.1/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/hedwigConsole.html
+++ b/content/archives/docs/r4.3.1/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/hedwigDesign.html
+++ b/content/archives/docs/r4.3.1/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/hedwigJMX.html
+++ b/content/archives/docs/r4.3.1/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/hedwigMessageFilter.html
+++ b/content/archives/docs/r4.3.1/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/hedwigMetadata.html
+++ b/content/archives/docs/r4.3.1/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/hedwigParams.html
+++ b/content/archives/docs/r4.3.1/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/hedwigUser.html
+++ b/content/archives/docs/r4.3.1/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/index.html
+++ b/content/archives/docs/r4.3.1/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -174,6 +174,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/metastore.html
+++ b/content/archives/docs/r4.3.1/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.1/releaseNotes.html
+++ b/content/archives/docs/r4.3.1/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -188,6 +188,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookieConfigParams.html
+++ b/content/archives/docs/r4.3.2/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -177,6 +177,6 @@ longs. This parameter should <em>not</em> be modified unless you know what you'r
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookieRecovery.html
+++ b/content/archives/docs/r4.3.2/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperConfig.html
+++ b/content/archives/docs/r4.3.2/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.3.2/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperInternals.html
+++ b/content/archives/docs/r4.3.2/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperJMX.html
+++ b/content/archives/docs/r4.3.2/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.3.2/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperOverview.html
+++ b/content/archives/docs/r4.3.2/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BooKeeper is to implement a write-ahead transaction log. A se
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.3.2/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperStarted.html
+++ b/content/archives/docs/r4.3.2/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/bookkeeperStream.html
+++ b/content/archives/docs/r4.3.2/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/doc.html
+++ b/content/archives/docs/r4.3.2/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/hedwigBuild.html
+++ b/content/archives/docs/r4.3.2/hedwigBuild.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/hedwigConsole.html
+++ b/content/archives/docs/r4.3.2/hedwigConsole.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -329,6 +329,6 @@ Finished 0.388 s.
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/hedwigDesign.html
+++ b/content/archives/docs/r4.3.2/hedwigDesign.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -189,6 +189,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/hedwigJMX.html
+++ b/content/archives/docs/r4.3.2/hedwigJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/hedwigMessageFilter.html
+++ b/content/archives/docs/r4.3.2/hedwigMessageFilter.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Message Filter</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -194,6 +194,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/hedwigMetadata.html
+++ b/content/archives/docs/r4.3.2/hedwigMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Hedwig Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -272,6 +272,6 @@ frequently while <i>SubscriptionState</i> is be updated frequently when messages
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/hedwigParams.html
+++ b/content/archives/docs/r4.3.2/hedwigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -185,6 +185,6 @@ delete those consumed ledgers in BookKeeper. Default is 1 minute (60,000 ms).</t
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/hedwigUser.html
+++ b/content/archives/docs/r4.3.2/hedwigUser.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -175,6 +175,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/index.html
+++ b/content/archives/docs/r4.3.2/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -174,6 +174,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/metastore.html
+++ b/content/archives/docs/r4.3.2/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.3.2/releaseNotes.html
+++ b/content/archives/docs/r4.3.2/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -141,6 +141,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookieConfigParams.html
+++ b/content/archives/docs/r4.4.0/bookieConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookie Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -177,6 +177,6 @@ longs. This parameter should <em>not</em> be modified unless you know what you'r
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookieRecovery.html
+++ b/content/archives/docs/r4.4.0/bookieRecovery.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Bookie Recovery</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -197,6 +197,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperConfig.html
+++ b/content/archives/docs/r4.4.0/bookkeeperConfig.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Administrator&#39;s Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -299,6 +299,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperConfigParams.html
+++ b/content/archives/docs/r4.4.0/bookkeeperConfigParams.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Configuration Parameters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -146,6 +146,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperInternals.html
+++ b/content/archives/docs/r4.4.0/bookkeeperInternals.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Internals</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -204,6 +204,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperJMX.html
+++ b/content/archives/docs/r4.4.0/bookkeeperJMX.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper JMX</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -140,6 +140,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperLedgers2Logs.html
+++ b/content/archives/docs/r4.4.0/bookkeeperLedgers2Logs.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - From Ledgers to Logs</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -167,6 +167,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperMetadata.html
+++ b/content/archives/docs/r4.4.0/bookkeeperMetadata.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Metadata Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -155,6 +155,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperOverview.html
+++ b/content/archives/docs/r4.4.0/bookkeeperOverview.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -326,6 +326,6 @@ p. A simple use of BookKeeper is to implement a write-ahead transaction log. A s
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperProgrammer.html
+++ b/content/archives/docs/r4.4.0/bookkeeperProgrammer.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -242,6 +242,6 @@ while (entries.hasMoreElements()) {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperProtocol.html
+++ b/content/archives/docs/r4.4.0/bookkeeperProtocol.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Replication Protocol</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -214,6 +214,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperStarted.html
+++ b/content/archives/docs/r4.4.0/bookkeeperStarted.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Getting Started Guide</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -221,6 +221,6 @@ bkc.close();
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperStream.html
+++ b/content/archives/docs/r4.4.0/bookkeeperStream.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Streaming with BookKeeper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -254,6 +254,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/bookkeeperTutorial.html
+++ b/content/archives/docs/r4.4.0/bookkeeperTutorial.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Bookkeeper Client tutorial</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -735,6 +735,6 @@ public class Dice extends LeaderSelectorListenerAdapter implements Closeable {
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/doc.html
+++ b/content/archives/docs/r4.4.0/doc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -136,6 +136,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/index.html
+++ b/content/archives/docs/r4.4.0/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -123,7 +123,7 @@
 
 <p><strong>Administrators</strong> will be more interested in the <a href="./bookkeeperConfig.html">BookKeeper Admin guide</a>. It describes the steps involved in setting up and maintaining a cluster. The available configuration parameters can be found <a href="./bookieConfigParams.html">here</a>. An important aspect of BookKeeper is how it deals with the failure of storage nodes. This is covered in <a href="./bookieRecovery.html">Bookie Recovery</a>.</p>
 
-<p><strong>Contributor</strong> documentation is less organized, <a href="./bookkeeperInternals.html">BookKeeper Internals</a> is a good place to start. From there you can check out our <a href="https://cwiki.apache.org/confluence/display/BOOKKEEPER/Index">wiki</a> and ask questions on our <a href="/lists.html">mailing lists</a> or <a href="/irc.html"><span class="caps">IRC</span></a>.</p>
+<p><strong>Contributor</strong> documentation is less organized, <a href="./bookkeeperInternals.html">BookKeeper Internals</a> is a good place to start. From there you can check out our <a href="https://cwiki.apache.org/confluence/display/BOOKKEEPER/Index">wiki</a> and ask questions on our <a href="/archives/lists.html">mailing lists</a> or <a href="/irc.html"><span class="caps">IRC</span></a>.</p>
 
 <h3>All documents</h3>
 
@@ -171,6 +171,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/metastore.html
+++ b/content/archives/docs/r4.4.0/metastore.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Metastore Interface</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -164,6 +164,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/docs/r4.4.0/releaseNotes.html
+++ b/content/archives/docs/r4.4.0/releaseNotes.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Documentation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -350,6 +350,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/index.html
+++ b/content/archives/index.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Home</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -158,6 +158,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/irc.html
+++ b/content/archives/irc.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper IRC</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -130,6 +130,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/lists.html
+++ b/content/archives/lists.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Mailing lists</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -167,6 +167,6 @@ In order to post to the list, it is necessary to first subscribe to it.</p>
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/privacy.html
+++ b/content/archives/privacy.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - Privacy Policy</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -142,6 +142,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/releases.html
+++ b/content/archives/releases.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Releases</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -224,6 +224,6 @@ See <a href="./docs/r4.0.0/releaseNotes.html">BookKeeper 4.0.0 Release Notes</a>
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/content/archives/svn.html
+++ b/content/archives/svn.html
@@ -21,15 +21,15 @@
     <title>Apache BookKeeper - BookKeeper Version Control</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/archives/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="/archives/css/styles.css" rel="stylesheet">
   </head>
   <body>
     <header class="navbar navbar-inverse navbar-static-top" role="banner">
       <div class="container">
     	<div class="navbar-header hidden-xs hidden-sm">
-    	  <a class="navbar-brand navbar-logo" href="/"><img class="img-responsive" src="/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
+    	  <a class="navbar-brand navbar-logo" href="/archives/"><img class="img-responsive" src="/archives/img/bookkeeper_blk40.png" alt="Bookkeeper Logo" /></a>
     	</div>
     	<div class="navbar-header">
     	  <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
@@ -38,43 +38,43 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
     	  </button>
-    	  <a class="navbar-brand" href="/">Apache BookKeeper</a>
+    	  <a class="navbar-brand" href="/archives/">Apache BookKeeper</a>
     	</div>
     	<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     	  <ul class="nav navbar-nav">
-    	    <li><a href="/releases.html">Download</a></li>
+    	    <li><a href="/archives/releases.html">Download</a></li>
 
     	    <li class="dropdown">
     	      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Documentation<span class="caret"></span></a>
     	      <ul class="dropdown-menu" role="menu">
-		<li><a href="/docs/master">Latest (master)</a></li>
+		<li><a href="/archives/docs/master">Latest (master)</a></li>
 		<li><ul>
-		    <li><a href="/docs/master/apidocs">Java API docs</a></li>
-		    <li><a href="/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
-		    <li><a href="/docs/master/bookkeeperConfig.html">Admin guide</a></li>
+		    <li><a href="/archives/docs/master/apidocs">Java API docs</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperTutorial.html">Tutorial</a></li>
+		    <li><a href="/archives/docs/master/bookkeeperConfig.html">Admin guide</a></li>
 		</ul><li>
-                <li><a href="/docs/r4.4.0">Release 4.4.0</a></li>
+                <li><a href="/archives/docs/r4.4.0">Release 4.4.0</a></li>
                 <li class="divider"></li>
                 <li>Older releases</li>
-                <li><a href="/docs/r4.3.2">Release 4.3.2</a></li>
-                <li><a href="/docs/r4.3.1">Release 4.3.1</a></li>
-                <li><a href="/docs/r4.3.0">Release 4.3.0</a></li>
-                <li><a href="/docs/r4.2.4">Release 4.2.4</a></li>
-                <li><a href="/docs/r4.2.3">Release 4.2.3</a></li>
-                <li><a href="/docs/r4.2.2">Release 4.2.2</a></li>
-                <li><a href="/docs/r4.2.1">Release 4.2.1</a></li>
-                <li><a href="/docs/r4.2.0">Release 4.2.0</a></li>
-                <li><a href="/docs/r4.1.0">Release 4.1.0</a></li>
-                <li><a href="/docs/r4.0.0">Release 4.0.0</a></li>
+                <li><a href="/archives/docs/r4.3.2">Release 4.3.2</a></li>
+                <li><a href="/archives/docs/r4.3.1">Release 4.3.1</a></li>
+                <li><a href="/archives/docs/r4.3.0">Release 4.3.0</a></li>
+                <li><a href="/archives/docs/r4.2.4">Release 4.2.4</a></li>
+                <li><a href="/archives/docs/r4.2.3">Release 4.2.3</a></li>
+                <li><a href="/archives/docs/r4.2.2">Release 4.2.2</a></li>
+                <li><a href="/archives/docs/r4.2.1">Release 4.2.1</a></li>
+                <li><a href="/archives/docs/r4.2.0">Release 4.2.0</a></li>
+                <li><a href="/archives/docs/r4.1.0">Release 4.1.0</a></li>
+                <li><a href="/archives/docs/r4.0.0">Release 4.0.0</a></li>
               </ul>
             </li>
             
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Get Involved<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/lists.html">Mailing Lists</a></li>
-                <li><a href="/irc.html">IRC</a></li>
-                <li><a href="/svn.html">Version Control</a></li>
+                <li><a href="/archives/lists.html">Mailing Lists</a></li>
+                <li><a href="/archives/irc.html">IRC</a></li>
+                <li><a href="/archives/svn.html">Version Control</a></li>
                 <li><a href="https://issues.apache.org/jira/browse/BOOKKEEPER">Issue Tracker</a></li>
               </ul>
             </li>
@@ -84,11 +84,11 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project Info<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/credits.html">Who are we?</a></li>
-                <li><a href="/bylaws.html">Bylaws</a></li>
+                <li><a href="/archives/credits.html">Who are we?</a></li>
+                <li><a href="/archives/bylaws.html">Bylaws</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li class="divider"></li>
-                <li><a href="/privacy.html">Privacy Policy</a></li>
+                <li><a href="/archives/privacy.html">Privacy Policy</a></li>
                 <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsership</a></li>
                 <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
               </ul>
@@ -143,6 +143,6 @@
     </footer>
 
     <script src="//code.jquery.com/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="/archives/js/bootstrap.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Descriptions of the changes in this PR:

The content was copied from cms to `archives`. Those pages are using absolute links, so css and js locations are wrong. This change to fix all css, js, image urls to base on '/archives'.
