### PR TITLE
Issue-596 Issue-583: Auto replication should honor ensemble placement policy

### DIFF
--- a/bookkeeper-server/conf/log4j.shell.properties
+++ b/bookkeeper-server/conf/log4j.shell.properties
@@ -36,6 +36,13 @@ log4j.appender.CONSOLE.Threshold=INFO
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ABSOLUTE} %-5p %m%n
 
+# verbose console logging
+log4j.appender.VERBOSECONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.VERBOSECONSOLE.Threshold=INFO
+log4j.appender.VERBOSECONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.VERBOSECONSOLE.layout.ConversionPattern=%m%n
+
+log4j.logger.verbose=INFO,VERBOSECONSOLE
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.apache.bookkeeper=ERROR
 log4j.logger.org.apache.bookkeeper.bookie.BookieShell=INFO

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -23,18 +23,22 @@ package org.apache.bookkeeper.client;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.AbstractFuture;
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -70,7 +74,6 @@ import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.KeeperException.Code;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.ZkUtils;
@@ -495,9 +498,20 @@ public class BookKeeperAdmin implements AutoCloseable {
      */
     public void recoverBookieData(final BookieSocketAddress bookieSrc, final BookieSocketAddress bookieDest)
             throws InterruptedException, BKException {
+        Set<BookieSocketAddress> bookiesSrc = Sets.newHashSet(bookieSrc);
+        recoverBookieData(bookiesSrc);
+    }
+
+    public void recoverBookieData(final Set<BookieSocketAddress> bookiesSrc)
+            throws InterruptedException, BKException {
+        recoverBookieData(bookiesSrc, false, false);
+    }
+
+    public void recoverBookieData(final Set<BookieSocketAddress> bookiesSrc, boolean dryrun, boolean skipOpenLedgers)
+            throws InterruptedException, BKException {
         SyncObject sync = new SyncObject();
         // Call the async method to recover bookie data.
-        asyncRecoverBookieData(bookieSrc, bookieDest, new RecoverCallback() {
+        asyncRecoverBookieData(bookiesSrc, dryrun, skipOpenLedgers, new RecoverCallback() {
             @Override
             public void recoverComplete(int rc, Object ctx) {
                 LOG.info("Recover bookie operation completed with rc: " + rc);
@@ -520,7 +534,7 @@ public class BookKeeperAdmin implements AutoCloseable {
             throw BKException.create(sync.rc);
         }
     }
-
+	
     /**
      * Async method to rebuild and recover the ledger fragments data that was
      * stored on the source bookie. That bookie could have failed completely and
@@ -535,89 +549,26 @@ public class BookKeeperAdmin implements AutoCloseable {
      * @param bookieSrc
      *            Source bookie that had a failure. We want to replicate the
      *            ledger fragments that were stored there.
-     * @param bookieDest
-     *            Optional destination bookie that if passed, we will copy all
-     *            of the ledger fragments from the source bookie over to it.
      * @param cb
      *            RecoverCallback to invoke once all of the data on the dead
      *            bookie has been recovered and replicated.
      * @param context
      *            Context for the RecoverCallback to call.
      */
-    public void asyncRecoverBookieData(final BookieSocketAddress bookieSrc, final BookieSocketAddress bookieDest,
+    public void asyncRecoverBookieData(final BookieSocketAddress bookieSrc,
                                        final RecoverCallback cb, final Object context) {
-        // Sync ZK to make sure we're reading the latest bookie data.
-        zk.sync(bookiesPath, new AsyncCallback.VoidCallback() {
-            @Override
-            public void processResult(int rc, String path, Object ctx) {
-                if (rc != Code.OK.intValue()) {
-                    LOG.error("ZK error syncing: ", KeeperException.create(KeeperException.Code.get(rc), path));
-                    cb.recoverComplete(BKException.Code.ZKException, context);
-                    return;
-                }
-                getAvailableBookies(bookieSrc, bookieDest, cb, context);
-            }
-
-        }, null);
+        Set<BookieSocketAddress> bookiesSrc = Sets.newHashSet(bookieSrc);
+        asyncRecoverBookieData(bookiesSrc, cb, context);
     }
 
-    /**
-     * This method asynchronously gets the set of available Bookies that the
-     * dead input bookie's data will be copied over into. If the user passed in
-     * a specific destination bookie, then just use that one. Otherwise, we'll
-     * randomly pick one of the other available bookies to use for each ledger
-     * fragment we are replicating.
-     *
-     * @param bookieSrc
-     *            Source bookie that had a failure. We want to replicate the
-     *            ledger fragments that were stored there.
-     * @param bookieDest
-     *            Optional destination bookie that if passed, we will copy all
-     *            of the ledger fragments from the source bookie over to it.
-     * @param cb
-     *            RecoverCallback to invoke once all of the data on the dead
-     *            bookie has been recovered and replicated.
-     * @param context
-     *            Context for the RecoverCallback to call.
-     */
-    private void getAvailableBookies(final BookieSocketAddress bookieSrc, final BookieSocketAddress bookieDest,
-                                     final RecoverCallback cb, final Object context) {
-        final List<BookieSocketAddress> availableBookies = new LinkedList<BookieSocketAddress>();
-        if (bookieDest != null) {
-            availableBookies.add(bookieDest);
-            // Now poll ZK to get the active ledgers
-            getActiveLedgers(bookieSrc, bookieDest, cb, context, availableBookies);
-        } else {
-            zk.getChildren(bookiesPath, null, new AsyncCallback.ChildrenCallback() {
-                @Override
-                public void processResult(int rc, String path, Object ctx, List<String> children) {
-                    if (rc != Code.OK.intValue()) {
-                        LOG.error("ZK error getting bookie nodes: ", KeeperException.create(KeeperException.Code
-                                  .get(rc), path));
-                        cb.recoverComplete(BKException.Code.ZKException, context);
-                        return;
-                    }
-                    for (String bookieNode : children) {
-                        if (BookKeeperConstants.READONLY
-                                        .equals(bookieNode)) {
-                            // exclude the readonly node from available bookies.
-                            continue;
-                        }
-                        BookieSocketAddress addr;
-                        try {
-                            addr = new BookieSocketAddress(bookieNode);
-                        } catch (UnknownHostException nhe) {
-                            LOG.error("Bookie Node retrieved from ZK has invalid name format: " + bookieNode);
-                            cb.recoverComplete(BKException.Code.ZKException, context);
-                            return;
-                        }
-                        availableBookies.add(addr);
-                    }
-                    // Now poll ZK to get the active ledgers
-                    getActiveLedgers(bookieSrc, null, cb, context, availableBookies);
-                }
-            }, null);
-        }
+    public void asyncRecoverBookieData(final Set<BookieSocketAddress> bookieSrc,
+                                       final RecoverCallback cb, final Object context) {
+        asyncRecoverBookieData(bookieSrc, false, false, cb, context);
+    }
+
+    public void asyncRecoverBookieData(final Set<BookieSocketAddress> bookieSrc, boolean dryrun,
+                                       final boolean skipOpenLedgers, final RecoverCallback cb, final Object context) {
+        getActiveLedgers(bookieSrc, dryrun, skipOpenLedgers, cb, context);
     }
 
     /**
@@ -626,25 +577,21 @@ public class BookKeeperAdmin implements AutoCloseable {
      * determine if any of the ledger fragments for it were stored at the dead
      * input bookie.
      *
-     * @param bookieSrc
-     *            Source bookie that had a failure. We want to replicate the
+     * @param bookiesSrc
+     *            Source bookies that had a failure. We want to replicate the
      *            ledger fragments that were stored there.
-     * @param bookieDest
-     *            Optional destination bookie that if passed, we will copy all
-     *            of the ledger fragments from the source bookie over to it.
+     * @param dryrun
+     *            dryrun the recover procedure.
+     * @param skipOpenLedgers
+     *            Skip recovering open ledgers.
      * @param cb
      *            RecoverCallback to invoke once all of the data on the dead
      *            bookie has been recovered and replicated.
      * @param context
      *            Context for the RecoverCallback to call.
-     * @param availableBookies
-     *            List of Bookie Servers that are available to use for
-     *            replicating data on the failed bookie. This could contain a
-     *            single bookie server if the user explicitly chose a bookie
-     *            server to replicate data to.
      */
-    private void getActiveLedgers(final BookieSocketAddress bookieSrc, final BookieSocketAddress bookieDest,
-            final RecoverCallback cb, final Object context, final List<BookieSocketAddress> availableBookies) {
+    private void getActiveLedgers(final Set<BookieSocketAddress> bookiesSrc, final boolean dryrun,
+                                  final boolean skipOpenLedgers, final RecoverCallback cb, final Object context) {
         // Wrapper class around the RecoverCallback so it can be used
         // as the final VoidCallback to process ledgers
         class RecoverCallbackWrapper implements AsyncCallback.VoidCallback {
@@ -663,7 +610,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         Processor<Long> ledgerProcessor = new Processor<Long>() {
             @Override
             public void process(Long ledgerId, AsyncCallback.VoidCallback iterCallback) {
-                recoverLedger(bookieSrc, ledgerId, iterCallback, availableBookies);
+                recoverLedger(bookiesSrc, ledgerId, dryrun, skipOpenLedgers, iterCallback);
             }
         };
         bkc.getLedgerManager().asyncProcessLedgers(
@@ -672,41 +619,24 @@ public class BookKeeperAdmin implements AutoCloseable {
     }
 
     /**
-     * Get a new random bookie, but ensure that it isn't one that is already
-     * in the ensemble for the ledger.
-     */
-    private BookieSocketAddress getNewBookie(final List<BookieSocketAddress> bookiesAlreadyInEnsemble,
-            final List<BookieSocketAddress> availableBookies)
-            throws BKException.BKNotEnoughBookiesException {
-        ArrayList<BookieSocketAddress> candidates = new ArrayList<BookieSocketAddress>();
-        candidates.addAll(availableBookies);
-        candidates.removeAll(bookiesAlreadyInEnsemble);
-        if (candidates.size() == 0) {
-            throw new BKException.BKNotEnoughBookiesException();
-        }
-        return candidates.get(rand.nextInt(candidates.size()));
-    }
-
-    /**
      * This method asynchronously recovers a given ledger if any of the ledger
      * entries were stored on the failed bookie.
      *
-     * @param bookieSrc
-     *            Source bookie that had a failure. We want to replicate the
+     * @param bookiesSrc
+     *            Source bookies that had a failure. We want to replicate the
      *            ledger fragments that were stored there.
      * @param lId
      *            Ledger id we want to recover.
-     * @param ledgerIterCb
+     * @param dryrun
+     *            printing the recovery plan without actually recovering bookies
+     * @param skipOpenLedgers
+     *            Skip recovering open ledgers.
+     * @param finalLedgerIterCb
      *            IterationCallback to invoke once we've recovered the current
      *            ledger.
-     * @param availableBookies
-     *            List of Bookie Servers that are available to use for
-     *            replicating data on the failed bookie. This could contain a
-     *            single bookie server if the user explicitly chose a bookie
-     *            server to replicate data to.
      */
-    private void recoverLedger(final BookieSocketAddress bookieSrc, final long lId,
-            final AsyncCallback.VoidCallback ledgerIterCb, final List<BookieSocketAddress> availableBookies) {
+    private void recoverLedger(final Set<BookieSocketAddress> bookiesSrc, final long lId, final boolean dryrun,
+                               final boolean skipOpenLedgers, final AsyncCallback.VoidCallback finalLedgerIterCb) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Recovering ledger : {}", lId);
         }
@@ -714,13 +644,27 @@ public class BookKeeperAdmin implements AutoCloseable {
         asyncOpenLedgerNoRecovery(lId, new OpenCallback() {
             @Override
             public void openComplete(int rc, final LedgerHandle lh, Object ctx) {
-                if (rc != Code.OK.intValue()) {
+                if (rc != BKException.Code.OK) {
                     LOG.error("BK error opening ledger: " + lId, BKException.create(rc));
-                    ledgerIterCb.processResult(rc, null, null);
+                    finalLedgerIterCb.processResult(rc, null, null);
                     return;
                 }
 
                 LedgerMetadata lm = lh.getLedgerMetadata();
+                if (skipOpenLedgers && !lm.isClosed() && !lm.isInRecovery()) {
+                    LOG.info("Skip recovering open ledger {}.", lId);
+                    try {
+                        lh.close();
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    } catch (BKException bke) {
+                        LOG.warn("Error on closing ledger handle for {}.", lId);
+                    }
+                    finalLedgerIterCb.processResult(BKException.Code.OK, null, null);
+                    return;
+                }
+
+                boolean fenceRequired = false;
                 if (!lm.isClosed() &&
                     lm.getEnsembles().size() > 0) {
                     Long lastKey = lm.getEnsembles().lastKey();
@@ -729,7 +673,8 @@ public class BookKeeperAdmin implements AutoCloseable {
                     // current ledger ensemble. to avoid data loss issue in
                     // the case of concurrent updates to the ensemble composition,
                     // the recovery tool should first close the ledger
-                    if (lastEnsemble.contains(bookieSrc)) {
+                    fenceRequired = containBookies(lastEnsemble, bookiesSrc);
+                    if (!dryrun && fenceRequired) {
                         // close opened non recovery ledger handle
                         try {
                             lh.close();
@@ -739,18 +684,39 @@ public class BookKeeperAdmin implements AutoCloseable {
                         asyncOpenLedger(lId, new OpenCallback() {
                             @Override
                             public void openComplete(int newrc, final LedgerHandle newlh, Object newctx) {
-                                if (newrc != Code.OK.intValue()) {
+                                if (newrc != BKException.Code.OK) {
                                     LOG.error("BK error close ledger: " + lId, BKException.create(newrc));
-                                    ledgerIterCb.processResult(newrc, null, null);
+                                    finalLedgerIterCb.processResult(newrc, null, null);
                                     return;
                                 }
-                                // do recovery
-                                recoverLedger(bookieSrc, lId, ledgerIterCb, availableBookies);
+                                bkc.mainWorkerPool.submit(() -> {
+                                    // do recovery
+                                    recoverLedger(bookiesSrc, lId, dryrun, skipOpenLedgers, finalLedgerIterCb);
+                                });
                             }
                         }, null);
                         return;
                     }
                 }
+
+                final AsyncCallback.VoidCallback ledgerIterCb = new AsyncCallback.VoidCallback() {
+                    @Override
+                    public void processResult(int rc, String path, Object ctx) {
+                        if (BKException.Code.OK != rc) {
+                            LOG.error("Failed to recover ledger {} : {}", lId, rc);
+                        } else {
+                            LOG.info("Recovered ledger {}.", lId);
+                        }
+                        try {
+                            lh.close();
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        } catch (BKException bke) {
+                            LOG.warn("Error on cloing ledger handle for {}.", lId);
+                        }
+                        finalLedgerIterCb.processResult(rc, path, ctx);
+                    }
+                };
 
                 /*
                  * This List stores the ledger fragments to recover indexed by
@@ -773,7 +739,7 @@ public class BookKeeperAdmin implements AutoCloseable {
                     if (curEntryId != null)
                         ledgerFragmentsRange.put(curEntryId, entry.getKey() - 1);
                     curEntryId = entry.getKey();
-                    if (entry.getValue().contains(bookieSrc)) {
+                    if (containBookies(entry.getValue(), bookiesSrc)) {
                         /*
                          * Current ledger fragment has entries stored on the
                          * dead bookie so we'll need to recover them.
@@ -797,6 +763,10 @@ public class BookKeeperAdmin implements AutoCloseable {
                     return;
                 }
 
+                if (dryrun) {
+                    System.out.println("Recovered ledger " + lId + " : " + (fenceRequired ? "[fence required]" : ""));
+                }
+
                 /*
                  * Multicallback for ledger. Once all fragments for the ledger have been recovered
                  * trigger the ledgerIterCb
@@ -810,45 +780,69 @@ public class BookKeeperAdmin implements AutoCloseable {
                  */
                 for (final Long startEntryId : ledgerFragmentsToRecover) {
                     Long endEntryId = ledgerFragmentsRange.get(startEntryId);
-                    BookieSocketAddress newBookie = null;
+                    ArrayList<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsembles().get(startEntryId);
+                    // Get bookies to replace
+                    Map<Integer, BookieSocketAddress> targetBookieAddresses;
                     try {
-                        newBookie = getNewBookie(lh.getLedgerMetadata().getEnsembles().get(startEntryId),
-                                                 availableBookies);
-                    } catch (BKException.BKNotEnoughBookiesException bke) {
-                        ledgerFragmentsMcb.processResult(BKException.Code.NotEnoughBookiesException,
-                                                         null, null);
+                        targetBookieAddresses = getReplacedBookies(lh, ensemble, bookiesSrc);
+                    } catch (BKException.BKNotEnoughBookiesException e) {
+                        if (!dryrun) {
+                            ledgerFragmentsMcb.processResult(BKException.Code.NotEnoughBookiesException, null, null);
+                        } else {
+                            System.out.println("  Fragment [" + startEntryId + " - " + endEntryId + " ] : "
+                                               + BKException.getMessage(BKException.Code.NotEnoughBookiesException));
+                        }
+                        continue;
+                    }
+
+                    if (dryrun) {
+                        ArrayList<BookieSocketAddress> newEnsemble =
+                                replaceBookiesInEnsemble(ensemble, targetBookieAddresses);
+                        System.out.println("  Fragment [" + startEntryId + " - " + endEntryId + " ] : ");
+                        System.out.println("    old ensemble : " + formatEnsemble(ensemble, bookiesSrc, '*'));
+                        System.out.println("    new ensemble : " + formatEnsemble(newEnsemble, bookiesSrc, '*'));
                         continue;
                     }
 
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Replicating fragment from [" + startEntryId
                                   + "," + endEntryId + "] of ledger " + lh.getId()
-                                  + " to " + newBookie);
+                                  + " to " + targetBookieAddresses);
                     }
                     try {
                         LedgerFragmentReplicator.SingleFragmentCallback cb = new LedgerFragmentReplicator.SingleFragmentCallback(
-                                                                               ledgerFragmentsMcb, lh, startEntryId, bookieSrc, newBookie);
-                        ArrayList<BookieSocketAddress> currentEnsemble = lh.getLedgerMetadata().getEnsemble(
-                                startEntryId);
-                        int bookieIndex = -1;
-                        if (null != currentEnsemble) {
-                            for (int i = 0; i < currentEnsemble.size(); i++) {
-                                if (currentEnsemble.get(i).equals(bookieSrc)) {
-                                    bookieIndex = i;
-                                    break;
-                                }
-                            }
-                        }
+                                ledgerFragmentsMcb, lh, startEntryId, getReplacedBookiesMap(ensemble, targetBookieAddresses));
                         LedgerFragment ledgerFragment = new LedgerFragment(lh,
-                                startEntryId, endEntryId, bookieIndex);
-                        asyncRecoverLedgerFragment(lh, ledgerFragment, cb, newBookie);
+                                startEntryId, endEntryId, targetBookieAddresses.keySet());
+                        asyncRecoverLedgerFragment(lh, ledgerFragment, cb, Sets.newHashSet(targetBookieAddresses.values()));
                     } catch(InterruptedException e) {
                         Thread.currentThread().interrupt();
                         return;
                     }
                 }
+                if (dryrun) {
+                    ledgerIterCb.processResult(BKException.Code.OK, null, null);
+                }
             }
             }, null);
+    }
+
+    static String formatEnsemble(ArrayList<BookieSocketAddress> ensemble, Set<BookieSocketAddress> bookiesSrc, char marker) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        for (int i = 0; i < ensemble.size(); i++) {
+            sb.append(ensemble.get(i));
+            if (bookiesSrc.contains(ensemble.get(i))) {
+                sb.append(marker);
+            } else {
+                sb.append(' ');
+            }
+            if (i != ensemble.size() - 1) {
+                sb.append(", ");
+            }
+        }
+        sb.append("]");
+        return sb.toString();
     }
 
     /**
@@ -863,16 +857,81 @@ public class BookKeeperAdmin implements AutoCloseable {
      * @param ledgerFragmentMcb
      *            - MultiCallback to invoke once we've recovered the current
      *            ledger fragment.
-     * @param newBookie
-     *            - New bookie we want to use to recover and replicate the
+     * @param newBookies
+     *            - New bookies we want to use to recover and replicate the
      *            ledger entries that were stored on the failed bookie.
      */
     private void asyncRecoverLedgerFragment(final LedgerHandle lh,
             final LedgerFragment ledgerFragment,
             final AsyncCallback.VoidCallback ledgerFragmentMcb,
-            final BookieSocketAddress newBookie)
-            throws InterruptedException {
-        lfr.replicate(lh, ledgerFragment, ledgerFragmentMcb, newBookie);
+            final Set<BookieSocketAddress> newBookies) throws InterruptedException {
+        lfr.replicate(lh, ledgerFragment, ledgerFragmentMcb, newBookies);
+    }
+
+    private Map<Integer, BookieSocketAddress> getReplacedBookies(
+                LedgerHandle lh,
+                List<BookieSocketAddress> ensemble,
+                Set<BookieSocketAddress> bookiesToRereplicate)
+            throws BKException.BKNotEnoughBookiesException {
+        Set<Integer> bookieIndexesToRereplicate = Sets.newHashSet();
+        for (int bookieIndex = 0; bookieIndex < ensemble.size(); bookieIndex++) {
+            BookieSocketAddress bookieInEnsemble = ensemble.get(bookieIndex);
+            if (bookiesToRereplicate.contains(bookieInEnsemble)) {
+                bookieIndexesToRereplicate.add(bookieIndex);
+            }
+        }
+        return getReplacedBookiesByIndexes(
+                lh, ensemble, bookieIndexesToRereplicate, Optional.of(bookiesToRereplicate));
+    }
+
+    private Map<Integer, BookieSocketAddress> getReplacedBookiesByIndexes(
+                LedgerHandle lh,
+                List<BookieSocketAddress> ensemble,
+                Set<Integer> bookieIndexesToRereplicate,
+                Optional<Set<BookieSocketAddress>> excludedBookies)
+            throws BKException.BKNotEnoughBookiesException {
+        // target bookies to replicate
+        Map<Integer, BookieSocketAddress> targetBookieAddresses =
+                Maps.newHashMapWithExpectedSize(bookieIndexesToRereplicate.size());
+        // bookies to exclude for ensemble allocation
+        Set<BookieSocketAddress> bookiesToExclude = Sets.newHashSet();
+        if (excludedBookies.isPresent()) {
+            bookiesToExclude.addAll(excludedBookies.get());
+        }
+
+        // excluding bookies that need to be replicated
+        for (Integer bookieIndex : bookieIndexesToRereplicate) {
+            BookieSocketAddress bookie = ensemble.get(bookieIndex);
+            bookiesToExclude.add(bookie);
+        }
+
+        // allocate bookies
+        for (Integer bookieIndex : bookieIndexesToRereplicate) {
+            BookieSocketAddress oldBookie = ensemble.get(bookieIndex);
+            BookieSocketAddress newBookie =
+                    bkc.getPlacementPolicy().replaceBookie(
+                            lh.getLedgerMetadata().getEnsembleSize(),
+                            lh.getLedgerMetadata().getWriteQuorumSize(),
+                            lh.getLedgerMetadata().getAckQuorumSize(),
+                            lh.getLedgerMetadata().getCustomMetadata(),
+                            ensemble,
+                            oldBookie,
+                            bookiesToExclude);
+            targetBookieAddresses.put(bookieIndex, newBookie);
+            bookiesToExclude.add(newBookie);
+        }
+
+        return targetBookieAddresses;
+    }
+
+    private ArrayList<BookieSocketAddress> replaceBookiesInEnsemble(
+            List<BookieSocketAddress> ensemble,
+            Map<Integer, BookieSocketAddress> replacedBookies) {
+        ArrayList<BookieSocketAddress> newEnsemble = Lists.newArrayList(ensemble);
+        for (Map.Entry<Integer, BookieSocketAddress> entry : replacedBookies.entrySet()) {
+            newEnsemble.set(entry.getKey(), entry.getValue());
+        }
+        return newEnsemble;
     }
 
     /**
@@ -882,26 +941,73 @@ public class BookKeeperAdmin implements AutoCloseable {
      *            - ledgerHandle
      * @param ledgerFragment
      *            - LedgerFragment to replicate
-     * @param targetBookieAddress
-     *            - target Bookie, to where entries should be replicated.
      */
     public void replicateLedgerFragment(LedgerHandle lh,
+            final LedgerFragment ledgerFragment)
+            throws InterruptedException, BKException {
+        Optional<Set<BookieSocketAddress>> excludedBookies = Optional.empty();
+        Map<Integer, BookieSocketAddress> targetBookieAddresses =
+                getReplacedBookiesByIndexes(lh, ledgerFragment.getEnsemble(),
+                        ledgerFragment.getBookiesIndexes(), excludedBookies);
+        replicateLedgerFragment(lh, ledgerFragment, targetBookieAddresses);
+    }
+
+    private void replicateLedgerFragment(LedgerHandle lh,
             final LedgerFragment ledgerFragment,
-            final BookieSocketAddress targetBookieAddress)
+            final Map<Integer, BookieSocketAddress> targetBookieAddresses)
             throws InterruptedException, BKException {
         CompletableFuture<Void> result = new CompletableFuture<>();
         ResultCallBack resultCallBack = new ResultCallBack(result);
-        SingleFragmentCallback cb = new SingleFragmentCallback(resultCallBack,
-                lh, ledgerFragment.getFirstEntryId(), ledgerFragment
-                        .getAddress(), targetBookieAddress);
+        SingleFragmentCallback cb = new SingleFragmentCallback(
+            resultCallBack,
+            lh,
+            ledgerFragment.getFirstEntryId(),
+            getReplacedBookiesMap(ledgerFragment, targetBookieAddresses));
 
-        asyncRecoverLedgerFragment(lh, ledgerFragment, cb, targetBookieAddress);
+        Set<BookieSocketAddress> targetBookieSet = Sets.newHashSet();
+        targetBookieSet.addAll(targetBookieAddresses.values());
+        asyncRecoverLedgerFragment(lh, ledgerFragment, cb, targetBookieSet);
 
         try {
             SyncCallbackUtils.waitForResult(result);
         } catch (BKException err) {
             throw BKException.create(bkc.getReturnRc(err.getCode()));
         }
+    }
+	
+	private static Map<BookieSocketAddress, BookieSocketAddress> getReplacedBookiesMap(
+            ArrayList<BookieSocketAddress> ensemble,
+            Map<Integer, BookieSocketAddress> targetBookieAddresses) {
+        Map<BookieSocketAddress, BookieSocketAddress> bookiesMap =
+                new HashMap<BookieSocketAddress, BookieSocketAddress>();
+        for (Map.Entry<Integer, BookieSocketAddress> entry : targetBookieAddresses.entrySet()) {
+            BookieSocketAddress oldBookie = ensemble.get(entry.getKey());
+            BookieSocketAddress newBookie = entry.getValue();
+            bookiesMap.put(oldBookie, newBookie);
+        }
+        return bookiesMap;
+    }
+
+    private static Map<BookieSocketAddress, BookieSocketAddress> getReplacedBookiesMap(
+            LedgerFragment ledgerFragment,
+            Map<Integer, BookieSocketAddress> targetBookieAddresses) {
+        Map<BookieSocketAddress, BookieSocketAddress> bookiesMap =
+                new HashMap<BookieSocketAddress, BookieSocketAddress>();
+        for (Integer bookieIndex : ledgerFragment.getBookiesIndexes()) {
+            BookieSocketAddress oldBookie = ledgerFragment.getAddress(bookieIndex);
+            BookieSocketAddress newBookie = targetBookieAddresses.get(bookieIndex);
+            bookiesMap.put(oldBookie, newBookie);
+        }
+        return bookiesMap;
+    }
+
+    private static boolean containBookies(ArrayList<BookieSocketAddress> ensemble, Set<BookieSocketAddress> bookies) {
+        for (BookieSocketAddress bookie : ensemble) {
+            if (bookies.contains(bookie)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** This is the class for getting the replication result */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -784,7 +784,7 @@ public class BookKeeperAdmin implements AutoCloseable {
                     // Get bookies to replace
                     Map<Integer, BookieSocketAddress> targetBookieAddresses;
                     try {
-                        targetBookieAddresses = getReplacedBookies(lh, ensemble, bookiesSrc);
+                        targetBookieAddresses = getReplacementBookies(lh, ensemble, bookiesSrc);
                     } catch (BKException.BKNotEnoughBookiesException e) {
                         if (!dryrun) {
                             ledgerFragmentsMcb.processResult(BKException.Code.NotEnoughBookiesException, null, null);
@@ -811,7 +811,7 @@ public class BookKeeperAdmin implements AutoCloseable {
                     }
                     try {
                         LedgerFragmentReplicator.SingleFragmentCallback cb = new LedgerFragmentReplicator.SingleFragmentCallback(
-                                ledgerFragmentsMcb, lh, startEntryId, getReplacedBookiesMap(ensemble, targetBookieAddresses));
+                                ledgerFragmentsMcb, lh, startEntryId, getReplacementBookiesMap(ensemble, targetBookieAddresses));
                         LedgerFragment ledgerFragment = new LedgerFragment(lh,
                                 startEntryId, endEntryId, targetBookieAddresses.keySet());
                         asyncRecoverLedgerFragment(lh, ledgerFragment, cb, Sets.newHashSet(targetBookieAddresses.values()));
@@ -868,7 +868,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         lfr.replicate(lh, ledgerFragment, ledgerFragmentMcb, newBookies);
     }
 
-    private Map<Integer, BookieSocketAddress> getReplacedBookies(
+    private Map<Integer, BookieSocketAddress> getReplacementBookies(
                 LedgerHandle lh,
                 List<BookieSocketAddress> ensemble,
                 Set<BookieSocketAddress> bookiesToRereplicate)
@@ -880,11 +880,11 @@ public class BookKeeperAdmin implements AutoCloseable {
                 bookieIndexesToRereplicate.add(bookieIndex);
             }
         }
-        return getReplacedBookiesByIndexes(
+        return getReplacementBookiesByIndexes(
                 lh, ensemble, bookieIndexesToRereplicate, Optional.of(bookiesToRereplicate));
     }
 
-    private Map<Integer, BookieSocketAddress> getReplacedBookiesByIndexes(
+    private Map<Integer, BookieSocketAddress> getReplacementBookiesByIndexes(
                 LedgerHandle lh,
                 List<BookieSocketAddress> ensemble,
                 Set<Integer> bookieIndexesToRereplicate,
@@ -947,7 +947,7 @@ public class BookKeeperAdmin implements AutoCloseable {
             throws InterruptedException, BKException {
         Optional<Set<BookieSocketAddress>> excludedBookies = Optional.empty();
         Map<Integer, BookieSocketAddress> targetBookieAddresses =
-                getReplacedBookiesByIndexes(lh, ledgerFragment.getEnsemble(),
+                getReplacementBookiesByIndexes(lh, ledgerFragment.getEnsemble(),
                         ledgerFragment.getBookiesIndexes(), excludedBookies);
         replicateLedgerFragment(lh, ledgerFragment, targetBookieAddresses);
     }
@@ -962,7 +962,7 @@ public class BookKeeperAdmin implements AutoCloseable {
             resultCallBack,
             lh,
             ledgerFragment.getFirstEntryId(),
-            getReplacedBookiesMap(ledgerFragment, targetBookieAddresses));
+            getReplacementBookiesMap(ledgerFragment, targetBookieAddresses));
 
         Set<BookieSocketAddress> targetBookieSet = Sets.newHashSet();
         targetBookieSet.addAll(targetBookieAddresses.values());
@@ -975,7 +975,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         }
     }
 	
-	private static Map<BookieSocketAddress, BookieSocketAddress> getReplacedBookiesMap(
+	private static Map<BookieSocketAddress, BookieSocketAddress> getReplacementBookiesMap(
             ArrayList<BookieSocketAddress> ensemble,
             Map<Integer, BookieSocketAddress> targetBookieAddresses) {
         Map<BookieSocketAddress, BookieSocketAddress> bookiesMap =
@@ -988,7 +988,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         return bookiesMap;
     }
 
-    private static Map<BookieSocketAddress, BookieSocketAddress> getReplacedBookiesMap(
+    private static Map<BookieSocketAddress, BookieSocketAddress> getReplacementBookiesMap(
             LedgerFragment ledgerFragment,
             Map<Integer, BookieSocketAddress> targetBookieAddresses) {
         Map<BookieSocketAddress, BookieSocketAddress> bookiesMap =

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
@@ -20,15 +20,14 @@
 package org.apache.bookkeeper.client;
 
 import io.netty.buffer.ByteBuf;
-
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
@@ -81,39 +80,125 @@ public class LedgerChecker {
         }
     }
 
+    /**
+     * This will collect the bad bookies inside a ledger fragment.
+     */
+    private static class LedgerFragmentCallback implements GenericCallback<LedgerFragment> {
+
+        private final LedgerFragment fragment;
+        private final int bookieIndex;
+        // bookie index -> return code
+        private final Map<Integer, Integer> badBookies;
+        private final AtomicInteger numBookies;
+        private final GenericCallback<LedgerFragment> cb;
+
+        LedgerFragmentCallback(LedgerFragment lf,
+                               int bookieIndex,
+                               GenericCallback<LedgerFragment> cb,
+                               Map<Integer, Integer> badBookies,
+                               AtomicInteger numBookies) {
+            this.fragment = lf;
+            this.bookieIndex = bookieIndex;
+            this.cb = cb;
+            this.badBookies = badBookies;
+            this.numBookies = numBookies;
+        }
+
+        @Override
+        public void operationComplete(int rc, LedgerFragment lf) {
+            if (BKException.Code.OK != rc) {
+                synchronized (badBookies) {
+                    badBookies.put(bookieIndex, rc);
+                }
+            }
+            if (numBookies.decrementAndGet() == 0) {
+                if (badBookies.isEmpty()) {
+                    cb.operationComplete(BKException.Code.OK, fragment);
+                } else {
+                    int rcToReturn = BKException.Code.NoBookieAvailableException;
+                    for (Map.Entry<Integer, Integer> entry : badBookies.entrySet()) {
+                        rcToReturn = entry.getValue();
+                        if (entry.getValue() == BKException.Code.ClientClosedException) {
+                            break;
+                        }
+                    }
+                    cb.operationComplete(rcToReturn,
+                            fragment.subset(badBookies.keySet()));
+                }
+            }
+        }
+    }
+
     public LedgerChecker(BookKeeper bkc) {
         bookieClient = bkc.getBookieClient();
     }
 
+    /**
+     * Verify a ledger fragment to collect bad bookies
+     *
+     * @param fragment
+     *          fragment to verify
+     * @param cb
+     *          callback
+     * @throws InvalidFragmentException
+     */
     private void verifyLedgerFragment(LedgerFragment fragment,
-            GenericCallback<LedgerFragment> cb) throws InvalidFragmentException {
-        long firstStored = fragment.getFirstStoredEntryId();
-        long lastStored = fragment.getLastStoredEntryId();
+                                      GenericCallback<LedgerFragment> cb)
+            throws InvalidFragmentException, BKException {
+        Set<Integer> bookiesToCheck = fragment.getBookiesIndexes();
+        if (bookiesToCheck.isEmpty()) {
+            cb.operationComplete(BKException.Code.OK, fragment);
+            return;
+        }
 
-        // because of this if block, even if the bookie of the fragment is 
-        // down, it considers Fragment is available/not-bad if firstStored
-        // and lastStored are LedgerHandle.INVALID_ENTRY_ID.
-        // So same logic is used in BookieShell.DecommissionBookieCmd.areEntriesOfSegmentStoredInTheBookie
-        // if any change is made here, then the changes should be in BookieShell also
+        AtomicInteger numBookies = new AtomicInteger(bookiesToCheck.size());
+        Map<Integer, Integer> badBookies = new HashMap<Integer, Integer>();
+        for (Integer bookieIndex : bookiesToCheck) {
+            LedgerFragmentCallback lfCb = new LedgerFragmentCallback(
+                    fragment, bookieIndex, cb, badBookies, numBookies);
+            verifyLedgerFragment(fragment, bookieIndex, lfCb);
+        }
+    }
+
+    /**
+     * Verify a bookie inside a ledger fragment.
+     *
+     * @param fragment
+     *          ledger fragment
+     * @param bookieIndex
+     *          bookie index in the fragment
+     * @param cb
+     *          callback
+     * @throws InvalidFragmentException
+     */
+    private void verifyLedgerFragment(LedgerFragment fragment,
+                                      int bookieIndex,
+                                      GenericCallback<LedgerFragment> cb)
+            throws InvalidFragmentException {
+        long firstStored = fragment.getFirstStoredEntryId(bookieIndex);
+        long lastStored = fragment.getLastStoredEntryId(bookieIndex);
+
+        BookieSocketAddress bookie = fragment.getAddress(bookieIndex);
+        if (null == bookie) {
+            throw new InvalidFragmentException();
+        }
+
         if (firstStored == LedgerHandle.INVALID_ENTRY_ID) {
+            // this fragment is not on this bookie
             if (lastStored != LedgerHandle.INVALID_ENTRY_ID) {
                 throw new InvalidFragmentException();
             }
             cb.operationComplete(BKException.Code.OK, fragment);
-            return;
-        }
-        if (firstStored == lastStored) {
+        } else if (firstStored == lastStored) {
             ReadManyEntriesCallback manycb = new ReadManyEntriesCallback(1,
                     fragment, cb);
-            bookieClient.readEntry(fragment.getAddress(), fragment
+            bookieClient.readEntry(bookie, fragment
                     .getLedgerId(), firstStored, manycb, null);
         } else {
             ReadManyEntriesCallback manycb = new ReadManyEntriesCallback(2,
                     fragment, cb);
-            bookieClient.readEntry(fragment.getAddress(), fragment
-                    .getLedgerId(), firstStored, manycb, null);
-            bookieClient.readEntry(fragment.getAddress(), fragment
-                    .getLedgerId(), lastStored, manycb, null);
+            bookieClient.readEntry(bookie, fragment.getLedgerId(), firstStored, manycb, null);
+            bookieClient.readEntry(bookie, fragment.getLedgerId(), lastStored, manycb, null);
         }
     }
 
@@ -191,44 +276,49 @@ public class LedgerChecker {
         for (Map.Entry<Long, ArrayList<BookieSocketAddress>> e : lh
                 .getLedgerMetadata().getEnsembles().entrySet()) {
             if (curEntryId != null) {
+                Set<Integer> bookieIndexes = new HashSet<Integer>();
                 for (int i = 0; i < curEnsemble.size(); i++) {
-                    fragments.add(new LedgerFragment(lh, curEntryId,
-                            e.getKey() - 1, i));
+                    bookieIndexes.add(i);
                 }
+                fragments.add(new LedgerFragment(lh, curEntryId,
+                        e.getKey() - 1, bookieIndexes));
             }
             curEntryId = e.getKey();
             curEnsemble = e.getValue();
         }
 
-        /* Checking the last fragment of the ledger can be complicated in some cases.
+
+
+
+        /* Checking the last segment of the ledger can be complicated in some cases.
          * In the case that the ledger is closed, we can just check the fragments of
-         * the ledger as normal, except in the case that no entry was ever written,
-         * to the ledger, in which case we check no fragments.
+         * the segment as normal even if no data has ever been written to.
          * In the case that the ledger is open, but enough entries have been written,
-         * for lastAddConfirmed to be set above the start entry of the fragment, we
+         * for lastAddConfirmed to be set above the start entry of the segment, we
          * can also check as normal.
-         * However, if lastAddConfirmed cannot be trusted, such as when it's lower than
-         * the first entry id, or not set at all, we cannot be sure if there has been
-         * data written to the fragment. For this reason, we have to send a read request
+         * However, if ledger is open, sometimes lastAddConfirmed cannot be trusted,
+         * such as when it's lower than the first entry id, or not set at all,
+         * we cannot be sure if there has been data written to the segment.
+         * For this reason, we have to send a read request
          * to the bookies which should have the first entry. If they respond with
          * NoSuchEntry we can assume it was never written. If they respond with anything
          * else, we must assume the entry has been written, so we run the check.
          */
-        if (curEntryId != null && !(lh.getLedgerMetadata().isClosed() && lh.getLastAddConfirmed() < curEntryId)) {
+        if (curEntryId != null) {
             long lastEntry = lh.getLastAddConfirmed();
 
-            if (lastEntry < curEntryId) {
+            if (!lh.isClosed() && lastEntry < curEntryId) {
                 lastEntry = curEntryId;
             }
 
-            final Set<LedgerFragment> finalFragments = new HashSet<LedgerFragment>();
+            Set<Integer> bookieIndexes = new HashSet<Integer>();
             for (int i = 0; i < curEnsemble.size(); i++) {
-                finalFragments.add(new LedgerFragment(lh, curEntryId,
-                        lastEntry, i));
+                bookieIndexes.add(i);
             }
+            final LedgerFragment lastLedgerFragment = new LedgerFragment(lh, curEntryId,
+                    lastEntry, bookieIndexes);
 
-            // Check for the case that no last confirmed entry has
-            // been set.
+            // Check for the case that no last confirmed entry has been set
             if (curEntryId == lastEntry) {
                 final long entryToRead = curEntryId;
 
@@ -237,7 +327,7 @@ public class LedgerChecker {
                                               new GenericCallback<Boolean>() {
                                                   public void operationComplete(int rc, Boolean result) {
                                                       if (result) {
-                                                          fragments.addAll(finalFragments);
+                                                          fragments.add(lastLedgerFragment);
                                                       }
                                                       checkFragments(fragments, cb);
                                                   }
@@ -250,7 +340,7 @@ public class LedgerChecker {
                 }
                 return;
             } else {
-                fragments.addAll(finalFragments);
+                fragments.add(lastLedgerFragment);
             }
         }
 
@@ -275,7 +365,10 @@ public class LedgerChecker {
                 LOG.error("Invalid fragment found : {}", r);
                 allFragmentsCb.operationComplete(
                         BKException.Code.IncorrectParameterException, r);
+            } catch (BKException e) {
+                LOG.error("BKException when checking fragment : {}", r, e);
             }
         }
     }
+
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -21,15 +21,16 @@ package org.apache.bookkeeper.client;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieProtocol;
@@ -79,7 +80,7 @@ public class LedgerFragmentReplicator {
     private void replicateFragmentInternal(final LedgerHandle lh,
             final LedgerFragment lf,
             final AsyncCallback.VoidCallback ledgerFragmentMcb,
-            final BookieSocketAddress newBookie) throws InterruptedException {
+            final Set<BookieSocketAddress> newBookies) throws InterruptedException {
         if (!lf.isClosed()) {
             LOG.error("Trying to replicate an unclosed fragment;"
                       + " This is not safe {}", lf);
@@ -94,13 +95,13 @@ public class LedgerFragmentReplicator {
              * Ideally this should never happen if bookie failure is taken care
              * of properly. Nothing we can do though in this case.
              */
-            LOG.warn("Dead bookie (" + lf.getAddress()
+            LOG.warn("Dead bookie (" + lf.getAddresses()
                     + ") is still part of the current"
                     + " active ensemble for ledgerId: " + lh.getId());
             ledgerFragmentMcb.processResult(BKException.Code.OK, null, null);
             return;
         }
-        if (startEntryId > endEntryId) {
+        if (startEntryId > endEntryId || endEntryId <= -1L) {
             // for open ledger which there is no entry, the start entry id is 0,
             // the end entry id is -1.
             // we can return immediately to trigger forward read
@@ -126,7 +127,7 @@ public class LedgerFragmentReplicator {
                 BKException.Code.LedgerRecoveryException);
         for (final Long entryId : entriesToReplicate) {
             recoverLedgerFragmentEntry(entryId, lh, ledgerFragmentEntryMcb,
-                    newBookie);
+                    newBookies);
         }
     }
 
@@ -146,27 +147,27 @@ public class LedgerFragmentReplicator {
      * @param ledgerFragmentMcb
      *            MultiCallback to invoke once we've recovered the current
      *            ledger fragment.
-     * @param targetBookieAddress
-     *            New bookie we want to use to recover and replicate the ledger
+     * @param targetBookieAddresses
+     *            New bookies we want to use to recover and replicate the ledger
      *            entries that were stored on the failed bookie.
      */
     void replicate(final LedgerHandle lh, final LedgerFragment lf,
             final AsyncCallback.VoidCallback ledgerFragmentMcb,
-            final BookieSocketAddress targetBookieAddress)
+            final Set<BookieSocketAddress> targetBookieAddresses)
             throws InterruptedException {
         Set<LedgerFragment> partionedFragments = splitIntoSubFragments(lh, lf,
                 bkc.getConf().getRereplicationEntryBatchSize());
-        LOG.info("Fragment :" + lf + " is split into sub fragments :"
-                + partionedFragments);
+        LOG.info("Replicating fragment {} in {} sub fragments.",
+                lf, partionedFragments.size());
         replicateNextBatch(lh, partionedFragments.iterator(),
-                ledgerFragmentMcb, targetBookieAddress);
+                ledgerFragmentMcb, targetBookieAddresses);
     }
 
     /** Replicate the batched entry fragments one after other */
     private void replicateNextBatch(final LedgerHandle lh,
             final Iterator<LedgerFragment> fragments,
             final AsyncCallback.VoidCallback ledgerFragmentMcb,
-            final BookieSocketAddress targetBookieAddress) {
+            final Set<BookieSocketAddress> targetBookieAddresses) {
         if (fragments.hasNext()) {
             try {
                 replicateFragmentInternal(lh, fragments.next(),
@@ -179,11 +180,11 @@ public class LedgerFragmentReplicator {
                                 } else {
                                     replicateNextBatch(lh, fragments,
                                             ledgerFragmentMcb,
-                                            targetBookieAddress);
+                                            targetBookieAddresses);
                                 }
                             }
 
-                        }, targetBookieAddress);
+                        }, targetBookieAddresses);
             } catch (InterruptedException e) {
                 ledgerFragmentMcb.processResult(
                         BKException.Code.InterruptedException, null, null);
@@ -224,7 +225,7 @@ public class LedgerFragmentReplicator {
         for (int i = 0; i < splitsWithFullEntries; i++) {
             fragmentSplitLastEntry = (firstEntryId + rereplicationEntryBatchSize) - 1;
             fragments.add(new LedgerFragment(lh, firstEntryId,
-                    fragmentSplitLastEntry, ledgerFragment.getBookiesIndex()));
+                    fragmentSplitLastEntry, ledgerFragment.getBookiesIndexes()));
             firstEntryId = fragmentSplitLastEntry + 1;
         }
 
@@ -233,7 +234,7 @@ public class LedgerFragmentReplicator {
         if (lastSplitWithPartialEntries > 0) {
             fragments.add(new LedgerFragment(lh, firstEntryId, firstEntryId
                     + lastSplitWithPartialEntries - 1, ledgerFragment
-                    .getBookiesIndex()));
+                    .getBookiesIndexes()));
         }
         return fragments;
     }
@@ -242,7 +243,7 @@ public class LedgerFragmentReplicator {
      * This method asynchronously recovers a specific ledger entry by reading
      * the values via the BookKeeper Client (which would read it from the other
      * replicas) and then writing it to the chosen new bookie.
-     * 
+     *
      * @param entryId
      *            Ledger Entry ID to recover.
      * @param lh
@@ -250,14 +251,41 @@ public class LedgerFragmentReplicator {
      * @param ledgerFragmentEntryMcb
      *            MultiCallback to invoke once we've recovered the current
      *            ledger entry.
-     * @param newBookie
-     *            New bookie we want to use to recover and replicate the ledger
+     * @param newBookies
+     *            New bookies we want to use to recover and replicate the ledger
      *            entries that were stored on the failed bookie.
      */
     private void recoverLedgerFragmentEntry(final Long entryId,
             final LedgerHandle lh,
             final AsyncCallback.VoidCallback ledgerFragmentEntryMcb,
-            final BookieSocketAddress newBookie) throws InterruptedException {
+            final Set<BookieSocketAddress> newBookies) throws InterruptedException {
+        final AtomicInteger numCompleted = new AtomicInteger(0);
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final WriteCallback multiWriteCallback = new WriteCallback() {
+            @Override
+            public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx) {
+                if (rc != BKException.Code.OK) {
+                    LOG.error("BK error writing entry for ledgerId: {}, entryId: {}, bookie: {}",
+                              new Object[] { ledgerId, entryId, addr, BKException.create(rc) });
+                    if (completed.compareAndSet(false, true)) {
+                        ledgerFragmentEntryMcb.processResult(rc, null, null);
+                    }
+                } else {
+                    numEntriesWritten.inc();
+                    if (ctx instanceof Long) {
+                        numBytesWritten.registerSuccessfulValue((Long) ctx);
+                    }
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Success writing ledger id {}, entry id {} to a new bookie {}!",
+                                  new Object[] { ledgerId, entryId, addr });
+                    }
+                    if (numCompleted.incrementAndGet() == newBookies.size() &&
+                        completed.compareAndSet(false, true)) {
+                        ledgerFragmentEntryMcb.processResult(rc, null, null);
+                    }
+                }
+            }
+        };
         /*
          * Read the ledger entry using the LedgerHandle. This will allow us to
          * read the entry from one of the other replicated bookies other than
@@ -286,42 +314,16 @@ public class LedgerFragmentReplicator {
                         .computeDigestAndPackageForSending(entryId,
                                 lh.getLastAddConfirmed(), entry.getLength(),
                                 Unpooled.wrappedBuffer(data, 0, data.length));
-                bkc.getBookieClient().addEntry(newBookie, lh.getId(),
-                        lh.getLedgerKey(), entryId, toSend,
-                        new WriteCallback() {
-                            @Override
-                            public void writeComplete(int rc, long ledgerId,
-                                    long entryId, BookieSocketAddress addr,
-                                    Object ctx) {
-                                if (rc != BKException.Code.OK) {
-                                    LOG.error(
-                                            "BK error writing entry for ledgerId: "
-                                                    + ledgerId + ", entryId: "
-                                                    + entryId + ", bookie: "
-                                                    + addr, BKException
-                                                    .create(rc));
-                                } else {
-                                    numEntriesWritten.inc();
-                                    numBytesWritten.registerSuccessfulValue(dataLength);
-                                    if (LOG.isDebugEnabled()) {
-                                        LOG.debug("Success writing ledger id "
-                                                + ledgerId + ", entry id "
-                                                + entryId + " to a new bookie "
-                                                + addr + "!");
-                                    }
-                                }
-                                /*
-                                 * Pass the return code result up the chain with
-                                 * the parent callback.
-                                 */
-                                ledgerFragmentEntryMcb.processResult(rc, null,
-                                        null);
-                            }
-                        }, null, BookieProtocol.FLAG_RECOVERY_ADD);
+                for (BookieSocketAddress newBookie : newBookies) {
+                    bkc.getBookieClient().addEntry(newBookie, lh.getId(),
+                            lh.getLedgerKey(), entryId, toSend.retainedSlice(),
+                            multiWriteCallback, dataLength, BookieProtocol.FLAG_RECOVERY_ADD);
+                }
+                toSend.release();
             }
         }, null);
     }
-    
+
     /**
      * Callback for recovery of a single ledger fragment. Once the fragment has
      * had all entries replicated, update the ensemble in zookeeper. Once
@@ -332,17 +334,15 @@ public class LedgerFragmentReplicator {
         final AsyncCallback.VoidCallback ledgerFragmentsMcb;
         final LedgerHandle lh;
         final long fragmentStartId;
-        final BookieSocketAddress oldBookie;
-        final BookieSocketAddress newBookie;
+        final Map<BookieSocketAddress, BookieSocketAddress> oldBookie2NewBookie;
 
         SingleFragmentCallback(AsyncCallback.VoidCallback ledgerFragmentsMcb,
                 LedgerHandle lh, long fragmentStartId,
-                BookieSocketAddress oldBookie, BookieSocketAddress newBookie) {
+                Map<BookieSocketAddress, BookieSocketAddress> oldBookie2NewBookie) {
             this.ledgerFragmentsMcb = ledgerFragmentsMcb;
             this.lh = lh;
             this.fragmentStartId = fragmentStartId;
-            this.newBookie = newBookie;
-            this.oldBookie = oldBookie;
+            this.oldBookie2NewBookie = oldBookie2NewBookie;
         }
 
         @Override
@@ -353,39 +353,32 @@ public class LedgerFragmentReplicator {
                 ledgerFragmentsMcb.processResult(rc, null, null);
                 return;
             }
-            updateEnsembleInfo(ledgerFragmentsMcb, fragmentStartId, lh,
-                                        oldBookie, newBookie);
+            updateEnsembleInfo(ledgerFragmentsMcb, fragmentStartId, lh, oldBookie2NewBookie);
         }
     }
 
     /** Updates the ensemble with newBookie and notify the ensembleUpdatedCb */
     private static void updateEnsembleInfo(
             AsyncCallback.VoidCallback ensembleUpdatedCb, long fragmentStartId,
-            LedgerHandle lh, BookieSocketAddress oldBookie,
-            BookieSocketAddress newBookie) {
+            LedgerHandle lh, Map<BookieSocketAddress, BookieSocketAddress> oldBookie2NewBookie) {
         /*
          * Update the ledger metadata's ensemble info to point to the new
          * bookie.
          */
         ArrayList<BookieSocketAddress> ensemble = lh.getLedgerMetadata()
                 .getEnsembles().get(fragmentStartId);
-        int deadBookieIndex = ensemble.indexOf(oldBookie);
-
-        /*
-         * An update to the ensemble info might happen after re-reading ledger metadata.
-         * Such an update might reflect a change to the ensemble membership such that 
-         * it might not be necessary to replace the bookie.
-         */
-        if (deadBookieIndex >= 0) {
-            ensemble.remove(deadBookieIndex);
-            ensemble.add(deadBookieIndex, newBookie);
-            lh.writeLedgerConfig(new UpdateEnsembleCb(ensembleUpdatedCb,
-                        fragmentStartId, lh, oldBookie, newBookie));
+        for (Map.Entry<BookieSocketAddress, BookieSocketAddress> entry : oldBookie2NewBookie.entrySet()) {
+            int deadBookieIndex = ensemble.indexOf(entry.getKey());
+            // update ensemble info might happen after re-read ledger metadata, so the ensemble might already
+            // change. if ensemble is already changed, skip replacing the bookie doesn't exist.
+            if (deadBookieIndex >= 0) {
+                ensemble.set(deadBookieIndex, entry.getValue());
+            } else {
+                LOG.info("Bookie {} doesn't exist in ensemble {} anymore.", entry.getKey(), ensemble);
+            }
         }
-        else {
-            LOG.warn("Bookie {} doesn't exist in ensemble {} anymore.", oldBookie, ensemble);
-            ensembleUpdatedCb.processResult(BKException.Code.UnexpectedConditionException, null, null);
-        }
+        lh.writeLedgerConfig(new UpdateEnsembleCb(ensembleUpdatedCb,
+                fragmentStartId, lh, oldBookie2NewBookie));
     }
 
     /**
@@ -397,17 +390,15 @@ public class LedgerFragmentReplicator {
         final AsyncCallback.VoidCallback ensembleUpdatedCb;
         final LedgerHandle lh;
         final long fragmentStartId;
-        final BookieSocketAddress oldBookie;
-        final BookieSocketAddress newBookie;
+        final Map<BookieSocketAddress, BookieSocketAddress> oldBookie2NewBookie;
 
         public UpdateEnsembleCb(AsyncCallback.VoidCallback ledgerFragmentsMcb,
                 long fragmentStartId, LedgerHandle lh,
-                BookieSocketAddress oldBookie, BookieSocketAddress newBookie) {
+                Map<BookieSocketAddress, BookieSocketAddress> oldBookie2NewBookie) {
             this.ensembleUpdatedCb = ledgerFragmentsMcb;
             this.lh = lh;
             this.fragmentStartId = fragmentStartId;
-            this.newBookie = newBookie;
-            this.oldBookie = oldBookie;
+            this.oldBookie2NewBookie = oldBookie2NewBookie;
         }
 
         @Override
@@ -418,9 +409,8 @@ public class LedgerFragmentReplicator {
                 // try again, the previous success (with which this has
                 // conflicted) will have updated the stat other operations
                 // such as (addEnsemble) would update it too.
-                lh
-                        .rereadMetadata(new OrderedSafeGenericCallback<LedgerMetadata>(
-                                lh.bk.getMainWorkerPool(), lh.getId()) {
+                lh.rereadMetadata(new OrderedSafeGenericCallback<LedgerMetadata>(
+                                lh.bk.mainWorkerPool, lh.getId()) {
                             @Override
                             public void safeOperationComplete(int rc,
                                     LedgerMetadata newMeta) {
@@ -433,8 +423,7 @@ public class LedgerFragmentReplicator {
                                 } else {
                                     lh.metadata = newMeta;
                                     updateEnsembleInfo(ensembleUpdatedCb,
-                                            fragmentStartId, lh, oldBookie,
-                                            newBookie);
+                                            fragmentStartId, lh, oldBookie2NewBookie);
                                 }
                             }
                             @Override
@@ -449,8 +438,8 @@ public class LedgerFragmentReplicator {
             } else {
                 LOG.info("Updated ZK for ledgerId: (" + lh.getId() + " : "
                         + fragmentStartId
-                        + ") to point ledger fragments from old dead bookie: ("
-                        + oldBookie + ") to new bookie: (" + newBookie + ")");
+                        + ") to point ledger fragments from old bookies to new bookies: "
+                        + oldBookie2NewBookie);
             }
             /*
              * Pass the return code result up the chain with the parent

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -19,6 +19,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.apache.bookkeeper.client.LedgerHandle.INVALID_ENTRY_ID;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
@@ -101,7 +103,7 @@ public class LedgerFragmentReplicator {
             ledgerFragmentMcb.processResult(BKException.Code.OK, null, null);
             return;
         }
-        if (startEntryId > endEntryId || endEntryId <= -1L) {
+        if (startEntryId > endEntryId || endEntryId <= INVALID_ENTRY_ID) {
             // for open ledger which there is no entry, the start entry id is 0,
             // the end entry id is -1.
             // we can return immediately to trigger forward read

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -113,10 +113,13 @@ public class ServerConfiguration extends AbstractConfiguration {
     protected final static String DISK_USAGE_WARN_THRESHOLD = "diskUsageWarnThreshold";
     protected final static String DISK_USAGE_LWM_THRESHOLD = "diskUsageLwmThreshold";
     protected final static String DISK_CHECK_INTERVAL = "diskCheckInterval";
+
+    // Replication parameters
     protected final static String AUDITOR_PERIODIC_CHECK_INTERVAL = "auditorPeriodicCheckInterval";
     protected final static String AUDITOR_PERIODIC_BOOKIE_CHECK_INTERVAL = "auditorPeriodicBookieCheckInterval";
     protected final static String AUTO_RECOVERY_DAEMON_ENABLED = "autoRecoveryDaemonEnabled";
     protected final static String LOST_BOOKIE_RECOVERY_DELAY = "lostBookieRecoveryDelay";
+    protected final static String RW_REREPLICATE_BACKOFF_MS = "rwRereplicateBackoffMs";
 
     // Worker Thread parameters.
     protected final static String NUM_ADD_WORKER_THREADS = "numAddWorkerThreads";
@@ -1752,6 +1755,24 @@ public class ServerConfiguration extends AbstractConfiguration {
      */
     public void setLostBookieRecoveryDelay(int interval) {
         setProperty(LOST_BOOKIE_RECOVERY_DELAY, interval);
+    }
+
+    /**
+     * Get how long to backoff when encountering exception on rereplicating a ledger.
+     *
+     * @return backoff time in milliseconds
+     */
+    public int getRwRereplicateBackoffMs() {
+        return getInt(RW_REREPLICATE_BACKOFF_MS, 5000);
+    }
+
+    /**
+     * Set how long to backoff when encountering exception on rereplicating a ledger.
+     *
+     * @param backoffMs backoff time in milliseconds
+     */
+    public void setRwRereplicateBackoffMs(int backoffMs) {
+        setProperty(RW_REREPLICATE_BACKOFF_MS, backoffMs);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -20,6 +20,10 @@
  */
 package org.apache.bookkeeper.replication;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.SettableFuture;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,7 +37,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
@@ -62,11 +65,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Stopwatch;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.SettableFuture;
 
 /**
  * Auditor is a single entity in the entire Bookie cluster and will be watching
@@ -570,7 +568,7 @@ public class Auditor implements BookiesListener {
                 if (rc == BKException.Code.OK) {
                     Set<BookieSocketAddress> bookies = Sets.newHashSet();
                     for (LedgerFragment f : fragments) {
-                        bookies.add(f.getAddress());
+                        bookies.addAll(f.getAddresses());
                     }
                     for (BookieSocketAddress bookie : bookies) {
                         publishSuspectedLedgers(bookie.toString(), Sets.newHashSet(lh.getId()));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -20,14 +20,12 @@
  */
 package org.apache.bookkeeper.replication;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.HashSet;
 import java.util.Set;
-
-import com.google.common.annotations.VisibleForTesting;
-
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieCriticalThread;
 import org.apache.bookkeeper.bookie.ExitCode;
@@ -105,8 +103,7 @@ public class AutoRecoveryMain {
                 .build();
         auditorElector = new AuditorElector(Bookie.getBookieAddress(conf).toString(), conf,
                 zk, statsLogger.scope(AUDITOR_SCOPE));
-        replicationWorker = new ReplicationWorker(zk, conf,
-                Bookie.getBookieAddress(conf), statsLogger.scope(REPLICATION_WORKER_SCOPE));
+        replicationWorker = new ReplicationWorker(zk, conf, statsLogger.scope(REPLICATION_WORKER_SCOPE));
         deathWatcher = new AutoRecoveryDeathWatcher(this);
     }
 
@@ -115,7 +112,7 @@ public class AutoRecoveryMain {
         this.conf = conf;
         this.zk = zk;
         auditorElector = new AuditorElector(Bookie.getBookieAddress(conf).toString(), conf, zk);
-        replicationWorker = new ReplicationWorker(zk, conf, Bookie.getBookieAddress(conf));
+        replicationWorker = new ReplicationWorker(zk, conf);
         deathWatcher = new AutoRecoveryDeathWatcher(this);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationStats.java
@@ -43,6 +43,7 @@ public interface ReplicationStats {
     public final static String NUM_BYTES_READ = "NUM_BYTES_READ";
     public final static String NUM_ENTRIES_WRITTEN = "NUM_ENTRIES_WRITTEN";
     public final static String NUM_BYTES_WRITTEN = "NUM_BYTES_WRITTEN";
+	public final static String REPLICATE_EXCEPTION = "exceptions";
 
     public final static String BK_CLIENT_SCOPE = "bk_client";
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationStats.java
@@ -43,7 +43,7 @@ public interface ReplicationStats {
     public final static String NUM_BYTES_READ = "NUM_BYTES_READ";
     public final static String NUM_ENTRIES_WRITTEN = "NUM_ENTRIES_WRITTEN";
     public final static String NUM_BYTES_WRITTEN = "NUM_BYTES_WRITTEN";
-	public final static String REPLICATE_EXCEPTION = "exceptions";
+    public final static String REPLICATE_EXCEPTION = "exceptions";
 
     public final static String BK_CLIENT_SCOPE = "bk_client";
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -19,8 +19,10 @@
  */
 package org.apache.bookkeeper.replication;
 
+import com.google.common.base.Stopwatch;
 import java.io.IOException;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -29,9 +31,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import com.google.common.base.Stopwatch;
-
 import org.apache.bookkeeper.bookie.BookieThread;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.BKBookieHandleNotAvailableException;
@@ -61,6 +60,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.bookkeeper.replication.ReplicationStats.BK_CLIENT_SCOPE;
+import static org.apache.bookkeeper.replication.ReplicationStats.NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED;
+import static org.apache.bookkeeper.replication.ReplicationStats.REPLICATE_EXCEPTION;
 import static org.apache.bookkeeper.replication.ReplicationStats.REREPLICATE_OP;
 
 /**
@@ -68,24 +69,24 @@ import static org.apache.bookkeeper.replication.ReplicationStats.REREPLICATE_OP;
  * ZKLedgerUnderreplicationManager and replicates to it.
  */
 public class ReplicationWorker implements Runnable {
-    private final static Logger LOG = LoggerFactory
+    private static final Logger LOG = LoggerFactory
             .getLogger(ReplicationWorker.class);
-    final private LedgerUnderreplicationManager underreplicationManager;
+    private final LedgerUnderreplicationManager underreplicationManager;
     private final ServerConfiguration conf;
     private final ZooKeeper zkc;
     private volatile boolean workerRunning = false;
-    private volatile boolean isInReadOnlyMode = false;
-    final private BookKeeperAdmin admin;
+    private final BookKeeperAdmin admin;
     private final LedgerChecker ledgerChecker;
-    private final BookieSocketAddress targetBookie;
     private final BookKeeper bkc;
     private final Thread workerThread;
     private final long openLedgerRereplicationGracePeriod;
     private final Timer pendingReplicationTimer;
 
     // Expose Stats
+    private final StatsLogger statsLogger;
     private final OpStatsLogger rereplicateOpStats;
     private final Counter numLedgersReplicated;
+    private final Map<String,Counter> exceptionCounters;
 
     /**
      * Replication worker for replicating the ledger fragments from
@@ -96,15 +97,12 @@ public class ReplicationWorker implements Runnable {
      *            - ZK instance
      * @param conf
      *            - configurations
-     * @param targetBKAddr
-     *            - to where replication should happen. Ideally this will be
-     *            local Bookie address.
      */
     public ReplicationWorker(final ZooKeeper zkc,
-                             final ServerConfiguration conf, BookieSocketAddress targetBKAddr)
+                             final ServerConfiguration conf)
             throws CompatibilityException, KeeperException,
             InterruptedException, IOException {
-        this(zkc, conf, targetBKAddr, NullStatsLogger.INSTANCE);
+        this(zkc, conf, NullStatsLogger.INSTANCE);
     }
 
     /**
@@ -116,18 +114,16 @@ public class ReplicationWorker implements Runnable {
      *            - ZK instance
      * @param conf
      *            - configurations
-     * @param targetBKAddr
-     *            - to where replication should happen. Ideally this will be
-     *            local Bookie address.
+     * @param statsLogger
+     *            - stats logger
      */
     public ReplicationWorker(final ZooKeeper zkc,
-                             final ServerConfiguration conf, BookieSocketAddress targetBKAddr,
+                             final ServerConfiguration conf,
                              StatsLogger statsLogger)
             throws CompatibilityException, KeeperException,
             InterruptedException, IOException {
         this.zkc = zkc;
         this.conf = conf;
-        this.targetBookie = targetBKAddr;
         LedgerManagerFactory mFactory = LedgerManagerFactory
                 .newLedgerManagerFactory(this.conf, this.zkc);
         this.underreplicationManager = mFactory
@@ -144,8 +140,10 @@ public class ReplicationWorker implements Runnable {
         this.pendingReplicationTimer = new Timer("PendingReplicationTimer");
 
         // Expose Stats
-        this.rereplicateOpStats = statsLogger.getOpStatsLogger(REREPLICATE_OP);
-        this.numLedgersReplicated = statsLogger.getCounter(ReplicationStats.NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED);
+        this.statsLogger = statsLogger;
+        this.rereplicateOpStats = this.statsLogger.getOpStatsLogger(REREPLICATE_OP);
+        this.numLedgersReplicated = this.statsLogger.getCounter(NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED);
+        this.exceptionCounters = new HashMap<String, Counter>();
     }
 
     /** Start the replication worker */
@@ -167,11 +165,7 @@ public class ReplicationWorker implements Runnable {
                 return;
             } catch (BKException e) {
                 LOG.error("BKException while replicating fragments", e);
-                if (e instanceof BKException.BKWriteOnReadOnlyBookieException) {
-                    waitTillTargetBookieIsWritable();
-                } else {
-                    waitBackOffTime();
-                }
+                waitBackOffTime();
             } catch (UnavailableException e) {
                 LOG.error("UnavailableException "
                         + "while replicating fragments", e);
@@ -186,17 +180,6 @@ public class ReplicationWorker implements Runnable {
             Thread.sleep(5000);
         } catch (InterruptedException e) {
         }
-    }
-
-    private void waitTillTargetBookieIsWritable() {
-        LOG.info("Waiting for target bookie {} to be back in read/write mode", targetBookie);
-        while (workerRunning && admin.getReadOnlyBookiesAsync().contains(targetBookie)) {
-            isInReadOnlyMode = true;
-            waitBackOffTime();
-        }
-
-        isInReadOnlyMode = false;
-        LOG.info("Target bookie {} is back in read/write mode", targetBookie);
     }
 
     /**
@@ -229,38 +212,31 @@ public class ReplicationWorker implements Runnable {
             LOG.debug("Going to replicate the fragments of the ledger: {}", ledgerIdToReplicate);
         }
         try (LedgerHandle lh = admin.openLedgerNoRecovery(ledgerIdToReplicate)) {
-            Set<LedgerFragment> fragments = getUnderreplicatedFragments(lh);
+            Set<LedgerFragment> fragmentsBeforeReplicate = getUnderreplicatedFragments(lh);
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Founds fragments {} for replication from ledger: {}", fragments, ledgerIdToReplicate);
+                LOG.debug("Founds fragments {} for replication from ledger: {}",
+                    fragmentsBeforeReplicate, ledgerIdToReplicate);
             }
 
             boolean foundOpenFragments = false;
             long numFragsReplicated = 0;
-            for (LedgerFragment ledgerFragment : fragments) {
+            for (LedgerFragment ledgerFragment : fragmentsBeforeReplicate) {
                 if (!ledgerFragment.isClosed()) {
                     foundOpenFragments = true;
                     continue;
-                } else if (isTargetBookieExistsInFragmentEnsemble(lh,
-                        ledgerFragment)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Target Bookie[{}] found in the fragment ensemble: {}", targetBookie,
-                                ledgerFragment.getEnsemble());
-                    }
-                    continue;
                 }
                 try {
-                    admin.replicateLedgerFragment(lh, ledgerFragment, targetBookie);
+                    LOG.info("Going to replicate the fragments of the ledger: {}", ledgerIdToReplicate);
+                    admin.replicateLedgerFragment(lh, ledgerFragment);
                     numFragsReplicated++;
                 } catch (BKException.BKBookieHandleNotAvailableException e) {
                     LOG.warn("BKBookieHandleNotAvailableException "
-                            + "while replicating the fragment", e);
+                            + "while replicating the fragment {}", ledgerFragment, e);
+                    getExceptionCounter("BKBookieHandleNotAvailableException").inc();
                 } catch (BKException.BKLedgerRecoveryException e) {
                     LOG.warn("BKLedgerRecoveryException "
-                            + "while replicating the fragment", e);
-                    if (admin.getReadOnlyBookiesAsync().contains(targetBookie)) {
-                        underreplicationManager.releaseUnderreplicatedLedger(ledgerIdToReplicate);
-                        throw new BKException.BKWriteOnReadOnlyBookieException();
-                    }
+                            + "while replicating the fragment {}", ledgerFragment, e);
+                    getExceptionCounter("BKLedgerRecoveryException").inc();
                 }
             }
 
@@ -273,13 +249,13 @@ public class ReplicationWorker implements Runnable {
                 return false;
             }
 
-            fragments = getUnderreplicatedFragments(lh);
-            if (fragments.size() == 0) {
-                LOG.info("Ledger replicated successfully. ledger id is: "
-                        + ledgerIdToReplicate);
+            Set<LedgerFragment> fragmentsAfterReplicate = getUnderreplicatedFragments(lh);
+            if (fragmentsAfterReplicate.size() == 0) {
+                LOG.info("Ledger {} is replicated successfully.", ledgerIdToReplicate);
                 underreplicationManager.markLedgerReplicated(ledgerIdToReplicate);
                 return true;
             } else {
+                LOG.info("Fail to replicate ledger {}.", ledgerIdToReplicate);
                 // Releasing the underReplication ledger lock and compete
                 // for the replication again for the pending fragments
                 underreplicationManager
@@ -289,24 +265,26 @@ public class ReplicationWorker implements Runnable {
         } catch (BKNoSuchLedgerExistsException e) {
             // Ledger might have been deleted by user
             LOG.info("BKNoSuchLedgerExistsException while opening "
-                    + "ledger for replication. Other clients "
+                    + "ledger {} for replication. Other clients "
                     + "might have deleted the ledger. "
-                    + "So, no harm to continue");
+                    + "So, no harm to continue", ledgerIdToReplicate);
             underreplicationManager.markLedgerReplicated(ledgerIdToReplicate);
+            getExceptionCounter("BKNoSuchLedgerExistsException").inc();
             return false;
         } catch (BKReadException e) {
             LOG.info("BKReadException while"
-                    + " opening ledger for replication."
+                    + " opening ledger {} for replication."
                     + " Enough Bookies might not have available"
-                    + "So, no harm to continue");
+                    + " So, no harm to continue", ledgerIdToReplicate);
             underreplicationManager
                     .releaseUnderreplicatedLedger(ledgerIdToReplicate);
+            getExceptionCounter("BKReadException").inc();
             return false;
         } catch (BKBookieHandleNotAvailableException e) {
             LOG.info("BKBookieHandleNotAvailableException while"
-                    + " opening ledger for replication."
+                    + " opening ledger {} for replication."
                     + " Enough Bookies might not have available"
-                    + "So, no harm to continue");
+                    + " So, no harm to continue", ledgerIdToReplicate);
             underreplicationManager
                     .releaseUnderreplicatedLedger(ledgerIdToReplicate);
             return false;
@@ -471,21 +449,6 @@ public class ReplicationWorker implements Runnable {
         return workerRunning && workerThread.isAlive();
     }
 
-    boolean isInReadOnlyMode() {
-        return isInReadOnlyMode;
-    }
-
-    private boolean isTargetBookieExistsInFragmentEnsemble(LedgerHandle lh,
-            LedgerFragment ledgerFragment) {
-        List<BookieSocketAddress> ensemble = ledgerFragment.getEnsemble();
-        for (BookieSocketAddress bkAddr : ensemble) {
-            if (targetBookie.equals(bkAddr)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /** Ledger checker call back */
     private static class CheckerCallback implements
             GenericCallback<Set<LedgerFragment>> {
@@ -506,6 +469,15 @@ public class ReplicationWorker implements Runnable {
             latch.await();
             return result;
         }
+    }
+
+    private Counter getExceptionCounter(String name) {
+        Counter counter = this.exceptionCounters.get(name);
+        if (counter == null) {
+            counter = this.statsLogger.scope(REPLICATE_EXCEPTION).getCounter(name);
+            this.exceptionCounters.put(name, counter);
+        }
+        return counter;
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
@@ -20,6 +20,14 @@
  */
 package org.apache.bookkeeper.client;
 
+import com.google.common.util.concurrent.SettableFuture;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
@@ -36,17 +44,6 @@ import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.util.concurrent.SettableFuture;
-
-import io.netty.buffer.ByteBuf;
-
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 
@@ -518,7 +515,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
             try {
                 bkadmin.replicateLedgerFragment(lh3,
-                        checkercb.getResult(10, TimeUnit.SECONDS).iterator().next(), newBookie);
+                        checkercb.getResult(10, TimeUnit.SECONDS).iterator().next());
                 fail("Shouldn't be able to replicate with a closed client");
             } catch (BKException.BKClientClosedException cce) {
                 // correct behaviour

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
@@ -322,13 +322,9 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         // Call the async recover bookie method.
         BookieSocketAddress bookieSrc = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
           initialPort);
-        BookieSocketAddress bookieDest = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
-          newBookiePort);
-        LOG.info("Now recover the data on the killed bookie (" + bookieSrc + ") and replicate it to the new one ("
-          + bookieDest + ")");
         // Initiate the sync object
         sync.value = false;
-        bkAdmin.asyncRecoverBookieData(bookieSrc, bookieDest, bookieRecoverCb, sync);
+        bkAdmin.asyncRecoverBookieData(bookieSrc, bookieRecoverCb, sync);
 
         // Wait for the async method to complete.
         synchronized (sync) {
@@ -380,12 +376,11 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         // Call the async recover bookie method.
         BookieSocketAddress bookieSrc = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
           initialPort);
-        BookieSocketAddress bookieDest = null;
         LOG.info("Now recover the data on the killed bookie (" + bookieSrc
           + ") and replicate it to a random available one");
         // Initiate the sync object
         sync.value = false;
-        bkAdmin.asyncRecoverBookieData(bookieSrc, bookieDest, bookieRecoverCb, sync);
+        bkAdmin.asyncRecoverBookieData(bookieSrc, bookieRecoverCb, sync);
 
         // Wait for the async method to complete.
         synchronized (sync) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerChecker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerChecker.java
@@ -91,8 +91,13 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
             LOG.info("unreplicated fragment: {}", r);
         }
         assertEquals("Should have one missing fragment", 1, result.size());
-        assertEquals("Fragment should be missing from first replica", result
-                .iterator().next().getAddress(), replicaToKill);
+        assertEquals("There should be 1 fragments. But returned fragments are "
+            + result, 1, result.size());
+        LedgerFragment lf = result.iterator().next();
+        assertEquals("There should be 1 failed bookies in first fragment " + lf,
+            1, lf.getBookiesIndexes().size());
+        assertEquals("Fragment should be missing from first replica",
+            lf.getAddress(0), replicaToKill);
 
         BookieSocketAddress replicaToKill2 = lh.getLedgerMetadata()
                 .getEnsembles().get(0L).get(1);
@@ -104,7 +109,16 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         for (LedgerFragment r : result) {
             LOG.info("unreplicated fragment: {}", r);
         }
-        assertEquals("Should have three missing fragments", 3, result.size());
+        assertEquals("Should have two missing fragments", 2, result.size());
+        for (LedgerFragment fragment : result) {
+            if (fragment.getFirstEntryId() == 0L) {
+                assertEquals("There should be 2 failed bookies in first fragment",
+                    2, fragment.getBookiesIndexes().size());
+            } else {
+                assertEquals("There should be 1 failed bookies in second fragment",
+                    1, fragment.getBookiesIndexes().size());
+            }
+        }
     }
 
     /**
@@ -191,7 +205,9 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
             LOG.info("unreplicated fragment: {}", r);
         }
 
-        assertEquals("There should be 2 fragments", 2, result.size());
+        assertEquals("There should be 1 fragments", 1, result.size());
+        assertEquals("There should be 2 failed bookies in the fragment",
+                2, result.iterator().next().getBookiesIndexes().size());
     }
 
     /**
@@ -264,7 +280,9 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
             LOG.info("unreplicated fragment: {}", r);
         }
 
-        assertEquals("There should be 3 fragments", 3, result.size());
+        assertEquals("There should be 1 fragments", 1, result.size());
+        assertEquals("There should be 3 failed bookies in the fragment",
+                3, result.iterator().next().getBookiesIndexes().size());
     }
 
     /**
@@ -297,7 +315,9 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         }
         Set<LedgerFragment> result = getUnderReplicatedFragments(lh);
         assertNotNull("Result shouldn't be null", result);
-        assertEquals("There should be 2 fragments.", 2, result.size());
+        assertEquals("There should be 1 fragments.", 1, result.size());
+        assertEquals("There should be 2 failed bookies in the fragment",
+                2, result.iterator().next().getBookiesIndexes().size());
     }
 
     /**
@@ -326,6 +346,8 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         assertNotNull("Result shouldn't be null", result);
         assertEquals("There should be 1 fragment. But returned fragments are "
                 + result, 1, result.size());
+        assertEquals("There should be 1 failed bookies in the fragment",
+                1, result.iterator().next().getBookiesIndexes().size());
     }
 
     /**
@@ -364,8 +386,17 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
 
         Set<LedgerFragment> result = getUnderReplicatedFragments(lh1);
         assertNotNull("Result shouldn't be null", result);
-        assertEquals("There should be 3 fragment. But returned fragments are "
-                + result, 3, result.size());
+        assertEquals("There should be 2 fragments. But returned fragments are "
+                + result, 2, result.size());
+        for (LedgerFragment lf : result) {
+            if (lf.getFirstEntryId() == 0L) {
+                assertEquals("There should be 2 failed bookies in first fragment",
+                        2, lf.getBookiesIndexes().size());
+            } else {
+                assertEquals("There should be 1 failed bookie in second fragment",
+                        1, lf.getBookiesIndexes().size());
+            }
+        }
     }
 
     /**
@@ -439,6 +470,8 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         assertNotNull("Result shouldn't be null", result);
         assertEquals("There should be 1 fragment. But returned fragments are "
                 + result, 1, result.size());
+        assertEquals("There should be 1 failed bookies in the fragment",
+                1, result.iterator().next().getBookiesIndexes().size());
         lh1.close();
 
         // kill bookie 0
@@ -454,8 +487,10 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
 
         result = getUnderReplicatedFragments(lh1);
         assertNotNull("Result shouldn't be null", result);
-        assertEquals("There should be 2 fragment. But returned fragments are "
-                + result, 2, result.size());
+        assertEquals("There should be 1 fragment. But returned fragments are "
+                + result, 1, result.size());
+        assertEquals("There should be 2 failed bookies in the fragment",
+                2, result.iterator().next().getBookiesIndexes().size());
         lh1.close();
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -79,6 +79,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         baseConf.setLedgerManagerFactoryClassName(
                 "org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory");
         baseConf.setOpenLedgerRereplicationGracePeriod(openLedgerRereplicationGracePeriod);
+        baseConf.setRwRereplicateBackoffMs(500);
         baseClientConf.setLedgerManagerFactoryClassName(
                 "org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory");
         this.digestType = DigestType.MAC;
@@ -550,8 +551,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
 
     }
 
-    private int getReplicaIndexInLedger(LedgerHandle lh,
- BookieSocketAddress replicaToKill) {
+    private int getReplicaIndexInLedger(LedgerHandle lh, BookieSocketAddress replicaToKill) {
         SortedMap<Long, ArrayList<BookieSocketAddress>> ensembles = LedgerHandleAdapter
                 .getLedgerMetadata(lh).getEnsembles();
         int ledgerReplicaIndex = -1;


### PR DESCRIPTION
Descriptions of the changes in this PR:

This pull request ports the changes from [twitter/bookkeeper@fc7e171](https://github.com/twitter/bookkeeper/commit/fc7e171135a58cddb9e91f5f614b3ceb6f9f9fee)

The changes include:

1. when bookkeeper admin re-replicates a ledger, it will pick a bookie from the available bookies in the cluster to satisfy the placement constraint. (#596)
2. hence, remove `targetBookie` from ReplicationWorker, because the parameter will volatile the placement constraint. (#583)
3. at the same time, change `LedgerFragement` to represent the number of bookies that need to be check and replicate. a) the ledger checker can use the correct bookie index for verifying the existence of entries in a bookie (for stripping case) b) only read entries one time when need to replicate them to multiple bookies.