### PR TITLE
Issue 440: Update "who are we?" page

### DIFF
--- a/site/project/who.md
+++ b/site/project/who.md
@@ -9,13 +9,17 @@ BookKeeper's PMC members are:
 Username | Name	| Organization | Timezone
 :--------|:-----|:-------------|:--------
 breed | Ben Reed | Facebook	| -8
+drusek | Dave Rusek | Twitter | -7
+fcuny | Franck Cuny | Twitter | -8
 fpj	| Flavio Junqueira | Microsoft | +1
+hsaputra | Henry Saputra | | -8
 ivank | Ivan Kelly | Midokura | +2
 jiannan	| Jiannan Wang | Yahoo Inc. | +8
-jujjuri | JV Jujjuri | Salesforce | -8
-mmerli | Matteo Merli | Yahoo Inc. | -8
+jujjuri | Venkateswararao (JV) Jujjuri | Salesforce | -8
+lstewart | Leigh Stewart | Twitter | -8
+mmerli | Matteo Merli | Streamlio | -8
 rakeshr | Rakesh Radhakrishnan | Huawei | +5:30
-sijie | Sijie Guo | Twitter | -8
+sijie | Sijie Guo | Streamlio | -8
 umamahesh | Uma Maheswara Rao G | Intel | +5
 
 ## Committers
@@ -25,16 +29,19 @@ BookKeeper's active committers are:
 Username | Name	| Organization | Timezone
 :--------|:-----|:-------------|:--------
 breed | Ben Reed | Facebook	| -8
+drusek | Dave Rusek | Twitter | -7
 eolivelli | Enrico Olivelli | Diennea | +2
+fcuny | Franck Cuny | Twitter | -8
 fpj	| Flavio Junqueira | Microsoft | +1
+hsaputra | Henry Saputra | | -8
 ivank | Ivan Kelly | Midokura | +2
 jiannan	| Jiannan Wang | Yahoo Inc. | +8
-jujjuri	| JV Jujjuri | Salesforce | -8
-mmerli | Matteo Merli | Yahoo Inc. | -8
+jujjuri	| Venkateswararao (JV) Jujjuri | Salesforce | -8
+mmerli | Matteo Merli | Streamlio | -8
 rakeshr | Rakesh Radhakrishnan | Huawei | +5:30
 reddycharan | Charan Reddy G | Salesforce | -8
 robindh	| Robin Dhamankar | Facebook | -8
 sboobna | Siddharth Boobna | Salesforce | -8
-sijie | Sijie Guo | Twitter | -8
+sijie | Sijie Guo | Streamlio | -8
 umamahesh | Uma Maheswara Rao G | Intel | +5
-zhaijia	| Jia Zhai | EMC | +8
+zhaijia	| Jia Zhai | Streamlio | +8


### PR DESCRIPTION
Descriptions of the changes in this PR:

- add new DL PPMC members to BK PMC
- fix full name and affiliations for a few members
