### PR TITLE
ISSUE-699: Docker healthchek is failing #699

### DIFF
--- a/docker/scripts/healthcheck.sh
+++ b/docker/scripts/healthcheck.sh
@@ -25,4 +25,4 @@
 set -x -e -u
 
 # Sanity check that creates a ledger, writes a few entries, reads them and deletes the ledger.
-bookkeeper shell bookiesanity
+/opt/bookkeeper/bin/bookkeeper shell bookiesanity


### PR DESCRIPTION
The docker healthcheck is failing because it's trying to run the
bookkeeper command without specifying a path.

Adding the full path to the command fix this issue.

Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>

Descriptions of the changes in this PR:

(PR description content here)...

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
