### PR TITLE
Issue 462: TestTLS failures

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -237,8 +237,10 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test(timeout = 60000)
     public void testClientWantsTLSNoServersHaveIt() throws Exception {
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setTLSProviderFactoryClass(null);
+        ServerConfiguration serverConf = new ServerConfiguration();
+        for (ServerConfiguration conf : bsConfs) {
+            conf.setTLSProviderFactoryClass(null);
+        }
         restartBookies(serverConf);
 
         ClientConfiguration clientConf = new ClientConfiguration(baseClientConf);
@@ -257,8 +259,10 @@ public class TestTLS extends BookKeeperClusterTestCase {
     @Test(timeout = 60000)
     public void testTLSClientButOnlyFewTLSServers() throws Exception {
         // disable TLS on initial set of bookies
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setTLSProviderFactoryClass(null);
+        ServerConfiguration serverConf = new ServerConfiguration();
+        for (ServerConfiguration conf : bsConfs) {
+            conf.setTLSProviderFactoryClass(null);
+        }
         restartBookies(serverConf);
 
         // add two bookies which support TLS


### PR DESCRIPTION
Descriptions of the changes in this PR:

Problem:

The behavior of loading configuration in `AbstractConfiguration` was changed recently.
So the TLS provider was not cleared correctly for the failed tests.

Solution:

Explicitly clear TLS provider for each configuratio to address the failed tests.
