### PR TITLE
ISSUE #501: Fix race in CompactionTest

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -397,8 +397,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         bkc.deleteLedger(lhs[2].getId());
 
         LOG.info("Finished deleting the ledgers contains most entries.");
-        getGCThread().enableForceGC();
-        getGCThread().triggerGC().get();
+        getGCThread().triggerGC(true, false, false).get();
 
         // after garbage collection, major compaction should not be executed
         assertEquals(lastMajorCompactionTime, getGCThread().lastMajorCompactionTime);


### PR DESCRIPTION
testMinorCompactionWithNoWritableLedgerDirsButIsForceGCAllowWhenNoSpaceIsSet
was failing regularly on jenkins. The issue was that it was trying to
kick off a forced garbage collection by setting the force flag and
triggering. However, in some cases another GC would be running and
would clear the flag after it had been set, but before the trigger was
called.

This patch adds a new form of triggering which allows the caller to
explicitly specify which flags will be active for the GC run.