### PR TITLE
BOOKKEEPER-1040: Use separate log for compaction and add transaction support

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
@@ -30,9 +30,9 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
  */
 public abstract class AbstractLogCompactor {
 
-    protected ServerConfiguration conf;
-    protected Throttler throttler;
-    protected GarbageCollectorThread gcThread;
+    protected final ServerConfiguration conf;
+    protected final Throttler throttler;
+    protected final GarbageCollectorThread gcThread;
 
     public AbstractLogCompactor(GarbageCollectorThread gcThread) {
         this.gcThread = gcThread;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
@@ -47,7 +47,7 @@ public abstract class AbstractLogCompactor {
      */
     public abstract boolean compact(EntryLogMetadata entryLogMeta);
 
-    class Throttler {
+    static class Throttler {
         private final RateLimiter rateLimiter;
         private final boolean isThrottleByBytes;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
@@ -1,0 +1,66 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+
+/**
+ * Abstract entry log compactor used for compaction.
+ */
+public abstract class AbstractLogCompactor {
+
+    protected ServerConfiguration conf;
+    protected Throttler throttler;
+    protected GarbageCollectorThread gcThread;
+
+    public AbstractLogCompactor(GarbageCollectorThread gcThread) {
+        this.gcThread = gcThread;
+        this.conf = gcThread.conf;
+        this.throttler = new Throttler(conf);
+    }
+
+    /**
+     * Compact entry log file.
+     * @param entryLogMeta log metadata for the entry log to be compacted
+     * @return true for succeed
+     */
+    public abstract boolean compact(EntryLogMetadata entryLogMeta);
+
+    class Throttler {
+        private final RateLimiter rateLimiter;
+        private final boolean isThrottleByBytes;
+
+        Throttler(ServerConfiguration conf) {
+            this.isThrottleByBytes  = conf.getIsThrottleByBytes();
+            this.rateLimiter = RateLimiter.create(this.isThrottleByBytes
+                ? conf.getCompactionRateByBytes() : conf.getCompactionRateByEntries());
+        }
+
+        // acquire. if bybytes: bytes of this entry; if byentries: 1.
+        void acquire(int permits) {
+            rateLimiter.acquire(this.isThrottleByBytes ? permits : 1);
+        }
+    }
+
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
@@ -47,6 +47,11 @@ public abstract class AbstractLogCompactor {
      */
     public abstract boolean compact(EntryLogMetadata entryLogMeta);
 
+    /**
+     * Do nothing by default. Intended for subclass to override this method.
+     */
+    public void cleanUpAndRecover() {}
+
     static class Throttler {
         private final RateLimiter rateLimiter;
         private final boolean isThrottleByBytes;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
@@ -107,7 +107,6 @@ public interface BookKeeperServerStats {
     // Compaction/Garbage Collection Related Counters
     String NUM_MINOR_COMP = "NUM_MINOR_COMP";
     String NUM_MAJOR_COMP = "NUM_MAJOR_COMP";
-    String GC_NUM_ENTRYLOGS_DELETED = "GC_NUM_ENTRYLOGS_DELETED";
     // Index Related Counters
     String INDEX_INMEM_ILLEGAL_STATE_RESET = "INDEX_INMEM_ILLEGAL_STATE_RESET";
     String INDEX_INMEM_ILLEGAL_STATE_DELETE = "INDEX_INMEM_ILLEGAL_STATE_DELETE";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
@@ -107,6 +107,7 @@ public interface BookKeeperServerStats {
     // Compaction/Garbage Collection Related Counters
     String NUM_MINOR_COMP = "NUM_MINOR_COMP";
     String NUM_MAJOR_COMP = "NUM_MAJOR_COMP";
+    String GC_NUM_ENTRYLOGS_DELETED = "GC_NUM_ENTRYLOGS_DELETED";
     // Index Related Counters
     String INDEX_INMEM_ILLEGAL_STATE_RESET = "INDEX_INMEM_ILLEGAL_STATE_RESET";
     String INDEX_INMEM_ILLEGAL_STATE_DELETE = "INDEX_INMEM_ILLEGAL_STATE_DELETE";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLocation.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLocation.java
@@ -34,4 +34,16 @@ public class EntryLocation {
         this.entry = entry;
         this.location = location;
     }
+
+    public long getLedger() {
+        return ledger;
+    }
+
+    public long getEntry() {
+        return entry;
+    }
+
+    public long getLocation() {
+        return location;
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
@@ -1,0 +1,123 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the basic entry log compactor to compact entry logs.
+ * The compaction is done by scanning the old entry log file, copy the active ledgers to the
+ * current entry logger and remove the old entry log when the scan is over.
+ */
+public class EntryLogCompactor extends AbstractLogCompactor {
+    private static final Logger LOG = LoggerFactory.getLogger(EntryLogCompactor.class);
+
+    final int maxOutstandingRequests;
+    final CompactionScannerFactory scannerFactory = new CompactionScannerFactory();
+    final EntryLogger entryLogger;
+    final CompactableLedgerStorage ledgerStorage;
+
+    public EntryLogCompactor(GarbageCollectorThread gcThread) {
+        super(gcThread);
+        this.maxOutstandingRequests = conf.getCompactionMaxOutstandingRequests();
+        this.entryLogger = gcThread.getEntryLogger();
+        this.ledgerStorage = gcThread.getLedgerStorage();
+    }
+
+    @Override
+    public boolean compact(EntryLogMetadata entryLogMeta) {
+        try {
+            entryLogger.scanEntryLog(entryLogMeta.getEntryLogId(),
+                scannerFactory.newScanner(entryLogMeta));
+            scannerFactory.flush();
+            LOG.info("Removing entry log {} after compaction", entryLogMeta.getEntryLogId());
+            gcThread.removeEntryLog(entryLogMeta.getEntryLogId());
+        } catch (LedgerDirsManager.NoWritableLedgerDirException nwlde) {
+            LOG.warn("No writable ledger directory available, aborting compaction", nwlde);
+            return false;
+        } catch (IOException ioe) {
+            // if compact entry log throws IOException, we don't want to remove that
+            // entry log. however, if some entries from that log have been re-added
+            // to the entry log, and the offset updated, it's ok to flush that
+            LOG.error("Error compacting entry log. Log won't be deleted", ioe);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * A scanner wrapper to check whether a ledger is alive in an entry log file.
+     */
+    class CompactionScannerFactory {
+        List<EntryLocation> offsets = new ArrayList<EntryLocation>();
+
+        EntryLogger.EntryLogScanner newScanner(final EntryLogMetadata meta) {
+
+            return new EntryLogger.EntryLogScanner() {
+                @Override
+                public boolean accept(long ledgerId) {
+                    return meta.containsLedger(ledgerId);
+                }
+
+                @Override
+                public void process(final long ledgerId, long offset, ByteBuffer entry) throws IOException {
+                    throttler.acquire(entry.remaining());
+
+                    if (offsets.size() > maxOutstandingRequests) {
+                        flush();
+                    }
+                    entry.getLong(); // discard ledger id, we already have it
+                    long entryId = entry.getLong();
+                    entry.rewind();
+
+                    long newoffset = entryLogger.addEntry(ledgerId, entry);
+                    offsets.add(new EntryLocation(ledgerId, entryId, newoffset));
+
+                }
+            };
+        }
+
+        void flush() throws IOException {
+            if (offsets.isEmpty()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Skipping entry log flushing, as there are no offset!");
+                }
+                return;
+            }
+
+            // Before updating the index, we want to wait until all the compacted entries are flushed into the
+            // entryLog
+            try {
+                entryLogger.flush();
+                ledgerStorage.updateEntriesLocations(offsets);
+            } finally {
+                offsets.clear();
+            }
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
@@ -37,10 +37,10 @@ import org.slf4j.LoggerFactory;
 public class EntryLogCompactor extends AbstractLogCompactor {
     private static final Logger LOG = LoggerFactory.getLogger(EntryLogCompactor.class);
 
-    final int maxOutstandingRequests;
     final CompactionScannerFactory scannerFactory = new CompactionScannerFactory();
     final EntryLogger entryLogger;
     final CompactableLedgerStorage ledgerStorage;
+    private final int maxOutstandingRequests;
 
     public EntryLogCompactor(GarbageCollectorThread gcThread) {
         super(gcThread);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -891,7 +891,9 @@ public class EntryLogger {
     void removeCurCompactionLog() {
         synchronized (compactionLogLock) {
             if (compactionLogChannel != null) {
-                compactionLogChannel.getLogFile().delete();
+                if (!compactionLogChannel.getLogFile().delete()) {
+                    LOG.warn("Could not delete compaction log file {}", compactionLogChannel.getLogFile());
+                }
                 try {
                     closeFileChannel(compactionLogChannel);
                 } catch (IOException e) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -22,10 +22,8 @@
 package org.apache.bookkeeper.bookie;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -37,7 +35,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
+
 import org.apache.bookkeeper.bookie.GarbageCollector.GarbageCleaner;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
@@ -76,15 +74,9 @@ public class GarbageCollectorThread extends SafeRunnable {
 
     final boolean isForceGCAllowWhenNoSpace;
 
-    final boolean isThrottleByBytes;
-    final int maxOutstandingRequests;
-    final int compactionRateByEntries;
-    final int compactionRateByBytes;
-    final CompactionScannerFactory scannerFactory;
-
     // Entry Logger Handle
     final EntryLogger entryLogger;
-
+    final AbstractLogCompactor compactor;
     final CompactableLedgerStorage ledgerStorage;
 
     // flag to ensure gc thread will not be interrupted during compaction
@@ -106,82 +98,7 @@ public class GarbageCollectorThread extends SafeRunnable {
     final GarbageCollector garbageCollector;
     final GarbageCleaner garbageCleaner;
 
-    private static class Throttler {
-        final RateLimiter rateLimiter;
-        final boolean isThrottleByBytes;
-        final int compactionRateByBytes;
-        final int compactionRateByEntries;
-
-        Throttler(boolean isThrottleByBytes,
-                  int compactionRateByBytes,
-                  int compactionRateByEntries) {
-            this.isThrottleByBytes  = isThrottleByBytes;
-            this.compactionRateByBytes = compactionRateByBytes;
-            this.compactionRateByEntries = compactionRateByEntries;
-            this.rateLimiter = RateLimiter.create(this.isThrottleByBytes
-                    ? this.compactionRateByBytes : this.compactionRateByEntries);
-        }
-
-        // acquire. if bybytes: bytes of this entry; if byentries: 1.
-        void acquire(int permits) {
-            rateLimiter.acquire(this.isThrottleByBytes ? permits : 1);
-        }
-    }
-
-    /**
-     * A scanner wrapper to check whether a ledger is alive in an entry log file.
-     */
-    class CompactionScannerFactory {
-        List<EntryLocation> offsets = new ArrayList<EntryLocation>();
-
-        EntryLogScanner newScanner(final EntryLogMetadata meta) {
-            final Throttler throttler = new Throttler (isThrottleByBytes,
-                                                       compactionRateByBytes,
-                                                       compactionRateByEntries);
-
-            return new EntryLogScanner() {
-                @Override
-                public boolean accept(long ledgerId) {
-                    return meta.containsLedger(ledgerId);
-                }
-
-                @Override
-                public void process(final long ledgerId, long offset, ByteBuffer entry) throws IOException {
-                    throttler.acquire(entry.remaining());
-
-                    if (offsets.size() > maxOutstandingRequests) {
-                        flush();
-                    }
-                    entry.getLong(); // discard ledger id, we already have it
-                    long entryId = entry.getLong();
-                    entry.rewind();
-
-                    long newoffset = entryLogger.addEntry(ledgerId, entry);
-                    offsets.add(new EntryLocation(ledgerId, entryId, newoffset));
-
-                }
-            };
-        }
-
-        void flush() throws IOException {
-            if (offsets.isEmpty()) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Skipping entry log flushing, as there are no offset!");
-                }
-                return;
-            }
-
-            // Before updating the index, we want to wait until all the compacted entries are flushed into the
-            // entryLog
-            try {
-                entryLogger.flush();
-
-                ledgerStorage.updateEntriesLocations(offsets);
-            } finally {
-                offsets.clear();
-            }
-        }
-    }
+    final ServerConfiguration conf;
 
 
     /**
@@ -198,40 +115,34 @@ public class GarbageCollectorThread extends SafeRunnable {
         gcExecutor = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("GarbageCollectorThread-%d").build()
         );
-
+        this.conf = conf;
         this.entryLogger = ledgerStorage.getEntryLogger();
         this.ledgerStorage = ledgerStorage;
-
         this.gcWaitTime = conf.getGcWaitTime();
-        this.isThrottleByBytes = conf.getIsThrottleByBytes();
-        this.maxOutstandingRequests = conf.getCompactionMaxOutstandingRequests();
-        this.compactionRateByEntries  = conf.getCompactionRateByEntries();
-        this.compactionRateByBytes = conf.getCompactionRateByBytes();
-        this.scannerFactory = new CompactionScannerFactory();
 
-        this.garbageCleaner = new GarbageCollector.GarbageCleaner() {
-            @Override
-            public void clean(long ledgerId) {
-                try {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("delete ledger : " + ledgerId);
-                    }
-
-                    ledgerStorage.deleteLedger(ledgerId);
-                } catch (IOException e) {
-                    LOG.error("Exception when deleting the ledger index file on the Bookie: ", e);
+        this.garbageCleaner = ledgerId -> {
+            try {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("delete ledger : " + ledgerId);
                 }
+                ledgerStorage.deleteLedger(ledgerId);
+            } catch (IOException e) {
+                LOG.error("Exception when deleting the ledger index file on the Bookie: ", e);
             }
         };
 
         this.garbageCollector = new ScanAndCompareGarbageCollector(ledgerManager, ledgerStorage, conf);
-
         // compaction parameters
         minorCompactionThreshold = conf.getMinorCompactionThreshold();
         minorCompactionInterval = conf.getMinorCompactionInterval() * SECOND;
         majorCompactionThreshold = conf.getMajorCompactionThreshold();
         majorCompactionInterval = conf.getMajorCompactionInterval() * SECOND;
         isForceGCAllowWhenNoSpace = conf.getIsForceGCAllowWhenNoSpace();
+        if (conf.getUseTransactionalCompaction()) {
+            this.compactor = new TransactionalEntryLogCompactor(this);
+        } else {
+            this.compactor = new EntryLogCompactor(this);
+        }
 
         if (minorCompactionInterval > 0 && minorCompactionThreshold > 0) {
             if (minorCompactionThreshold > 1.0f) {
@@ -335,7 +246,10 @@ public class GarbageCollectorThread extends SafeRunnable {
         if (force) {
             LOG.info("Garbage collector thread forced to perform GC before expiry of wait time.");
         }
-
+        // Recover and clean up previous state if using transactional compaction
+        if (compactor instanceof TransactionalEntryLogCompactor) {
+            ((TransactionalEntryLogCompactor) compactor).cleanUpAndRecover();
+        }
         // Extract all of the ledger ID's that comprise all of the entry logs
         // (except for the current new one which is still being written to).
         entryLogMetaMap = extractMetaFromEntryLogs(entryLogMetaMap);
@@ -423,51 +337,26 @@ public class GarbageCollectorThread extends SafeRunnable {
      */
     @VisibleForTesting
     void doCompactEntryLogs(double threshold) {
-        LOG.info("Do compaction to compact those files lower than " + threshold);
+        LOG.info("Do compaction to compact those files lower than {}", threshold);
         // sort the ledger meta by occupied unused space
-        Comparator<EntryLogMetadata> sizeComparator = new Comparator<EntryLogMetadata>() {
-            @Override
-            public int compare(EntryLogMetadata m1, EntryLogMetadata m2) {
-                long unusedSize1 = m1.getTotalSize() - m1.getRemainingSize();
-                long unusedSize2 = m2.getTotalSize() - m2.getRemainingSize();
-                if (unusedSize1 > unusedSize2) {
-                    return -1;
-                } else if (unusedSize1 < unusedSize2) {
-                    return 1;
-                } else {
-                    return 0;
-                }
-            }
+        // sort the ledger meta by occupied unused space
+        Comparator<EntryLogMetadata> usageComparator = (m1, m2) -> {
+            double usage1 = m1.getUsage();
+            double usage2 = m2.getUsage();
+            return Double.compare(usage1, usage2);
         };
         List<EntryLogMetadata> logsToCompact = new ArrayList<EntryLogMetadata>();
         logsToCompact.addAll(entryLogMetaMap.values());
-        Collections.sort(logsToCompact, sizeComparator);
+        Collections.sort(logsToCompact, usageComparator);
 
         for (EntryLogMetadata meta : logsToCompact) {
             if (meta.getUsage() >= threshold) {
                 break;
             }
-
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Compacting entry log {} below threshold {}", meta.getEntryLogId(), threshold);
             }
-            try {
-                compactEntryLog(scannerFactory, meta);
-                scannerFactory.flush();
-
-                LOG.info("Removing entry log {} after compaction", meta.getEntryLogId());
-                removeEntryLog(meta.getEntryLogId());
-
-            } catch (LedgerDirsManager.NoWritableLedgerDirException nwlde) {
-                LOG.warn("No writable ledger directory available, aborting compaction", nwlde);
-                break;
-            } catch (IOException ioe) {
-                // if compact entry log throws IOException, we don't want to remove that
-                // entry log. however, if some entries from that log have been readded
-                // to the entry log, and the offset updated, it's ok to flush that
-                LOG.error("Error compacting entry log. Log won't be deleted", ioe);
-            }
-
+            compactEntryLog(meta);
             if (!running) { // if gc thread is not running, stop compaction
                 return;
             }
@@ -498,9 +387,10 @@ public class GarbageCollectorThread extends SafeRunnable {
      * @param entryLogId
      *          Entry Log File Id
      */
-    private void removeEntryLog(long entryLogId) {
+    protected void removeEntryLog(long entryLogId) {
         // remove entry log file successfully
         if (entryLogger.removeEntryLog(entryLogId)) {
+            LOG.info("Removing entry log metadata for {}", entryLogId);
             entryLogMetaMap.remove(entryLogId);
         }
     }
@@ -508,11 +398,9 @@ public class GarbageCollectorThread extends SafeRunnable {
     /**
      * Compact an entry log.
      *
-     * @param scannerFactory
      * @param entryLogMeta
      */
-    protected void compactEntryLog(CompactionScannerFactory scannerFactory,
-                                   EntryLogMetadata entryLogMeta) throws IOException {
+    protected void compactEntryLog(EntryLogMetadata entryLogMeta) {
         // Similar with Sync Thread
         // try to mark compacting flag to make sure it would not be interrupted
         // by shutdown during compaction. otherwise it will receive
@@ -523,16 +411,10 @@ public class GarbageCollectorThread extends SafeRunnable {
             // indicates that compaction is in progress for this EntryLogId.
             return;
         }
-
-        LOG.info("Compacting entry log : {} - Usage: {} %", entryLogMeta.getEntryLogId(), entryLogMeta.getUsage());
-
-        try {
-            entryLogger.scanEntryLog(entryLogMeta.getEntryLogId(),
-                                     scannerFactory.newScanner(entryLogMeta));
-        } finally {
-            // clear compacting flag
-            compacting.set(false);
-        }
+        // Do the actual compaction
+        compactor.compact(entryLogMeta);
+        // Mark compaction done
+        compacting.set(false);
     }
 
     /**
@@ -581,5 +463,13 @@ public class GarbageCollectorThread extends SafeRunnable {
             }
         }
         return entryLogMetaMap;
+    }
+
+    EntryLogger getEntryLogger() {
+        return entryLogger;
+    }
+
+    CompactableLedgerStorage getLedgerStorage() {
+        return ledgerStorage;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -63,6 +63,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
     /**
      * Delete all previously incomplete compacting logs and recover the index for compacted logs.
      */
+    @Override
     public void cleanUpAndRecover() {
         // clean up compacting logs and recover index for already compacted logs
         List<File> ledgerDirs = entryLogger.getLedgerDirsManager().getAllLedgerDirs();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -154,7 +154,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
      * If anything failed in this phase, we should delete the compaction log and clean the offsets.
      */
     class ScanEntryLogPhase extends CompactionPhase {
-        private EntryLogMetadata metadata;
+        private final EntryLogMetadata metadata;
 
         ScanEntryLogPhase(EntryLogMetadata metadata) {
             super("ScanEntryLogPhase");
@@ -174,7 +174,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                 @Override
                 public void process(long ledgerId, long offset, ByteBuffer entry) throws IOException {
                     throttler.acquire(entry.remaining());
-                    synchronized (this) {
+                    synchronized (TransactionalEntryLogCompactor.this) {
                         long lid = entry.getLong();
                         long entryId = entry.getLong();
                         if (lid != ledgerId || entryId < -1) {
@@ -225,8 +225,8 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
      * a hardlink file "3.log.1.compacted" should be created, and "3.log.compacting" should be deleted.
      */
     class FlushCompactionLogPhase extends CompactionPhase {
-        long compactingLogId;
-        File compactedLogFile;
+        private final long compactingLogId;
+        private File compactedLogFile;
 
         FlushCompactionLogPhase(long compactingLogId) {
             super("FlushCompactionLogPhase");
@@ -284,9 +284,9 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
      * This phase can also used to recover partially flushed index when we pass isInRecovery=true
      */
     class UpdateIndexPhase extends CompactionPhase {
-        File compactedLogFile;
-        File newEntryLogFile;
-        boolean isInRecovery;
+        private File compactedLogFile;
+        private File newEntryLogFile;
+        private final boolean isInRecovery;
 
         public UpdateIndexPhase(File compactedLogFile) {
             this(compactedLogFile, false);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -1,0 +1,413 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
+import org.apache.bookkeeper.util.HardLink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is used for compaction. Compaction is done in several transactional phases.
+ * Phase 1: Scan old entry log and compact entries to a new .compacting log file.
+ * Phase 2: Flush .compacting log to disk and it becomes .compacted log file when this completes.
+ * Phase 3: Flush ledger cache and .compacted file becomes .log file when this completes. Remove old
+ * entry log file afterwards.
+ */
+public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TransactionalEntryLogCompactor.class);
+
+    final EntryLogger entryLogger;
+    final CompactableLedgerStorage ledgerStorage;
+    final Throttler throttler;
+    final List<EntryLocation> offsets = new ArrayList<>();
+
+    // compaction log file suffix
+    static final String COMPACTING_SUFFIX = ".log.compacting";
+    // flushed compaction log file suffix
+    static final String COMPACTED_SUFFIX = ".compacted";
+
+    private class Throttler {
+        final RateLimiter rateLimiter;
+        final boolean isThrottleByBytes;
+        final int compactionRateByBytes;
+        final int compactionRateByEntries;
+
+        Throttler(boolean isThrottleByBytes,
+                  int compactionRateByBytes,
+                  int compactionRateByEntries) {
+            this.isThrottleByBytes = isThrottleByBytes;
+            this.compactionRateByBytes = compactionRateByBytes;
+            this.compactionRateByEntries = compactionRateByEntries;
+            this.rateLimiter = RateLimiter.create(this.isThrottleByBytes ?
+                this.compactionRateByBytes :
+                this.compactionRateByEntries);
+        }
+
+        // acquire. if bybytes: bytes of this entry; if byentries: 1.
+        void acquire(int permits) {
+            rateLimiter.acquire(this.isThrottleByBytes ? permits : 1);
+        }
+    }
+
+    public TransactionalEntryLogCompactor(GarbageCollectorThread gcThread) {
+        super(gcThread);
+        this.entryLogger = gcThread.getEntryLogger();
+        this.ledgerStorage = gcThread.getLedgerStorage();
+        boolean isThrottleByBytes = conf.getIsThrottleByBytes();
+        int compactionRateByEntries = conf.getCompactionRateByEntries();
+        int compactionRateByBytes = conf.getCompactionRateByBytes();
+        // Compaction Throttler
+        this.throttler = new Throttler(isThrottleByBytes,
+            compactionRateByBytes,
+            compactionRateByEntries);
+    }
+
+    /**
+     * Delete all previously incomplete compacting logs and recover the index for compacted logs.
+     */
+    public void cleanUpAndRecover() {
+        // clean up compacting logs and recover index for already compacted logs
+        List<File> ledgerDirs = entryLogger.getLedgerDirsManager().getAllLedgerDirs();
+        for (File dir : ledgerDirs) {
+            File[] compactingPhaseFiles = dir.listFiles(file -> file.getName().endsWith(COMPACTING_SUFFIX));
+            if (compactingPhaseFiles != null) {
+                for (File file : compactingPhaseFiles) {
+                    LOG.info("Deleting failed compaction file {}", file);
+                    file.delete();
+                }
+            }
+            File[] compactedPhaseFiles = dir.listFiles(file -> file.getName().endsWith(COMPACTED_SUFFIX));
+            if (compactedPhaseFiles != null) {
+                for (File compactedFile : compactedPhaseFiles) {
+                    LOG.info("Found compacted log file {} has partially flushed index, recovering index.", compactedFile);
+                    CompactionPhase updateIndex = new UpdateIndexPhase(compactedFile, true);
+                    updateIndex.run();
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean compact(EntryLogMetadata metadata) {
+        if (metadata != null) {
+            LOG.info("Compacting entry log {} with usage {}.",
+                new Object[]{metadata.getEntryLogId(), metadata.getUsage()});
+            CompactionPhase scanEntryLog = new ScanEntryLogPhase(metadata);
+            if (!scanEntryLog.run()) {
+                LOG.info("Compaction for entry log {} end in ScanEntryLogPhase.", metadata.getEntryLogId());
+                return false;
+            }
+            File compactionLogFile = entryLogger.getCurCompactionLogFile();
+            CompactionPhase flushCompactionLog = new FlushCompactionLogPhase(metadata.getEntryLogId());
+            if (!flushCompactionLog.run()) {
+                LOG.info("Compaction for entry log {} end in FlushCompactionLogPhase.", metadata.getEntryLogId());
+                return false;
+            }
+            File compactedLogFile = getCompactedLogFile(compactionLogFile, metadata.getEntryLogId());
+            CompactionPhase updateIndex = new UpdateIndexPhase(compactedLogFile);
+            if (!updateIndex.run()) {
+                LOG.info("Compaction for entry log {} end in UpdateIndexPhase.", metadata.getEntryLogId());
+                return false;
+            }
+            LOG.info("Compacted entry log : {}.", metadata.getEntryLogId());
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * An abstract class that would be extended to be the actual transactional phases for compaction
+     */
+    abstract static class CompactionPhase {
+        private String phaseName = "";
+
+        CompactionPhase(String phaseName) {
+            this.phaseName = phaseName;
+        }
+
+        boolean run() {
+            try {
+                start();
+                return complete();
+            } catch (IOException e) {
+                LOG.error("Encounter exception in compaction phase {}. Abort current compaction.", phaseName, e);
+                abort();
+            }
+            return false;
+        }
+
+        abstract void start() throws IOException;
+
+        abstract boolean complete() throws IOException;
+
+        abstract void abort();
+
+    }
+
+    /**
+     * Assume we're compacting entry log 1 to entry log 3.
+     * The first phase is to scan entries in 1.log and copy them to compaction log file "3.log.compacting".
+     * We'll try to allocate a new compaction log before scanning to make sure we have a log file to write.
+     * If after scanning, there's no data written, it means there's no valid entries to be compacted,
+     * so we can remove 1.log directly, clear the offsets and end the compaction.
+     * Otherwise, we should move on to the next phase.
+     * <p>
+     * If anything failed in this phase, we should delete the compaction log and clean the offsets.
+     */
+    class ScanEntryLogPhase extends CompactionPhase {
+        private EntryLogMetadata metadata;
+
+        ScanEntryLogPhase(EntryLogMetadata metadata) {
+            super("ScanEntryLogPhase");
+            this.metadata = metadata;
+        }
+
+        @Override
+        void start() throws IOException {
+            // scan entry log into compaction log and offset list
+            entryLogger.createNewCompactionLog();
+            entryLogger.scanEntryLog(metadata.getEntryLogId(), new EntryLogScanner() {
+                @Override
+                public boolean accept(long ledgerId) {
+                    return metadata.containsLedger(ledgerId);
+                }
+
+                @Override
+                public void process(long ledgerId, long offset, ByteBuffer entry) throws IOException {
+                    throttler.acquire(entry.remaining());
+                    synchronized (this) {
+                        long lid = entry.getLong();
+                        long entryId = entry.getLong();
+                        if (lid != ledgerId || entryId < -1) {
+                            LOG.warn("Scanning expected ledgerId {}, but found invalid entry " +
+                                    "with ledgerId {} entryId {} at offset {}",
+                                new Object[]{ledgerId, lid, entryId, offset});
+                            throw new IOException("Invalid entry found @ offset " + offset);
+                        }
+                        entry.rewind();
+                        long newOffset = entryLogger.addEntryForCompaction(ledgerId, entry);
+                        offsets.add(new EntryLocation(ledgerId, entryId, newOffset));
+
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Compact add entry : lid = {}, eid = {}, offset = {}",
+                                new Object[]{ledgerId, entryId, newOffset});
+                        }
+                    }
+                }
+            });
+        }
+
+        @Override
+        boolean complete() {
+            if (offsets.isEmpty()) {
+                // no valid entries is compacted, delete entry log file
+                LOG.info("No valid entry is found in entry log after scan, removing entry log now.");
+                gcThread.removeEntryLog(metadata.getEntryLogId());
+                entryLogger.removeCurCompactionLog();
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        void abort() {
+            offsets.clear();
+            // since we haven't flushed yet, we only need to delete the unflushed compaction file.
+            entryLogger.removeCurCompactionLog();
+        }
+
+    }
+
+    /**
+     * Assume we're compacting log 1 to log 3.
+     * This phase is to flush the compaction log.
+     * When this phase starts, there should be a compaction log file like "3.log.compacting"
+     * When compaction log is flushed, in order to indicate this phase is completed,
+     * a hardlink file "3.log.1.compacted" should be created, and "3.log.compacting" should be deleted.
+     */
+    class FlushCompactionLogPhase extends CompactionPhase {
+        long compactingLogId;
+        File compactedLogFile;
+
+        FlushCompactionLogPhase(long compactingLogId) {
+            super("FlushCompactionLogPhase");
+            this.compactingLogId = compactingLogId;
+        }
+
+        @Override
+        void start() throws IOException {
+            // flush the current compaction log.
+            File compactionLogFile = entryLogger.getCurCompactionLogFile();
+            if (compactionLogFile == null || !compactionLogFile.exists()) {
+                throw new IOException("Compaction log doesn't exist during flushing");
+            }
+            entryLogger.flushCompactionLog();
+        }
+
+        @Override
+        boolean complete() throws IOException {
+            // create a hard link file named "x.log.y.compacted" for file "x.log.compacting".
+            // where x is compactionLogId and y is compactingLogId.
+            File compactionLogFile = entryLogger.getCurCompactionLogFile();
+            if (compactionLogFile == null || !compactionLogFile.exists()) {
+                LOG.warn("Compaction log doesn't exist any more after flush");
+                return false;
+            }
+            compactedLogFile = getCompactedLogFile(compactionLogFile, compactingLogId);
+            if (compactedLogFile != null && !compactedLogFile.exists()) {
+                HardLink.createHardLink(compactionLogFile, compactedLogFile);
+            }
+            entryLogger.removeCurCompactionLog();
+            return true;
+        }
+
+        @Override
+        void abort() {
+            offsets.clear();
+            // remove compaction log file and its hardlink
+            entryLogger.removeCurCompactionLog();
+            if (compactedLogFile != null && compactedLogFile.exists()) {
+                compactedLogFile.delete();
+            }
+        }
+    }
+
+    /**
+     * Assume we're compacting log 1 to log 3.
+     * This phase is to update the entry locations and flush the index.
+     * When the phase start, there should be a compacted file like "3.log.1.compacted",
+     * where 3 is the new compaction logId and 1 is the old entry logId.
+     * After the index the flushed successfully, a hardlink "3.log" file should be created,
+     * and 3.log.1.compacted file should be deleted to indicate the phase is succeed.
+     * <p>
+     * This phase can also used to recover partially flushed index when we pass isInRecovery=true
+     */
+    class UpdateIndexPhase extends CompactionPhase {
+        File compactedLogFile;
+        File newEntryLogFile;
+        boolean isInRecovery;
+
+        public UpdateIndexPhase(File compactedLogFile) {
+            this(compactedLogFile, false);
+        }
+
+        public UpdateIndexPhase(File compactedLogFile, boolean isInRecovery) {
+            super("UpdateIndexPhase");
+            this.compactedLogFile = compactedLogFile;
+            this.isInRecovery = isInRecovery;
+        }
+
+        @Override
+        void start() throws IOException {
+            if (compactedLogFile != null && compactedLogFile.exists()) {
+                File dir = compactedLogFile.getParentFile();
+                String compactedFilename = compactedLogFile.getName();
+                // create a hard link "x.log" for file "x.log.y.compacted"
+                this.newEntryLogFile = new File(dir, compactedFilename.substring(0, compactedFilename.indexOf(".log") + 4));
+                if (!newEntryLogFile.exists()) {
+                    HardLink.createHardLink(compactedLogFile, newEntryLogFile);
+                }
+                if (isInRecovery) {
+                    recoverEntryLocations(EntryLogger.fileName2LogId(newEntryLogFile.getName()));
+                }
+                if (!offsets.isEmpty()) {
+                    // update entry locations and flush index
+                    ledgerStorage.updateEntriesLocations(offsets);
+                    ledgerStorage.flushEntriesLocationsIndex();
+                }
+            } else {
+                throw new IOException("Failed to find compacted log file in UpdateIndexPhase");
+            }
+        }
+
+        @Override
+        boolean complete() {
+            // When index is flushed, and entry log is removed,
+            // delete the ".compacted" file to indicate this phase is completed.
+            if (compactedLogFile != null) {
+                compactedLogFile.delete();
+            }
+            offsets.clear();
+            // Now delete the old entry log file since it's compacted
+            String compactedFilename = compactedLogFile.getName();
+            String oldEntryLogFilename = compactedFilename.substring(compactedFilename.indexOf(".log") + 5);
+            long entryLogId = EntryLogger.fileName2LogId(oldEntryLogFilename);
+            gcThread.removeEntryLog(entryLogId);
+            return true;
+        }
+
+        @Override
+        void abort() {
+            offsets.clear();
+        }
+
+        /**
+         * Scan entry log to recover entry locations.
+         */
+        private void recoverEntryLocations(long compactedLogId) throws IOException {
+            entryLogger.scanEntryLog(compactedLogId, new EntryLogScanner() {
+                @Override
+                public boolean accept(long ledgerId) {
+                    return true;
+                }
+
+                @Override
+                public void process(long ledgerId, long offset, ByteBuffer entry) throws IOException {
+                    long lid = entry.getLong();
+                    long entryId = entry.getLong();
+                    if (lid != ledgerId || entryId < -1) {
+                        LOG.warn("Scanning expected ledgerId {}, but found invalid entry " +
+                                "with ledgerId {} entryId {} at offset {}",
+                            new Object[]{ledgerId, lid, entryId, offset});
+                        throw new IOException("Invalid entry found @ offset " + offset);
+                    }
+                    entry.rewind();
+                    long location = (compactedLogId << 32L) | (offset + 4);
+                    offsets.add(new EntryLocation(lid, entryId, location));
+                }
+            });
+            LOG.info("Recovered {} entry locations from compacted log {}", offsets.size(), compactedLogId);
+        }
+    }
+
+    File getCompactedLogFile(File compactionLogFile, long compactingLogId) {
+        if (compactionLogFile == null) {
+            return null;
+        }
+        File dir = compactionLogFile.getParentFile();
+        String filename = compactionLogFile.getName();
+        String newSuffix = ".log." + EntryLogger.logId2HexString(compactingLogId) + COMPACTED_SUFFIX;
+        String hardLinkFilename = filename.replace(COMPACTING_SUFFIX, newSuffix);
+        return new File(dir, hardLinkFilename);
+    }
+
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -284,8 +284,8 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
      * This phase can also used to recover partially flushed index when we pass isInRecovery=true
      */
     class UpdateIndexPhase extends CompactionPhase {
-        private File compactedLogFile;
-        private File newEntryLogFile;
+        File compactedLogFile;
+        File newEntryLogFile;
         private final boolean isInRecovery;
 
         public UpdateIndexPhase(File compactedLogFile) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -56,6 +56,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     protected final static String GC_WAIT_TIME = "gcWaitTime";
     protected final static String IS_FORCE_GC_ALLOW_WHEN_NO_SPACE = "isForceGCAllowWhenNoSpace";
     protected final static String GC_OVERREPLICATED_LEDGER_WAIT_TIME = "gcOverreplicatedLedgerWaitTime";
+    protected final static String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
     // Sync Parameters
     protected final static String FLUSH_INTERVAL = "flushInterval";
     protected final static String FLUSH_ENTRYLOG_INTERVAL_BYTES = "flushEntrylogBytes";
@@ -288,6 +289,25 @@ public class ServerConfiguration extends AbstractConfiguration {
      */
     public ServerConfiguration setGcOverreplicatedLedgerWaitTime(long gcWaitTime, TimeUnit unit) {
         this.setProperty(GC_OVERREPLICATED_LEDGER_WAIT_TIME, Long.toString(unit.toMillis(gcWaitTime)));
+        return this;
+    }
+
+    /**
+     * Get whether to use transactional compaction and using a separate log for compaction or not.
+     *
+     * @return use transactional compaction
+     */
+    public boolean getUseTransactionalCompaction() {
+        return this.getBoolean(USE_TRANSACTIONAL_COMPACTION, false);
+    }
+
+    /**
+     * Set whether to use transactional compaction and using a separate log for compaction or not.
+     * @param useTransactionalCompaction
+     * @return server configuration
+     */
+    public ServerConfiguration setUseTransactionalCompaction(boolean useTransactionalCompaction) {
+        this.setProperty(USE_TRANSACTIONAL_COMPACTION, useTransactionalCompaction);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -841,17 +841,23 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             lh.close();
         }
 
+        // disable compaction
+        baseConf.setMinorCompactionThreshold(0.0f);
+        baseConf.setMajorCompactionThreshold(0.0f);
+        baseConf.setGcWaitTime(600000);
+
+        // restart bookies
+        restartBookies(baseConf);
+
         Bookie bookie = bs.get(0).getBookie();
         InterleavedLedgerStorage storage = (InterleavedLedgerStorage) bookie.ledgerStorage;
-        // disable periodic compaction and recovery, we use manual compaction and recovery
-        storage.gcThread.triggerGC().get();
+
 
         // remove ledger2 and ledger3
         bkc.deleteLedger(lhs[1].getId());
         bkc.deleteLedger(lhs[2].getId());
 
         LOG.info("Finished deleting the ledgers contains most entries.");
-
 
         MockTransactionalEntryLogCompactor partialCompactionWorker = new MockTransactionalEntryLogCompactor(
             ((InterleavedLedgerStorage) bookie.ledgerStorage).gcThread);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -852,7 +852,6 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         Bookie bookie = bs.get(0).getBookie();
         InterleavedLedgerStorage storage = (InterleavedLedgerStorage) bookie.ledgerStorage;
 
-
         // remove ledger2 and ledger3
         bkc.deleteLedger(lhs[1].getId());
         bkc.deleteLedger(lhs[2].getId());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -25,6 +25,8 @@ import io.netty.buffer.Unpooled;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,8 +36,6 @@ import java.util.Enumeration;
 import java.util.List;
 
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
-import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
-import org.apache.bookkeeper.bookie.GarbageCollectorThread.CompactionScannerFactory;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
@@ -51,17 +51,18 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.LedgerMetadataLis
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.Processor;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.DiskChecker;
+import org.apache.bookkeeper.util.HardLink;
 import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.TestUtils;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.zookeeper.AsyncCallback;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.bookkeeper.bookie.TransactionalEntryLogCompactor.COMPACTED_SUFFIX;
 import static org.junit.Assert.*;
 /**
  * This class tests the entry log compaction functionality.
@@ -356,25 +357,37 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testMinorCompactionWithNoWritableLedgerDirsButIsForceGCAllowWhenNoSpaceIsSet() throws Exception {
+        stopAllBookies();
+        ServerConfiguration conf = newServerConfiguration();
+        // disable major compaction
+        conf.setMajorCompactionThreshold(0.0f);
+        // here we are setting isForceGCAllowWhenNoSpace to true, so Major and Minor compaction wont be disabled in case
+        // when discs are full
+        conf.setIsForceGCAllowWhenNoSpace(true);
+        conf.setGcWaitTime(600000);
+        conf.setMinorCompactionInterval(120000);
+        conf.setMajorCompactionInterval(240000);
+        // We need at least 2 ledger dirs because compaction will flush ledger cache, and will
+        // trigger relocateIndexFileAndFlushHeader. If we only have one ledger dir, compaction will always fail
+        // when there's no writeable ledger dir.
+        File ledgerDir1 = createTempDir("ledger", "test1");
+        File ledgerDir2 = createTempDir("ledger","test2");
+        File journalDir = createTempDir("journal","test");
+        String[] ledgerDirNames = new String[]{
+            ledgerDir1.getPath(),
+            ledgerDir2.getPath()
+        };
+        conf.setLedgerDirNames(ledgerDirNames);
+        conf.setJournalDirName(journalDir.getPath());
+        BookieServer server = startBookie(conf);
+        bs.add(server);
+        bsConfs.add(conf);
         // prepare data
         LedgerHandle[] lhs = prepareData(3, false);
 
         for (LedgerHandle lh : lhs) {
             lh.close();
         }
-
-        // disable major compaction
-        baseConf.setMajorCompactionThreshold(0.0f);
-
-        // here we are setting isForceGCAllowWhenNoSpace to true, so Major and Minor compaction wont be disabled in case
-        // when discs are full
-        baseConf.setIsForceGCAllowWhenNoSpace(true);
-        baseConf.setGcWaitTime(60000);
-        baseConf.setMinorCompactionInterval(120000);
-        baseConf.setMajorCompactionInterval(240000);
-
-        // restart bookies
-        restartBookies(baseConf);
 
         long lastMinorCompactionTime = getGCThread().lastMinorCompactionTime;
         long lastMajorCompactionTime = getGCThread().lastMajorCompactionTime;
@@ -383,6 +396,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
 
         for (BookieServer bookieServer : bs) {
             Bookie bookie = bookieServer.getBookie();
+            bookie.ledgerStorage.flush();
+            bookie.ledgerMonitor.shutdown();
             LedgerDirsManager ledgerDirsManager = bookie.getLedgerDirsManager();
             List<File> ledgerDirs = ledgerDirsManager.getAllLedgerDirs();
             // Major and Minor compaction are not disabled even though discs are full. Check LedgerDirsListener of
@@ -408,9 +423,9 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         // allocating newlog
         // we get getWritableLedgerDirsForNewLog() of ledgerDirsManager instead of getWritableLedgerDirs()
         // entry logs ([0,1,2].log) should be compacted.
-        for (File ledgerDirectory : tmpDirs) {
+        for (File ledgerDirectory : server.getBookie().getLedgerDirsManager().getAllLedgerDirs()) {
             assertFalse("Found entry log file ([0,1,2].log that should have not been compacted in ledgerDirectory: "
-                    + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1, 2));
+                    + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory.getParentFile(), true, 0, 1, 2));
         }
 
         // even entry log files are removed, we still can access entries for ledger1
@@ -818,13 +833,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
     }
 
     @Test
-    public void testCompactionWithEntryLogRollover() throws Exception {
-        // Disable bookie gc during this test
-        baseConf.setGcWaitTime(60000);
-        baseConf.setMinorCompactionInterval(0);
-        baseConf.setMajorCompactionInterval(0);
-        restartBookies(baseConf);
-
+    public void testRecoverIndexWhenIndexIsPartiallyFlush() throws Exception {
         // prepare data
         LedgerHandle[] lhs = prepareData(3, false);
 
@@ -832,46 +841,247 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             lh.close();
         }
 
+        Bookie bookie = bs.get(0).getBookie();
+        InterleavedLedgerStorage storage = (InterleavedLedgerStorage) bookie.ledgerStorage;
+        // disable periodic compaction and recovery, we use manual compaction and recovery
+        storage.gcThread.enableForceGC();
+
         // remove ledger2 and ledger3
         bkc.deleteLedger(lhs[1].getId());
         bkc.deleteLedger(lhs[2].getId());
+
         LOG.info("Finished deleting the ledgers contains most entries.");
+        // wait for one more gc
+        Thread.sleep(baseConf.getMajorCompactionInterval() * 1000
+            + baseConf.getGcWaitTime());
 
-        InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) bs.get(0).getBookie().ledgerStorage;
-        GarbageCollectorThread garbageCollectorThread = ledgerStorage.gcThread;
-        CompactionScannerFactory compactionScannerFactory = garbageCollectorThread.scannerFactory;
-        long entryLogId = 0;
-        EntryLogger entryLogger = ledgerStorage.entryLogger;
 
-        LOG.info("Before compaction -- Least unflushed log id: {}", entryLogger.getLeastUnflushedLogId());
+        MockTransactionalEntryLogCompactor partialCompactionWorker = new MockTransactionalEntryLogCompactor(
+            ((InterleavedLedgerStorage) bookie.ledgerStorage).gcThread);
 
-        // Compact entryLog 0
-        EntryLogScanner scanner = compactionScannerFactory.newScanner(entryLogger.getEntryLogMetadata(entryLogId));
+        for (long logId = 0; logId < 3; logId++) {
+            EntryLogMetadata meta = storage.entryLogger.getEntryLogMetadata(logId);
+            partialCompactionWorker.compactWithIndexFlushFailure(meta);
+        }
 
-        entryLogger.scanEntryLog(entryLogId, scanner);
+        // entry logs ([0,1,2].log) should not be compacted because of partial flush throw IOException
+        for (File ledgerDirectory : tmpDirs) {
+            assertTrue("Entry log file ([0,1,2].log should not be compacted in ledgerDirectory: "
+                + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1, 2));
+        }
 
-        long entryLogIdAfterCompaction = entryLogger.getLeastUnflushedLogId();
-        LOG.info("After compaction -- Least unflushed log id: {}", entryLogIdAfterCompaction);
+        // entries should be available
+        verifyLedger(lhs[0].getId(), 0, lhs[0].getLastAddConfirmed());
 
-        // Add more entries to trigger entrylog roll over
-        LedgerHandle[] lhs2 = prepareData(3, false);
+        // But we should see .compacted file with index flush failure
+        assertEquals(findCompactedEntryLogFiles().size(), 3);
 
-        for (LedgerHandle lh : lhs2) {
+        // Now try to recover those flush failed index files
+        partialCompactionWorker.cleanUpAndRecover();
+
+        // There should be no .compacted files after recovery
+        assertEquals(findCompactedEntryLogFiles().size(), 0);
+
+        // compaction worker should recover partial flushed index and delete [0,1,2].log
+        for (File ledgerDirectory : tmpDirs) {
+            assertFalse("Entry log file ([0,1,2].log should have been compacted in ledgerDirectory: "
+                + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1, 2));
+        }
+
+        // even entry log files are removed, we still can access entries for ledger1
+        // since those entries has been compacted to new entry log
+        verifyLedger(lhs[0].getId(), 0, lhs[0].getLastAddConfirmed());
+    }
+
+    @Test
+    public void testCompactionFailureShouldNotResultInDuplicatedData() throws Exception {
+        // prepare data
+        LedgerHandle[] lhs = prepareData(5, false);
+
+        for (LedgerHandle lh : lhs) {
             lh.close();
         }
 
-        // Wait for entry logger to move forward
-        while (entryLogger.getLeastUnflushedLogId() <= entryLogIdAfterCompaction) {
-            Thread.sleep(100);
+        // disable compaction
+        baseConf.setMinorCompactionThreshold(0.0f);
+        baseConf.setMajorCompactionThreshold(0.0f);
+        baseConf.setUseTransactionalCompaction(true);
+
+        // restart bookies
+        restartBookies(baseConf);
+
+        // remove ledger2 and ledger3
+        bkc.deleteLedger(lhs[1].getId());
+        bkc.deleteLedger(lhs[2].getId());
+
+        LOG.info("Finished deleting the ledgers contains most entries.");
+        Thread.sleep(baseConf.getMajorCompactionInterval() * 1000
+            + baseConf.getGcWaitTime());
+        Bookie bookie = bs.get(0).getBookie();
+        InterleavedLedgerStorage storage = (InterleavedLedgerStorage) bookie.ledgerStorage;
+
+        List<File> ledgerDirs = bookie.getLedgerDirsManager().getAllLedgerDirs();
+        List<Long> usageBeforeCompaction = new ArrayList<>();
+        ledgerDirs.forEach(file -> usageBeforeCompaction.add(getDirectorySpaceUsage(file)));
+
+        MockTransactionalEntryLogCompactor partialCompactionWorker = new MockTransactionalEntryLogCompactor(
+            ((InterleavedLedgerStorage) bookie.ledgerStorage).gcThread);
+
+        for (long logId = 0; logId < 5; logId++) {
+            EntryLogMetadata meta = storage.entryLogger.getEntryLogMetadata(logId);
+            partialCompactionWorker.compactWithLogFlushFailure(meta);
         }
 
-        long entryLogIdBeforeFlushing = entryLogger.getLeastUnflushedLogId();
-        LOG.info("Added more data -- Least unflushed log id: {}", entryLogIdBeforeFlushing);
+        // entry logs ([0-4].log) should not be compacted because of failure in flush compaction log
+        for (File ledgerDirectory : tmpDirs) {
+            assertTrue("Entry log file ([0,1,2].log should not be compacted in ledgerDirectory: "
+                + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1, 2, 3, 4));
+        }
+        // even entry log files are removed, we still can access entries for ledger1
+        // since those entries has been compacted to new entry log
+        verifyLedger(lhs[0].getId(), 0, lhs[0].getLastAddConfirmed());
 
-        Assert.assertTrue(entryLogIdAfterCompaction < entryLogIdBeforeFlushing);
+        List<Long> freeSpaceAfterCompactionFailed = new ArrayList<>();
+        ledgerDirs.forEach(file -> freeSpaceAfterCompactionFailed.add(getDirectorySpaceUsage(file)));
 
-        // Wait for entries to be flushed on entry logs and update index
-        // This operation should succeed even if the entry log rolls over after the last entry was compacted
-        compactionScannerFactory.flush();
+        // No extra data is generated after compaction fail
+        for (int i = 0; i < usageBeforeCompaction.size(); i++) {
+            assertEquals(usageBeforeCompaction.get(i), freeSpaceAfterCompactionFailed.get(i));
+        }
+
+        // now enable normal compaction
+        baseConf.setMajorCompactionThreshold(0.5f);
+
+        // restart bookies
+        restartBookies(baseConf);
+
+        Thread.sleep(baseConf.getMajorCompactionInterval() * 1000
+            + baseConf.getGcWaitTime());
+        // compaction worker should compact [0-4].log
+        for (File ledgerDirectory : tmpDirs) {
+            assertFalse("Entry log file ([0,1,2].log should have been compacted in ledgerDirectory: "
+                + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1, 2, 3, 4));
+        }
+
+        // even entry log files are removed, we still can access entries for ledger1
+        // since those entries has been compacted to new entry log
+        verifyLedger(lhs[0].getId(), 0, lhs[0].getLastAddConfirmed());
     }
+
+    private long getDirectorySpaceUsage(File dir) {
+        long size = 0;
+        for (File file : dir.listFiles()) {
+            size += file.length();
+        }
+        return size;
+    }
+
+    private Set<File> findCompactedEntryLogFiles() {
+        Set<File> compactedLogFiles = new HashSet<>();
+        for (File ledgerDirectory : tmpDirs) {
+            File[] files = Bookie.getCurrentDirectory(ledgerDirectory).listFiles(
+                file -> file.getName().endsWith(COMPACTED_SUFFIX));
+            if (files != null) {
+                for (File file : files) {
+                    compactedLogFiles.add(file);
+                }
+            }
+        }
+        return compactedLogFiles;
+    }
+
+    private static class MockTransactionalEntryLogCompactor extends TransactionalEntryLogCompactor {
+
+        public MockTransactionalEntryLogCompactor(GarbageCollectorThread gcThread) {
+            super(gcThread);
+        }
+
+        synchronized void compactWithIndexFlushFailure(EntryLogMetadata metadata) {
+            LOG.info("Compacting entry log {}.", metadata.getEntryLogId());
+            CompactionPhase scanEntryLog = new ScanEntryLogPhase(metadata);
+            if (!scanEntryLog.run()) {
+                LOG.info("Compaction for {} end in ScanEntryLogPhase.", metadata.getEntryLogId());
+                return;
+            }
+            File compactionLogFile = entryLogger.getCurCompactionLogFile();
+            CompactionPhase flushCompactionLog = new FlushCompactionLogPhase(metadata.getEntryLogId());
+            if (!flushCompactionLog.run()) {
+                LOG.info("Compaction for {} end in FlushCompactionLogPhase.", metadata.getEntryLogId());
+                return;
+            }
+            File compactedLogFile = getCompactedLogFile(compactionLogFile, metadata.getEntryLogId());
+            CompactionPhase partialFlushIndexPhase = new PartialFlushIndexPhase(compactedLogFile);
+            if (!partialFlushIndexPhase.run()) {
+                LOG.info("Compaction for {} end in PartialFlushIndexPhase.", metadata.getEntryLogId());
+                return;
+            }
+            gcThread.removeEntryLog(metadata.getEntryLogId());
+            LOG.info("Compacted entry log : {}.", metadata.getEntryLogId());
+        }
+
+        synchronized void compactWithLogFlushFailure(EntryLogMetadata metadata) {
+            LOG.info("Compacting entry log {}", metadata.getEntryLogId());
+            CompactionPhase scanEntryLog = new ScanEntryLogPhase(metadata);
+            if (!scanEntryLog.run()) {
+                LOG.info("Compaction for {} end in ScanEntryLogPhase.", metadata.getEntryLogId());
+                return;
+            }
+            File compactionLogFile = entryLogger.getCurCompactionLogFile();
+            CompactionPhase logFlushFailurePhase = new LogFlushFailurePhase(metadata.getEntryLogId());
+            if (!logFlushFailurePhase.run()) {
+                LOG.info("Compaction for {} end in FlushCompactionLogPhase.", metadata.getEntryLogId());
+                return;
+            }
+            File compactedLogFile = getCompactedLogFile(compactionLogFile, metadata.getEntryLogId());
+            CompactionPhase updateIndex = new UpdateIndexPhase(compactedLogFile);
+            if (!updateIndex.run()) {
+                LOG.info("Compaction for entry log {} end in UpdateIndexPhase.", metadata.getEntryLogId());
+                return;
+            }
+            gcThread.removeEntryLog(metadata.getEntryLogId());
+            LOG.info("Compacted entry log : {}.", metadata.getEntryLogId());
+        }
+
+        private class PartialFlushIndexPhase extends UpdateIndexPhase {
+
+            public PartialFlushIndexPhase(File compactedLogFile) {
+                super(compactedLogFile);
+            }
+
+            @Override
+            void start() throws IOException {
+                if (compactedLogFile != null && compactedLogFile.exists()) {
+                    File dir = compactedLogFile.getParentFile();
+                    String compactedFilename = compactedLogFile.getName();
+                    // create a hard link "x.log" for file "x.log.y.compacted"
+                    this.newEntryLogFile = new File(dir, compactedFilename.substring(0, compactedFilename.indexOf(".log") + 4));
+                    File hardlinkFile = new File(dir, newEntryLogFile.getName());
+                    if (!hardlinkFile.exists()) {
+                        HardLink.createHardLink(compactedLogFile, hardlinkFile);
+                    }
+                    assertTrue(offsets.size() > 1);
+                    // only flush index for one entry location
+                    EntryLocation el = offsets.get(0);
+                    ledgerStorage.updateEntriesLocations(offsets);
+                    ledgerStorage.flushEntriesLocationsIndex();
+                    throw new IOException("Flush ledger index encounter exception");
+                }
+            }
+        }
+
+        private class LogFlushFailurePhase extends FlushCompactionLogPhase {
+
+            LogFlushFailurePhase(long compactingLogId) {
+                super(compactingLogId);
+            }
+
+            @Override
+            void start() throws IOException {
+                // flush the current compaction log
+                entryLogger.flushCompactionLog();
+                throw new IOException("Encounter IOException when trying to flush compaction log");
+            }
+        }
+    }
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -844,16 +844,13 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         Bookie bookie = bs.get(0).getBookie();
         InterleavedLedgerStorage storage = (InterleavedLedgerStorage) bookie.ledgerStorage;
         // disable periodic compaction and recovery, we use manual compaction and recovery
-        storage.gcThread.enableForceGC();
+        storage.gcThread.triggerGC().get();
 
         // remove ledger2 and ledger3
         bkc.deleteLedger(lhs[1].getId());
         bkc.deleteLedger(lhs[2].getId());
 
         LOG.info("Finished deleting the ledgers contains most entries.");
-        // wait for one more gc
-        Thread.sleep(baseConf.getMajorCompactionInterval() * 1000
-            + baseConf.getGcWaitTime());
 
 
         MockTransactionalEntryLogCompactor partialCompactionWorker = new MockTransactionalEntryLogCompactor(

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -241,7 +241,12 @@ public abstract class BookKeeperClusterTestCase {
         for (BookieServer server : bs) {
             server.shutdown();
         }
+        bsConfs.clear();
         bs.clear();
+        if (bkc != null) {
+            bkc.close();
+            bkc = null;
+        }
     }
 
     protected void startAllBookies() throws Exception {
@@ -597,6 +602,10 @@ public abstract class BookKeeperClusterTestCase {
             }
         };
         server.start();
+
+        if (bkc == null) {
+            bkc = new BookKeeperTestClient(baseClientConf);
+        }
 
         int port = conf.getBookiePort();
         String host = InetAddress.getLocalHost().getHostAddress();


### PR DESCRIPTION
Problem:
Compaction might keep generating duplicated data which would cause disk full.
This is because we don't have transactional operation for compaction. So if compaction
keeps failing in the middle, bookie would end up with a lot of garbage data.

Change:
1. Introduce abstract class AbstractLogCompactor with an interface compact().
2. Move the existing compaction logic to a separate class called EntryLogCompactor.
3. Introduce transactional compaction, we can recover an incomplete compaction or rollback a compaction failure.
4. Add an configuration to enable transactional compaction

Potential Risk:
1. No risk if we keep using the default compactor.
2. If we choose to enable transactional compaction with separate log file, we need to be careful about it, since we use a separate log for compaction, if we have a lot of old small ledgers in the bookie, we will end up with a lot of small entry log files. And this will potentially cause bookkeeper "Too many open files" because GC will scan all the entry log files and keep them open.

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
