### PR TITLE
Recycle PendingAddOps

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -874,7 +874,6 @@ public class LedgerHandle implements WriteHandle {
             throttler.acquire();
         }
 
-        final long entryId;
         boolean wasClosed = false;
         synchronized(this) {
             // synchronized on this to ensure that
@@ -882,11 +881,11 @@ public class LedgerHandle implements WriteHandle {
             // updating lastAddPushed
             if (metadata.isClosed()) {
                 wasClosed = true;
-                entryId = -1;
             } else {
-                entryId = ++lastAddPushed;
+                long entryId = ++lastAddPushed;
                 long currentLedgerLength = addToLength(op.payload.readableBytes());
-                op.setEntryIdAndLedgerLength(entryId, currentLedgerLength);
+                op.setEntryId(entryId);
+                op.setLedgerLength(currentLedgerLength);
                 pendingAddOps.add(op);
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -822,8 +822,8 @@ public class LedgerHandle implements WriteHandle {
 
     public void asyncAddEntry(ByteBuf data, final AddCallback cb, final Object ctx) {
         data.retain();
-        PendingAddOp op = new PendingAddOp(LedgerHandle.this, cb, ctx);
-        doAsyncAddEntry(op, data, cb, ctx);
+        PendingAddOp op = PendingAddOp.create(this, data, cb, ctx);
+        doAsyncAddEntry(op);
     }
 
     /**
@@ -864,17 +864,17 @@ public class LedgerHandle implements WriteHandle {
      */
     void asyncRecoveryAddEntry(final byte[] data, final int offset, final int length,
                                final AddCallback cb, final Object ctx) {
-        PendingAddOp op = new PendingAddOp(LedgerHandle.this, cb, ctx).enableRecoveryAdd();
-        doAsyncAddEntry(op, Unpooled.wrappedBuffer(data, offset, length), cb, ctx);
+        PendingAddOp op = PendingAddOp.create(this, Unpooled.wrappedBuffer(data, offset, length), cb, ctx)
+                .enableRecoveryAdd();
+        doAsyncAddEntry(op);
     }
 
-    protected void doAsyncAddEntry(final PendingAddOp op, final ByteBuf data, final AddCallback cb, final Object ctx) {
+    protected void doAsyncAddEntry(final PendingAddOp op) {
         if (throttler != null) {
             throttler.acquire();
         }
 
         final long entryId;
-        final long currentLength;
         boolean wasClosed = false;
         synchronized(this) {
             // synchronized on this to ensure that
@@ -883,11 +883,10 @@ public class LedgerHandle implements WriteHandle {
             if (metadata.isClosed()) {
                 wasClosed = true;
                 entryId = -1;
-                currentLength = 0;
             } else {
                 entryId = ++lastAddPushed;
-                currentLength = addToLength(data.readableBytes());
-                op.setEntryId(entryId);
+                long currentLedgerLength = addToLength(op.payload.readableBytes());
+                op.setEntryIdAndLedgerLength(entryId, currentLedgerLength);
                 pendingAddOps.add(op);
             }
         }
@@ -899,8 +898,8 @@ public class LedgerHandle implements WriteHandle {
                     @Override
                     public void safeRun() {
                         LOG.warn("Attempt to add to closed ledger: {}", ledgerId);
-                        cb.addComplete(BKException.Code.LedgerClosedException,
-                                LedgerHandle.this, INVALID_ENTRY_ID, ctx);
+                        op.cb.addComplete(BKException.Code.LedgerClosedException,
+                                LedgerHandle.this, INVALID_ENTRY_ID, op.ctx);
                     }
 
                     @Override
@@ -909,32 +908,17 @@ public class LedgerHandle implements WriteHandle {
                     }
                 });
             } catch (RejectedExecutionException e) {
-                cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
-                        LedgerHandle.this, INVALID_ENTRY_ID, ctx);
+                op.cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
+                        LedgerHandle.this, INVALID_ENTRY_ID, op.ctx);
             }
             return;
         }
 
         try {
-            bk.getMainWorkerPool().submitOrdered(ledgerId, new SafeRunnable() {
-                @Override
-                public void safeRun() {
-                    ByteBuf toSend = macManager.computeDigestAndPackageForSending(entryId, lastAddConfirmed,
-                            currentLength, data);
-                    try {
-                        op.initiate(toSend, data.readableBytes());
-                    } finally {
-                        toSend.release();
-                    }
-                }
-                @Override
-                public String toString() {
-                    return String.format("AsyncAddEntry(lid=%d, eid=%d)", ledgerId, entryId);
-                }
-            });
+            bk.getMainWorkerPool().submitOrdered(ledgerId, op);
         } catch (RejectedExecutionException e) {
-            cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
-                    LedgerHandle.this, INVALID_ENTRY_ID, ctx);
+            op.cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
+                    LedgerHandle.this, INVALID_ENTRY_ID, op.ctx);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -154,7 +154,7 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
     private void asyncAddEntry(final long entryId, ByteBuf data,
             final AddCallback cb, final Object ctx) {
         PendingAddOp op = PendingAddOp.create(this, data, cb, ctx);
-        op.setEntryIdAndLedgerLength(entryId, length);
+        op.setEntryId(entryId);
 
         if ((entryId <= this.lastAddConfirmed) || pendingAddOps.contains(op)) {
             LOG.error("Trying to re-add duplicate entryid:{}", entryId);
@@ -188,7 +188,7 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
                 currentLength = addToLength(op.payload.readableBytes());
                 pendingAddOps.add(op);
             }
-            op.setEntryIdAndLedgerLength(op.entryId, currentLength);
+            op.setLedgerLength(currentLength);
         }
 
         if (wasClosed) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -153,15 +153,15 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
 
     private void asyncAddEntry(final long entryId, ByteBuf data,
             final AddCallback cb, final Object ctx) {
-        PendingAddOp op = new PendingAddOp(this, cb, ctx);
-        op.setEntryId(entryId);
+        PendingAddOp op = PendingAddOp.create(this, data, cb, ctx);
+        op.setEntryIdAndLedgerLength(entryId, length);
+
         if ((entryId <= this.lastAddConfirmed) || pendingAddOps.contains(op)) {
             LOG.error("Trying to re-add duplicate entryid:{}", entryId);
-            cb.addComplete(BKException.Code.DuplicateEntryIdException,
-                    LedgerHandleAdv.this, entryId, ctx);
+            op.submitCallback(BKException.Code.DuplicateEntryIdException);
             return;
         }
-        doAsyncAddEntry(op, data, cb, ctx);
+        doAsyncAddEntry(op);
     }
 
     /**
@@ -170,7 +170,7 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
      * unaltered in the base class.
      */
     @Override
-    protected void doAsyncAddEntry(final PendingAddOp op, final ByteBuf data, final AddCallback cb, final Object ctx) {
+    protected void doAsyncAddEntry(final PendingAddOp op) {
         if (throttler != null) {
             throttler.acquire();
         }
@@ -185,9 +185,10 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
                 wasClosed = true;
                 currentLength = 0;
             } else {
-                currentLength = addToLength(length);
+                currentLength = addToLength(op.payload.readableBytes());
                 pendingAddOps.add(op);
             }
+            op.setEntryIdAndLedgerLength(op.entryId, currentLength);
         }
 
         if (wasClosed) {
@@ -197,8 +198,8 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
                     @Override
                     public void safeRun() {
                         LOG.warn("Attempt to add to closed ledger: {}", ledgerId);
-                        cb.addComplete(BKException.Code.LedgerClosedException,
-                                LedgerHandleAdv.this, op.getEntryId(), ctx);
+                        op.cb.addComplete(BKException.Code.LedgerClosedException,
+                                LedgerHandleAdv.this, op.getEntryId(), op.ctx);
                     }
                     @Override
                     public String toString() {
@@ -206,28 +207,17 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
                     }
                 });
             } catch (RejectedExecutionException e) {
-                cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
-                        LedgerHandleAdv.this, op.getEntryId(), ctx);
+                op.cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
+                        LedgerHandleAdv.this, op.getEntryId(), op.ctx);
             }
             return;
         }
 
         try {
-            bk.getMainWorkerPool().submit(new SafeRunnable() {
-                @Override
-                public void safeRun() {
-                    ByteBuf toSend = macManager.computeDigestAndPackageForSending(op.getEntryId(), lastAddConfirmed,
-                            currentLength, data);
-                    try {
-                        op.initiate(toSend, toSend.readableBytes());
-                    } finally {
-                        toSend.release();
-                    }
-                }
-            });
+            bk.getMainWorkerPool().submitOrdered(ledgerId, op);
         } catch (RejectedExecutionException e) {
-            cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
-                    LedgerHandleAdv.this, op.getEntryId(), ctx);
+            op.cb.addComplete(bk.getReturnRc(BKException.Code.InterruptedException),
+                              LedgerHandleAdv.this, op.getEntryId(), op.ctx);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -17,7 +17,10 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
@@ -48,9 +51,10 @@ import java.util.concurrent.RejectedExecutionException;
  *
  *
  */
