### PR TITLE
Issue 490: Add a flag to not serialize `ctime` field

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -93,7 +93,14 @@ class LedgerCreateOp implements GenericCallback<Void> {
     LedgerCreateOp(BookKeeper bk, int ensembleSize, int writeQuorumSize, int ackQuorumSize, DigestType digestType,
             byte[] passwd, CreateCallback cb, Object ctx, final Map<String, byte[]> customMetadata) {
         this.bk = bk;
-        this.metadata = new LedgerMetadata(ensembleSize, writeQuorumSize, ackQuorumSize, digestType, passwd, customMetadata);
+        this.metadata = new LedgerMetadata(
+            ensembleSize,
+            writeQuorumSize,
+            ackQuorumSize,
+            digestType,
+            passwd,
+            customMetadata,
+            bk.getConf().getStoreSystemtimeAsLedgerCreationTime());
         this.digestType = digestType;
         this.passwd = passwd;
         this.cb = cb;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -114,6 +114,9 @@ public class ClientConfiguration extends AbstractConfiguration {
     protected final static String ENSEMBLE_PLACEMENT_POLICY = "ensemblePlacementPolicy";
     protected final static String NETWORK_TOPOLOGY_STABILIZE_PERIOD_SECONDS = "networkTopologyStabilizePeriodSeconds";
 
+    // Ledger Metadata Parameters
+    protected static final String STORE_SYSTEMTIME_AS_LEDGER_CREATION_TIME = "storeSystemTimeAsLedgerCreationTime";
+
     // Stats
     protected final static String ENABLE_TASK_EXECUTION_STATS = "enableTaskExecutionStats";
     protected final static String TASK_EXECUTION_WARN_TIME_MICROS = "taskExecutionWarnTimeMicros";
@@ -1632,9 +1635,10 @@ public class ClientConfiguration extends AbstractConfiguration {
      * @param regClientClass
      *            ClientClass
      */
-    public void setRegistrationClientClass(
+    public ClientConfiguration setRegistrationClientClass(
             Class<? extends RegistrationClient> regClientClass) {
         setProperty(REGISTRATION_CLIENT_CLASS, regClientClass);
+        return this;
     }
 
     /**
@@ -1647,5 +1651,30 @@ public class ClientConfiguration extends AbstractConfiguration {
         return ReflectionUtils.getClass(this, REGISTRATION_CLIENT_CLASS,
                 ZKRegistrationClient.class, RegistrationClient.class,
                 defaultLoader);
+    }
+
+    /**
+     * Enable the client to use system time as the ledger creation time.
+     *
+     * <p>If this is enabled, the client will write a ctime field into the ledger metadata.
+     * Otherwise, nothing will be written. The creation time of this ledger will be the ctime
+     * of the metadata record in metadata store.
+     *
+     * @param enabled flag to enable/disable client using system time as the ledger creation time.
+     */
+    public ClientConfiguration setStoreSystemtimeAsLedgerCreationTime(boolean enabled) {
+        setProperty(STORE_SYSTEMTIME_AS_LEDGER_CREATION_TIME, enabled);
+        return this;
+    }
+
+    /**
+     * Return the flag that indicates whether client is using system time as the ledger creation time when
+     * creating ledgers.
+     *
+     * @return the flag that indicates whether client is using system time as the ledger creation time when
+     *         creating ledgers.
+     */
+    public boolean getStoreSystemtimeAsLedgerCreationTime() {
+        return getBoolean(STORE_SYSTEMTIME_AS_LEDGER_CREATION_TIME, false);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerMetadataTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerMetadataTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bookkeeper.client;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat;
+import org.junit.Test;
+
+/**
+ * Unit test for ledger metadata
+ */
+public class LedgerMetadataTest {
+
+    @Test
+    public void testStoreSystemtimeAsLedgerCtimeEnabled()
+            throws Exception {
+        byte[] passwd = "testPasswd".getBytes(UTF_8);
+
+        LedgerMetadata lm = new LedgerMetadata(
+            3,
+            3,
+            2,
+            DigestType.CRC32,
+            passwd,
+            Collections.emptyMap(),
+            true);
+        LedgerMetadataFormat format = lm.buildProtoFormat();
+        assertTrue(format.hasCtime());
+    }
+
+    @Test
+    public void testStoreSystemtimeAsLedgerCtimeDisabled()
+            throws Exception {
+        byte[] passwd = "testPasswd".getBytes(UTF_8);
+
+        LedgerMetadata lm = new LedgerMetadata(
+            3,
+            3,
+            2,
+            DigestType.CRC32,
+            passwd,
+            Collections.emptyMap(),
+            false);
+        LedgerMetadataFormat format = lm.buildProtoFormat();
+        assertFalse(format.hasCtime());
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ListLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ListLedgersTest.java
@@ -101,28 +101,6 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
 
     }
     
-    @Test
-    public void testCtimeRecorded()
-            throws Exception {
 
-        ClientConfiguration conf = new ClientConfiguration()
-                .setZkServers(zkUtil.getZooKeeperConnectString());
-
-        BookKeeper bkc = new BookKeeper(conf);
-
-        bkc.createLedger(digestType, "testPasswd".
-                getBytes()).close();
-
-        BookKeeperAdmin admin = new BookKeeperAdmin(zkUtil.
-                getZooKeeperConnectString());
-        Iterable<Long> iterable = admin.listLedgers();
-
-        for (Long lId : iterable) {
-            LedgerHandle ledger = bkc.openLedger(lId, digestType, "testPasswd".getBytes());
-            LedgerMetadata metaData = ledger.getLedgerMetadata();
-            Assert.assertTrue("ctime was not recorded", metaData.getCtime() > 0);
-        }
-
-    }
     
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
@@ -309,8 +309,14 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
     protected LedgerMetadata generateLedgerMetadata(int ensembleSize,
         int writeQuorumSize, int ackQuorumSize, byte[] password,
         Map<String, byte[]> customMetadata) {
-        LedgerMetadata ledgerMetadata = new LedgerMetadata(ensembleSize, writeQuorumSize,
-            ackQuorumSize, BookKeeper.DigestType.CRC32, password, customMetadata);
+        LedgerMetadata ledgerMetadata = new LedgerMetadata(
+            ensembleSize,
+            writeQuorumSize,
+            ackQuorumSize,
+            BookKeeper.DigestType.CRC32,
+            password,
+            customMetadata,
+            true);
         ledgerMetadata.addEnsemble(0, generateNewEnsemble(ensembleSize));
         return ledgerMetadata;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -524,7 +524,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         int numofledgers = 5;
         Random rand = new Random();
         for (int i = 0; i < numofledgers; i++) {
-            LedgerMetadata metadata = new LedgerMetadata(3, 2, 2, DigestType.CRC32, "passwd".getBytes(), null);
+            LedgerMetadata metadata = new LedgerMetadata(3, 2, 2, DigestType.CRC32, "passwd".getBytes());
             ArrayList<BookieSocketAddress> ensemble = new ArrayList<BookieSocketAddress>();
             ensemble.add(new BookieSocketAddress("99.99.99.99:9999"));
             ensemble.add(new BookieSocketAddress("11.11.11.11:1111"));


### PR DESCRIPTION


Descriptions of the changes in this PR:

This request is for DL bookkeeper version upgrade. Because twitter's bk version doesn't include this change, so any ledgers written by new bk version will fail to be read by old version. To simplify the upgrade story, it is good to allow not serialize ctime field.