### PR TITLE
Issue-530 BP-14 BP-14 Relax Durability - protocol changes preview

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchBookie.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchBookie.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.api.LedgerType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
@@ -54,7 +55,7 @@ public class BenchBookie {
     static class LatencyCallback implements WriteCallback {
         boolean complete;
         @Override
-        public synchronized void writeComplete(int rc, long ledgerId, long entryId,
+        public synchronized void writeComplete(int rc, long ledgerId, long entryId, long lastAddSyncedEntryId,
                 BookieSocketAddress addr, Object ctx) {
             if (rc != 0) {
                 LOG.error("Got error " + rc);
@@ -75,7 +76,7 @@ public class BenchBookie {
     static class ThroughputCallback implements WriteCallback {
         int count;
         int waitingCount = Integer.MAX_VALUE;
-        public synchronized void writeComplete(int rc, long ledgerId, long entryId,
+        public synchronized void writeComplete(int rc, long ledgerId, long entryId, long lastAddSyncedEnryId,
                 BookieSocketAddress addr, Object ctx) {
             if (rc != 0) {
                 LOG.error("Got error " + rc);
@@ -175,7 +176,7 @@ public class BenchBookie {
             toSend.writeLong(entry);
             toSend.writerIndex(toSend.capacity());
             bc.addEntry(new BookieSocketAddress(addr, port), ledger, new byte[20],
-                        entry, toSend, tc, null, BookieProtocol.FLAG_NONE);
+                        entry, toSend, tc, null, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
         }
         LOG.info("Waiting for warmup");
         tc.waitFor(warmUpCount);
@@ -193,7 +194,7 @@ public class BenchBookie {
             toSend.writerIndex(toSend.capacity());
             lc.resetComplete();
             bc.addEntry(new BookieSocketAddress(addr, port), ledger, new byte[20],
-                        entry, toSend, lc, null, BookieProtocol.FLAG_NONE);
+                        entry, toSend, lc, null, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
             lc.waitForComplete();
         }
         long endTime = System.nanoTime();
@@ -213,7 +214,7 @@ public class BenchBookie {
             toSend.writeLong(entry);
             toSend.writerIndex(toSend.capacity());
             bc.addEntry(new BookieSocketAddress(addr, port), ledger, new byte[20],
-                        entry, toSend, tc, null, BookieProtocol.FLAG_NONE);
+                        entry, toSend, tc, null, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
         }
         tc.waitFor(entryCount);
         endTime = System.currentTimeMillis();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.bookkeeper.proto.BookieProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +123,8 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
             result = logFenceResult = SettableFuture.create();
         }
         ByteBuf entry = createLedgerFenceEntry(ledgerId);
-        journal.logAddEntry(entry, (rc, ledgerId, entryId, addr, ctx) -> {
+        journal.logAddEntry(entry, BookieProtocol.LEDGERTYPE_PD_JOURNAL,
+            (rc, ledgerId, entryId, lastAddSyncedEntryId,addr, ctx) -> {
             LOG.debug("Record fenced state for ledger {} in journal with rc {}", ledgerId, rc);
             if (rc == 0) {
                 fenceEntryPersisted.compareAndSet(false, true);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.AsyncCallback.CreateCallback;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.LedgerType;
 import org.apache.bookkeeper.meta.LedgerIdGenerator;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
@@ -84,7 +85,8 @@ class LedgerCreateOp implements GenericCallback<Void> {
     LedgerCreateOp(BookKeeper bk, int ensembleSize, int writeQuorumSize, int ackQuorumSize, DigestType digestType,
             byte[] passwd, CreateCallback cb, Object ctx, final Map<String, byte[]> customMetadata) {
         this.bk = bk;
-        this.metadata = new LedgerMetadata(ensembleSize, writeQuorumSize, ackQuorumSize, digestType, passwd, customMetadata);
+        this.metadata = new LedgerMetadata(ensembleSize, writeQuorumSize, ackQuorumSize, digestType, passwd, customMetadata,
+                LedgerType.PD_JOURNAL);
         this.digestType = digestType;
         this.passwd = passwd;
         this.cb = cb;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
+import org.apache.bookkeeper.client.api.LedgerType;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
@@ -291,7 +292,7 @@ public class LedgerFragmentReplicator {
                         new WriteCallback() {
                             @Override
                             public void writeComplete(int rc, long ledgerId,
-                                    long entryId, BookieSocketAddress addr,
+                                    long entryId, long lastAddSyncedEntryId, BookieSocketAddress addr,
                                     Object ctx) {
                                 if (rc != BKException.Code.OK) {
                                     LOG.error(
@@ -317,7 +318,9 @@ public class LedgerFragmentReplicator {
                                 ledgerFragmentEntryMcb.processResult(rc, null,
                                         null);
                             }
-                        }, null, BookieProtocol.FLAG_RECOVERY_ADD);
+                            // TODO: using LedgerType.PD_JOURNAL as we want recovery to be guaranteed to succeeed
+                            //       could this be a problem for other LedgerTypes ?
+                        }, null, BookieProtocol.FLAG_RECOVERY_ADD, LedgerType.PD_JOURNAL);
             }
         }, null);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -51,11 +51,13 @@ import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadLastConfirmedCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.LedgerType;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.TimedGenericCallback;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest;
 import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.Gauge;
@@ -100,6 +102,9 @@ public class LedgerHandle implements AutoCloseable {
     final Counter ensembleChangeCounter;
     final Counter lacUpdateHitsCounter;
     final Counter lacUpdateMissesCounter;
+
+    // TODO: use BP-15 API to set ledgerType
+    final LedgerType ledgerType = LedgerType.PD_JOURNAL;
 
     // This empty master key is used when an empty password is provided which is the hash of an empty string
     private final static byte[] emptyLedgerKey;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -103,7 +103,7 @@ class PendingAddOp implements WriteCallback, TimerTask {
         int flags = isRecoveryAdd ? BookieProtocol.FLAG_RECOVERY_ADD : BookieProtocol.FLAG_NONE;
 
         lh.bk.bookieClient.addEntry(lh.metadata.currentEnsemble.get(bookieIndex), lh.ledgerId, lh.ledgerKey, entryId, toSend,
-                this, bookieIndex, flags);
+                this, bookieIndex, flags, lh.ledgerType);
     }
 
     @Override
@@ -198,7 +198,11 @@ class PendingAddOp implements WriteCallback, TimerTask {
     }
 
     @Override
-    public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx) {
+    public void writeComplete(int rc, long ledgerId, long entryId, long lastAddSyncedEntryId,
+        BookieSocketAddress addr, Object ctx) {
+
+        // TODO: lastAddSyncedEntryId and lederType will be handled in next patches for BP-14
+
         int bookieIndex = (Integer) ctx;
 
         if (!lh.metadata.currentEnsemble.get(bookieIndex).equals(addr)) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerType.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client.api;
+
+/**
+ * Describes the type of ledger.
+ * LedgerTypes describes the behaviour of the ledger in respect to durability and
+ * provides hints to the storage of data on Bookies
+ *
+ * @since 4.6
+ */
+public enum LedgerType {
+    /**
+     * Persistent Durability, using Journal.<br>
+     * Each entry is persisted to the journal and every writes receives and acknowledgement only with the guarantee that
+     * it has been persisted durabily to it (data is fsync'd to the disk)
+     */
+    PD_JOURNAL,
+    /**
+     * Volatile Durability, using Journal.<br>
+     * Each entry is persisted to the journal and writes receive acknowledgement without guarantees of persistence
+     * (data is eventually fsync'd to disk).<br>
+     * For this kind of ledgers the client MUST explicitly call {@link LedgerHandle#asyncSync(long, org.apache.bookkeeper.client.AsyncCallback.SyncCallback, java.lang.Object) }
+     * in order to have guarantees of the durability of writes and in order to advance the LastAddConfirmed entry id
+     */
+    VD_JOURNAL
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
@@ -105,7 +105,7 @@ class AuthHandler {
                     ctx.channel().writeAndFlush(
                             new BookieProtocol.AddResponse(
                                     req.getProtocolVersion(), BookieProtocol.EUA,
-                                    req.getLedgerId(), req.getEntryId()));
+                                    req.getLedgerId(), req.getEntryId(), BookieProtocol.INVALID_ENTRY_ID));
                 } else if (req.getOpCode() == BookieProtocol.READENTRY) {
                     ctx.channel().writeAndFlush(
                             new BookieProtocol.ReadResponse(

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -155,7 +155,8 @@ public class BookieProtoEncoding {
                 // Read ledger and entry id without advancing the reader index
                 ledgerId = packet.getLong(packet.readerIndex());
                 entryId = packet.getLong(packet.readerIndex() + 8);
-                return new BookieProtocol.AddRequest(version, ledgerId, entryId, flags, masterKey, packet.retain());
+                return new BookieProtocol.AddRequest(version, ledgerId, entryId, flags, masterKey, packet.retain(),
+                                                     BookieProtocol.LEDGERTYPE_PD_JOURNAL);
             }
 
             case BookieProtocol.READENTRY:
@@ -263,7 +264,8 @@ public class BookieProtoEncoding {
                 rc = buffer.readInt();
                 ledgerId = buffer.readLong();
                 entryId = buffer.readLong();
-                return new BookieProtocol.AddResponse(version, rc, ledgerId, entryId);
+                return new BookieProtocol.AddResponse(version, rc, ledgerId, entryId,
+                                                     BookieProtocol.LEDGERTYPE_PD_JOURNAL);
             case BookieProtocol.READENTRY:
                 rc = buffer.readInt();
                 ledgerId = buffer.readLong();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
@@ -68,7 +68,8 @@ public class BookkeeperInternalCallbacks {
     }
 
     public interface WriteCallback {
-        void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx);
+        void writeComplete(int rc, long ledgerId, long entryId, long lastAddSyncedEntry,
+                           BookieSocketAddress addr, Object ctx);
     }
 
     public interface ReadLacCallback {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ResponseBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ResponseBuilder.java
@@ -26,7 +26,7 @@ class ResponseBuilder {
     static BookieProtocol.Response buildErrorResponse(int errorCode, BookieProtocol.Request r) {
         if (r.getOpCode() == BookieProtocol.ADDENTRY) {
             return new BookieProtocol.AddResponse(r.getProtocolVersion(), errorCode,
-                                                  r.getLedgerId(), r.getEntryId());
+                                                  r.getLedgerId(), r.getEntryId(), BookieProtocol.INVALID_ENTRY_ID);
         } else {
             assert(r.getOpCode() == BookieProtocol.READENTRY);
             return new BookieProtocol.ReadResponse(r.getProtocolVersion(), errorCode,
@@ -34,9 +34,9 @@ class ResponseBuilder {
         }
     }
 
-    static BookieProtocol.Response buildAddResponse(BookieProtocol.Request r) {
+    static BookieProtocol.Response buildAddResponse(BookieProtocol.Request r, long lastAddSyncedEntry) {
         return new BookieProtocol.AddResponse(r.getProtocolVersion(), BookieProtocol.EOK, r.getLedgerId(),
-                                              r.getEntryId());
+                                              r.getEntryId(), lastAddSyncedEntry);
     }
 
     static BookieProtocol.Response buildReadResponse(ByteBuf data, BookieProtocol.Request r) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -64,7 +64,8 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
             if (add.isRecoveryAdd()) {
                 requestProcessor.bookie.recoveryAddEntry(add.getData(), this, channel, add.getMasterKey());
             } else {
-                requestProcessor.bookie.addEntry(add.getData(), this, channel, add.getMasterKey());
+                requestProcessor.bookie.addEntry(add.getData(), BookieProtocol.LEDGERTYPE_PD_JOURNAL,
+                    this, channel, add.getMasterKey());
             }
         } catch (IOException e) {
             LOG.error("Error writing " + add, e);
@@ -89,7 +90,7 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
     }
 
     @Override
-    public void writeComplete(int rc, long ledgerId, long entryId,
+    public void writeComplete(int rc, long ledgerId, long entryId, long lastAddSyncedEntry,
                               BookieSocketAddress addr, Object ctx) {
         if (BookieProtocol.EOK == rc) {
             requestProcessor.addEntryStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),
@@ -99,7 +100,7 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
                     TimeUnit.NANOSECONDS);
         }
         sendResponse(rc,
-                     ResponseBuilder.buildAddResponse(request),
+                     ResponseBuilder.buildAddResponse(request, lastAddSyncedEntry),
                      requestProcessor.addRequestStats);
     }
 

--- a/bookkeeper-server/src/main/proto/BookkeeperProtocol.proto
+++ b/bookkeeper-server/src/main/proto/BookkeeperProtocol.proto
@@ -62,6 +62,7 @@ enum OperationType {
     READ_LAC = 7;
     GET_BOOKIE_INFO = 8;
     START_TLS = 9;
+    SYNC = 10;
 }
 
 /**
@@ -111,6 +112,12 @@ message AddRequest {
     required int64 entryId = 2;
     required bytes masterKey = 3;
     required bytes body = 4;
+
+    enum LedgerType {
+        PD_JOURNAL = 0;
+        VD_JOURNAL = 1;
+    }
+    optional LedgerType ledgerType = 5;
 }
 
 message StartTLSRequest {
@@ -136,6 +143,13 @@ message GetBookieInfoRequest {
     optional int64 requested = 1;
 }
 
+message SyncRequest {
+    required int64 ledgerId = 1;
+    required bytes masterKey = 2;
+    required int64 firstEntryId = 3;
+    required int64 lastEntryId = 4;
+}
+
 message Response {
 
     required BKPacketHeader header = 1;
@@ -150,6 +164,7 @@ message Response {
     optional ReadLacResponse readLacResponse = 104;
     optional GetBookieInfoResponse getBookieInfoResponse = 105;
     optional StartTLSResponse startTLSResponse = 106;
+    optional SyncResponse syncResponse = 107;
 }
 
 message ReadResponse {
@@ -166,6 +181,8 @@ message AddResponse {
     required StatusCode status = 1;
     required int64 ledgerId = 2;
     required int64 entryId = 3;
+    // Piggyback LAS
+    optional int64 lastAddSynced = 4;
 }
 
 message AuthMessage {
@@ -192,4 +209,10 @@ message GetBookieInfoResponse {
 }
 
 message StartTLSResponse {
+}
+
+message SyncResponse {
+    required StatusCode status = 1;
+    required int64 ledgerId = 2;
+    required int64 lastPersistedEntryId = 3;
 }

--- a/bookkeeper-server/src/main/proto/DataFormats.proto
+++ b/bookkeeper-server/src/main/proto/DataFormats.proto
@@ -58,6 +58,12 @@ message LedgerMetadataFormat {
         optional bytes value = 2;
     }
     repeated cMetadataMapEntry customMetadata = 11;
+
+    enum LedgerType {
+        PD_JOURNAL = 0;
+        VD_JOURNAL = 1;
+    }
+    optional LedgerType ledgerType = 12 [default = PD_JOURNAL];
 }
 
 message LedgerRereplicationLayoutFormat {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.bookkeeper.proto.BookieProtocol;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -334,7 +335,7 @@ public class LedgerCacheTest {
         b.start();
         for (int i = 1; i <= numLedgers; i++) {
             ByteBuf packet = generateEntry(i, 1);
-            b.addEntry(packet, new Bookie.NopWriteCallback(), null, "passwd".getBytes());
+            b.addEntry(packet, BookieProtocol.LEDGERTYPE_PD_JOURNAL, new Bookie.NopWriteCallback(), null, "passwd".getBytes());
         }
 
         conf = TestBKConfiguration.newServerConfiguration()
@@ -513,7 +514,7 @@ public class LedgerCacheTest {
 
         // this bookie.addEntry call is required. FileInfo for Ledger 1 would be created with this call.
         // without the fileinfo, 'flushTestSortedLedgerStorage.addEntry' calls will fail because of BOOKKEEPER-965 change.
-        bookie.addEntry(generateEntry(1, 1), new Bookie.NopWriteCallback(), null, "passwd".getBytes());
+        bookie.addEntry(generateEntry(1, 1), BookieProtocol.LEDGERTYPE_PD_JOURNAL, new Bookie.NopWriteCallback(), null, "passwd".getBytes());
 
         flushTestSortedLedgerStorage.addEntry(generateEntry(1, 2));
         assertFalse("Bookie is expected to be in ReadWrite mode", bookie.isReadOnly());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
@@ -87,7 +87,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
                 }
 
                 @Override
-                public void addEntry(ByteBuf entry, WriteCallback cb,
+                public void addEntry(ByteBuf entry, short ledgerType, WriteCallback cb,
                                      Object ctx, byte[] masterKey)
                         throws IOException, BookieException {
                     try {
@@ -97,7 +97,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
                         // and an exception would spam the logs
                         Thread.currentThread().interrupt();
                     }
-                    super.addEntry(entry, cb, ctx, masterKey);
+                    super.addEntry(entry, ledgerType, cb, ctx, masterKey);
                 }
 
                 @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
@@ -195,7 +195,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
             throws Exception {
         Bookie sBookie = new Bookie(conf) {
             @Override
-            public void addEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void addEntry(ByteBuf entry, short ledgerType, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 try {
                     latch.await();
@@ -218,8 +218,9 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
     // so no ensemble change when recovering ledger on this bookie.
     private void startDeadBookie(ServerConfiguration conf, final CountDownLatch latch) throws Exception {
         Bookie dBookie = new Bookie(conf) {
+
             @Override
-            public void addEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void addEntry(ByteBuf entry, short ledgerType, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 try {
                     latch.await();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
@@ -188,7 +188,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
 
         Bookie fakeBookie = new Bookie(conf) {
             @Override
-            public void addEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
+            public void addEntry(ByteBuf entry, short ledgerType, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
                 // drop request to simulate a slow and failed bookie
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.client;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -28,6 +29,7 @@ import java.util.SortedMap;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.LedgerType;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
@@ -236,7 +238,8 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
     public void testSplitIntoSubFragmentsWithDifferentFragmentBoundaries()
             throws Exception {
         LedgerMetadata metadata = new LedgerMetadata(3, 3, 3, TEST_DIGEST_TYPE,
-                TEST_PSSWD) {
+                TEST_PSSWD,
+                null, LedgerType.PD_JOURNAL) {
             @Override
             ArrayList<BookieSocketAddress> getEnsemble(long entryId) {
                 return null;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWatchEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWatchEnsembleChange.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.client.api.LedgerType;
 
 import static org.junit.Assert.*;
 
@@ -120,7 +121,8 @@ public class TestWatchEnsembleChange extends BookKeeperClusterTestCase {
         idGenerator.generateLedgerId(new GenericCallback<Long>() {
             @Override
             public void operationComplete(int rc, final Long lid) {
-                manager.createLedgerMetadata(lid, new LedgerMetadata(4, 2, 2, digestType, "fpj was here".getBytes()),
+                manager.createLedgerMetadata(lid, new LedgerMetadata(4, 2, 2, digestType, "fpj was here".getBytes(),
+                null, LedgerType.PD_JOURNAL),
                          new BookkeeperInternalCallbacks.GenericCallback<Void>(){
 
                     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -61,6 +61,7 @@ import org.apache.bookkeeper.bookie.ScanAndCompareGarbageCollector;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerMetadata;
+import org.apache.bookkeeper.client.api.LedgerType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRange;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
@@ -101,7 +102,8 @@ public class GcLedgersTest extends LedgerManagerTestCase {
                     }
 
                     getLedgerManager().createLedgerMetadata(ledgerId,
-                            new LedgerMetadata(1, 1, 1, DigestType.MAC, "".getBytes()), new GenericCallback<Void>() {
+                            new LedgerMetadata(1, 1, 1, DigestType.MAC, "".getBytes(),
+                                null, LedgerType.PD_JOURNAL), new GenericCallback<Void>() {
                                 @Override
                                 public void operationComplete(int rc, Void result) {
                                     if (rc == BKException.Code.OK) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -46,6 +46,7 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.LedgerMetadata;
+import org.apache.bookkeeper.client.api.LedgerType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
@@ -518,7 +519,8 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         int numofledgers = 5;
         Random rand = new Random();
         for (int i = 0; i < numofledgers; i++) {
-            LedgerMetadata metadata = new LedgerMetadata(3, 2, 2, DigestType.CRC32, "passwd".getBytes(), null);
+            LedgerMetadata metadata = new LedgerMetadata(3, 2, 2, DigestType.CRC32, "passwd".getBytes(),
+                    null, LedgerType.PD_JOURNAL);
             ArrayList<BookieSocketAddress> ensemble = new ArrayList<BookieSocketAddress>();
             ensemble.add(new BookieSocketAddress("99.99.99.99:9999"));
             ensemble.add(new BookieSocketAddress("11.11.11.11:1111"));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
+import org.apache.bookkeeper.client.api.LedgerType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -122,7 +123,8 @@ public class BookieClientTest {
     };
 
     WriteCallback wrcb = new WriteCallback() {
-        public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx) {
+        public void writeComplete(int rc, long ledgerId, long entryId, long lastAddSyncedEntryId,
+            BookieSocketAddress addr, Object ctx) {
             if (ctx != null) {
                 synchronized (ctx) {
                     if (ctx instanceof ResultStruct) {
@@ -145,7 +147,7 @@ public class BookieClientTest {
 
         BookieClient bc = new BookieClient(new ClientConfiguration(), eventLoopGroup, executor);
         ByteBuf bb = createByteBuffer(1, 1, 1);
-        bc.addEntry(addr, 1, passwd, 1, bb, wrcb, arc, BookieProtocol.FLAG_NONE);
+        bc.addEntry(addr, 1, passwd, 1, bb, wrcb, arc, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
         synchronized (arc) {
             arc.wait(1000);
             assertEquals(0, arc.rc);
@@ -155,16 +157,16 @@ public class BookieClientTest {
             assertEquals(1, arc.entry.getInt());
         }
         bb = createByteBuffer(2, 1, 2);
-        bc.addEntry(addr, 1, passwd, 2, bb, wrcb, null, BookieProtocol.FLAG_NONE);
+        bc.addEntry(addr, 1, passwd, 2, bb, wrcb, null, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
         bb = createByteBuffer(3, 1, 3);
-        bc.addEntry(addr, 1, passwd, 3, bb, wrcb, null, BookieProtocol.FLAG_NONE);
+        bc.addEntry(addr, 1, passwd, 3, bb, wrcb, null, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
         bb = createByteBuffer(5, 1, 5);
-        bc.addEntry(addr, 1, passwd, 5, bb, wrcb, null, BookieProtocol.FLAG_NONE);
+        bc.addEntry(addr, 1, passwd, 5, bb, wrcb, null, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
         bb = createByteBuffer(7, 1, 7);
-        bc.addEntry(addr, 1, passwd, 7, bb, wrcb, null, BookieProtocol.FLAG_NONE);
+        bc.addEntry(addr, 1, passwd, 7, bb, wrcb, null, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
         synchronized (notifyObject) {
             bb = createByteBuffer(11, 1, 11);
-            bc.addEntry(addr, 1, passwd, 11, bb, wrcb, notifyObject, BookieProtocol.FLAG_NONE);
+            bc.addEntry(addr, 1, passwd, 11, bb, wrcb, notifyObject, BookieProtocol.FLAG_NONE, LedgerType.PD_JOURNAL);
             notifyObject.wait();
         }
         synchronized (arc) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
 import org.junit.After;
 import org.junit.Before;
@@ -167,7 +168,7 @@ public class ConcurrentLedgerTest {
         throttle = new Semaphore(10000);
         WriteCallback cb = new WriteCallback() {
             @Override
-            public void writeComplete(int rc, long ledgerId, long entryId,
+            public void writeComplete(int rc, long ledgerId, long entryId, long lastAddSyncedEntryId,
                     BookieSocketAddress addr, Object ctx) {
                 AtomicInteger counter = (AtomicInteger)ctx;
                 counter.getAndIncrement();
@@ -187,7 +188,7 @@ public class ConcurrentLedgerTest {
                 bytes.position(0);
                 bytes.limit(bytes.capacity());
                 throttle.acquire();
-                bookie.addEntry(Unpooled.wrappedBuffer(bytes), cb, counter, zeros);
+                bookie.addEntry(Unpooled.wrappedBuffer(bytes), BookieProtocol.LEDGERTYPE_PD_JOURNAL, cb, counter, zeros);
             }
         }
         long finish = System.currentTimeMillis();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LoopbackClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LoopbackClient.java
@@ -27,6 +27,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 
 import java.io.IOException;
 import java.util.Arrays;
+import org.apache.bookkeeper.client.api.LedgerType;
 
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -76,11 +77,12 @@ class LoopbackClient implements WriteCallback {
         byte[] passwd = new byte[20];
         Arrays.fill(passwd, (byte) 'a');
 
-        client.addEntry(addr, ledgerId, passwd, entry, Unpooled.wrappedBuffer(data), cb, ctx, BookieProtocol.FLAG_NONE);
+        client.addEntry(addr, ledgerId, passwd, entry, Unpooled.wrappedBuffer(data), cb, ctx, BookieProtocol.FLAG_NONE,
+            LedgerType.PD_JOURNAL);
     }
 
     @Override
-    public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx) {
+    public void writeComplete(int rc, long ledgerId, long entryId, long lastAddSyncedEntryId, BookieSocketAddress addr, Object ctx) {
         Counter counter = (Counter) ctx;
         counter.increment();
     }


### PR DESCRIPTION
This is the first part of #471.
This patch includes changes to the v3 wire protocol and to metadata stored on zookkeeper

On metadata we are goign to introduce the LedgerType attribute for ledgers:
- PD_JOURNAL: Persistent Durability ledgers using the Journal
- VD_JOURNAL: Volatile Durability ledgers using the Journal

On the wire protocol we are going to change AddRequest and AddResponse to supporto VD_JOURNAL protocol changes to the LAC protocol and to introduce the brand new Sync protocol

More patches will come to implement client side changes and bookie side changes:
- LAC Protocol changes for VD_JOURNAL ledgers
- Introduction of the new 'sync' API
- Changes to the journal to support VD_JOURNAL ledgers and 'sync' API

**Please not that this patch is only a preview** and it needs the changes in #510 to support the creation of VD_JOURNAL ledgers.
It uses the org.apache.bookkeper.client.api package just to have the new LedgerType enum

