### PR TITLE
Issue 535: Prometheus metrics provider fails to initialize

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusCounter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusCounter.java
@@ -14,11 +14,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.bookkeeper.stats;
+package org.apache.bookkeeper.stats.prometheus;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
+import org.apache.bookkeeper.stats.Counter;
 
 /**
  * A {@link Counter} implementation based on <i>Prometheus</i> metrics library.

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.bookkeeper.stats;
+package org.apache.bookkeeper.stats.prometheus;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.MetricsServlet;
@@ -23,6 +23,8 @@ import io.prometheus.client.hotspot.MemoryPoolsExports;
 import io.prometheus.client.hotspot.StandardExports;
 import io.prometheus.client.hotspot.ThreadExports;
 import java.net.InetSocketAddress;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.commons.configuration.Configuration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusOpStatsLogger.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusOpStatsLogger.java
@@ -14,11 +14,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.bookkeeper.stats;
+package org.apache.bookkeeper.stats.prometheus;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Summary;
 import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.stats.OpStatsData;
+import org.apache.bookkeeper.stats.OpStatsLogger;
 
 /**
  * A {@code Prometheus} based {@link OpStatsLogger} implementation.

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusStatsLogger.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusStatsLogger.java
@@ -14,11 +14,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.bookkeeper.stats;
+package org.apache.bookkeeper.stats.prometheus;
 
 import com.google.common.base.Joiner;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
+import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.Gauge;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
 
 /**
  * A {@code Prometheus} based {@link StatsLogger} implementation.

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusUtil.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusUtil.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.bookkeeper.stats;
+package org.apache.bookkeeper.stats.prometheus;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
@@ -39,7 +39,7 @@ public class PrometheusUtil {
             collectorsMapField = CollectorRegistry.class.getDeclaredField("namesToCollectors");
             collectorsMapField.setAccessible(true);
 
-            collectorsNamesMethod = CollectorRegistry.class.getDeclaredMethod("collectorNames", String.class);
+            collectorsNamesMethod = CollectorRegistry.class.getDeclaredMethod("collectorNames", Collector.class);
             collectorsNamesMethod.setAccessible(true);
 
         } catch (NoSuchFieldException | SecurityException | NoSuchMethodException e) {

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/package-info.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/package-info.java
@@ -15,6 +15,6 @@
  * the License.
  */
 /**
- * A stats provider implementation based on {@link Prometheus}.
+ * A stats provider implementation based on {@link https://prometheus.io/}.
  */
-package org.apache.bookkeeper.stats;
+package org.apache.bookkeeper.stats.prometheus;

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.bookkeeper.stats.prometheus;
+
+import static org.junit.Assert.assertEquals;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.junit.Test;
+
+public class TestPrometheusMetricsProvider {
+
+    private final CollectorRegistry registry = new CollectorRegistry();
+
+    @Test
+    public void testCounter() {
+        PrometheusCounter counter = new PrometheusCounter(registry, "testcounter");
+        long value = counter.get();
+        assertEquals(0L, value);
+        counter.inc();
+        assertEquals(1L, counter.get().longValue());
+        counter.dec();
+        assertEquals(0L, counter.get().longValue());
+        counter.add(3);
+        assertEquals(3L, counter.get().longValue());
+    }
+
+    @Test
+    public void testTwoCounters() throws Exception {
+        PrometheusCounter counter1 = new PrometheusCounter(registry, "testcounter");
+        PrometheusCounter counter2 = new PrometheusCounter(registry, "testcounter");
+        Field collectorsMapField = CollectorRegistry.class.getDeclaredField("namesToCollectors");
+        collectorsMapField.setAccessible(true);
+        Map<String, Collector> collectorMap = (Map<String, Collector>) collectorsMapField.get(registry);
+        assertEquals(1, collectorMap.size());
+    }
+
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

- the parameter of `collectorNames` should be Collector rather than String
- add test case for prometheus metrics provider
- rename the classes to under `org.apache.bookkeeper.stats.prometheus` rather than taking the common `stats` package.
