### PR TITLE
Issue 747: Reorder releases menu - 4.5.1 should appear before 4.5.0

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -10,8 +10,8 @@ twitter_url: https://twitter.com/asfbookkeeper
 livereload: true
 
 versions:
-- "4.5.0"
 - "4.5.1"
+- "4.5.0"
 # [next_version_placehodler]
 
 archived_versions:
@@ -29,7 +29,7 @@ archived_versions:
 latest_version: "4.6.0-SNAPSHOT"
 latest_release: "4.5.1"
 stable_release: "4.5.0"
-distributedlog_version: "2.1.0-0.4.0"
+distributedlog_version: "0.5.0"
 
 defaults:
 - scope:

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -10,9 +10,9 @@ twitter_url: https://twitter.com/asfbookkeeper
 livereload: true
 
 versions:
+# [next_version_placehodler]
 - "4.5.1"
 - "4.5.0"
-# [next_version_placehodler]
 
 archived_versions:
 - "4.4.0"


### PR DESCRIPTION
Descriptions of the changes in this PR:

- 4.5.1 should appear before 4.5.0
- bump dlog version to 0.5.0
