### PR TITLE
Issue 724: fix wrong link for slack signup

### DIFF
--- a/site/community/slack.md
+++ b/site/community/slack.md
@@ -6,4 +6,4 @@ There is an [Apache BookKeeper](http://apachebookkeeper.slack.com/) channel that
 
 The Slack channel is at [http://apachebookkeeper.slack.com/](http://apachebookkeeper.slack.com/).
 
-You can self-register at [https://apachebookkeeper.herokuapp.com/](http://apachebookkeeper.slack.com/).
+You can self-register at [https://apachebookkeeper.herokuapp.com/](https://apachebookkeeper.herokuapp.com/).


### PR DESCRIPTION
Descriptions of the changes in this PR:
Change the link of slack signup from http://apachebookkeeper.slack.com/ to https://apachebookkeeper.herokuapp.com/ in https://bookkeeper.apache.org/community/slack/ and click the self-register link.

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
> 
> - [x] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [x] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [x] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
