### PR TITLE
Issue 441: fix typos

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1144,9 +1144,9 @@ Release 4.0.0 - 2011-11-30
 
         BOOKKEEPER-19: BookKeeper doesn't support more than 2Gig of memory (ivan via fpj)
 
-        BOOKEEPER-22: Exception in LedgerCache causes addEntry request to fail (fpj via fpj)
+        BOOKKEEPER-22: Exception in LedgerCache causes addEntry request to fail (fpj via fpj)
 
-        BOOKEEPER-5: Issue with Netty in BookKeeper (fpj and ivank via fpj)
+        BOOKKEEPER-5: Issue with Netty in BookKeeper (fpj and ivank via fpj)
 
         BOOKKEEPER-30: Test are too noisy (ivank via fpj)
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -581,7 +581,7 @@ public class LedgerHandle implements AutoCloseable {
      * read entries for which the writer has not received the acknowledge yet. <br>
      * For entries which are within the range 0..LastAddConfirmed BookKeeper guarantees that the writer has successfully
      * received the acknowledge.<br>
-     * For entries outside that range it is possible that the writer never received the acknoledge
+     * For entries outside that range it is possible that the writer never received the acknowledge
      * and so there is the risk that the reader is seeing entries before the writer and this could result in a consistency
      * issue in some cases.<br>
      * With this method you can even read entries before the LastAddConfirmed and entries after it with one call,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -40,7 +40,7 @@ import io.netty.buffer.Unpooled;
 
 /**
  * Ledger Advanced handle extends {@link LedgerHandle} to provide API to add entries with
- * user supplied entryIds. Through this interface Ledger Length may not be accurate wile the
+ * user supplied entryIds. Through this interface Ledger Length may not be accurate while the
  * ledger being written.
  */
 public class LedgerHandleAdv extends LedgerHandle {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/Main.java
@@ -29,7 +29,7 @@ import org.apache.bookkeeper.proto.BookieServer;
 public class Main {
 
     static void usage() {
-        System.err.println("USAGE: bookeeper client|bookie");
+        System.err.println("USAGE: bookkeeper client|bookie");
     }
 
     /**

--- a/doc/bookkeeperSecurity.textile
+++ b/doc/bookkeeperSecurity.textile
@@ -20,7 +20,7 @@ Metadata are stored on ZooKeeper, so first of all you will need to secure your Z
 
 Then you have to take care of access to Bookies, you can configure authentication and encryption using TLS, out of the box BookKeeper supports Kerberos authentication, DIGEST-MD5 authentication and TLS encryption. You can also leverage TLS client authentication in order to protect your data.
 
-h1. ZookKeeper security on BookKeeper
+h1. ZooKeeper security on BookKeeper
 
 Both clients and Bookies read and write metadata on ZooKeeper, it is also used for Bookie discovery. 
 The best way to protect data stored on ZooKeeper is to put ACLs on every z-node, this way only authorized users will be able to access (read/write) data

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -36,7 +36,7 @@ BK_DIR = /data
 BK_zkLedgersRootPath = /ledgers
 
 ZK_CONTAINER_NAME=test_zookeeper
-ZK_LOCAL_DATA_DIR=$(BK_LOCAL_DATA_DIR)/zookkeeper
+ZK_LOCAL_DATA_DIR=$(BK_LOCAL_DATA_DIR)/zookeeper
 
 TERMINAL_EMULATOR=gnome-terminal
 
@@ -62,7 +62,7 @@ build:
 
 # -------------------------------- #
 
-# Create and run a bookkeeper container with data persisted on local filesystem. It needs the zookkeeper container.
+# Create and run a bookkeeper container with data persisted on local filesystem. It needs the zookeeper container.
 # In order to launch several bookies, the command need the bookie number
 #   make run-bk BOOKIE=4
 
@@ -88,7 +88,7 @@ run-bk:
 
 # -------------------------------- #
 
-# Create run and destroy a container that will format zookkeeper metadata
+# Create run and destroy a container that will format zookeeper metadata
 #   make run-format
 
 run-format:
@@ -100,7 +100,7 @@ run-format:
 
 # -------------------------------- #
 
-# Create and run the zookkeeper container needed by the ensemble
+# Create and run the zookeeper container needed by the ensemble
 #   make run-zk
 
 run-zk:
@@ -129,7 +129,7 @@ run-dice:
 
 # -------------------------------- #
 
-# This is an example of a full bookkeeper ensemble of 3 bookies, a zookkeeper server and 2 client dice applications.
+# This is an example of a full bookkeeper ensemble of 3 bookies, a zookeeper server and 2 client dice applications.
 # On MacOS please run these command manually in several terminals
 #   make run-demo
 run-demo:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,14 @@
 
 # What is Apache Bookkeeper?
 
-Apache ZooKeeper is a software project of the Apache Software Foundation, providing a replicated log service which can be used to build replicated state machines. A log contains a sequence of events which can be applied to a state machine. BookKeeper guarantees that each replica state machine will see all the same entries, in the same order.
+Apache Bookkeeper is a software project of the Apache Software Foundation, providing a replicated log service which can be used to build replicated state machines. A log contains a sequence of events which can be applied to a state machine. BookKeeper guarantees that each replica state machine will see all the same entries, in the same order.
 
 > [Apache Bookkeeper](http://bookkeeper.apache.org/)
 
 
 # How to use this image
 
-Bookkeeper needs [Zookeeper](https://zookeeper.apache.org/) in order to preserve its state and publish its bookies (bookkepeer servers). The client only need to connect to a Zookkeeper server in the ensamble in order to obtain the list of Bookkeeper servers.
+Bookkeeper needs [Zookeeper](https://zookeeper.apache.org/) in order to preserve its state and publish its bookies (bookkeeper servers). The client only need to connect to a Zookeeper server in the ensamble in order to obtain the list of Bookkeeper servers.
 
 ## TL;DR
 
@@ -70,7 +70,7 @@ Start a dice application (you can run it several times to view the behavior in a
 ```
 docker run -it --rm \
     --network "my-bookkeeper-network" \
-    --env ZK_URL=my-zookkeeper:2181 \
+    --env ZK_URL=my-zookeeper:2181 \
     caiok/bookkeeper-tutorial
 ```
 

--- a/site/README.md
+++ b/site/README.md
@@ -50,7 +50,7 @@ When you submit a pull request for modifying website or documentation, you are r
 Here are a few steps to follow to stage your changes:
 
 1. You need to create a github repo called `bookkeeper-staging-site` under your github account. You can fork this [staging repo](https://github.com/sijie/bookkeeper-staging-site) as well.
-2. In your `bookeeper-staging-site` repo, go to `Settings > GitHub Pages`. Enable `GitHub Pages` on `master branch /docs folder`.
+2. In your `bookkeeper-staging-site` repo, go to `Settings > GitHub Pages`. Enable `GitHub Pages` on `master branch /docs folder`.
 3. Make changes to the website, follow the steps above to verify the changes locally.
 4. Once the changes are verified locally, you can run `make staging`. It will generate the files under `site/local-generated`.
 5. Run `scripts/staging-website.sh`. It would push the generated website to your `bookkeeper-staging-site`.

--- a/site/docs/latest/getting-started/run-locally.md
+++ b/site/docs/latest/getting-started/run-locally.md
@@ -10,7 +10,7 @@ toc_disable: true
 This would start up an ensemble with 10 bookies:
 
 ```shell
-$ bookeeper-server/bin/bookeeper localbookie 10
+$ bookkeeper-server/bin/bookkeeper localbookie 10
 ```
 
 > When you start up an ensemble using `localbookie`, all bookies run in a single JVM process.


### PR DESCRIPTION
Descriptions of the changes in this PR:
Fix typos in docker readme.
"Apache ZooKeeper is a software project of the Apache Software Foundation"
->
"Apache Bookkeeper is a software project of the Apache Software Foundation"

"bookkepeer servers" -> "bookkeeper servers"

"The client only need to connect to a Zookkeeper server in the ensamble"
->
"The client only need to connect to a Zookeeper server in the ensemble"

typo of other place:
bookeeper
->
bookkeeper

wile
->
while

acknoledge
->
acknowledge

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
> 
> - [X] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [X] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
