### PR TITLE
Fixed simultaneus reads on same ledger/entry with v2 protocol

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -159,8 +159,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
 
     // Map that hold duplicated read requests. The idea is to only use this map (synchronized) when there is a duplicate
     // read request for the same ledgerId/entryId
-    private final ListMultimap<CompletionKey, CompletionValue> completionObjectsV2Conflicts
-        = LinkedListMultimap.create();
+    private final ListMultimap<CompletionKey, CompletionValue> completionObjectsV2Conflicts =
+        LinkedListMultimap.create();
 
     private final StatsLogger statsLogger;
     private final OpStatsLogger readEntryOpLogger;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -159,8 +159,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
 
     // Map that hold duplicated read requests. The idea is to only use this map (synchronized) when there is a duplicate
     // read request for the same ledgerId/entryId
-    private final ListMultimap<CompletionKey, CompletionValue> completionObjectsV2Conflicts = LinkedListMultimap
-            .create();
+    private final ListMultimap<CompletionKey, CompletionValue> completionObjectsV2Conflicts
+        = LinkedListMultimap.create();
 
     private final StatsLogger statsLogger;
     private final OpStatsLogger readEntryOpLogger;
@@ -615,7 +615,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         CompletionValue existingValue = completionObjects.putIfAbsent(completionKey, readCompletion);
         if (existingValue != null) {
             // There's a pending read request on same ledger/entry. Use the multimap to track all of them
-            synchronized (this) {
+            synchronized (completionObjectsV2Conflicts) {
                 completionObjectsV2Conflicts.put(completionKey, readCompletion);
             }
         }
@@ -736,15 +736,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         CompletionValue existingValue = completionObjects.putIfAbsent(completionKey, readCompletion);
         if (existingValue != null) {
             // There's a pending read request on same ledger/entry. Use the multimap to track all of them
-            synchronized (this) {
+            synchronized (completionObjectsV2Conflicts) {
                 completionObjectsV2Conflicts.put(completionKey, readCompletion);
             }
-        }
-
-        final Channel c = channel;
-        if (c == null) {
-            errorOutReadKey(completionKey);
-            return;
         }
 
         writeAndFlush(channel, completionKey, request);
@@ -849,56 +843,6 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             errorOut(key);
         }
     }
