### PR TITLE
Issue 274: Ensuring the right number of bookies are passed.

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
@@ -441,7 +441,7 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
                 LOG.error("Couldn't connect to zookeeper at " + servers);
                 throw new IOException("Couldn't connect to zookeeper " + servers);
             }
-            bookies = zk.getChildren(bookieRegistrationPath, false).size();
+            bookies = zk.getChildren(bookieRegistrationPath, false).size() - 1;
         } finally {
             if (zk != null) {
                 zk.close();


### PR DESCRIPTION
Descriptions of the changes in this PR:
This fixes #274. Ensures that benchmark measure right number of bookies for the warmup.
