### PR TITLE
Issue 422: Don't use community layout for documentation pages

### DIFF
--- a/site/docs/latest/index.md
+++ b/site/docs/latest/index.md
@@ -1,6 +1,5 @@
 ---
 title: Apache BookKeeper 4.5.0-SNAPSHOT Documentation 
-layout: community
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/site/docs/latest/releaseNotes.md
+++ b/site/docs/latest/releaseNotes.md
@@ -1,6 +1,5 @@
 ---
 title: Apache BookKeeper 4.5.0-SNAPSHOT Release Notes
-layout: community
 ---
 
 Apache BookKeeper {{ site.latest_version }} is still under developement.

--- a/site/docs/latest/releaseNotesTemplate.md
+++ b/site/docs/latest/releaseNotesTemplate.md
@@ -1,6 +1,5 @@
 ---
 title: Apache BookKeeper 4.5.0-SNAPSHOT Release Notes
-layout: community
 ---
 
 [provide a summary of this release]


### PR DESCRIPTION
Descriptions of the changes in this PR:

The layout of documentation page is marked as community. when users navigate to this page, it is a bit difficult for the users to figure out where they are. We should stick documentation pages to doc layout.