### PR TITLE
Issue 496: some docker images don't need port forwarding

### DIFF
--- a/dev/docker/ci.sh
+++ b/dev/docker/ci.sh
@@ -56,7 +56,6 @@ docker run \
   -u "${USER}" \
   -v "${BOOKKEEPER_ROOT}:${BOOKKEEPER_ROOT}" \
   -v "${LOCAL_HOME}:/home/${USER_NAME}" \
-  -p 4000:4000 \
   -e MAVEN_OPTS='-Xmx4g -Xms2g' \
   ${IMAGE_NAME}-${USER_NAME} \
   bash -c "mvn clean apache-rat:check package findbugs:check"

--- a/dev/docker/run.sh
+++ b/dev/docker/run.sh
@@ -65,7 +65,6 @@ docker run -i -t \
   -u "${USER}" \
   -v "${BOOKKEEPER_ROOT}:${BOOKKEEPER_ROOT}" \
   -v "${LOCAL_HOME}:/home/${USER_NAME}" \
-  -p 4000:4000 \
   ${IMAGE_NAME}-${USER_NAME} \
   bash -c "${CMD}"
 

--- a/site/docker/ci.sh
+++ b/site/docker/ci.sh
@@ -56,7 +56,6 @@ docker run \
   -u "${USER}" \
   -v "${BOOKKEEPER_DOC_ROOT}:${BOOKKEEPER_DOC_ROOT}" \
   -v "${LOCAL_HOME}:/home/${USER_NAME}" \
-  -p 4000:4000 \
   -e JEKYLL_ENV='production' \
   ${IMAGE_NAME}-${USER_NAME} \
   bash -c "make setup && make apache"


### PR DESCRIPTION
Descriptions of the changes in this PR:

some docker images don't need port forwarding. remove port forwarding from them.