### PR TITLE
Issue-409 BookKeeper Server distribution contains useless jar guava

### DIFF
--- a/src/assemble/bin.xml
+++ b/src/assemble/bin.xml
@@ -71,6 +71,9 @@
       <unpack>false</unpack>
       <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>
+      <excludes>
+         <exclude>com.google.guava:guava</exclude>
+      </excludes>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
Exclude Guava Jar from assembly configuration. Guava is still present by relocated