### PR TITLE
Issue 693: add interface and implementation of LedgerEntries

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -63,6 +63,7 @@ import org.apache.bookkeeper.client.SyncCallbackUtils.SyncReadCallback;
 import org.apache.bookkeeper.client.SyncCallbackUtils.SyncReadLastConfirmedCallback;
 import org.apache.bookkeeper.client.api.BKException.Code;
 import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
+import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.WriteHandle;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.common.concurrent.FutureEventListener;
@@ -634,7 +635,7 @@ public class LedgerHandle implements WriteHandle {
      *          id of last entry of sequence
      */
     @Override
-    public CompletableFuture<org.apache.bookkeeper.client.api.LedgerEntries> read(long firstEntry, long lastEntry) {
+    public CompletableFuture<LedgerEntries> read(long firstEntry, long lastEntry) {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
@@ -675,8 +676,8 @@ public class LedgerHandle implements WriteHandle {
      * @see #readUnconfirmedEntries(long, long)
      */
     @Override
-    public CompletableFuture<org.apache.bookkeeper.client.api.LedgerEntries> readUnconfirmed(long firstEntry,
-                                                                                             long lastEntry) {        // Little sanity check
+    public CompletableFuture<LedgerEntries> readUnconfirmed(long firstEntry, long lastEntry) {
+        // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
                     new Object[] { ledgerId, firstEntry, lastEntry });
@@ -689,14 +690,14 @@ public class LedgerHandle implements WriteHandle {
     void asyncReadEntriesInternal(long firstEntry, long lastEntry, ReadCallback cb, Object ctx) {
         if(!bk.isClosed()) {
             readEntriesInternalAsync(firstEntry, lastEntry)
-                .whenCompleteAsync(new FutureEventListener<org.apache.bookkeeper.client.api.LedgerEntries>() {
+                .whenCompleteAsync(new FutureEventListener<LedgerEntries>() {
                     @Override
-                    public void onSuccess(org.apache.bookkeeper.client.api.LedgerEntries iterable) {
+                    public void onSuccess(LedgerEntries entries) {
                         cb.readComplete(
                             Code.OK,
                             LedgerHandle.this,
                             IteratorUtils.asEnumeration(
-                                Iterators.transform(iterable.iterator(), le -> {
+                                Iterators.transform(entries.iterator(), le -> {
                                     LedgerEntry entry = new LedgerEntry((LedgerEntryImpl) le);
                                     le.close();
                                     return entry;
@@ -719,8 +720,8 @@ public class LedgerHandle implements WriteHandle {
         }
     }
 
-    CompletableFuture<org.apache.bookkeeper.client.api.LedgerEntries> readEntriesInternalAsync(long firstEntry,
-                                                                                               long lastEntry) {
+    CompletableFuture<LedgerEntries> readEntriesInternalAsync(long firstEntry,
+                                                              long lastEntry) {
         PendingReadOp op = new PendingReadOp(this, bk.getScheduler(), firstEntry, lastEntry);
         if(!bk.isClosed()) {
             bk.getMainWorkerPool().submitOrdered(ledgerId, op);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -634,7 +634,7 @@ public class LedgerHandle implements WriteHandle {
      *          id of last entry of sequence
      */
     @Override
-    public CompletableFuture<Iterable<org.apache.bookkeeper.client.api.LedgerEntry>> read(long firstEntry, long lastEntry) {
+    public CompletableFuture<org.apache.bookkeeper.client.api.LedgerEntries> read(long firstEntry, long lastEntry) {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
@@ -675,8 +675,8 @@ public class LedgerHandle implements WriteHandle {
      * @see #readUnconfirmedEntries(long, long)
      */
     @Override
-    public CompletableFuture<Iterable<org.apache.bookkeeper.client.api.LedgerEntry>> readUnconfirmed(long firstEntry, long lastEntry) {
-        // Little sanity check
+    public CompletableFuture<org.apache.bookkeeper.client.api.LedgerEntries> readUnconfirmed(long firstEntry,
+                                                                                             long lastEntry) {        // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
                     new Object[] { ledgerId, firstEntry, lastEntry });
@@ -689,9 +689,9 @@ public class LedgerHandle implements WriteHandle {
     void asyncReadEntriesInternal(long firstEntry, long lastEntry, ReadCallback cb, Object ctx) {
         if(!bk.isClosed()) {
             readEntriesInternalAsync(firstEntry, lastEntry)
-                .whenCompleteAsync(new FutureEventListener<Iterable<org.apache.bookkeeper.client.api.LedgerEntry>>() {
+                .whenCompleteAsync(new FutureEventListener<org.apache.bookkeeper.client.api.LedgerEntries>() {
                     @Override
-                    public void onSuccess(Iterable<org.apache.bookkeeper.client.api.LedgerEntry> iterable) {
+                    public void onSuccess(org.apache.bookkeeper.client.api.LedgerEntries iterable) {
                         cb.readComplete(
                             Code.OK,
                             LedgerHandle.this,
@@ -719,8 +719,8 @@ public class LedgerHandle implements WriteHandle {
         }
     }
 
-    CompletableFuture<Iterable<org.apache.bookkeeper.client.api.LedgerEntry>> readEntriesInternalAsync(long firstEntry,
-                                                                                                       long lastEntry) {
+    CompletableFuture<org.apache.bookkeeper.client.api.LedgerEntries> readEntriesInternalAsync(long firstEntry,
+                                                                                               long lastEntry) {
         PendingReadOp op = new PendingReadOp(this, bk.getScheduler(), firstEntry, lastEntry);
         if(!bk.isClosed()) {
             bk.getMainWorkerPool().submitOrdered(ledgerId, op);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -35,7 +35,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
-import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.apache.bookkeeper.client.api.*;
+import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -59,7 +60,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
     private final ScheduledExecutorService scheduler;
     private ScheduledFuture<?> speculativeTask = null;
     protected final List<LedgerEntryRequest> seq;
-    private final CompletableFuture<Iterable<LedgerEntry>> future;
+    private final CompletableFuture<LedgerEntries> future;
     Set<BookieSocketAddress> heardFromHosts;
     BitSet heardFromHostsBitSet;
     LedgerHandle lh;
@@ -454,7 +455,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
         readOpLogger = lh.bk.getReadOpLogger();
     }
 
-    CompletableFuture<Iterable<LedgerEntry>> future() {
+    CompletableFuture<LedgerEntries> future() {
         return future;
     }
 
@@ -600,7 +601,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
             future.completeExceptionally(BKException.create(code));
         } else {
             readOpLogger.registerSuccessfulEvent(latencyNanos, TimeUnit.NANOSECONDS);
-            future.complete(Lists.transform(seq, input -> input.entryImpl));
+            future.complete(LedgerEntriesImpl.create(Lists.transform(seq, input -> input.entryImpl)));
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -36,7 +36,7 @@ public interface LedgerEntries extends AutoCloseable {
 
     /**
      * In this, It does not retain the ByteBuf references for the entries in this LedgerEntries.
-     * The caller who calls #iterator() should be careful for not releasing the references.
+     * The caller who calls {@link #iterator()} should be careful for not releasing the references.
      *
      * @return the iterator of type LedgerEntry
      */
@@ -44,7 +44,7 @@ public interface LedgerEntries extends AutoCloseable {
 
     /**
      * In this, It retains the ByteBuf references for the entries in this LedgerEntries.
-     * The caller who calls #iterator() is responsible for releasing the retained references.
+     * The caller who calls {@link #retainIterator()} is responsible for releasing the retained references.
      *
      * @return the iterator of type LedgerEntry that has been retained
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -35,10 +35,15 @@ public interface LedgerEntries extends AutoCloseable {
     LedgerEntry getEntry(long entryId);
 
     /**
-     * In this, It does not retain the ByteBuf references for the entries in this LedgerEntries.
+     * In this method, It does not increment the reference counts of ByteBuf for the entries in this LedgerEntries.
      * The caller who calls {@link #iterator()} should be careful for not releasing the references.
      *
-     * @return the iterator of type LedgerEntry
+     * when iterator is called, you are handing out the entries, you may not know when the caller will
+     * complete iterating the entries. In this case, please use {@link #retainIterator()}, it will increment
+     * the refCnt, and the application who is holding iterator should be responsible for releasing one refCnt
+     * that {@link #retainIterator()} retains for entries.
+     *
+     *  @return the iterator of type LedgerEntry
      */
     Iterator<LedgerEntry> iterator();
 
@@ -48,5 +53,6 @@ public interface LedgerEntries extends AutoCloseable {
      *
      * @return the iterator of type LedgerEntry that has been retained
      */
+
     Iterator<LedgerEntry> retainIterator();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -35,24 +35,11 @@ public interface LedgerEntries extends AutoCloseable {
     LedgerEntry getEntry(long entryId);
 
     /**
-     * In this method, It does not increment the reference counts of ByteBuf for the entries in this LedgerEntries.
+     * This method does not increment the reference count of ByteBuf for the entries in this LedgerEntries.
      * The caller who calls {@link #iterator()} should be careful for not releasing the references.
-     *
-     * when iterator is called, you are handing out the entries, you may not know when the caller will
-     * complete iterating the entries. In this case, please use {@link #retainedIterator()}, it will increment
-     * the refCnt, and the application who is holding iterator should be responsible for releasing one refCnt
-     * that {@link #retainedIterator()} retains for entries.
+     * The implementation of this interface will release all the Entries ByteBuf reference when close.
      *
      *  @return the iterator of type LedgerEntry
      */
     Iterator<LedgerEntry> iterator();
-
-    /**
-     * In this, It retains the ByteBuf references for the entries in this LedgerEntries.
-     * The caller who calls {@link #retainedIterator()} is responsible for releasing the retained references.
-     *
-     * @return the iterator of type LedgerEntry that has been retained
-     */
-
-    Iterator<LedgerEntry> retainedIterator();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -39,9 +39,9 @@ public interface LedgerEntries extends AutoCloseable {
      * The caller who calls {@link #iterator()} should be careful for not releasing the references.
      *
      * when iterator is called, you are handing out the entries, you may not know when the caller will
-     * complete iterating the entries. In this case, please use {@link #retainIterator()}, it will increment
+     * complete iterating the entries. In this case, please use {@link #retainedIterator()}, it will increment
      * the refCnt, and the application who is holding iterator should be responsible for releasing one refCnt
-     * that {@link #retainIterator()} retains for entries.
+     * that {@link #retainedIterator()} retains for entries.
      *
      *  @return the iterator of type LedgerEntry
      */
@@ -49,10 +49,10 @@ public interface LedgerEntries extends AutoCloseable {
 
     /**
      * In this, It retains the ByteBuf references for the entries in this LedgerEntries.
-     * The caller who calls {@link #retainIterator()} is responsible for releasing the retained references.
+     * The caller who calls {@link #retainedIterator()} is responsible for releasing the retained references.
      *
      * @return the iterator of type LedgerEntry that has been retained
      */
 
-    Iterator<LedgerEntry> retainIterator();
+    Iterator<LedgerEntry> retainedIterator();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client.api;
+
+import java.util.Iterator;
+
+/**
+ * Interface to wrap the entries.
+ *
+ * @since 4.6
+ */
+public interface LedgerEntries extends AutoCloseable {
+
+    /**
+     * Gets a specific LedgerEntry by entryId.
+     *
+     * @param entryId the LedgerEntry id
+     * @return the LedgerEntry, null if no LedgerEntry with such entryId.
+     */
+    LedgerEntry getEntry(long entryId);
+
+    /**
+     * In this, It does not retain the ByteBuf references for the entries in this LedgerEntries.
+     * The caller who calls #iterator() should be careful for not releasing the references.
+     *
+     * @return the iterator of type LedgerEntry
+     */
+    Iterator<LedgerEntry> iterator();
+
+    /**
+     * In this, It retains the ByteBuf references for the entries in this LedgerEntries.
+     * The caller who calls #iterator() is responsible for releasing the retained references.
+     *
+     * @return the iterator of type LedgerEntry that has been retained
+     */
+    Iterator<LedgerEntry> retainIterator();
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -35,11 +35,12 @@ public interface LedgerEntries extends AutoCloseable {
     LedgerEntry getEntry(long entryId);
 
     /**
-     * This method does not increment the reference count of ByteBuf for the entries in this LedgerEntries.
-     * The caller who calls {@link #iterator()} should be careful for not releasing the references.
-     * The implementation of this interface will release all the Entries ByteBuf reference when close.
+     * Calling this method does not modify the reference count of the ByteBuf in the returned LedgerEntry objects.
+     * The caller who calls {@link #iterator()} should make sure that they do not call ByteBuf.release() on the
+     * LedgerEntry objects to avoid a double free.
+     * All reference counts will be decremented when the containing LedgerEntries object is closed.
      *
-     *  @return the iterator of type LedgerEntry
+     * @return the iterator of type LedgerEntry.
      */
     Iterator<LedgerEntry> iterator();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
@@ -42,7 +42,7 @@ public interface ReadHandle extends Handle {
      *          id of last entry of sequence, inclusive
      * @return an handle to the result of the operation
      */
-    CompletableFuture<Iterable<LedgerEntry>> read(long firstEntry, long lastEntry);
+    CompletableFuture<LedgerEntries> read(long firstEntry, long lastEntry);
 
     /**
      * Read a sequence of entries asynchronously, allowing to read after the LastAddConfirmed range.
@@ -67,7 +67,7 @@ public interface ReadHandle extends Handle {
      * @see #read(long, long)
      * @see #readLastAddConfirmed()
      */
-    CompletableFuture<Iterable<LedgerEntry>> readUnconfirmed(long firstEntry, long lastEntry);
+    CompletableFuture<LedgerEntries> readUnconfirmed(long firstEntry, long lastEntry);
 
     /**
      * Obtains asynchronously the last confirmed write from a quorum of bookies. This

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
@@ -101,7 +101,7 @@ public class LedgerEntriesImpl implements LedgerEntries {
      * {@inheritDoc}
      */
     @Override
-    public Iterator<LedgerEntry> retainIterator() {
+    public Iterator<LedgerEntry> retainedIterator() {
         checkNotNull(entries, "entries has been recycled");
         // Retains the references for all the entries, caller is responsible for releasing.
         entries.forEach(ledgerEntry -> ledgerEntry.getEntryBuffer().retain());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
@@ -1,0 +1,104 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client.impl;
+
+import io.netty.util.Recycler;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.bookkeeper.client.api.LedgerEntry;
+
+public class LedgerEntriesImpl implements org.apache.bookkeeper.client.api.LedgerEntries {
+    private List<LedgerEntry> entries;
+    private final Recycler.Handle<LedgerEntriesImpl> recyclerHandle;
+
+    private LedgerEntriesImpl(Recycler.Handle<LedgerEntriesImpl> recyclerHandle) {
+        this.recyclerHandle = recyclerHandle;
+    }
+
+    private static final Recycler<LedgerEntriesImpl> RECYCLER = new Recycler<LedgerEntriesImpl>() {
+        @Override
+        protected LedgerEntriesImpl newObject(Recycler.Handle<LedgerEntriesImpl> handle) {
+            return new LedgerEntriesImpl(handle);
+        }
+    };
+
+    private void recycle() {
+        releaseByteBuf();
+        recyclerHandle.recycle(this);
+    }
+
+    private void releaseByteBuf() {
+        if (entries != null) {
+            for (LedgerEntry entry : entries) {
+                entry.getEntryBuffer().release(1);
+            }
+        }
+    }
+
+    /**
+     * Create ledger entries.
+     *
+     * @param entries the entries with ordering
+     * @return the LedgerEntriesImpl
+     */
+    public static LedgerEntriesImpl create(List<LedgerEntry> entries) {
+        LedgerEntriesImpl ledgerEntries = RECYCLER.get();
+        ledgerEntries.entries = entries;
+        return ledgerEntries;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LedgerEntry getEntry(long entryId) {
+        long firstId = entries.get(0).getEntryId();
+        long lastId = entries.get(entries.size() - 1).getEntryId();
+        if (entryId < firstId || entryId > lastId) {
+            return null;
+        }
+        return entries.get((int)(entryId - firstId));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterator<LedgerEntry> iterator() {
+        return entries.iterator();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterator<LedgerEntry> retainIterator() {
+        // Retains the references for all the entries, caller is responsible for releasing.
+        entries.forEach(ledgerEntry -> ledgerEntry.getEntryBuffer().retain());
+
+        return iterator();
+    }
+
+    @Override
+    public void close(){
+        recycle();
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 
 /**
@@ -77,6 +78,7 @@ public class LedgerEntriesImpl implements LedgerEntries {
      */
     @Override
     public LedgerEntry getEntry(long entryId) {
+        checkNotNull(entries, "entries has been recycled");
         long firstId = entries.get(0).getEntryId();
         long lastId = entries.get(entries.size() - 1).getEntryId();
         if (entryId < firstId || entryId > lastId) {
@@ -91,6 +93,7 @@ public class LedgerEntriesImpl implements LedgerEntries {
      */
     @Override
     public Iterator<LedgerEntry> iterator() {
+        checkNotNull(entries, "entries has been recycled");
         return entries.iterator();
     }
     
@@ -99,6 +102,7 @@ public class LedgerEntriesImpl implements LedgerEntries {
      */
     @Override
     public Iterator<LedgerEntry> retainIterator() {
+        checkNotNull(entries, "entries has been recycled");
         // Retains the references for all the entries, caller is responsible for releasing.
         entries.forEach(ledgerEntry -> ledgerEntry.getEntryBuffer().retain());
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
@@ -96,18 +96,6 @@ public class LedgerEntriesImpl implements LedgerEntries {
         checkNotNull(entries, "entries has been recycled");
         return entries.iterator();
     }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Iterator<LedgerEntry> retainedIterator() {
-        checkNotNull(entries, "entries has been recycled");
-        // Retains the references for all the entries, caller is responsible for releasing.
-        entries.forEach(ledgerEntry -> ledgerEntry.getEntryBuffer().retain());
-
-        return iterator();
-    }
 
     @Override
     public void close(){

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
@@ -78,9 +78,7 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
             PendingReadOp readOp =
                     new PendingReadOp(lh, lh.bk.scheduler, i, i);
             readOp.parallelRead(true).submit();
-            Iterable<LedgerEntry> iterable = readOp.future().get();
-            assertNotNull(iterable);
-            Iterator<LedgerEntry> entries = iterable.iterator();
+            Iterator<LedgerEntry> entries = readOp.future().get().iterator();
             assertTrue(entries.hasNext());
             LedgerEntry entry = entries.next();
             assertNotNull(entry);
@@ -93,9 +91,7 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         PendingReadOp readOp =
                 new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1);
         readOp.parallelRead(true).submit();
-        Iterable<LedgerEntry> iterable = readOp.future().get();
-        assertNotNull(iterable);
-        Iterator<LedgerEntry> iterator = iterable.iterator();
+        Iterator<LedgerEntry> iterator = readOp.future().get().iterator();
 
         int numReads = 0;
         while (iterator.hasNext()) {
@@ -198,9 +194,7 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         PendingReadOp readOp =
                 new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1);
         readOp.parallelRead(true).submit();
-        Iterable<LedgerEntry> iterable = readOp.future().get();
-        assertNotNull(iterable);
-        Iterator<LedgerEntry> entries = iterable.iterator();
+        Iterator<LedgerEntry> entries = readOp.future().get().iterator();
 
         int numReads = 0;
         while (entries.hasNext()) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 
 import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.client.BKException.BKDuplicateEntryIdException;
@@ -275,11 +276,12 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
         result(newDeleteLedgerOp().withLedgerId(lId).execute());
     }
 
-    private static void checkEntries(Iterable<LedgerEntry> entries, byte[] data)
+    private static void checkEntries(LedgerEntries entries, byte[] data)
         throws InterruptedException, BKException {
-        for (LedgerEntry le : entries) {
-            assertArrayEquals(data, le.getEntryBytes());
+        Iterator<LedgerEntry> iterator = entries.retainIterator();
+        while(iterator.hasNext()) {
+            LedgerEntry entry = iterator.next();
+            assertArrayEquals(data, entry.getEntryBytes());
         }
     }
-
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
@@ -278,7 +278,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
 
     private static void checkEntries(LedgerEntries entries, byte[] data)
         throws InterruptedException, BKException {
-        Iterator<LedgerEntry> iterator = entries.retainIterator();
+        Iterator<LedgerEntry> iterator = entries.iterator();
         while(iterator.hasNext()) {
             LedgerEntry entry = iterator.next();
             assertArrayEquals(data, entry.getEntryBytes());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
@@ -124,7 +124,11 @@ public class LedgerEntriesImplTest {
     @Test
     public void testRetainIterator() {
         Iterator<LedgerEntry> entryIterator = ledgerEntriesImpl.retainIterator();
-        entryIterator.forEachRemaining(ledgerEntry -> assertEquals(2, ledgerEntry.getEntryBuffer().refCnt()));
-        entryIterator.forEachRemaining(ledgerEntry -> ledgerEntry.getEntryBuffer().release());
+
+        entryIterator.forEachRemaining(ledgerEntry -> {
+            assertEquals(2, ledgerEntry.getEntryBuffer().refCnt());
+            ledgerEntry.getEntryBuffer().release();
+            assertEquals(1, ledgerEntry.getEntryBuffer().refCnt());
+        });
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
@@ -75,13 +75,6 @@ public class LedgerEntriesImplTest {
         } catch (NullPointerException e) {
             // expected behavior
         }
-
-        try {
-            ledgerEntriesImpl.retainedIterator();
-            fail("should fail retainedIterator after close");
-        } catch (NullPointerException e) {
-            // expected behavior
-        }
     }
 
     @Test
@@ -119,16 +112,5 @@ public class LedgerEntriesImplTest {
     public void testIterator() {
         Iterator<LedgerEntry> entryIterator = ledgerEntriesImpl.iterator();
         entryIterator.forEachRemaining(ledgerEntry -> assertEquals(1, ledgerEntry.getEntryBuffer().refCnt()));
-    }
-
-    @Test
-    public void testRetainedIterator() {
-        Iterator<LedgerEntry> entryIterator = ledgerEntriesImpl.retainedIterator();
-
-        entryIterator.forEachRemaining(ledgerEntry -> {
-            assertEquals(2, ledgerEntry.getEntryBuffer().refCnt());
-            ledgerEntry.getEntryBuffer().release();
-            assertEquals(1, ledgerEntry.getEntryBuffer().refCnt());
-        });
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
@@ -66,21 +66,21 @@ public class LedgerEntriesImplTest {
             ledgerEntriesImpl.getEntry(entryId);
             fail("should fail getEntry after close");
         } catch (NullPointerException e) {
-
+            // expected behavior
         }
 
         try {
             ledgerEntriesImpl.iterator();
             fail("should fail iterator after close");
         } catch (NullPointerException e) {
-
+            // expected behavior
         }
 
         try {
             ledgerEntriesImpl.retainIterator();
             fail("should fail retainIterator after close");
         } catch (NullPointerException e) {
-
+            // expected behavior
         }
     }
 
@@ -104,14 +104,14 @@ public class LedgerEntriesImplTest {
             LedgerEntry entry = ledgerEntriesImpl.getEntry(entryId - 1);
             fail("Should get IndexOutOfBoundsException");
         } catch (IndexOutOfBoundsException e) {
-
+            // expected behavior
         }
 
         try {
             LedgerEntry entry = ledgerEntriesImpl.getEntry(entryId + entryNumber);
             fail("Should get IndexOutOfBoundsException");
         } catch (IndexOutOfBoundsException e) {
-
+            // expected behavior
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
@@ -77,8 +77,8 @@ public class LedgerEntriesImplTest {
         }
 
         try {
-            ledgerEntriesImpl.retainIterator();
-            fail("should fail retainIterator after close");
+            ledgerEntriesImpl.retainedIterator();
+            fail("should fail retainedIterator after close");
         } catch (NullPointerException e) {
             // expected behavior
         }
@@ -122,8 +122,8 @@ public class LedgerEntriesImplTest {
     }
 
     @Test
-    public void testRetainIterator() {
-        Iterator<LedgerEntry> entryIterator = ledgerEntriesImpl.retainIterator();
+    public void testRetainedIterator() {
+        Iterator<LedgerEntry> entryIterator = ledgerEntriesImpl.retainedIterator();
 
         entryIterator.forEachRemaining(ledgerEntry -> {
             assertEquals(2, ledgerEntry.getEntryBuffer().refCnt());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bookkeeper.client.impl;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.Lists;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link LedgerEntriesImpl}.
+ */
+public class LedgerEntriesImplTest {
+    private final int entryNumber = 7;
+    private LedgerEntriesImpl ledgerEntriesImpl;
+    private final List<LedgerEntry> entryList = Lists.newArrayList();
+
+    // content for each entry
+    private final long ledgerId = 1234L;
+    private final long entryId = 5678L;
+    private final long length = 9876L;
+    private final byte[] dataBytes = "test-ledger-entry-impl".getBytes(UTF_8);
+
+    public LedgerEntriesImplTest () {
+        for(int i = 0; i < entryNumber; i++) {
+            entryList.add(LedgerEntryImpl.create(ledgerId + i,
+                entryId + i,
+                length + i,
+                Unpooled.wrappedBuffer(dataBytes)));
+        }
+
+        ledgerEntriesImpl = LedgerEntriesImpl.create(entryList);
+    }
+
+    @After
+    public void tearDown() {
+        ledgerEntriesImpl.close();
+
+        try {
+            ledgerEntriesImpl.getEntry(entryId);
+            fail("should fail getEntry after close");
+        } catch (NullPointerException e) {
+
+        }
+
+        try {
+            ledgerEntriesImpl.iterator();
+            fail("should fail iterator after close");
+        } catch (NullPointerException e) {
+
+        }
+
+        try {
+            ledgerEntriesImpl.retainIterator();
+            fail("should fail retainIterator after close");
+        } catch (NullPointerException e) {
+
+        }
+    }
+
+    @Test
+    public void testGetEntry() {
+        for(int i = 0; i < entryNumber; i ++) {
+            LedgerEntry entry = ledgerEntriesImpl.getEntry(entryId + i);
+            assertEquals(entryList.get(i).getLedgerId(),  entry.getLedgerId());
+            assertEquals(entryList.get(i).getEntryId(),  entry.getEntryId());
+            assertEquals(entryList.get(i).getLength(),  entry.getLength());
+
+            ByteBuf buf = entry.getEntryBuffer();
+            byte[]  content = new byte[buf.readableBytes()];
+            buf.readBytes(content);
+            assertArrayEquals(dataBytes, content);
+
+            assertEquals(1, entry.getEntryBuffer().refCnt());
+        }
+
+        try {
+            LedgerEntry entry = ledgerEntriesImpl.getEntry(entryId - 1);
+            fail("Should get IndexOutOfBoundsException");
+        } catch (IndexOutOfBoundsException e) {
+
+        }
+
+        try {
+            LedgerEntry entry = ledgerEntriesImpl.getEntry(entryId + entryNumber);
+            fail("Should get IndexOutOfBoundsException");
+        } catch (IndexOutOfBoundsException e) {
+
+        }
+    }
+
+    @Test
+    public void testIterator() {
+        Iterator<LedgerEntry> entryIterator = ledgerEntriesImpl.iterator();
+        entryIterator.forEachRemaining(ledgerEntry -> assertEquals(1, ledgerEntry.getEntryBuffer().refCnt()));
+    }
+
+    @Test
+    public void testRetainIterator() {
+        Iterator<LedgerEntry> entryIterator = ledgerEntriesImpl.retainIterator();
+        entryIterator.forEachRemaining(ledgerEntry -> assertEquals(2, ledgerEntry.getEntryBuffer().refCnt()));
+        entryIterator.forEachRemaining(ledgerEntry -> ledgerEntry.getEntryBuffer().release());
+    }
+}


### PR DESCRIPTION
In the new API proposed in #506 , we return Iterable<LedgerEntry> for read entries. It is a bit problematic when returning multiple iterators and have no ability to release the entry buffers hold by ledger entries.
In this change, the implementation of retainIterator() increased the reference of the buffers when creating an iterator, it will be easy for byteBuf's management; it also make LedgerEntries a recycle object, and it is returned to the pool when #close() is called. on #close(), it also releases all the references to release resources.

Descriptions of the changes in this PR:
1. add interface LedgerEntries;
2. add implemtation of LedgerEntries;
3. fix related build and test errors.

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
> 
> - [x] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [x] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [x] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
