### PR TITLE
Issue 492: set the protobuf syntax to 'proto2'

### DIFF
--- a/bookkeeper-server/src/main/proto/BookkeeperProtocol.proto
+++ b/bookkeeper-server/src/main/proto/BookkeeperProtocol.proto
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+syntax = "proto2";
 
- option java_package = "org.apache.bookkeeper.proto";
- option optimize_for = SPEED;
+option java_package = "org.apache.bookkeeper.proto";
+option optimize_for = SPEED;
 
 /**
  * Protocol Versions.

--- a/bookkeeper-server/src/main/proto/DataFormats.proto
+++ b/bookkeeper-server/src/main/proto/DataFormats.proto
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+syntax = "proto2";
+
 option java_package = "org.apache.bookkeeper.proto";
 option optimize_for = SPEED;
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Explicitly set protobuf syntax to `proto2`.