### PR TITLE
BOOKKEEPER-1062: Fixed the race in AuditorLedgerCheckerTest

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1125,7 +1125,7 @@ public class BookieShell implements Tool {
                 bookies.addAll(availableBookies);
             } else if (cmdLine.hasOption("ro")) {
                 Collection<BookieSocketAddress> roBookies = bka
-                        .getReadOnlyBookies();
+                        .getReadOnlyBookiesAsync();
                 bookies.addAll(roBookies);
             }
             for (BookieSocketAddress b : bookies) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -231,12 +231,22 @@ public class BookKeeperAdmin implements AutoCloseable {
     }
 
     /**
-     * Get a list of readonly bookies
+     * Get a list of readonly bookies synchronously.
+     *
+     * @return a collection of bookie addresses
+     * @throws BKException if there are issues trying to read the list.
+     */
+    public Collection<BookieSocketAddress> getReadOnlyBookiesSync() throws BKException {
+        return bkc.bookieWatcher.getReadOnlyBookiesSync();
+    }
+
+    /**
+     * Get a list of readonly bookies asynchronously (may be slightly out of date).
      *
      * @return a collection of bookie addresses
      */
-    public Collection<BookieSocketAddress> getReadOnlyBookies() {
-        return bkc.bookieWatcher.getReadOnlyBookies();
+    public Collection<BookieSocketAddress> getReadOnlyBookiesAsync() {
+        return bkc.bookieWatcher.getReadOnlyBookiesAsync();
     }
 
     /**
@@ -1186,7 +1196,7 @@ public class BookKeeperAdmin implements AutoCloseable {
     public void decommissionBookie(BookieSocketAddress bookieAddress)
             throws CompatibilityException, UnavailableException, KeeperException, InterruptedException, IOException,
             BKAuditException, TimeoutException, BKException {
-        if (getAvailableBookies().contains(bookieAddress) || getReadOnlyBookies().contains(bookieAddress)) {
+        if (getAvailableBookies().contains(bookieAddress) || getReadOnlyBookiesAsync().contains(bookieAddress)) {
             LOG.error("Bookie: {} is not shutdown yet", bookieAddress);
             throw BKException.create(BKException.Code.IllegalOpException);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
@@ -402,7 +402,7 @@ public class BookieInfoReader {
 
         Collection<BookieSocketAddress> bookies;
         bookies = bk.bookieWatcher.getBookies();
-        bookies.addAll(bk.bookieWatcher.getReadOnlyBookies());
+        bookies.addAll(bk.bookieWatcher.getReadOnlyBookiesAsync());
 
         totalSent.set(bookies.size());
         for (BookieSocketAddress b : bookies) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcher.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcher.java
@@ -133,6 +133,21 @@ class BookieWatcher implements Watcher, ChildrenCallback {
         readOnlyBookieWatcher.notifyBookiesChanged(listener);
     }
 
+    public Collection<BookieSocketAddress> getReadOnlyBookiesSync() throws BKException {
+        try {
+            String znode = this.bookieRegistrationPath + "/" + BookKeeperConstants.READONLY;
+            List<String> children = bk.getZkHandle().getChildren(znode, false);
+            return convertToBookieAddresses(children);
+        } catch (KeeperException ke) {
+            logger.error("Failed to get read only bookie list : ", ke);
+            throw new BKException.ZKException();
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            logger.error("Interrupted reading read only bookie list", ie);
+            throw new BKException.BKInterruptedException();
+        }
+    }
+
     public Collection<BookieSocketAddress> getBookies() throws BKException {
         try {
             List<String> children = bk.getZkHandle().getChildren(this.bookieRegistrationPath, false);
@@ -148,7 +163,7 @@ class BookieWatcher implements Watcher, ChildrenCallback {
         }
     }
 
-    Collection<BookieSocketAddress> getReadOnlyBookies() {
+    Collection<BookieSocketAddress> getReadOnlyBookiesAsync() {
         return new HashSet<BookieSocketAddress>(readOnlyBookieWatcher.getReadOnlyBookies());
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/ListBookiesService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/http/ListBookiesService.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
-import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.service.HttpEndpointService;
 import org.apache.bookkeeper.http.service.HttpServiceRequest;
@@ -71,7 +70,7 @@ public class ListBookiesService implements HttpEndpointService {
               params.get("print_hostnames").equals("true");
 
             if (readOnly) {
-                bookies.addAll(bka.getReadOnlyBookies());
+                bookies.addAll(bka.getReadOnlyBookiesAsync());
             } else {
                 bookies.addAll(bka.getAvailableBookies());
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -235,4 +235,16 @@ public class BookieServer {
     public static void main(String[] args) {
         Main.main(args);
     }
+
+    @Override
+    public  String toString() {
+        String id = "UNKNOWN";
+
+        try {
+            id = Bookie.getBookieAddress(conf).toString();
+        } catch (UnknownHostException e) {
+            //Ignored...
+        }
+        return "Bookie Server listening on " + id;
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -429,7 +429,7 @@ public class Auditor implements BookiesListener {
     private List<String> getAvailableBookies() throws BKException {
         // Get the available bookies
         Collection<BookieSocketAddress> availableBkAddresses = admin.getAvailableBookies();
-        Collection<BookieSocketAddress> readOnlyBkAddresses = admin.getReadOnlyBookies();
+        Collection<BookieSocketAddress> readOnlyBkAddresses = admin.getReadOnlyBookiesSync();
         availableBkAddresses.addAll(readOnlyBkAddresses);
 
         List<String> availableBookies = new ArrayList<String>();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
@@ -365,6 +365,11 @@ public class AuditorElector {
         return running.get();
     }
 
+    @Override
+    public String toString() {
+        return "AuditorElector for " + bookieId;
+    }
+
     /**
      * Compare the votes in the ascending order of the sequence number. Vote
      * format is 'V_sequencenumber', comparator will do sorting based on the

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -190,7 +190,7 @@ public class ReplicationWorker implements Runnable {
 
     private void waitTillTargetBookieIsWritable() {
         LOG.info("Waiting for target bookie {} to be back in read/write mode", targetBookie);
-        while (workerRunning && admin.getReadOnlyBookies().contains(targetBookie)) {
+        while (workerRunning && admin.getReadOnlyBookiesAsync().contains(targetBookie)) {
             isInReadOnlyMode = true;
             waitBackOffTime();
         }
@@ -257,7 +257,7 @@ public class ReplicationWorker implements Runnable {
                 } catch (BKException.BKLedgerRecoveryException e) {
                     LOG.warn("BKLedgerRecoveryException "
                             + "while replicating the fragment", e);
-                    if (admin.getReadOnlyBookies().contains(targetBookie)) {
+                    if (admin.getReadOnlyBookiesAsync().contains(targetBookie)) {
                         underreplicationManager.releaseUnderreplicatedLedger(ledgerIdToReplicate);
                         throw new BKException.BKWriteOnReadOnlyBookieException();
                     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

This fixes the race condition in the auditor between read only bookies and available bookies.  But because I am not sure of the performance impacts to modifying getReadOnlyBookies, I have opted to add in a new getROBookies.  But I am happy to change it.  This pull request is mostly to show my work and see what others think.
