### PR TITLE
Issue 726: Unit Tests failure with BKMetadataVersionException

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -98,7 +98,13 @@ public class LedgerMetadata {
         this.ensembleSize = ensembleSize;
         this.writeQuorumSize = writeQuorumSize;
         this.ackQuorumSize = ackQuorumSize;
-        this.ctime = System.currentTimeMillis();
+        if (storeSystemtimeAsLedgerCreationTime) {
+            this.ctime = System.currentTimeMillis();
+        } else {
+            // if client disables storing its system time as ledger creation time, there should be no ctime at this
+            // moment.
+            this.ctime = -1L;
+        }
         this.storeSystemtimeAsLedgerCreationTime = storeSystemtimeAsLedgerCreationTime;
 
         /*
@@ -119,6 +125,10 @@ public class LedgerMetadata {
         }
     }
 
+    /**
+     * Used for testing purpose only.
+     */
+    @VisibleForTesting
     public LedgerMetadata(int ensembleSize, int writeQuorumSize, int ackQuorumSize,
             BookKeeper.DigestType digestType, byte[] password) {
         this(ensembleSize, writeQuorumSize, ackQuorumSize, digestType, password, null, false);
@@ -130,7 +140,6 @@ public class LedgerMetadata {
     LedgerMetadata(LedgerMetadata other) {
         this.ensembleSize = other.ensembleSize;
         this.writeQuorumSize = other.writeQuorumSize;
-        this.ctime = other.ctime;
         this.ackQuorumSize = other.ackQuorumSize;
         this.length = other.length;
         this.lastEntryId = other.lastEntryId;
@@ -139,6 +148,8 @@ public class LedgerMetadata {
         this.version = other.version;
         this.hasPassword = other.hasPassword;
         this.digestType = other.digestType;
+        this.ctime = other.ctime;
+        this.storeSystemtimeAsLedgerCreationTime = other.storeSystemtimeAsLedgerCreationTime;
         this.password = new byte[other.password.length];
         System.arraycopy(other.password, 0, this.password, 0, other.password.length);
         // copy the ensembles
@@ -178,6 +189,10 @@ public class LedgerMetadata {
         return writeQuorumSize;
     }
 
+    public int getAckQuorumSize() {
+        return ackQuorumSize;
+    }
+
     /**
      * Get the creation timestamp of the ledger
      * @return
@@ -186,8 +201,9 @@ public class LedgerMetadata {
         return ctime;
     }
 
-    public int getAckQuorumSize() {
-        return ackQuorumSize;
+    @VisibleForTesting
+    void setCtime(long ctime) {
+        this.ctime = ctime;
     }
 
     /**
@@ -430,8 +446,10 @@ public class LedgerMetadata {
         lc.writeQuorumSize = data.getQuorumSize();
         if (data.hasCtime()) {
             lc.ctime = data.getCtime();
+            lc.storeSystemtimeAsLedgerCreationTime = true;
         } else if (msCtime.isPresent()) {
             lc.ctime = msCtime.get();
+            lc.storeSystemtimeAsLedgerCreationTime = false;
         }
         if (data.hasAckQuorumSize()) {
             lc.ackQuorumSize = data.getAckQuorumSize();
@@ -583,7 +601,6 @@ public class LedgerMetadata {
         if (metadataFormatVersion != newMeta.metadataFormatVersion ||
             ensembleSize != newMeta.ensembleSize ||
             writeQuorumSize != newMeta.writeQuorumSize ||
-            ctime != newMeta.ctime ||
             ackQuorumSize != newMeta.ackQuorumSize ||
             length != newMeta.length ||
             state != newMeta.state ||
@@ -592,6 +609,14 @@ public class LedgerMetadata {
             !LedgerMetadata.areByteArrayValMapsEqual(customMetadata, newMeta.customMetadata)) {
             return true;
         }
+
+        // verify the ctime
+        if (storeSystemtimeAsLedgerCreationTime != newMeta.storeSystemtimeAsLedgerCreationTime) {
+            return true;
+        } else if (storeSystemtimeAsLedgerCreationTime) {
+            return ctime != newMeta.ctime;
+        }
+
         if (state == LedgerMetadataFormat.State.CLOSED
             && lastEntryId != newMeta.lastEntryId) {
             return true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -386,6 +386,7 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
                 }
                 LedgerMetadata metadata;
                 try {
+                    LOG.info("Ctime = {}", stat.getCtime());
                     metadata = LedgerMetadata.parseConfig(data, new LongVersion(stat.getVersion()), Optional.of(stat.getCtime()));
                 } catch (IOException e) {
                     LOG.error("Could not parse ledger metadata for ledger: " + ledgerId, e);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -386,7 +386,6 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
                 }
                 LedgerMetadata metadata;
                 try {
-                    LOG.info("Ctime = {}", stat.getCtime());
                     metadata = LedgerMetadata.parseConfig(data, new LongVersion(stat.getVersion()), Optional.of(stat.getCtime()));
                 } catch (IOException e) {
                     LOG.error("Could not parse ledger metadata for ledger: " + ledgerId, e);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerMetadataTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerMetadataTest.java
@@ -33,11 +33,11 @@ import org.junit.Test;
  */
 public class LedgerMetadataTest {
 
+    private static final byte[] passwd = "testPasswd".getBytes(UTF_8);
+
     @Test
     public void testStoreSystemtimeAsLedgerCtimeEnabled()
             throws Exception {
-        byte[] passwd = "testPasswd".getBytes(UTF_8);
-
         LedgerMetadata lm = new LedgerMetadata(
             3,
             3,
@@ -53,8 +53,6 @@ public class LedgerMetadataTest {
     @Test
     public void testStoreSystemtimeAsLedgerCtimeDisabled()
             throws Exception {
-        byte[] passwd = "testPasswd".getBytes(UTF_8);
-
         LedgerMetadata lm = new LedgerMetadata(
             3,
             3,
@@ -65,6 +63,62 @@ public class LedgerMetadataTest {
             false);
         LedgerMetadataFormat format = lm.buildProtoFormat();
         assertFalse(format.hasCtime());
+    }
+
+    @Test
+    public void testIsConflictWithStoreSystemtimeAsLedgerCtimeDisabled() {
+        LedgerMetadata lm1 = new LedgerMetadata(
+            3,
+            3,
+            2,
+            DigestType.CRC32,
+            passwd,
+            Collections.emptyMap(),
+            false);
+        LedgerMetadata lm2 = new LedgerMetadata(lm1);
+
+        lm1.setCtime(1L);
+        lm2.setCtime(2L);
+        assertFalse(lm1.isConflictWith(lm2));
+    }
+
+    @Test
+    public void testIsConflictWithStoreSystemtimeAsLedgerCtimeEnabled() {
+        LedgerMetadata lm1 = new LedgerMetadata(
+            3,
+            3,
+            2,
+            DigestType.CRC32,
+            passwd,
+            Collections.emptyMap(),
+            true);
+        LedgerMetadata lm2 = new LedgerMetadata(lm1);
+
+        lm1.setCtime(1L);
+        lm2.setCtime(2L);
+        assertTrue(lm1.isConflictWith(lm2));
+    }
+
+    @Test
+    public void testIsConflictWithDifferentStoreSystemtimeAsLedgerCtimeFlags() {
+        LedgerMetadata lm1 = new LedgerMetadata(
+            3,
+            3,
+            2,
+            DigestType.CRC32,
+            passwd,
+            Collections.emptyMap(),
+            true);
+        LedgerMetadata lm2 = new LedgerMetadata(
+            3,
+            3,
+            2,
+            DigestType.CRC32,
+            passwd,
+            Collections.emptyMap(),
+            false);
+
+        assertTrue(lm1.isConflictWith(lm2));
     }
 
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Problem:

The problem is introduced after making storing ctime optional. the verification become inconsistent because the way how ctime was assigned and compared. It causes the test cases failing in #726 

Solution:

This change is to change `isConflict` to ignore comparing ctime if client disables storing system time as ctime.
