### PR TITLE
Increase timeouts in TestDisableEnsembleChange

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
@@ -206,7 +206,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
         bsConfs.add(killedConf);
         bs.add(startBookie(killedConf));
         assertTrue("Add entry operation should complete at this point.",
-                addLatch.await(1000, TimeUnit.MILLISECONDS));
+                addLatch.await(10000, TimeUnit.MILLISECONDS));
         assertEquals(res.get(), BKException.Code.OK);
     }
 
@@ -270,7 +270,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
         // wakeup the sleep bookie
         wakeupLatch.countDown();
         assertTrue("Add entry operation should complete at this point.",
-                addLatch.await(1000, TimeUnit.MILLISECONDS));
+                addLatch.await(10000, TimeUnit.MILLISECONDS));
         assertEquals(res.get(), BKException.Code.OK);
     }
 


### PR DESCRIPTION
In some narrow cases, if we manage to connect to the bookie, but the bookie
hasn't fully initialized, an add entry message will be dropped, and the
client will wait for the timeout to complete. The timeout is 5 seconds
by default, which was 5x the timeout in the test. This patch increases
the test timeout to 10s, which should give enough time for the addEntry
to fail and be retried.