### PR TITLE
Issue 435: Build javadoc for releases

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -27,7 +27,10 @@ apache: clean
 		--config _config.yml,_config.apache.yml
 
 javadoc:
-	scripts/javadoc-gen.sh
+	scripts/javadoc-gen.sh "all"
+
+latest_javadoc:
+	scripts/javadoc-gen.sh "latest"
 
 staging: clean
 	${JEKYLL} build --config _config.yml,_config.staging.yml

--- a/site/_data/sidebar.yaml
+++ b/site/_data/sidebar.yaml
@@ -45,6 +45,8 @@ groups:
     endpoint: ledger-adv-api
   - name: DistributedLog
     endpoint: distributedlog-api
+  - name: Java API Docs
+    endpoint: javadoc
 - name: Security
   dir: security
   docs:

--- a/site/docker/ci.sh
+++ b/site/docker/ci.sh
@@ -57,6 +57,7 @@ docker run \
   -v "${BOOKKEEPER_DOC_ROOT}:${BOOKKEEPER_DOC_ROOT}" \
   -v "${LOCAL_HOME}:/home/${USER_NAME}" \
   -p 4000:4000 \
+  -e JEKYLL_ENV='production' \
   ${IMAGE_NAME}-${USER_NAME} \
   bash -c "make setup && make apache"
 

--- a/site/docs/4.5.0/overview/overview.md
+++ b/site/docs/4.5.0/overview/overview.md
@@ -35,6 +35,7 @@ It is suitable for being used in following scenerios:
 Learn more about Apache BookKeeper and what it can do for your organization:
 
 - [Apache BookKeeper 4.5.0 Release Notes](../releaseNotes)
+- [Java API docs](../../api/javadoc)
 
 Or start using Apache BookKeeper today.
 

--- a/site/docs/latest/overview/overview.md
+++ b/site/docs/latest/overview/overview.md
@@ -35,6 +35,7 @@ It is suitable for being used in following scenerios:
 Learn more about Apache BookKeeper and what it can do for your organization:
 
 - [Apache BookKeeper {{ site.latest_version }} Release Notes](../releaseNotes)
+- [Java API docs](../../api/javadoc)
 
 Or start using Apache BookKeeper today.
 

--- a/site/scripts/javadoc-gen.sh
+++ b/site/scripts/javadoc-gen.sh
@@ -2,9 +2,42 @@
 
 source scripts/common.sh
 
-(
-  rm -rf $JAVADOC_GEN_DIR $JAVADOC_DEST_DIR
-  cd $ROOT_DIR
+function build_javadoc() {
+  version=$1
+
+  echo "Building the javadoc for version ${version}."
+  if [ "$version" == "latest" ]; then
+    javadoc_gen_dir="${ROOT_DIR}/target/site/apidocs"
+    cd $ROOT_DIR
+  else
+    javadoc_gen_dir="/tmp/bookkeeper-${version}/target/site/apidocs"
+    rm -rf /tmp/bookkeeper-${version}
+    git clone https://github.com/apache/bookkeeper /tmp/bookkeeper-${version}
+    cd /tmp/bookkeeper-${version}
+    git checkout "release-${version}"
+  fi
+  javadoc_dest_dir="${ROOT_DIR}/site/docs/${version}/api/javadoc"
+  rm -rf $javadoc_dest_dir
   mvn clean install javadoc:aggregate -DskipTests
-  mv $JAVADOC_GEN_DIR $JAVADOC_DEST_DIR
-)
+  mv $javadoc_gen_dir $javadoc_dest_dir
+
+  echo "Built the javadoc for version ${version}."
+}
+
+# get arguments
+version=$1
+shift
+
+case "${version}" in
+  latest)
+    build_javadoc ${version}
+    ;;
+  all)
+    for d in `ls ${ROOT_DIR}/site/docs`; do
+      build_javadoc $d
+    done
+    ;;
+  *)
+    echo "Unknown version '${version}' to build doc"
+    ;;
+esac


### PR DESCRIPTION
Descriptions of the changes in this PR:

- add javadoc links on sidebar and overview pages (try to promote this link for users to find the link easier)
- update javadoc-gen.sh to be able to generate latest javadoc and all javadocs for versions under `docs`

minor fixes:
- pass "JEKYLL_ENV=production" to docker because ci uses docker to build the documentation
- 