### PR TITLE
Issue 343: TestFencing.testManyOpenParallel

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
+import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.DigestManager.RecoveryData;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryListener;
@@ -63,7 +64,7 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
         RecoveryReadOp(LedgerHandle lh, ScheduledExecutorService scheduler,
                        long startEntryId, long endEntryId,
                        ReadEntryListener cb, Object ctx) {
-            super(lh, scheduler, startEntryId, endEntryId, cb, ctx);
+            super(lh, scheduler, startEntryId, endEntryId, cb, ctx, true);
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ListenerBasedPendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ListenerBasedPendingReadOp.java
@@ -30,10 +30,30 @@ class ListenerBasedPendingReadOp extends PendingReadOp {
 
     final ReadEntryListener listener;
 
-    ListenerBasedPendingReadOp(LedgerHandle lh, ScheduledExecutorService scheduler,
-                               long startEntryId, long endEntryId,
-                               ReadEntryListener listener, Object ctx) {
-        super(lh, scheduler, startEntryId, endEntryId, null, ctx);
+    ListenerBasedPendingReadOp(LedgerHandle lh,
+                               ScheduledExecutorService scheduler,
+                               long startEntryId,
+                               long endEntryId,
+                               ReadEntryListener listener,
+                               Object ctx) {
+        this(
+            lh,
+            scheduler,
+            startEntryId,
+            endEntryId,
+            listener,
+            ctx,
+            false);
+    }
+
+    ListenerBasedPendingReadOp(LedgerHandle lh,
+                               ScheduledExecutorService scheduler,
+                               long startEntryId,
+                               long endEntryId,
+                               ReadEntryListener listener,
+                               Object ctx,
+                               boolean isRecoveryRead) {
+        super(lh, scheduler, startEntryId, endEntryId, null, ctx, isRecoveryRead);
         this.listener = listener;
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Problem:

The `LastAddConfirmed` was advanced due to piggyback on recovery adds. It will cause recovery adds become stall because
of the entry id check.

This problem only occurs when there are multiple clients concurrently recover same ledger.

Solution:

Disable lac piggyback on recovery adds.