### PR TITLE
Issue 479: CompactionTest#testCompactionWithEntryLogRollover failed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -57,7 +57,7 @@ public class GarbageCollectorThread extends SafeRunnable {
     // Maps entry log files to the set of ledgers that comprise the file and the size usage per ledger
     private Map<Long, EntryLogMetadata> entryLogMetaMap = new ConcurrentHashMap<Long, EntryLogMetadata>();
 
-    ScheduledExecutorService gcExecutor;
+    private final ScheduledExecutorService gcExecutor;
     Future<?> scheduledFuture = null;
 
     // This is how often we want to run the Garbage Collector Thread (in milliseconds).
@@ -67,15 +67,14 @@ public class GarbageCollectorThread extends SafeRunnable {
     boolean enableMinorCompaction = false;
     final double minorCompactionThreshold;
     final long minorCompactionInterval;
+    long lastMinorCompactionTime;
 
     boolean enableMajorCompaction = false;
     final double majorCompactionThreshold;
     final long majorCompactionInterval;
+    long lastMajorCompactionTime;
 
     final boolean isForceGCAllowWhenNoSpace;
-
-    long lastMinorCompactionTime;
-    long lastMajorCompactionTime;
 
     final boolean isThrottleByBytes;
     final int maxOutstandingRequests;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -266,6 +266,9 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
 
         // disable major compaction
         baseConf.setMajorCompactionThreshold(0.0f);
+        baseConf.setGcWaitTime(60000);
+        baseConf.setMinorCompactionInterval(120000);
+        baseConf.setMajorCompactionInterval(240000);
 
         // restart bookies
         restartBookies(baseConf);
@@ -309,6 +312,9 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
 
         // disable major compaction
         baseConf.setMajorCompactionThreshold(0.0f);
+        baseConf.setGcWaitTime(60000);
+        baseConf.setMinorCompactionInterval(120000);
+        baseConf.setMajorCompactionInterval(240000);
 
         // restart bookies
         restartBookies(baseConf);
@@ -363,6 +369,9 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         // here we are setting isForceGCAllowWhenNoSpace to true, so Major and Minor compaction wont be disabled in case
         // when discs are full
         baseConf.setIsForceGCAllowWhenNoSpace(true);
+        baseConf.setGcWaitTime(60000);
+        baseConf.setMinorCompactionInterval(120000);
+        baseConf.setMajorCompactionInterval(240000);
 
         // restart bookies
         restartBookies(baseConf);
@@ -434,6 +443,9 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
 
         // disable minor compaction
         baseConf.setMinorCompactionThreshold(0.0f);
+        baseConf.setGcWaitTime(60000);
+        baseConf.setMinorCompactionInterval(120000);
+        baseConf.setMajorCompactionInterval(240000);
 
         // restart bookies
         restartBookies(baseConf);


### PR DESCRIPTION
Descriptions of the changes in this PR:

- restart bookie with disabling gc for #testCompactionWithEntryLogRollover
- improve other tests to remove `Thread.sleep` and use a more deterministic way for doing gc