### PR TITLE
ISSUE #683: Correctly update length in LedgerHandleAdv

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -179,7 +179,7 @@ public class LedgerHandleAdv extends LedgerHandle {
                 wasClosed = true;
                 currentLength = 0;
             } else {
-                currentLength = addToLength(length);
+                currentLength = addToLength(data.readableBytes());
                 pendingAddOps.add(op);
             }
         }


### PR DESCRIPTION
Commit 7b1eec introduced a change which removed the length parameter
to doAsyncAddEntry. This resulted in the length of the ledger being
added to itself each time for a LedgerHandleAdv, which ultimately
meant that that length would be 0, as it never had anything non-zero
added to it.

This change corrects this, by adding the length of the data parameter
to the ledger length.