### PR TITLE
ISSUE 525 Refactor PerChannelBookieClient

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -63,4 +63,5 @@ public interface BookKeeperClientStats {
     public final static String CHANNEL_TIMEOUT_READ_LAC = "TIMEOUT_READ_LAC";
     public final static String TIMEOUT_GET_BOOKIE_INFO = "TIMEOUT_GET_BOOKIE_INFO";
     public final static String CHANNEL_START_TLS_OP = "START_TLS";
+    public final static String CHANNEL_TIMEOUT_START_TLS_OP = "TIMEOUT_START_TLS";
 }


### PR DESCRIPTION
There's a lot of duplicate code in PerChannelBookieClient, particularly in the completions. It makes it more difficult to add anything to the class.

Concretely the patch:
- Factors out common code from PCBC completions
- Makes erroring out a member of completion classes
- Refactors out writing and flushing messages, so all RPCs use same code path
- Moves timeout handling into CompletionValue
- Moves response handling into completions
- Moves logging and status conversion into a common method