### PR TITLE
Issue-612 BOOKKEEPER-818: Make bookie recovery work with recovering multiple bookies

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.bookie;
 
 import static com.google.common.base.Charsets.UTF_8;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AbstractFuture;
 import java.io.File;
@@ -42,9 +43,13 @@ import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.Formatter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import org.apache.bookkeeper.bookie.BookieException.CookieNotFoundException;
@@ -92,6 +97,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.mutable.MutableBoolean;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,6 +293,11 @@ public class BookieShell implements Tool {
 
         public RecoverCmd() {
             super(CMD_RECOVER);
+            opts.addOption("q", "query", false, "Query the ledgers that contain given bookies");
+            opts.addOption("dr", "dryrun", false, "Printing the recovery plan w/o doing actual recovery");
+            opts.addOption("f", "force", false, "Force recovery without confirmation");
+            opts.addOption("l", "ledger", true, "Recover a specific ledger");
+            opts.addOption("sk", "skipOpenLedgers", false, "Skip recovering open ledgers");
             opts.addOption("d", "deleteCookie", false, "Delete cookie node for the bookie.");
         }
 
@@ -302,7 +313,7 @@ public class BookieShell implements Tool {
 
         @Override
         String getUsage() {
-            return "recover [-deleteCookie] <bookieSrc> [bookieDest]";
+            return "recover [-deleteCookie] <bookieSrc[:bookieSrc]>";
         }
 
         @Override
@@ -312,54 +323,160 @@ public class BookieShell implements Tool {
                 throw new MissingArgumentException(
                         "'bookieSrc' argument required");
             }
+            if (args.length > 1) {
+                System.err.println("The provided bookie dest " + args[1] + " will be ignored!");
+            }
+            boolean query = cmdLine.hasOption("q");
+            boolean dryrun = cmdLine.hasOption("dr");
+            boolean force = cmdLine.hasOption("f");
+            boolean skipOpenLedgers = cmdLine.hasOption("sk");
+            boolean removeCookies = !dryrun && cmdLine.hasOption("d");
 
+            Long ledgerId = null;
+            if (cmdLine.hasOption("l")) {
+                try {
+                    ledgerId = Long.parseLong(cmdLine.getOptionValue("l"));
+                } catch (NumberFormatException nfe) {
+                    throw new IOException("Invalid ledger id provided : " + cmdLine.getOptionValue("l"));
+                }
+            }
+
+            // Get bookies list
+            final String[] bookieStrs = args[0].split(",");
+            final Set<BookieSocketAddress> bookieAddrs = new HashSet<>();
+            for (String bookieStr : bookieStrs) {
+                final String bookieStrParts[] = bookieStr.split(":");
+                if (bookieStrParts.length != 2) {
+                    System.err.println("BookieSrcs has invalid bookie address format (host:port expected) : "
+                            + bookieStr);
+                    return -1;
+                }
+                bookieAddrs.add(new BookieSocketAddress(bookieStrParts[0],
+                        Integer.parseInt(bookieStrParts[1])));
+            }
+
+            if (!force) {
+                System.err.println("Bookies : " + bookieAddrs);
+                if (!IOUtils.confirmPrompt("Are you sure to recover them : (Y/N)")) {
+                    System.err.println("Give up!");
+                    return -1;
+                }
+            }
+
+            LOG.info("Constructing admin");
             ClientConfiguration adminConf = new ClientConfiguration(bkConf);
             BookKeeperAdmin admin = new BookKeeperAdmin(adminConf);
+            LOG.info("Construct admin : {}", admin);
             try {
-                return bkRecovery(adminConf, admin, args, cmdLine.hasOption("d"));
+                if (query) {
+                    return bkQuery(admin, bookieAddrs);
+                }
+                if (null != ledgerId) {
+                    return bkRecoveryLedger(admin, ledgerId, bookieAddrs, dryrun, skipOpenLedgers, removeCookies);
+                }
+                return bkRecovery(admin, bookieAddrs, dryrun, skipOpenLedgers, removeCookies);
             } finally {
                 admin.close();
             }
         }
 
-        private int bkRecovery(ClientConfiguration conf, BookKeeperAdmin bkAdmin,
-                               String[] args, boolean deleteCookie)
-                throws InterruptedException, BKException, BookieException, IOException {
-            final String bookieSrcString[] = args[0].split(":");
-            if (bookieSrcString.length != 2) {
-                System.err.println("BookieSrc inputted has invalid format"
-                        + "(host:port expected): " + args[0]);
-                return -1;
-            }
-            final BookieSocketAddress bookieSrc = new BookieSocketAddress(
-                    bookieSrcString[0], Integer.parseInt(bookieSrcString[1]));
-            BookieSocketAddress bookieDest = null;
-            if (args.length >= 2) {
-                final String bookieDestString[] = args[1].split(":");
-                if (bookieDestString.length < 2) {
-                    System.err.println("BookieDest inputted has invalid format"
-                            + "(host:port expected): " + args[1]);
-                    return -1;
+        private int bkQuery(BookKeeperAdmin bkAdmin, Set<BookieSocketAddress> bookieAddrs)
+                throws InterruptedException, BKException {
+            SortedMap<Long, LedgerMetadata> ledgersContainBookies =
+                    bkAdmin.getLedgersContainBookies(bookieAddrs);
+            System.err.println("NOTE: Bookies in inspection list are marked with '*'.");
+            for (Map.Entry<Long, LedgerMetadata> ledger : ledgersContainBookies.entrySet()) {
+                System.out.println("ledger " + ledger.getKey() + " : " + ledger.getValue().getState());
+                Map<Long, Integer> numBookiesToReplacePerEnsemble =
+                        inspectLedger(ledger.getValue(), bookieAddrs);
+                System.out.print("summary: [");
+                for (Map.Entry<Long, Integer> entry : numBookiesToReplacePerEnsemble.entrySet()) {
+                    System.out.print(entry.getKey() + "=" + entry.getValue() + ", ");
                 }
-                bookieDest = new BookieSocketAddress(bookieDestString[0],
-                        Integer.parseInt(bookieDestString[1]));
+                System.out.println("]");
+                System.out.println();
             }
+            System.err.println("Done");
+            return 0;
+        }
 
-            bkAdmin.recoverBookieData(bookieSrc, bookieDest);
-            if (deleteCookie) {
-                ServerConfiguration serverConf = new ServerConfiguration();
-                serverConf.addConfiguration(conf);
-                RegistrationManager rm = new ZKRegistrationManager();
-                try {
-                    rm.initialize(serverConf, () -> {}, NullStatsLogger.INSTANCE);
-                    Versioned<Cookie> cookie = Cookie.readFromRegistrationManager(rm, bookieSrc);
-                    cookie.getValue().deleteFromRegistrationManager(rm, bookieSrc, cookie.getVersion());
-                } catch (CookieNotFoundException nne) {
-                    LOG.warn("No cookie to remove for {} : ", bookieSrc, nne);
+        private Map<Long, Integer> inspectLedger(LedgerMetadata metadata, Set<BookieSocketAddress> bookiesToInspect) {
+            Map<Long, Integer> numBookiesToReplacePerEnsemble = new TreeMap<Long, Integer>();
+            for (Map.Entry<Long, ArrayList<BookieSocketAddress>> ensemble : metadata.getEnsembles().entrySet()) {
+                ArrayList<BookieSocketAddress> bookieList = ensemble.getValue();
+                System.out.print(ensemble.getKey() + ":\t");
+                int numBookiesToReplace = 0;
+                for (BookieSocketAddress bookie: bookieList) {
+                    System.out.print(bookie);
+                    if (bookiesToInspect.contains(bookie)) {
+                        System.out.print("*");
+                        ++numBookiesToReplace;
+                    } else {
+                        System.out.print(" ");
+                    }
+                    System.out.print(" ");
                 }
+                System.out.println();
+                numBookiesToReplacePerEnsemble.put(ensemble.getKey(), numBookiesToReplace);
+            }
+            return numBookiesToReplacePerEnsemble;
+        }
+
+        private int bkRecoveryLedger(BookKeeperAdmin bkAdmin,
+                                     long lid,
+                                     Set<BookieSocketAddress> bookieAddrs,
+                                     boolean dryrun,
+                                     boolean skipOpenLedgers,
+                                     boolean removeCookies)
+                throws InterruptedException, BKException, KeeperException {
+            bkAdmin.recoverBookieData(lid, bookieAddrs, dryrun, skipOpenLedgers);
+            if (removeCookies) {
+                deleteCookies(bkAdmin.getConf(), bookieAddrs);
             }
             return 0;
         }
+
+        private int bkRecovery(BookKeeperAdmin bkAdmin,
+                               Set<BookieSocketAddress> bookieAddrs,
+                               boolean dryrun,
+                               boolean skipOpenLedgers,
+                               boolean removeCookies)
+                throws InterruptedException, BKException, KeeperException {
+            bkAdmin.recoverBookieData(bookieAddrs, dryrun, skipOpenLedgers);
+            if (removeCookies) {
+                deleteCookies(bkAdmin.getConf(), bookieAddrs);
+            }
+            return 0;
+        }
+
+        private void deleteCookies(ClientConfiguration conf,
+                                   Set<BookieSocketAddress> bookieAddrs) throws BKException {
+            ServerConfiguration serverConf = new ServerConfiguration(conf);
+            RegistrationManager rm = new ZKRegistrationManager();
+            try {
+                rm.initialize(serverConf, () -> {}, NullStatsLogger.INSTANCE);
+                for (BookieSocketAddress addr : bookieAddrs) {
+                    deleteCookie(rm, addr);
+                }
+            } catch (BookieException be) {
+                BKException bke = new BKException.MetaStoreException();
+                bke.initCause(be);
+                throw bke;
+            } finally {
+                rm.close();
+            }
+        }
+
+        private void deleteCookie(RegistrationManager rm,
+                                  BookieSocketAddress bookieSrc) throws BookieException {
+            try {
+                Versioned<Cookie> cookie = Cookie.readFromRegistrationManager(rm, bookieSrc);
+                cookie.getValue().deleteFromRegistrationManager(rm, bookieSrc, cookie.getVersion());
+            } catch (CookieNotFoundException nne) {
+                LOG.warn("No cookie to remove for {} : ", bookieSrc, nne);
+            }
+        }
+
     }
 
     /**
@@ -2056,6 +2173,11 @@ public class BookieShell implements Tool {
         for (String s : commandNames) {
             System.err.println(s);
         }
+    }
+
+    @VisibleForTesting
+    public int execute(String... args) throws Exception {
+        return run(args);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -17,33 +17,32 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Charsets.UTF_8;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.TextFormat;
-
-import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat;
-import org.apache.bookkeeper.versioning.Version;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
-import static com.google.common.base.Charsets.UTF_8;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Maps;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat;
+import org.apache.bookkeeper.versioning.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class encapsulates all the ledger metadata that is persistently stored
@@ -227,7 +226,7 @@ public class LedgerMetadata {
         return state == LedgerMetadataFormat.State.IN_RECOVERY;
     }
 
-    LedgerMetadataFormat.State getState() {
+    public LedgerMetadataFormat.State getState() {
         return state;
     }
 
@@ -631,6 +630,14 @@ public class LedgerMetadata {
                 ensembles.put(key, ensemble);
             }
         }
+    }
+
+    Set<BookieSocketAddress> getBookiesInThisLedger() {
+        Set<BookieSocketAddress> bookies = new HashSet<BookieSocketAddress>();
+        for (ArrayList<BookieSocketAddress> ensemble : ensembles.values()) {
+            bookies.addAll(ensemble);
+        }
+        return bookies;
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShellTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShellTest.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import com.google.common.collect.Maps;
+import java.util.Set;
+import java.util.SortedMap;
+import org.apache.bookkeeper.bookie.BookieShell.MyCommand;
+import org.apache.bookkeeper.bookie.BookieShell.RecoverCmd;
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.client.LedgerMetadata;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.discover.RegistrationManager.RegistrationListener;
+import org.apache.bookkeeper.discover.ZKRegistrationManager;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.versioning.LongVersion;
+import org.apache.bookkeeper.versioning.Version;
+import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.commons.cli.BasicParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.MissingArgumentException;
+import org.apache.commons.cli.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Unit test for {@link BookieShell}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(BookieShell.class)
+public class BookieShellTest {
+
+    private ClientConfiguration clientConf;
+    private BookieShell shell;
+    private BookKeeperAdmin admin;
+    private ZKRegistrationManager rm;
+    private Cookie cookie;
+    private Version version;
+
+    @Before
+    public void setup() throws Exception {
+        this.shell = new BookieShell();
+        this.admin = PowerMockito.mock(BookKeeperAdmin.class);
+        whenNew(BookKeeperAdmin.class)
+            .withParameterTypes(ClientConfiguration.class)
+            .withArguments(any(ClientConfiguration.class))
+            .thenReturn(admin);
+        this.clientConf = new ClientConfiguration();
+        when(admin.getConf()).thenReturn(this.clientConf);
+        this.rm = PowerMockito.mock(ZKRegistrationManager.class);
+        this.cookie = Cookie.newBuilder()
+            .setBookieHost("127.0.0.1:3181")
+            .setInstanceId("xyz")
+            .setJournalDirs("/path/to/journal/dir")
+            .setLedgerDirs("/path/to/journal/dir")
+            .setLayoutVersion(Cookie.CURRENT_COOKIE_LAYOUT_VERSION)
+            .build();
+        this.version = new LongVersion(1L);
+        when(rm.readCookie(anyString()))
+            .thenReturn(new Versioned<>(cookie.toString().getBytes(UTF_8), version));
+        whenNew(ZKRegistrationManager.class)
+            .withNoArguments()
+            .thenReturn(rm);
+    }
+
+    private static CommandLine parseCommandLine(MyCommand cmd, String... args) throws ParseException {
+        BasicParser parser = new BasicParser();
+        return parser.parse(cmd.getOptions(), args);
+    }
+
+    @Test
+    public void testRecoverCmdMissingArgument() throws Exception {
+        RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
+        CommandLine cmdLine = parseCommandLine(cmd);
+        try {
+            cmd.runCmd(cmdLine);
+            fail("should fail running command when the arguments are missing");
+        } catch (MissingArgumentException e) {
+            // expected
+        }
+        PowerMockito.verifyNew(BookKeeperAdmin.class, never()).withArguments(any(ClientConfiguration.class));
+    }
+
+    @Test
+    public void testRecoverCmdInvalidBookieAddress() throws Exception {
+        RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
+        CommandLine cmdLine = parseCommandLine(cmd, "127.0.0.1");
+        assertEquals(-1, cmd.runCmd(cmdLine));
+        PowerMockito.verifyNew(BookKeeperAdmin.class, never()).withArguments(any(ClientConfiguration.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRecoverCmdQuery() throws Exception {
+        SortedMap<Long, LedgerMetadata> ledgersContainBookies = Maps.newTreeMap();
+        when(admin.getLedgersContainBookies(any(Set.class)))
+            .thenReturn(ledgersContainBookies);
+
+        RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
+        CommandLine cmdLine = parseCommandLine(cmd, "-force", "-q", "127.0.0.1:3181");
+        assertEquals(0, cmd.runCmd(cmdLine));
+        PowerMockito
+            .verifyNew(BookKeeperAdmin.class, times(1))
+            .withArguments(any(ClientConfiguration.class));
+        verify(admin, times(1)).getLedgersContainBookies(any(Set.class));
+        verify(admin, times(1)).close();
+    }
+
+    @Test
+    public void testRecoverCmdRecoverLedgerDefault() throws Exception {
+        // default behavior
+        testRecoverCmdRecoverLedger(
+            12345, false, false, false,
+            "-force", "-l", "12345", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverCmdRecoverLedgerDeleteCookie() throws Exception {
+        // dryrun
+        testRecoverCmdRecoverLedger(
+            12345, false, false, true,
+            "-force", "-l", "12345", "-deleteCookie", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverCmdRecoverLedgerSkipOpenLedgersDeleteCookie() throws Exception {
+        // dryrun
+        testRecoverCmdRecoverLedger(
+            12345, false, true, true,
+            "-force", "-l", "12345", "-deleteCookie", "-skipOpenLedgers", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverCmdRecoverLedgerDryrun() throws Exception {
+        // dryrun
+        testRecoverCmdRecoverLedger(
+            12345, true, false, false,
+            "-force", "-l", "12345", "-dryrun", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverCmdRecoverLedgerDryrunDeleteCookie() throws Exception {
+        // dryrun & removeCookie : removeCookie should be false
+        testRecoverCmdRecoverLedger(
+            12345, true, false, false,
+            "-force", "-l", "12345", "-dryrun", "-deleteCookie", "127.0.0.1:3181");
+    }
+
+    @SuppressWarnings("unchecked")
+    void testRecoverCmdRecoverLedger(long ledgerId,
+                                     boolean dryrun,
+                                     boolean skipOpenLedgers,
+                                     boolean removeCookies,
+                                     String... args) throws Exception {
+        RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
+        CommandLine cmdLine = parseCommandLine(cmd, args);
+        assertEquals(0, cmd.runCmd(cmdLine));
+        PowerMockito
+            .verifyNew(BookKeeperAdmin.class, times(1))
+            .withArguments(any(ClientConfiguration.class));
+        verify(admin, times(1))
+            .recoverBookieData(eq(ledgerId), any(Set.class), eq(dryrun), eq(skipOpenLedgers));
+        verify(admin, times(1)).close();
+        if (removeCookies) {
+            PowerMockito
+                .verifyNew(ZKRegistrationManager.class, times(1))
+                .withNoArguments();
+            verify(rm, times(1)).initialize(
+                any(ServerConfiguration.class), any(RegistrationListener.class), eq(NullStatsLogger.INSTANCE));
+            verify(rm, times(1)).readCookie(anyString());
+            verify(rm, times(1)).removeCookie(anyString(), eq(version));
+        } else {
+            PowerMockito
+                .verifyNew(ZKRegistrationManager.class, never())
+                .withNoArguments();
+        }
+    }
+
+    @Test
+    public void testRecoverCmdRecoverDefault() throws Exception {
+        // default behavior
+        testRecoverCmdRecover(
+            false, false, false,
+            "-force", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverCmdRecoverDeleteCookie() throws Exception {
+        // dryrun
+        testRecoverCmdRecover(
+            false, false, true,
+            "-force", "-deleteCookie", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverCmdRecoverSkipOpenLedgersDeleteCookie() throws Exception {
+        // dryrun
+        testRecoverCmdRecover(
+            false, true, true,
+            "-force", "-deleteCookie", "-skipOpenLedgers", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverCmdRecoverDryrun() throws Exception {
+        // dryrun
+        testRecoverCmdRecover(
+            true, false, false,
+            "-force", "-dryrun", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverCmdRecoverDryrunDeleteCookie() throws Exception {
+        // dryrun & removeCookie : removeCookie should be false
+        testRecoverCmdRecover(
+            true, false, false,
+            "-force", "-dryrun", "-deleteCookie", "127.0.0.1:3181");
+    }
+
+    @SuppressWarnings("unchecked")
+    void testRecoverCmdRecover(boolean dryrun,
+                               boolean skipOpenLedgers,
+                               boolean removeCookies,
+                               String... args) throws Exception {
+        RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
+        CommandLine cmdLine = parseCommandLine(cmd, args);
+        assertEquals(0, cmd.runCmd(cmdLine));
+        PowerMockito
+            .verifyNew(BookKeeperAdmin.class, times(1))
+            .withArguments(any(ClientConfiguration.class));
+        verify(admin, times(1))
+            .recoverBookieData(any(Set.class), eq(dryrun), eq(skipOpenLedgers));
+        verify(admin, times(1)).close();
+        if (removeCookies) {
+            PowerMockito
+                .verifyNew(ZKRegistrationManager.class, times(1))
+                .withNoArguments();
+            verify(rm, times(1)).initialize(
+                any(ServerConfiguration.class), any(RegistrationListener.class), eq(NullStatsLogger.INSTANCE));
+            verify(rm, times(1)).readCookie(anyString());
+            verify(rm, times(1)).removeCookie(anyString(), eq(version));
+        } else {
+            PowerMockito
+                .verifyNew(ZKRegistrationManager.class, never())
+                .withNoArguments();
+        }
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
@@ -476,7 +476,6 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
             BookieSocketAddress bookieToKill = getBookie(0);
             killBookie(bookieToKill);
             startNewBookie();
-            BookieSocketAddress newBookie = getBookie(2);
 
             CheckerCb checkercb = new CheckerCb();
             LedgerChecker lc = new LedgerChecker(bk);
@@ -507,7 +506,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
             }
 
             try {
-                bkadmin.recoverBookieData(bookieToKill, newBookie);
+                bkadmin.recoverBookieData(bookieToKill);
                 fail("Shouldn't be able to recover with a closed client");
             } catch (BKException.BKClientClosedException cce) {
                 // correct behaviour

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
@@ -271,7 +271,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         for (int i = 0; i < numEntries; i++) {
             lh.addEntry(data);
         }
-        bkAdmin.recoverBookieData(bookieToKill, null);
+        bkAdmin.recoverBookieData(bookieToKill);
         // fail another bookie to cause ensemble change again
         bookieToKill = lh.getLedgerMetadata().getEnsemble(2 * numEntries - 1).get(1);
         ServerConfiguration confOfKilledBookie = killBookie(bookieToKill);
@@ -433,7 +433,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
           newBookiePort);
         LOG.info("Now recover the data on the killed bookie (" + bookieSrc + ") and replicate it to the new one ("
           + bookieDest + ")");
-        bkAdmin.recoverBookieData(bookieSrc, bookieDest);
+        bkAdmin.recoverBookieData(bookieSrc);
 
         // Verify the recovered ledger entries are okay.
         verifyRecoveredLedgers(lhs, 0, 2 * numMsgs - 1);
@@ -477,10 +477,9 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         // Call the sync recover bookie method.
         BookieSocketAddress bookieSrc = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
           initialPort);
-        BookieSocketAddress bookieDest = null;
         LOG.info("Now recover the data on the killed bookie (" + bookieSrc
           + ") and replicate it to a random available one");
-        bkAdmin.recoverBookieData(bookieSrc, bookieDest);
+        bkAdmin.recoverBookieData(bookieSrc);
 
         // Verify the recovered ledger entries are okay.
         verifyRecoveredLedgers(lhs, 0, 2 * numMsgs - 1);
@@ -639,11 +638,10 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         // start a new bookie
         startNewBookie();
 
-        BookieSocketAddress bookieDest = null;
         LOG.info("Now recover the data on the killed bookie (" + bookieToKill
           + ") and replicate it to a random available one");
 
-        bkAdmin.recoverBookieData(bookieToKill, bookieDest);
+        bkAdmin.recoverBookieData(bookieToKill);
         for (LedgerHandle lh : lhs) {
             assertTrue("Not fully replicated", verifyFullyReplicated(lh, numMsgs));
             lh.close();
@@ -669,11 +667,10 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         // start a new bookie
         startNewBookie();
 
-        BookieSocketAddress bookieDest = null;
         LOG.info("Now recover the data on the killed bookie (" + bookieToKill
           + ") and replicate it to a random available one");
 
-        bkAdmin.recoverBookieData(bookieToKill, bookieDest);
+        bkAdmin.recoverBookieData(bookieToKill);
 
         for (LedgerHandle lh : lhs) {
             assertTrue("Not fully replicated", verifyFullyReplicated(lh, numMsgs));
@@ -720,7 +717,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         }
 
         try {
-            bkAdmin.recoverBookieData(bookieToKill, null);
+            bkAdmin.recoverBookieData(bookieToKill);
             fail("Should have thrown exception");
         } catch (BKException.BKLedgerRecoveryException bke) {
             // correct behaviour
@@ -731,7 +728,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         bsConfs.add(conf2);
 
         // recover them
-        bkAdmin.recoverBookieData(bookieToKill, null);
+        bkAdmin.recoverBookieData(bookieToKill);
 
         for (LedgerHandle lh : lhs) {
             assertTrue("Not fully replicated", verifyFullyReplicated(lh, numMsgs));
@@ -773,7 +770,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         // Initiate the sync object
         sync.value = false;
         try {
-            bkAdmin.recoverBookieData(bookieSrc, null);
+            bkAdmin.recoverBookieData(bookieSrc);
             fail("Should have thrown exception");
         } catch (BKException.BKLedgerRecoveryException bke) {
             // correct behaviour
@@ -811,7 +808,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
           + ") and replicate it to a random available one");
         // Initiate the sync object
         sync.value = false;
-        bkAdmin.recoverBookieData(bookieSrc, null);
+        bkAdmin.recoverBookieData(bookieSrc);
 
         assertFalse("Dupes exist in ensembles", findDupesInEnsembles(lhs));
 
@@ -857,7 +854,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         setMetastoreImplClass(adminConf);
 
         BookKeeperAdmin bka = new BookKeeperAdmin(adminConf);
-        bka.recoverBookieData(bookieSrc, null);
+        bka.recoverBookieData(bookieSrc);
         bka.close();
 
         lh = bkc.openLedgerNoRecovery(ledgerId, digestCorrect, passwdCorrect);
@@ -880,7 +877,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         setMetastoreImplClass(adminConf);
 
         bka = new BookKeeperAdmin(adminConf);
-        bka.recoverBookieData(bookieSrc, null);
+        bka.recoverBookieData(bookieSrc);
         bka.close();
 
         lh = bkc.openLedgerNoRecovery(ledgerId, digestCorrect, passwdCorrect);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestFencing.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestFencing.java
@@ -274,7 +274,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
             writelh.addEntry(tmp.getBytes());
         }
 
-        admin.recoverBookieData(bookieToKill, null);
+        admin.recoverBookieData(bookieToKill);
 
         for (int i = 0; i < numEntries; i++) {
             writelh.addEntry(tmp.getBytes());
@@ -321,7 +321,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
         BookieSocketAddress bookieToKill
             = writelh.getLedgerMetadata().getEnsemble(numEntries).get(0);
         killBookie(bookieToKill);
-        admin.recoverBookieData(bookieToKill, null);
+        admin.recoverBookieData(bookieToKill);
 
         try {
             writelh.addEntry(tmp.getBytes());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/http/TestHttpService.java
@@ -575,20 +575,11 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
         //3, body with bookie_src, bookie_dest and delete_cookie of PUT, should success.
         String bookieSrc = getBookie(0).toString();
-        String bookieDest = getBookie(1).toString();
-        String putBody = "{\"bookie_src\": [ \"" + bookieSrc + "\" ],"
-          + "\"bookie_dest\": [ \"" + bookieDest + "\" ],"
-          + "\"delete_cookie\": true }";
-        HttpServiceRequest request3 = new HttpServiceRequest(putBody, HttpServer.Method.PUT, null);
+        String putBody3 = "{\"bookie_src\": [ \"" + bookieSrc + "\" ],"
+          + "\"delete_cookie\": false }";
+        HttpServiceRequest request3 = new HttpServiceRequest(putBody3, HttpServer.Method.PUT, null);
         HttpServiceResponse response3 = recoveryBookieService.handle(request3);
         assertEquals(HttpServer.StatusCode.OK.getValue(), response3.getStatusCode());
-
-        //4, body with bookie_src, and delete_cookie of PUT, should success.
-        String putBody4 = "{\"bookie_src\": [ \"" + bookieSrc + "\" ],"
-          + "\"delete_cookie\": false }";
-        HttpServiceRequest request4 = new HttpServiceRequest(putBody4, HttpServer.Method.PUT, null);
-        HttpServiceResponse response4 = recoveryBookieService.handle(request4);
-        assertEquals(HttpServer.StatusCode.OK.getValue(), response4.getStatusCode());
 
         //5, body with bookie_src of PUT, should success.
         String putBody5 = "{\"bookie_src\": [ \"" + bookieSrc + "\" ] }";

--- a/tests/backward/src/test/java/org/apache/bookkeeper/tests/backward/TestBookieRecovery.java
+++ b/tests/backward/src/test/java/org/apache/bookkeeper/tests/backward/TestBookieRecovery.java
@@ -318,7 +318,7 @@ public class TestBookieRecovery extends BookKeeperClusterTestCase {
 
             bka = new BookKeeperAdmin(adminConf);
             try {
-                bka.recoverBookieData(bookieSrc, null);
+                bka.recoverBookieData(bookieSrc);
                 fail("Shouldn't be able to recover with wrong password");
             } catch (BKException bke) {
                 // correct behaviour
@@ -336,7 +336,7 @@ public class TestBookieRecovery extends BookKeeperClusterTestCase {
 
         bka = new BookKeeperAdmin(adminConf);
         try {
-            bka.recoverBookieData(bookieSrc, null);
+            bka.recoverBookieData(bookieSrc);
             fail("Shouldn't be able to recover with wrong digest");
         } catch (BKException bke) {
             // correct behaviour
@@ -353,7 +353,7 @@ public class TestBookieRecovery extends BookKeeperClusterTestCase {
         adminConf.setBookieRecoveryPasswd(passwdCorrect);
 
         bka = new BookKeeperAdmin(adminConf);
-        bka.recoverBookieData(bookieSrc, null);
+        bka.recoverBookieData(bookieSrc);
         bka.close();
 
         lh = bkc.openLedgerNoRecovery(ledgerId, digestCorrect, passwdCorrect);


### PR DESCRIPTION

Descriptions of the changes in this PR:

This is a change ported from twitter branch.

- Enable recovering multiple bookies in bookie shell
- Add a unit test for BookieShell.