### PR TITLE
Fail earlier when encountering DNS issues

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -131,7 +131,7 @@ class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsemblePlacemen
                 for (int i = 0; i < rNames.size(); ++i) {
                     if (rNames.get(i) == null) {
                         LOG.warn("Failed to resolve network location for {}, using default rack for it : {}.",
-                                rNames.get(i), defaultRack);
+                                names.get(i), defaultRack);
                         rNames.set(i, defaultRack);
                     }
                 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -65,7 +65,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostAddress(), rack);
         StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostName(), rack);
         StaticDNSResolver.addNodeToRack("127.0.0.1", rack);
-        StaticDNSResolver.addNodeToRack("localhost", rack);        
+        StaticDNSResolver.addNodeToRack("localhost", rack);
     }
 
     @Override
@@ -128,10 +128,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
         repp = new RegionAwareEnsemblePlacementPolicy();
         repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer, DISABLE_ALL, NullStatsLogger.INSTANCE);
-        
+
         // make sure we've detected the right region
         assertEquals("r1", repp.myRegion);
-        
+
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
         addrs.add(addr2);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -145,7 +145,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         expectedSet.add(3);
         expectedSet.add(1);
         expectedSet.add(2);
-        LOG.info("reorder set : {}", reoderSet);
+        LOG.info("reorder set : {}", reorderSet);
         assertFalse(reorderSet == writeSet);
         assertEquals(expectedSet, reorderSet);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -65,7 +65,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostAddress(), rack);
         StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostName(), rack);
         StaticDNSResolver.addNodeToRack("127.0.0.1", rack);
-        StaticDNSResolver.addNodeToRack("localhost", rack);
+        StaticDNSResolver.addNodeToRack("localhost", rack);        
     }
 
     @Override
@@ -128,7 +128,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
         repp = new RegionAwareEnsemblePlacementPolicy();
         repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer, DISABLE_ALL, NullStatsLogger.INSTANCE);
-
+        
+        // make sure we've detected the right region
+        assertEquals("r1", repp.myRegion);
+        
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
         addrs.add(addr2);
@@ -136,15 +139,15 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         addrs.add(addr4);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
 
-        List<Integer> reoderSet = repp.reorderReadSequence(ensemble, writeSet, new HashMap<BookieSocketAddress, Long>());
+        List<Integer> reorderSet = repp.reorderReadSequence(ensemble, writeSet, new HashMap<BookieSocketAddress, Long>());
         List<Integer> expectedSet = new ArrayList<Integer>();
         expectedSet.add(0);
         expectedSet.add(3);
         expectedSet.add(1);
         expectedSet.add(2);
         LOG.info("reorder set : {}", reoderSet);
-        assertFalse(reoderSet == writeSet);
-        assertEquals(expectedSet, reoderSet);
+        assertFalse(reorderSet == writeSet);
+        assertEquals(expectedSet, reorderSet);
     }
 
     @Test


### PR DESCRIPTION
We had some DNS issues today and various TestRegionAwareEnsemblePlacementPolicy tests were failing for me.  

The LOG warning in RackawareEnsemblePlacementPolicyIml was not printing the right variable, which would have given a clue.  

Additionally, the repp.myRegion was set to UNKNOWN, causing incorrect code flow.  Added an assert to kill the test as soon as this occurs.


