### PR TITLE
Issue 432: Add "Google Analytics" to the website

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -23,7 +23,7 @@ build: clean
 		--config _config.yml
 
 apache: clean
-	${JEKYLL} build \
+	JEKYLL_ENV=production ${JEKYLL} build \
 		--config _config.yml,_config.apache.yml
 
 javadoc:

--- a/site/_includes/google-analytics.html
+++ b/site/_includes/google-analytics.html
@@ -1,0 +1,26 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-104419626-1', 'auto');
+  ga('send', 'pageview');
+
+</script>

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -14,4 +14,7 @@
   </body>
 
   {% include javascript.html %}
+  {% if jekyll.environment == "production" %}
+  {% include google-analytics.html %}
+  {% endif %}
 </html>


### PR DESCRIPTION
Descriptions of the changes in this PR:

Add "google analytics" script to the website for tracking the documentation traffic. We can learn the pattern and improve documentation.

The google account for analytics is managed by bookkeeper pmc.
