### PR TITLE
Issue-532 Drop all @Test(timeout) annotations

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/IndexPersistenceMgrTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/IndexPersistenceMgrTest.java
@@ -134,7 +134,7 @@ public class IndexPersistenceMgrTest {
     final long lid = 1L;
     final byte[] masterKey = "write".getBytes();
 
-    @Test(timeout = 60000)
+    @Test
     public void testGetFileInfoReadBeforeWrite() throws Exception {
         IndexPersistenceMgr indexPersistenceMgr = null;
         try {
@@ -162,7 +162,7 @@ public class IndexPersistenceMgrTest {
         }
     }
 
-    @Test(timeout = 60000)
+    @Test
     public void testGetFileInfoWriteBeforeRead() throws Exception {
         IndexPersistenceMgr indexPersistenceMgr = null;
         try {
@@ -188,7 +188,7 @@ public class IndexPersistenceMgrTest {
         }
     }
 
-    @Test(timeout = 60000)
+    @Test
     public void testReadFileInfoCacheEviction() throws Exception {
         IndexPersistenceMgr indexPersistenceMgr = null;
         try {
@@ -232,7 +232,7 @@ public class IndexPersistenceMgrTest {
         }
     }
 
-    @Test(timeout = 60000)
+    @Test
     public void testEvictionShouldNotAffectLongPollRead() throws Exception {
         IndexPersistenceMgr indexPersistenceMgr = null;
         Observer observer = (obs, obj) -> {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/versioning/TestLongVersion.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/versioning/TestLongVersion.java
@@ -23,7 +23,7 @@ import org.junit.Assert;
 
 public class TestLongVersion {
 
-    @Test(timeout=60000)
+    @Test
     public void testNullIntVersion() {
         LongVersion longVersion = new LongVersion(99);
         try {
@@ -33,7 +33,7 @@ public class TestLongVersion {
         }
     }
 
-    @Test(timeout=60000)
+    @Test
     public void testInvalidVersion() {
         LongVersion longVersion = new LongVersion(99);
         try {
@@ -43,7 +43,7 @@ public class TestLongVersion {
         }
     }
 
-    @Test(timeout=60000)
+    @Test
     public void testCompare() {
         LongVersion iv = new LongVersion(99);
         Assert.assertEquals(Occurred.AFTER, iv.compare(new LongVersion(98)));


### PR DESCRIPTION
Simply drop the 'timeout' parameter for @Test annotations, we have already a global timeout set in surefire configuration