### PR TITLE
Issue 716: PendingAddOp accesses a released ByteBuf

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -344,9 +344,6 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
             timeout.cancel();
         }
 
-
-        ReferenceCountUtil.release(toSend);
-
         if (LOG.isDebugEnabled()) {
             LOG.debug("Submit callback (lid:{}, eid: {}). rc:{}", lh.getId(), entryId, rc);
         }
@@ -418,6 +415,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
     private void recycle() {
         entryId = LedgerHandle.INVALID_ENTRY_ID;
         currentLedgerLength = -1;
+        ReferenceCountUtil.release(toSend);
         payload = null;
         toSend = null;
         cb = null;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -237,6 +237,7 @@ public abstract class MockBookKeeperTestCase {
         return mockLedgerMetadataRegistry.get(ledgerId);
     }
 
+    @SuppressWarnings("unchecked")
     private void setupReadLedgerMetadata() {
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
@@ -254,6 +255,7 @@ public abstract class MockBookKeeperTestCase {
         }).when(ledgerManager).readLedgerMetadata(anyLong(), any());
     }
 
+    @SuppressWarnings("unchecked")
     private void setupRemoveLedgerMetadata() {
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
@@ -280,19 +282,17 @@ public abstract class MockBookKeeperTestCase {
         }).when(ledgerManager).registerLedgerMetadataListener(anyLong(), any());
     }
 
+    @SuppressWarnings("unchecked")
     private void setupLedgerIdGenerator() {
-        Mockito.doAnswer((Answer<Void>) new Answer<Void>() {
-            @Override
-            @SuppressWarnings("unchecked")
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                BookkeeperInternalCallbacks.GenericCallback cb = (BookkeeperInternalCallbacks.GenericCallback) args[0];
-                cb.operationComplete(BKException.Code.OK, mockNextLedgerId.getAndIncrement());
-                return null;
-            }
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            BookkeeperInternalCallbacks.GenericCallback cb = (BookkeeperInternalCallbacks.GenericCallback) args[0];
+            cb.operationComplete(Code.OK, mockNextLedgerId.getAndIncrement());
+            return null;
         }).when(ledgerIdGenerator).generateLedgerId(any());
     }
 
+    @SuppressWarnings("unchecked")
     private void setupCreateLedgerMetadata() {
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
@@ -307,6 +307,7 @@ public abstract class MockBookKeeperTestCase {
         }).when(ledgerManager).createLedgerMetadata(anyLong(), any(), any());
     }
 
+    @SuppressWarnings("unchecked")
     private void setupWriteLedgerMetadata() {
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
@@ -321,6 +322,7 @@ public abstract class MockBookKeeperTestCase {
         }).when(ledgerManager).writeLedgerMetadata(anyLong(), any(), any());
     }
 
+    @SuppressWarnings("unchecked")
     protected void setupBookieClientReadEntry() {
         doAnswer(invokation -> {
             Object[] args = invokation.getArguments();
@@ -386,6 +388,7 @@ public abstract class MockBookKeeperTestCase {
         return entry;
     }
 
+    @SuppressWarnings("unchecked")
     protected void setupBookieClientAddEntry() {
         doAnswer(invokation -> {
             Object[] args = invokation.getArguments();


### PR DESCRIPTION
Descriptions of the changes in this PR:

- release `toSend` bytebuf only when a PendingAddOp is recycled.
- fix MockBookKeeperTestCase to run callbacks in the same executor thread.
