### PR TITLE
add .travis.yml to skip build asf-site branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+language: java
+
+# blacklist
+branches:
+  except:
+    - asf-site
+    - gh-pages
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+    - os: linux
+      env: CUSTOM_JDK="oraclejdk8"
+
+before_install:
+  - echo "MAVEN_OPTS='-Xmx3072m -XX:MaxPermSize=512m'" > ~/.mavenrc
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "$CUSTOM_JDK"; fi
+
+script:
+  - travis_retry mvn --batch-mode clean apache-rat:check compile findbugs:check
+# Disabled the tests here. Since tests are running much slower on Travis than on Jenkins
+#  - ./dev/ticktoc.sh "mvn --batch-mode clean package"
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,31 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-language: java
 
 # blacklist
 branches:
   except:
     - asf-site
-    - gh-pages
-
-matrix:
-  include:
-    - os: osx
-      osx_image: xcode8
-    - os: linux
-      env: CUSTOM_JDK="oraclejdk8"
-
-before_install:
-  - echo "MAVEN_OPTS='-Xmx3072m -XX:MaxPermSize=512m'" > ~/.mavenrc
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "$CUSTOM_JDK"; fi
-
-script:
-  - travis_retry mvn --batch-mode clean apache-rat:check compile findbugs:check
-# Disabled the tests here. Since tests are running much slower on Travis than on Jenkins
-#  - ./dev/ticktoc.sh "mvn --batch-mode clean package"
-
-cache:
-  directories:
-    - $HOME/.m2


### PR DESCRIPTION
Descriptions of the changes in this PR:

although we exclude `asf-site` branch in travis.yml, but the file only exists in master and other release branches. copy the `travis.yml` to `asf-site` branch.

https://travis-ci.org/apache/bookkeeper/builds/298028474