### PR TITLE
Issue 414: use a clone of baseconf in new ServerConfiguration(baseConf)

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -84,7 +84,6 @@ import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -2028,7 +2027,7 @@ public class BookieShell implements Tool {
     }
 
     @Override
-    public void setConf(Configuration conf) throws Exception {
+    public void setConf(CompositeConfiguration conf) throws Exception {
         bkConf.loadConf(conf);
         journalDirectories = Bookie.getCurrentDirectories(bkConf.getJournalDirs());
         ledgerDirectories = Bookie.getCurrentDirectories(bkConf.getLedgerDirs());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -118,7 +118,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
      */
     public void loadConf(URL confURL) throws ConfigurationException {
         Configuration loadedConf = new PropertiesConfiguration(confURL);
-        addConfiguration(loadedConf);
+        addConfiguration((Configuration)((PropertiesConfiguration)loadedConf).clone());
     }
 
     /**
@@ -127,18 +127,8 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
      * @param baseConf
      *          Other Configuration
      */
-    public void loadConf(AbstractConfiguration baseConf) {
-        addConfiguration(baseConf); 
-    }
-
-    /**
-     * Load configuration from other configuration object
-     *
-     * @param otherConf
-     *          Other configuration object
-     */
-    public void loadConf(Configuration otherConf) {
-        addConfiguration(otherConf);
+    public void loadConf(CompositeConfiguration baseConf) {
+        addConfiguration((CompositeConfiguration)baseConf.clone());
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -117,8 +117,8 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
      *          Configuration URL
      */
     public void loadConf(URL confURL) throws ConfigurationException {
-        Configuration loadedConf = new PropertiesConfiguration(confURL);
-        addConfiguration((Configuration)((PropertiesConfiguration)loadedConf).clone());
+        PropertiesConfiguration loadedConf = new PropertiesConfiguration(confURL);
+        addConfiguration((Configuration)loadedConf.clone());
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/Tool.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/Tool.java
@@ -18,7 +18,7 @@
 
 package org.apache.bookkeeper.util;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.CompositeConfiguration;
 
 /**
  * A tool interface that supports handling of generic command-line options.
@@ -39,5 +39,5 @@ public interface Tool {
      * @param conf configuration object
      * @throws Exception
      */
-    public void setConf(Configuration conf) throws Exception;
+    public void setConf(CompositeConfiguration conf) throws Exception;
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:
This PR fix Issue #414 , and in the comments of that issue contains the anysis of the bug.  Main changes:
- Privde a clone of baseConf while do loadconf(baseConf), so make baseConf and newConf work independently.
- Remove 'loadConf(Configuration otherConf) ', since Configuration is an interface in common-configs and not have a clone method.

---
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

- [X] Make sure the PR title is formatted like:
    `<Issue # or BOOKKEEPER-#>: Description of pull request`
    `e.g. Issue 123: Description ...`
    `e.g. BOOKKEEPER-1234: Description ...`
- [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
- [X] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.

---
