### PR TITLE
Issue 419: dockerfile - auto verify asc file GPG_KEY

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,6 @@ MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
 
 ARG BK_VERSION=4.4.0
 ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
-ARG GPG_KEY=B3D56514
 
 ENV BOOKIE_PORT=3181
 EXPOSE $BOOKIE_PORT
@@ -31,7 +30,7 @@ ENV BK_USER=bookkeeper
 # Download Apache Bookkeeper, untar and clean up
 RUN set -x \
     && adduser "${BK_USER}" \
-    && yum install -y java-1.8.0-openjdk-headless wget bash python md5sum sha1sum sudo \
+    && yum install -y java-1.8.0-openjdk-headless wget bash python sudo \
     && mkdir -pv /opt \
     && cd /opt \
     && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz" \
@@ -40,12 +39,14 @@ RUN set -x \
     && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.sha1" \
     && md5sum -c ${DISTRO_NAME}.tar.gz.md5 \
     && sha1sum -c ${DISTRO_NAME}.tar.gz.sha1 \
+    && tmpKey=`gpg --verify ${DISTRO_NAME}.tar.gz.asc ${DISTRO_NAME}.tar.gz 2>&1` || echo "ignore command error" \
+    && GPG_KEY=`echo $tmpKey | grep -o '\<[0-9A-F]\{7,\}\>'` \
     && gpg --keyserver ha.pool.sks-keyservers.net --recv-key "$GPG_KEY" \
     && gpg --batch --verify "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz" \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
     && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.md5" "$DISTRO_NAME.tar.gz.sha1" \
-    && yum remove -y wget md5sum sha1sum \
+    && yum remove -y wget \
     && yum clean all
 
 WORKDIR /opt/bookkeeper

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,11 +37,10 @@ RUN set -x \
     && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.asc" \
     && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.md5" \
     && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.sha1" \
+    && wget -q "https://archive.apache.org/dist/bookkeeper/KEYS" \
     && md5sum -c ${DISTRO_NAME}.tar.gz.md5 \
     && sha1sum -c ${DISTRO_NAME}.tar.gz.sha1 \
-    && tmpKey=`gpg --verify ${DISTRO_NAME}.tar.gz.asc ${DISTRO_NAME}.tar.gz 2>&1` || echo "ignore command error" \
-    && GPG_KEY=`echo $tmpKey | grep -o '\<[0-9A-F]\{7,\}\>'` \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-key "$GPG_KEY" \
+    && gpg --import KEYS \
     && gpg --batch --verify "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz" \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \


### PR DESCRIPTION
Descriptions of the changes in this PR:
- Add script to get GPG_KEY, this would avoid manually provide it, and good to update to other version of BK binary.
- Also delete yum install for md5sum and sha1sum, since they are already in coreutils, which is default installed; and left them here will report error: 'No Match for argument: md5sum/sha1sum', while 'yum remove' in docker build. 

---
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

- [X] Make sure the PR title is formatted like:
    `<Issue # or BOOKKEEPER-#>: Description of pull request`
    `e.g. Issue 123: Description ...`
    `e.g. BOOKKEEPER-1234: Description ...`
- [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
- [X] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.

---
