### PR TITLE
Issue 731: refine LedgerEntry interface and implementation

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerEntry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerEntry.java
@@ -23,8 +23,8 @@ package org.apache.bookkeeper.client;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
-
 import java.io.InputStream;
+import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 
 /**
@@ -32,30 +32,28 @@ import org.apache.bookkeeper.conf.ClientConfiguration;
  * the entry content.
  *
  */
-public class LedgerEntry
-    implements org.apache.bookkeeper.client.api.LedgerEntry {
+public class LedgerEntry {
 
     final long ledgerId;
-    long entryId;
-    long length;
+    final long entryId;
+    final long length;
     ByteBuf data;
 
-    LedgerEntry(long lId, long eId) {
-        this.ledgerId = lId;
-        this.entryId = eId;
+    LedgerEntry(LedgerEntryImpl entry) {
+        this.ledgerId = entry.getLedgerId();
+        this.entryId = entry.getEntryId();
+        this.length = entry.getLength();
+        this.data = entry.getEntryBuffer().retain();
     }
 
-    @Override
     public long getLedgerId() {
         return ledgerId;
     }
 
-    @Override
     public long getEntryId() {
         return entryId;
     }
 
-    @Override
     public long getLength() {
         return length;
     }
@@ -68,7 +66,6 @@ public class LedgerEntry
      * @return the content of the entry
      * @throws IllegalStateException if this method is called twice
      */
-    @Override
     public byte[] getEntry() {
         Preconditions.checkState(null != data, "entry content can be accessed only once");
         byte[] entry = new byte[data.readableBytes()];
@@ -105,7 +102,6 @@ public class LedgerEntry
      * @throws IllegalStateException if the entry has been retrieved by {@link #getEntry()}
      * or {@link #getEntryInputStream()}.
      */
-    @Override
     public ByteBuf getEntryBuffer() {
         Preconditions.checkState(null != data, "entry content has been retrieved" +
             " by #getEntry or #getEntryInputStream");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -21,10 +21,8 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
-import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.DigestManager.RecoveryData;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryListener;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
@@ -24,17 +24,16 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
 import org.apache.bookkeeper.proto.ReadLastConfirmedAndEntryContext;
 import org.apache.bookkeeper.util.MathUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +64,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
     private long lastAddConfirmed;
     private long timeOutInMillis;
 
-    abstract class ReadLACAndEntryRequest extends LedgerEntry {
+    abstract class ReadLACAndEntryRequest implements AutoCloseable {
 
         final AtomicBoolean complete = new AtomicBoolean(false);
 
@@ -76,18 +75,22 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
         final ArrayList<BookieSocketAddress> ensemble;
         final DistributionSchedule.WriteSet writeSet;
         final DistributionSchedule.WriteSet orderedEnsemble;
+        final LedgerEntryImpl entryImpl;
 
         ReadLACAndEntryRequest(ArrayList<BookieSocketAddress> ensemble, long lId, long eId) {
-            super(lId, eId);
-
+            this.entryImpl = LedgerEntryImpl.create(lId, eId);
             this.ensemble = ensemble;
-            this.writeSet = lh.distributionSchedule.getWriteSet(entryId);
+            this.writeSet = lh.distributionSchedule.getWriteSet(eId);
             if (lh.bk.reorderReadSequence) {
                 this.orderedEnsemble = lh.bk.placementPolicy.reorderReadLACSequence(ensemble,
                         lh.bookieFailureHistory.asMap(), writeSet.copy());
             } else {
                 this.orderedEnsemble = writeSet.copy();
             }
+        }
+
+        public void close() {
+            entryImpl.close();
         }
 
         synchronized int getFirstError() {
@@ -125,13 +128,12 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                 writeSet.recycle();
                 orderedEnsemble.recycle();
                 rc = BKException.Code.OK;
-                this.entryId = entryId;
                 /*
                  * The length is a long and it is the last field of the metadata of an entry.
                  * Consequently, we have to subtract 8 from METADATA_LENGTH to get the length.
                  */
-                length = buffer.getLong(DigestManager.METADATA_LENGTH - 8);
-                data = content;
+                entryImpl.setLength(buffer.getLong(DigestManager.METADATA_LENGTH - 8));
+                entryImpl.setEntryBuf(content);
                 return true;
             } else {
                 return false;
@@ -193,13 +195,13 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                 // treat these errors as failures if the node from which we received this is part of
                 // the writeSet
                 if (this.writeSet.contains(bookieIndex)) {
-                    lh.registerOperationFailureOnBookie(host, entryId);
+                    lh.registerOperationFailureOnBookie(host, entryImpl.getEntryId());
                 }
                 ++numMissedEntryReads;
             }
 
             if (LOG.isDebugEnabled()) {
-                LOG.debug(errMsg + " while reading entry: " + entryId + " ledgerId: " + lh.ledgerId + " from bookie: "
+                LOG.debug(errMsg + " while reading entry: " + entryImpl.getEntryId() + " ledgerId: " + lh.ledgerId + " from bookie: "
                     + host);
             }
         }
@@ -234,7 +236,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
 
         @Override
         public String toString() {
-            return String.format("L%d-E%d", ledgerId, entryId);
+            return String.format("L%d-E%d", entryImpl.getLedgerId(), entryImpl.getEntryId());
         }
     }
 
@@ -493,15 +495,24 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
         public void readLastConfirmedAndEntryComplete(int rc, long lastAddConfirmed, LedgerEntry entry);
     }
 
-    private void submitCallback(int rc, long lastAddConfirmed, LedgerEntry entry) {
+    private void submitCallback(int rc) {
         long latencyMicros = MathUtils.elapsedMicroSec(requestTimeNano);
+        LedgerEntry entry;
         if (BKException.Code.OK != rc) {
             lh.bk.getReadLacAndEntryOpLogger()
                 .registerFailedEvent(latencyMicros, TimeUnit.MICROSECONDS);
+            entry = null;
         } else {
+            // could received advanced lac, with no entry
             lh.bk.getReadLacAndEntryOpLogger()
                 .registerSuccessfulEvent(latencyMicros, TimeUnit.MICROSECONDS);
+            if (request.entryImpl.getEntryBuffer() != null) {
+                entry = new LedgerEntry(request.entryImpl);
+            } else {
+                entry = null;
+            }
         }
+        request.close();
         cb.readLastConfirmedAndEntryComplete(rc, lastAddConfirmed, entry);
     }
 
@@ -537,7 +548,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                             .registerSuccessfulEvent(elapsedMicros, TimeUnit.MICROSECONDS);
                     }
 
-                    submitCallback(BKException.Code.OK, lastAddConfirmed, request);
+                    submitCallback(BKException.Code.OK);
                     requestComplete.set(true);
                     heardFromHostsBitSet.set(rCtx.getBookieIndex(), true);
                 }
@@ -564,7 +575,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                 return;
             }
         } else if (BKException.Code.UnauthorizedAccessException == rc && !requestComplete.get()) {
-            submitCallback(rc, lastAddConfirmed, null);
+            submitCallback(rc);
             requestComplete.set(true);
         } else {
             request.logErrorAndReattemptRead(rCtx.getBookieIndex(), bookie, "Error: " + BKException.getMessage(rc), rc);
@@ -580,10 +591,10 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
         if (requestComplete.compareAndSet(false, true)) {
             if (!hasValidResponse) {
                 // no success called
-                submitCallback(request.getFirstError(), lastAddConfirmed, null);
+                submitCallback(request.getFirstError());
             } else {
                 // callback
-                submitCallback(BKException.Code.OK, lastAddConfirmed, null);
+                submitCallback(BKException.Code.OK);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCallbackUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCallbackUtils.java
@@ -17,13 +17,11 @@
  */
 package org.apache.bookkeeper.client;
 
-import com.google.common.collect.Iterators;
 import java.util.Enumeration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
-import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.LastConfirmedAndEntryImpl;
 
 /**
@@ -220,34 +218,6 @@ class SyncCallbackUtils {
         }
     }
 
-    static class FutureReadResult
-        extends CompletableFuture<Iterable<org.apache.bookkeeper.client.api.LedgerEntry>>
-        implements AsyncCallback.ReadCallback {
-
-        /**
-         * Implementation of callback interface for read method of {@link ReadHandle}.
-         *
-         * @param rc
-         *          return code
-         * @param lh
-         *          ledger handle
-         * @param seq
-         *          sequence of entries
-         * @param ctx
-         *          control object
-         */
-        @Override
-        @SuppressWarnings("unchecked")
-        public void readComplete(int rc, LedgerHandle lh,
-                                 Enumeration<LedgerEntry> seq, Object ctx) {
-            if (rc != BKException.Code.OK) {
-                this.completeExceptionally(BKException.create(rc).fillInStackTrace());
-            } else {
-                this.complete((Iterable) () -> Iterators.forEnumeration(seq));
-            }
-        }
-    }
-
     static class SyncAddCallback extends CompletableFuture<Long> implements AsyncCallback.AddCallback {
 
         /**
@@ -320,7 +290,7 @@ class SyncCallbackUtils {
 
         @Override
         public void readLastConfirmedAndEntryComplete(int rc, long lastConfirmed, LedgerEntry entry, Object ctx) {
-            LastConfirmedAndEntry result = new LastConfirmedAndEntryImpl(lastConfirmed, entry);
+            LastConfirmedAndEntry result = LastConfirmedAndEntryImpl.create(lastConfirmed, entry);
             finish(rc, result, this);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LastConfirmedAndEntry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LastConfirmedAndEntry.java
@@ -24,14 +24,14 @@ package org.apache.bookkeeper.client.api;
  * This contains LastAddConfirmed entryId and a LedgerEntry wanted to read.
  * It is used for readLastAddConfirmedAndEntry.
  */
-public interface LastConfirmedAndEntry {
+public interface LastConfirmedAndEntry extends AutoCloseable {
 
     /**
      * Gets LastAddConfirmed entryId.
      *
      * @return the LastAddConfirmed
      */
-    Long getLastAddConfirmed();
+    long getLastAddConfirmed();
 
     /**
      * Whether this entity contains an entry.
@@ -46,5 +46,10 @@ public interface LastConfirmedAndEntry {
      * @return the LedgerEntry
      */
     LedgerEntry getEntry();
+
+    /**
+     * {@inheritDoc}
+     */
+    void close();
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntry.java
@@ -23,7 +23,6 @@ package org.apache.bookkeeper.client.api;
 import io.netty.buffer.ByteBuf;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
-import org.apache.bookkeeper.conf.ClientConfiguration;
 
 /**
  * An entry.
@@ -32,7 +31,7 @@ import org.apache.bookkeeper.conf.ClientConfiguration;
  */
 @Public
 @Unstable
-public interface LedgerEntry {
+public interface LedgerEntry extends AutoCloseable {
 
     /**
      * The id of the ledger which contains the entry.
@@ -56,25 +55,31 @@ public interface LedgerEntry {
     long getLength();
 
     /**
-     * Returns the content of the entry. This method can be called only once. While using v2 wire protocol this method
-     * will automatically release the internal ByteBuf.
+     * Returns the content of the entry.
      *
      * @return the content of the entry
-     * @throws IllegalStateException if this method is called twice
      */
     byte[] getEntry();
 
     /**
      * Return the internal buffer that contains the entry payload.
      *
-     * <p>Note: Using v2 wire protocol it is responsibility of the caller
-     * to ensure to release the buffer after usage.
-     *
      * @return a ByteBuf which contains the data
-     *
-     * @see ClientConfiguration#setNettyUsePooledBuffers(boolean)
-     * @throws IllegalStateException if the entry has been retrieved by {@link #getEntry()}
      */
     ByteBuf getEntryBuffer();
+
+    /**
+     * Returns a duplicate of this entry.
+     *
+     * <p>This call will retain a slice of the underneath byte buffer.
+     *
+     * @return a duplicated ledger entry.
+     */
+    LedgerEntry duplicate();
+
+    /**
+     * {@inheritDoc}
+     */
+    void close();
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntryImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntryImpl.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.client.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.bookkeeper.client.api.LedgerEntry;
+
+/**
+ * Ledger entry. Its a simple tuple containing the ledger id, the entry-id, and
+ * the entry content.
+ */
+public class LedgerEntryImpl implements LedgerEntry {
+
+    private static final Recycler<LedgerEntryImpl> RECYCLER = new Recycler<LedgerEntryImpl>() {
+        @Override
+        protected LedgerEntryImpl newObject(Handle<LedgerEntryImpl> handle) {
+            return new LedgerEntryImpl(handle);
+        }
+    };
+
+    public static LedgerEntryImpl create(long ledgerId,
+                                         long entryId) {
+        LedgerEntryImpl entry = RECYCLER.get();
+        entry.ledgerId = ledgerId;
+        entry.entryId = entryId;
+        return entry;
+    }
+
+    public static LedgerEntryImpl create(long ledgerId,
+                                         long entryId,
+                                         long length,
+                                         ByteBuf buf) {
+        LedgerEntryImpl entry = RECYCLER.get();
+        entry.ledgerId = ledgerId;
+        entry.entryId = entryId;
+        entry.length = length;
+        entry.entryBuf = buf;
+        return entry;
+    }
+
+    public static LedgerEntryImpl duplicate(LedgerEntry entry) {
+        return create(
+            entry.getLedgerId(),
+            entry.getEntryId(),
+            entry.getLength(),
+            entry.getEntryBuffer().retainedSlice());
+    }
+
+    private final Handle<LedgerEntryImpl> recycleHandle;
+    private long ledgerId;
+    private long entryId;
+    private long length;
+    private ByteBuf entryBuf;
+
+    private LedgerEntryImpl(Handle<LedgerEntryImpl> handle) {
+        this.recycleHandle = handle;
+    }
+
+    public void setEntryId(long entryId) {
+        this.entryId = entryId;
+    }
+
+    public void setLength(long length) {
+        this.length = length;
+    }
+
+    public void setEntryBuf(ByteBuf buf) {
+        this.entryBuf = buf;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getLedgerId() {
+        return ledgerId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getEntryId() {
+        return entryId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getLength() {
+        return length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte[] getEntry() {
+        return ByteBufUtil.getBytes(entryBuf);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ByteBuf getEntryBuffer() {
+        return entryBuf;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LedgerEntryImpl duplicate() {
+        return duplicate(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        recycle();
+    }
+
+    private void recycle() {
+        this.ledgerId = -1L;
+        this.entryId = -1L;
+        this.length = -1L;
+        ReferenceCountUtil.release(entryBuf);
+        this.entryBuf = null;
+        recycleHandle.recycle(this);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -53,7 +53,6 @@ import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
 import org.junit.After;
 import org.junit.Before;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -336,13 +335,13 @@ public abstract class MockBookKeeperTestCase {
                 fencedLedgers.add(ledgerId);
                 MockEntry mockEntry = getMockLedgerEntry(ledgerId, bookieSocketAddress, entryId);
                 if (mockEntry != null) {
-                    LOG.info("readEntryAndFenceLedger - found mock entry {}@{} at {}", ledgerId, entryId, bookieSocketAddress);
+                    LOG.info("readEntryAndFenceLedger - found mock entry {}@{} at {}", entryId, ledgerId, bookieSocketAddress);
                     ByteBuf entry = macManager.computeDigestAndPackageForSending(entryId, mockEntry.lastAddConfirmed,
                         mockEntry.payload.length, Unpooled.wrappedBuffer(mockEntry.payload));
                     callback.readEntryComplete(BKException.Code.OK, ledgerId, entryId, Unpooled.copiedBuffer(entry), args[5]);
                     entry.release();
                 } else {
-                    LOG.info("readEntryAndFenceLedger - no such mock entry {}@{} at {}", ledgerId, entryId, bookieSocketAddress);
+                    LOG.info("readEntryAndFenceLedger - no such mock entry {}@{} at {}", entryId, ledgerId, bookieSocketAddress);
                     callback.readEntryComplete(BKException.Code.NoSuchEntryException, ledgerId, entryId, null, args[5]);
                 }
             });
@@ -361,13 +360,13 @@ public abstract class MockBookKeeperTestCase {
                 DigestManager macManager = new CRC32DigestManager(ledgerId);
                 MockEntry mockEntry = getMockLedgerEntry(ledgerId, bookieSocketAddress, entryId);
                 if (mockEntry != null) {
-                    LOG.info("readEntry - found mock entry {}@{} at {}", ledgerId, entryId, bookieSocketAddress);
+                    LOG.info("readEntry - found mock entry {}@{} at {}", entryId, ledgerId, bookieSocketAddress);
                     ByteBuf entry = macManager.computeDigestAndPackageForSending(entryId,
                         mockEntry.lastAddConfirmed, mockEntry.payload.length, Unpooled.wrappedBuffer(mockEntry.payload));
                     callback.readEntryComplete(BKException.Code.OK, ledgerId, entryId, Unpooled.copiedBuffer(entry), args[4]);
                     entry.release();
                 } else {
-                    LOG.info("readEntry - no such mock entry {}@{} at {}", ledgerId, entryId, bookieSocketAddress);
+                    LOG.info("readEntry - no such mock entry {}@{} at {}", entryId, ledgerId, bookieSocketAddress);
                     callback.readEntryComplete(BKException.Code.NoSuchEntryException, ledgerId, entryId, null, args[4]);
                 }
             });

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
@@ -20,23 +20,26 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * Unit tests for parallel reading
@@ -63,39 +66,6 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         return lh.getId();
     }
 
-    static class LatchCallback implements ReadCallback {
-
-        final CountDownLatch l = new CountDownLatch(1);
-        int rc = -0x1314;
-        Enumeration<LedgerEntry> entries;
-
-        Enumeration<LedgerEntry> getEntries() {
-            return entries;
-        }
-
-        int getRc() {
-            return rc;
-        }
-
-        @Override
-        public void readComplete(int rc, LedgerHandle lh, Enumeration<LedgerEntry> seq, Object ctx) {
-            this.rc = rc;
-            this.entries = seq;
-            l.countDown();
-        }
-
-        void expectSuccess() throws Exception {
-            l.await();
-            assertTrue(BKException.Code.OK == rc);
-        }
-
-        void expectFail() throws Exception {
-            l.await();
-            assertFalse(BKException.Code.OK == rc);
-        }
-
-    }
-
     @Test
     public void testNormalParallelRead() throws Exception {
         int numEntries = 10;
@@ -105,39 +75,50 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
 
         // read single entry
         for (int i = 0; i < numEntries; i++) {
-            LatchCallback latch = new LatchCallback();
             PendingReadOp readOp =
-                    new PendingReadOp(lh, lh.bk.scheduler, i, i, latch, null);
-            readOp.parallelRead(true).initiate();
-            latch.expectSuccess();
-            Enumeration<LedgerEntry> entries = latch.getEntries();
-            assertNotNull(entries);
-            assertTrue(entries.hasMoreElements());
-            LedgerEntry entry = entries.nextElement();
+                    new PendingReadOp(lh, lh.bk.scheduler, i, i);
+            readOp.parallelRead(true).submit();
+            Iterable<LedgerEntry> iterable = readOp.future().get();
+            assertNotNull(iterable);
+            Iterator<LedgerEntry> entries = iterable.iterator();
+            assertTrue(entries.hasNext());
+            LedgerEntry entry = entries.next();
             assertNotNull(entry);
             assertEquals(i, Integer.parseInt(new String(entry.getEntry())));
-            assertFalse(entries.hasMoreElements());
+            entry.close();
+            assertFalse(entries.hasNext());
         }
 
         // read multiple entries
-        LatchCallback latch = new LatchCallback();
         PendingReadOp readOp =
-                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, latch, null);
-        readOp.parallelRead(true).initiate();
-        latch.expectSuccess();
-        Enumeration<LedgerEntry> entries = latch.getEntries();
-        assertNotNull(entries);
+                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1);
+        readOp.parallelRead(true).submit();
+        Iterable<LedgerEntry> iterable = readOp.future().get();
+        assertNotNull(iterable);
+        Iterator<LedgerEntry> iterator = iterable.iterator();
 
         int numReads = 0;
-        while (entries.hasMoreElements()) {
-            LedgerEntry entry = entries.nextElement();
+        while (iterator.hasNext()) {
+            LedgerEntry entry = iterator.next();
             assertNotNull(entry);
             assertEquals(numReads, Integer.parseInt(new String(entry.getEntry())));
+            entry.close();
             ++numReads;
         }
         assertEquals(numEntries, numReads);
 
         lh.close();
+    }
+
+    private static <T> void expectFail(CompletableFuture<T> future, int expectedRc) {
+        try {
+            result(future);
+            fail("Expect to fail");
+        } catch (Exception e) {
+            assertTrue(e instanceof BKException);
+            BKException bke = (BKException) e;
+            assertEquals(expectedRc, bke.getCode());
+        }
     }
 
     @Test
@@ -148,19 +129,15 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
 
         // read single entry
-        LatchCallback latch = new LatchCallback();
         PendingReadOp readOp =
-                new PendingReadOp(lh, lh.bk.scheduler, 11, 11, latch, null);
-        readOp.parallelRead(true).initiate();
-        latch.expectFail();
-        assertEquals(BKException.Code.NoSuchEntryException, latch.getRc());
+                new PendingReadOp(lh, lh.bk.scheduler, 11, 11);
+        readOp.parallelRead(true).submit();
+        expectFail(readOp.future(), Code.NoSuchEntryException);
 
         // read multiple entries
-        latch = new LatchCallback();
-        readOp = new PendingReadOp(lh, lh.bk.scheduler, 8, 11, latch, null);
-        readOp.parallelRead(true).initiate();
-        latch.expectFail();
-        assertEquals(BKException.Code.NoSuchEntryException, latch.getRc());
+        readOp = new PendingReadOp(lh, lh.bk.scheduler, 8, 11);
+        readOp.parallelRead(true).submit();
+        expectFail(readOp.future(), Code.NoSuchEntryException);
 
         lh.close();
     }
@@ -186,13 +163,11 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         sleepBookie(ensemble.get(0), latch1);
         sleepBookie(ensemble.get(1), latch2);
 
-        LatchCallback latchCallback = new LatchCallback();
         PendingReadOp readOp =
-                new PendingReadOp(lh, lh.bk.scheduler, 10, 10, latchCallback, null);
-        readOp.parallelRead(true).initiate();
+                new PendingReadOp(lh, lh.bk.scheduler, 10, 10);
+        readOp.parallelRead(true).submit();
         // would fail immediately if found missing entries don't cover ack quorum
-        latchCallback.expectFail();
-        assertEquals(BKException.Code.NoSuchEntryException, latchCallback.getRc());
+        expectFail(readOp.future(), Code.NoSuchEntryException);
         latch1.countDown();
         latch2.countDown();
 
@@ -220,17 +195,16 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         killBookie(ensemble.get(1));
 
         // read multiple entries
-        LatchCallback latch = new LatchCallback();
         PendingReadOp readOp =
-                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, latch, null);
-        readOp.parallelRead(true).initiate();
-        latch.expectSuccess();
-        Enumeration<LedgerEntry> entries = latch.getEntries();
-        assertNotNull(entries);
+                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1);
+        readOp.parallelRead(true).submit();
+        Iterable<LedgerEntry> iterable = readOp.future().get();
+        assertNotNull(iterable);
+        Iterator<LedgerEntry> entries = iterable.iterator();
 
         int numReads = 0;
-        while (entries.hasMoreElements()) {
-            LedgerEntry entry = entries.nextElement();
+        while (entries.hasNext()) {
+            LedgerEntry entry = entries.next();
             assertNotNull(entry);
             assertEquals(numReads, Integer.parseInt(new String(entry.getEntry())));
             ++numReads;
@@ -262,12 +236,10 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         killBookie(ensemble.get(2));
 
         // read multiple entries
-        LatchCallback latch = new LatchCallback();
         PendingReadOp readOp =
-                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, latch, null);
-        readOp.parallelRead(true).initiate();
-        latch.expectFail();
-        assertEquals(BKException.Code.BookieHandleNotAvailableException, latch.getRc());
+                new PendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1);
+        readOp.parallelRead(true).submit();
+        expectFail(readOp.future(), Code.BookieHandleNotAvailableException);
 
         lh.close();
         newBk.close();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
@@ -20,6 +20,10 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Enumeration;
@@ -33,8 +37,6 @@ import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.*;
 
 /**
  * This unit test tests ledger fencing;
@@ -292,9 +294,7 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
         secondHostOnly.set(1, true);
         PendingReadOp.LedgerEntryRequest req0 = null, req2 = null, req4 = null;
         try {
-            LatchCallback latch0 = new LatchCallback();
-            PendingReadOp op = new PendingReadOp(l, bkspec.scheduler,
-                                                 0, 5, latch0, null);
+            PendingReadOp op = new PendingReadOp(l, bkspec.scheduler, 0, 5);
 
             // if we've already heard from all hosts,
             // we only send the initial read

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
@@ -207,8 +207,9 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
             // test readLastAddConfirmedAndEntry
             LastConfirmedAndEntry lastConfirmedAndEntry =
                 result(reader.readLastAddConfirmedAndEntry(0, 999, false));
-            assertEquals(2, lastConfirmedAndEntry.getLastAddConfirmed().intValue());
+            assertEquals(2L, lastConfirmedAndEntry.getLastAddConfirmed());
             assertArrayEquals(data, lastConfirmedAndEntry.getEntry().getEntry());
+            lastConfirmedAndEntry.close();
         }
     }
 


### PR DESCRIPTION
In LedgerEntry interface, getEntry() and getEntryBuffer() have completely different behaviours. getEntry() releases bytebuf automatically, while getEntryBuffer() returns the bytebuf (if you don't call getEntry, you are responsible for releasing the entry buffer.

In this change:
make getEntry() reenter-able; make LedgerEntry implement AutoCloseable; LedgerEntry is responsible for releasing the bytebuf it is holding.

Descriptions of the changes in this PR:
1.  add `close` and `duplicate` in `api.LedgerEntry`,
1.  LedgerEntryImpl implements `api.LedgerEntry`,
1.  client.LedgerEntry doesn't implement the new api. it wraps an `api.LedgerEntry`,  
1.  add `close` in api.LastConfirmedAndEntry."
1.  fix build and test errors.

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
> 
> - [x] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [x] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [x] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