-class PendingAddOp implements WriteCallback, TimerTask {
+class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
     private final static Logger LOG = LoggerFactory.getLogger(PendingAddOp.class);
 
+    ByteBuf payload;
     ByteBuf toSend;
     AddCallback cb;
     Object ctx;
@@ -64,21 +68,38 @@ class PendingAddOp implements WriteCallback, TimerTask {
     boolean isRecoveryAdd = false;
     long requestTimeNanos;
 
-    final int timeoutSec;
+    int timeoutSec;
     Timeout timeout = null;
 
     OpStatsLogger addOpLogger;
-    boolean callbackTriggered = false;
+    long currentLedgerLength;
+    int pendingWriteRequests;
+    boolean callbackTriggered;
+    boolean hasRun;
 
-    PendingAddOp(LedgerHandle lh, AddCallback cb, Object ctx) {
-        this.lh = lh;
-        this.cb = cb;
-        this.ctx = ctx;
-        this.entryId = LedgerHandle.INVALID_ENTRY_ID;
+    static PendingAddOp create(LedgerHandle lh, ByteBuf payload, AddCallback cb, Object ctx) {
+        PendingAddOp op = RECYCLER.get();
+        op.lh = lh;
+        op.isRecoveryAdd = false;
+        op.cb = cb;
+        op.ctx = ctx;
+        op.entryId = LedgerHandle.INVALID_ENTRY_ID;
+        op.currentLedgerLength = -1;
+        op.payload = payload;
+        op.entryLength = payload.readableBytes();
 
-        this.ackSet = lh.distributionSchedule.getAckSet();
-        this.addOpLogger = lh.bk.getAddOpLogger();
-        this.timeoutSec = lh.bk.getConf().getAddEntryQuorumTimeout();
+        op.completed = false;
+        op.ackSet = lh.distributionSchedule.getAckSet();
+        op.addOpLogger = lh.bk.getAddOpLogger();
+        if (op.timeout != null) {
+            op.timeout.cancel();
+        }
+        op.timeout = null;
+        op.timeoutSec = lh.bk.getConf().getAddEntryQuorumTimeout();
+        op.pendingWriteRequests = 0;
+        op.callbackTriggered = false;
+        op.hasRun = false;
+        return op;
     }
 
     /**
@@ -90,8 +111,9 @@ class PendingAddOp implements WriteCallback, TimerTask {
         return this;
     }
 
-    void setEntryId(long entryId) {
+    void setEntryIdAndLedgerLength(long entryId, long ledgerLength) {
         this.entryId = entryId;
+        this.currentLedgerLength = ledgerLength;
     }
 
     long getEntryId() {
@@ -103,6 +125,7 @@ class PendingAddOp implements WriteCallback, TimerTask {
 
         lh.bk.getBookieClient().addEntry(lh.metadata.currentEnsemble.get(bookieIndex), lh.ledgerId, lh.ledgerKey, entryId, toSend,
                 this, bookieIndex, flags);
+        ++pendingWriteRequests;
     }
 
     @Override
@@ -182,21 +205,31 @@ class PendingAddOp implements WriteCallback, TimerTask {
         sendWriteRequest(bookieIndex);
     }
 
-    void initiate(ByteBuf toSend, int entryLength) {
+    /**
+     * Initiate the add operation
+     */
+    public void safeRun() {
+        hasRun = true;
         if (callbackTriggered) {
-            // this should only be true if the request was failed due to another request ahead in the pending queue,
+            // this should only be true if the request was failed due
+            // to another request ahead in the pending queue,
             // so we can just ignore this request
+            maybeRecycle();
             return;
         }
 
         if (timeoutSec > -1) {
-            this.timeout = lh.bk.getBookieClient().scheduleTimeout(this, timeoutSec, TimeUnit.SECONDS);
+            this.timeout = lh.bk.getBookieClient().scheduleTimeout(
+                    this, timeoutSec, TimeUnit.SECONDS);
         }
+
         this.requestTimeNanos = MathUtils.nowInNano();
-        this.toSend = toSend;
-        // Retain the buffer until all writes are complete
-        this.toSend.retain();
-        this.entryLength = entryLength;
+        checkNotNull(lh);
+        checkNotNull(lh.macManager);
+
+        this.toSend = lh.macManager.computeDigestAndPackageForSending(
+                entryId, lh.lastAddConfirmed, currentLedgerLength,
+                payload);
 
         // Iterate over set and trigger the sendWriteRequests
         DistributionSchedule.WriteSet writeSet
@@ -213,6 +246,7 @@ class PendingAddOp implements WriteCallback, TimerTask {
     @Override
     public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx) {
         int bookieIndex = (Integer) ctx;
+        --pendingWriteRequests;
 
         if (!lh.metadata.currentEnsemble.get(bookieIndex).equals(addr)) {
             // ensemble has already changed, failure of this addr is immaterial
@@ -246,6 +280,7 @@ class PendingAddOp implements WriteCallback, TimerTask {
             sendAddSuccessCallbacks();
             // I am already finished, ignore incoming responses.
             // otherwise, we might hit the following error handling logic, which might cause bad things.
+            maybeRecycle();
             return;
         }
 
@@ -292,7 +327,6 @@ class PendingAddOp implements WriteCallback, TimerTask {
 
         if (ackQuorum && !completed) {
             completed = true;
-            ackSet.recycle();
 
             sendAddSuccessCallbacks();
         }
@@ -324,6 +358,8 @@ class PendingAddOp implements WriteCallback, TimerTask {
         }
         cb.addComplete(rc, lh, entryId, ctx);
         callbackTriggered = true;
+
+        maybeRecycle();
     }
 
     @Override
@@ -348,4 +384,57 @@ class PendingAddOp implements WriteCallback, TimerTask {
        return (this == o);
     }
 
+    private final Handle<PendingAddOp> recyclerHandle;
+    private static final Recycler<PendingAddOp> RECYCLER = new Recycler<PendingAddOp>() {
+        protected PendingAddOp newObject(Recycler.Handle<PendingAddOp> handle) {
+            return new PendingAddOp(handle);
+        }
+    };
+
+    private PendingAddOp(Handle<PendingAddOp> recyclerHandle) {
+        this.recyclerHandle = recyclerHandle;
+    }
+
+    private void maybeRecycle() {
+        // The reference to PendingAddOp can be held in 3 places
+        // - LedgerHandle#pendingAddOp
+        //   This reference is released when the callback is run
+        // - The executor
+        //   Released after safeRun finishes
+        // - BookieClient
+        //   Holds a reference from the point the addEntry requests are
+        //   sent.
+        // The object can only be recycled after all references are
+        // released, otherwise we could end up recycling twice and all
+        // joy that goes along with that.
+        if (hasRun && callbackTriggered && pendingWriteRequests == 0) {
+            recycle();
+        }
+    }
+
+    private void recycle() {
+        entryId = LedgerHandle.INVALID_ENTRY_ID;
+        currentLedgerLength = -1;
+        payload = null;
+        toSend = null;
+        cb = null;
+        ctx = null;
+        ackSet.recycle();
+        ackSet = null;
+        lh = null;
+        isRecoveryAdd = false;
+        addOpLogger = null;
+        writeQuorumSize = -1;
+        Arrays.fill(writeSet, -12345);
+        completed = false;
+        pendingWriteRequests = 0;
+        callbackTriggered = false;
+        hasRun = false;
+        if (timeout != null) {
+            timeout.cancel();
+        }
+        timeout = null;
+
+        recyclerHandle.recycle(this);
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -424,8 +424,6 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
         lh = null;
         isRecoveryAdd = false;
         addOpLogger = null;
-        writeQuorumSize = -1;
-        Arrays.fill(writeSet, -12345);
         completed = false;
         pendingWriteRequests = 0;
         callbackTriggered = false;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -111,8 +111,11 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
         return this;
     }
 
-    void setEntryIdAndLedgerLength(long entryId, long ledgerLength) {
+    void setEntryId(long entryId) {
         this.entryId = entryId;
+    }
+
+    void setLedgerLength(long ledgerLength) {
         this.currentLedgerLength = ledgerLength;
     }
 


### PR DESCRIPTION
Avoid creating a new PendingAddOp object for each entry added, thus
saving on garbage.

Originally commit 55ba4723 on the yahoo-4.3 branch.