-    
-    void errorOutReadKey(final CompletionKey key) {
-        errorOutReadKey(key, BKException.Code.BookieHandleNotAvailableException);
-    }
-
-    void errorOutReadKey(final CompletionKey key, final int rc) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Removing completion key: {}", key);
-        }
-        ReadCompletion readCompletion = (ReadCompletion) completionObjects.remove(key);
-        if (readCompletion == null) {
-            // If there's no completion object here, try in the multimap
-            synchronized (this) {
-                if (completionObjectsV2Conflicts.containsKey(key)) {
-                    readCompletion = (ReadCompletion) completionObjectsV2Conflicts.get(key).get(0);
-                    completionObjectsV2Conflicts.remove(key, readCompletion);
-                }
-            }
-        }
-
-        // If it's still null, give up
-        if (null == readCompletion) {
-            return;
-        }
-        
-        final ReadCompletion finalReadCompletion = readCompletion;
-        executor.submitOrdered(readCompletion.ledgerId, new SafeRunnable() {
-            @Override
-            public void safeRun() {
-                String bAddress = "null";
-                Channel c = channel;
-                if (c != null && c.remoteAddress() != null) {
-                    bAddress = c.remoteAddress().toString();
-                }
-
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Could not write request for reading entry: {} ledger-id: {} bookie: {} rc: {}",
-                            finalReadCompletion.entryId, finalReadCompletion.ledgerId, bAddress, rc);
-                }
-
-                finalReadCompletion.cb.readEntryComplete(rc, finalReadCompletion.ledgerId, finalReadCompletion.entryId,
-                        null, finalReadCompletion.ctx);
-            }
-
-            @Override
-            public String toString() {
-                return String.format("ErrorOutReadKey(%s)", key);
-            }
-        });
-    }
 
     private static String requestToString(Object request) {
         if (request instanceof BookkeeperProtocol.Request) {
@@ -928,6 +872,16 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         CompletionValue completion = completionObjects.remove(key);
         if (completion != null) {
             completion.errorOut(rc);
+        } else {
+            // If there's no completion object here, try in the multimap
+            synchronized (completionObjectsV2Conflicts) {
+                if (completionObjectsV2Conflicts.containsKey(key)) {
+                    completion = completionObjectsV2Conflicts.get(key).get(0);
+                    completionObjectsV2Conflicts.remove(key, completion);
+
+                    completion.errorOut(rc);
+                }
+            }
         }
     }
 
@@ -1072,13 +1026,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             long orderingKey = completionValue.ledgerId;
             final CompletionValue finalCompletionValue = completionValue;
 
-            executor.submitOrdered(orderingKey, new SafeRunnable() {
-                @Override
-                public void safeRun() {
+            executor.submitOrdered(orderingKey, () -> {
                     finalCompletionValue.handleV2Response(ledgerId, entryId, status, response);
                     response.recycle();
-                }
-            });
+                });
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -893,13 +893,17 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
      */
 
     void errorOutOutstandingEntries(int rc) {
-
         // DO NOT rewrite these using Map.Entry iterations. We want to iterate
         // on keys and see if we are successfully able to remove the key from
         // the map. Because the add and the read methods also do the same thing
         // in case they get a write failure on the socket. The one who
         // successfully removes the key from the map is the one responsible for
         // calling the application callback.
+        for (CompletionKey key : completionObjectsV2Conflicts.keySet()) {
+            while (completionObjectsV2Conflicts.get(key).size() > 0) {
+                errorOut(key, rc);
+            }
+        }
         for (CompletionKey key : completionObjects.keySet()) {
             errorOut(key, rc);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -824,7 +824,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
      *
      * @throws Exception
      */
-    @Test(timeout = 20000)
+    @Test
     public void testDoubleRead() throws Exception {
         LedgerHandle lh = bkc.createLedger(digestType, "".getBytes());
 
@@ -854,7 +854,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
      *
      * @throws Exception
      */
-    @Test(timeout = 20000)
+    @Test
     public void testDoubleReadWithV2Protocol() throws Exception {
         ClientConfiguration conf = new ClientConfiguration(baseClientConf);
         conf.setUseV2WireProtocol(true);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -400,11 +400,11 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         Assert.assertTrue(
                 "Expected LAC of wlh: " + (2 * numOfEntries - 1) + " actual LAC of wlh: " + wlh.getLastAddConfirmed(),
                 (wlh.getLastAddConfirmed() == (2 * numOfEntries - 1)));
-        // readhandle's lastaddconfirmed wont be updated until readExplicitLastConfirmed call is made   
+        // readhandle's lastaddconfirmed wont be updated until readExplicitLastConfirmed call is made
         Assert.assertTrue(
                 "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
                 (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
-        
+
         long explicitlac = rlh.readExplicitLastConfirmed();
         Assert.assertTrue(
                 "Expected Explicit LAC of rlh: " + (2 * numOfEntries - 1) + " actual ExplicitLAC of rlh: " + explicitlac,
@@ -413,7 +413,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         Assert.assertTrue(
                 "Expected LAC of rlh: " + (2 * numOfEntries - 1) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
                 (rlh.getLastAddConfirmed() == (2 * numOfEntries - 1)));
-        
+
         Enumeration<LedgerEntry> entries = rlh.readEntries(numOfEntries, 2 * numOfEntries - 1);
         int entryId = numOfEntries;
         while (entries.hasMoreElements()) {
@@ -817,5 +817,69 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
                 }
             }
         }
+    }
+
+    /**
+     * Tests that issuing multiple reads for the same entry at the same time works as expected.
+     *
+     * @throws Exception
+     */
+    @Test(timeout = 20000)
+    public void testDoubleRead() throws Exception {
+        LedgerHandle lh = bkc.createLedger(digestType, "".getBytes());
+
+        lh.addEntry("test".getBytes());
+
+        // Read the same entry more times asynchronously
+        final int N = 10;
+        final CountDownLatch latch = new CountDownLatch(N);
+        for (int i = 0; i < N; i++) {
+            lh.asyncReadEntries(0, 0, new ReadCallback() {
+                public void readComplete(int rc, LedgerHandle lh,
+                                         Enumeration<LedgerEntry> seq, Object ctx) {
+                    if (rc == BKException.Code.OK) {
+                        latch.countDown();
+                    } else {
+                        fail("Read fail");
+                    }
+                }
+            }, null);
+        }
+
+        latch.await();
+    }
+
+    /**
+     * Tests that issuing multiple reads for the same entry at the same time works as expected.
+     *
+     * @throws Exception
+     */
+    @Test(timeout = 20000)
+    public void testDoubleReadWithV2Protocol() throws Exception {
+        ClientConfiguration conf = new ClientConfiguration(baseClientConf);
+        conf.setUseV2WireProtocol(true);
+        BookKeeperTestClient bkc = new BookKeeperTestClient(conf);
+        LedgerHandle lh = bkc.createLedger(digestType, "".getBytes());
+
+        lh.addEntry("test".getBytes());
+
+        // Read the same entry more times asynchronously
+        final int N = 10;
+        final CountDownLatch latch = new CountDownLatch(N);
+        for (int i = 0; i < N; i++) {
+            lh.asyncReadEntries(0, 0, new ReadCallback() {
+                public void readComplete(int rc, LedgerHandle lh,
+                                         Enumeration<LedgerEntry> seq, Object ctx) {
+                    if (rc == BKException.Code.OK) {
+                        latch.countDown();
+                    } else {
+                        fail("Read fail");
+                    }
+                }
+            }, null);
+        }
+
+        latch.await();
+        bkc.close();
     }
 }


### PR DESCRIPTION
This change is coming from yahoo branch at yahoo/bookkeeper@ce7b0f7

With v2 protocol there's no way to disambiguate the read request since the completion key is made from (ledgerId, entryId).
This PR introduced an additional multimap to handle the conflicts (multiple simultaneus read requests for the same entry).