### PR TITLE
Fix a typo in PCBC logging

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1263,7 +1263,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                                 bAddress = c.remoteAddress().toString();
                             }
                             if (LOG.isDebugEnabled()) {
-                                LOG.debug("Could not write {} request writeLac to bookie {} for ledger {}, entry {}",
+                                LOG.debug("Could not write {} request to bookie {} for ledger {}, entry {}",
                                           operationName, bAddress,
                                           ledgerId, entryId);
                             }


### PR DESCRIPTION
All ops had writeLac in their logged text, which is confusing