### PR TITLE
Issue 540: BookieServer failed to start because lifecycle component name is not provided

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/LifecycleComponentStack.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/LifecycleComponentStack.java
@@ -59,7 +59,7 @@ public class LifecycleComponentStack implements LifecycleComponent {
 
         public LifecycleComponentStack build() {
             checkNotNull(name, "Lifecycle component stack name is not provided");
-            checkArgument(!components.isEmpty(), "Lifecycle component stack is empty");
+            checkArgument(!components.isEmpty(), "Lifecycle component stack is empty : " + components);
             return new LifecycleComponentStack(
                 name,
                 ImmutableList.copyOf(components));

--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -470,7 +470,7 @@ ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFa
 # enableStatistics=true
 
 # Stats Provider Class (if statistics are enabled)
-statsProviderClass=org.apache.bookkeeper.stats.PrometheusMetricsProvider
+# statsProviderClass=org.apache.bookkeeper.stats.PrometheusMetricsProvider
 
 #############################################################################
 ## Read-only mode support

--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -470,7 +470,7 @@ ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFa
 # enableStatistics=true
 
 # Stats Provider Class (if statistics are enabled)
-# statsProviderClass=org.apache.bookkeeper.stats.PrometheusMetricsProvider
+# statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 
 #############################################################################
 ## Read-only mode support

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -268,45 +268,39 @@ public class Main {
      * @return lifecycle stack
      */
     private static LifecycleComponent buildBookieServer(BookieConfiguration conf) throws Exception {
-        LifecycleComponentStack.Builder serverBuilder = LifecycleComponentStack.newBuilder();
+        LifecycleComponentStack.Builder serverBuilder = LifecycleComponentStack.newBuilder().withName("bookie-server");
 
-        try {
-            // 1. build stats provider
-            StatsProviderService statsProviderService =
-                new StatsProviderService(conf);
-            StatsLogger rootStatsLogger = statsProviderService.getStatsProvider().getStatsLogger("");
+        // 1. build stats provider
+        StatsProviderService statsProviderService =
+            new StatsProviderService(conf);
+        StatsLogger rootStatsLogger = statsProviderService.getStatsProvider().getStatsLogger("");
 
-            serverBuilder.addComponent(statsProviderService);
+        serverBuilder.addComponent(statsProviderService);
 
-            // 2. build bookie server
-            BookieService bookieService =
-                new BookieService(conf, rootStatsLogger);
+        // 2. build bookie server
+        BookieService bookieService =
+            new BookieService(conf, rootStatsLogger);
 
-            serverBuilder.addComponent(bookieService);
+        serverBuilder.addComponent(bookieService);
 
-            // 3. build auto recovery
-            if (conf.getServerConf().isAutoRecoveryDaemonEnabled()) {
-                AutoRecoveryService autoRecoveryService =
-                    new AutoRecoveryService(conf, rootStatsLogger.scope(REPLICATION_SCOPE));
+        // 3. build auto recovery
+        if (conf.getServerConf().isAutoRecoveryDaemonEnabled()) {
+            AutoRecoveryService autoRecoveryService =
+                new AutoRecoveryService(conf, rootStatsLogger.scope(REPLICATION_SCOPE));
 
-                serverBuilder.addComponent(autoRecoveryService);
-            }
+            serverBuilder.addComponent(autoRecoveryService);
+        }
 
-            // 4. build http service
-            if (conf.getServerConf().isHttpServerEnabled()) {
-                BKServiceProvider provider = new BKServiceProvider.Builder()
-                    .setBookieServer(bookieService.getServer())
-                    .setServerConfiguration(conf.getServerConf())
-                    .build();
-                HttpService httpService =
-                    new HttpService(provider, conf, rootStatsLogger);
+        // 4. build http service
+        if (conf.getServerConf().isHttpServerEnabled()) {
+            BKServiceProvider provider = new BKServiceProvider.Builder()
+                .setBookieServer(bookieService.getServer())
+                .setServerConfiguration(conf.getServerConf())
+                .build();
+            HttpService httpService =
+                new HttpService(provider, conf, rootStatsLogger);
 
-                serverBuilder.addComponent(httpService);
-            }
-        } catch (Exception e) {
-            LifecycleComponent component = serverBuilder.build();
-            component.close();
-            throw e;
+            serverBuilder.addComponent(httpService);
         }
 
         return serverBuilder.build();

--- a/deploy/kubernetes/gke/bookkeeper.yaml
+++ b/deploy/kubernetes/gke/bookkeeper.yaml
@@ -33,7 +33,7 @@ data:
     # the default manager is flat, which is not good for supporting large number of ledgers
     BK_ledgerManagerType: "hierarchical"
     # TODO: Issue 458: https://github.com/apache/bookkeeper/issues/458
-    #BK_statsProviderClass: org.apache.bookkeeper.stats.PrometheusMetricsProvider
+    #BK_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 ---
 
 ## BookKeeper servers need to access the local disks and the pods

--- a/site/docs/latest/admin/metrics.md
+++ b/site/docs/latest/admin/metrics.md
@@ -13,7 +13,7 @@ BookKeeper has stats provider implementations for four five sinks:
 Provider | Provider class name
 :--------|:-------------------
 [Codahale Metrics](https://mvnrepository.com/artifact/org.apache.bookkeeper.stats/codahale-metrics-provider) | `org.apache.bookkeeper.stats.CodahaleMetricsProvider`
-[Prometheus](https://prometheus.io/) | `org.apache.bookkeeper.stats.PrometheusMetricsProvider`
+[Prometheus](https://prometheus.io/) | `org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider`
 [Finagle](https://twitter.github.io/finagle/guide/Metrics.html) | `org.apache.bookkeeper.stats.FinagleStatsProvider`
 [Ostrich](https://github.com/twitter/ostrich) | `org.apache.bookkeeper.stats.OstrichProvider`
 [Twitter Science Provider](https://mvnrepository.com/artifact/org.apache.bookkeeper.stats/twitter-science-provider) | `org.apache.bookkeeper.stats.TwitterStatsProvider`


### PR DESCRIPTION
Descriptions of the changes in this PR:

- add component name `bookie-server`
- remove the catch block
- fix the prometheus stats provider package name in configuration files.
