### PR TITLE
Issue #753: Allow option to disable data sync on journal

### DIFF
--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -296,6 +296,10 @@ journalDirectory=/tmp/bk-txn
 # Should we remove pages from page cache after force write
 # journalRemoveFromPageCache=false
 
+# Should the data be fsynced on journal before acknowledgment
+# Default is 'true'
+# journalSyncData=true
+
 # Should we group journal force writes, which optimize group commit
 # for higher throughput
 # journalAdaptiveGroupWrites=true

--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -296,8 +296,12 @@ journalDirectory=/tmp/bk-txn
 # Should we remove pages from page cache after force write
 # journalRemoveFromPageCache=false
 
-# Should the data be fsynced on journal before acknowledgment
-# Default is 'true'
+# Should the data be fsynced on journal before acknowledgment.
+# By default, data sync is enabled to guarantee durability of writes.
+# Beware: while disabling data sync in the Bookie journal might improve the bookie write performance, it will also
+# introduce the possibility of data loss. With no sync, the journal entries are written in the OS page cache but
+# not flushed to disk. In case of power failure, the affected bookie might lose the unflushed data. If the ledger
+# is replicated to multiple bookies, the chances of data loss are reduced though still present.
 # journalSyncData=true
 
 # Should we group journal force writes, which optimize group commit

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -1549,9 +1549,17 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Enable or disable journal syncs
+     * Enable or disable journal syncs.
+     * <p>
+     * By default, data sync is enabled to guarantee durability of writes.
+     * <p>
+     * Beware: while disabling data sync in the Bookie journal might improve the bookie write performance, it will also
+     * introduce the possibility of data loss. With no sync, the journal entries are written in the OS page cache but
+     * not flushed to disk. In case of power failure, the affected bookie might lose the unflushed data. If the ledger
+     * is replicated to multiple bookies, the chances of data loss are reduced though still present.
      *
-     * @param syncData whether to sync data on disk before acknowledgement
+     * @param syncData
+     *            whether to sync data on disk before acknowledgement
      * @return server configuration object
      */
     public ServerConfiguration setJournalSyncData(boolean syncData) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -71,6 +71,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     // Journal Parameters
     protected final static String MAX_JOURNAL_SIZE = "journalMaxSizeMB";
     protected final static String MAX_BACKUP_JOURNALS = "journalMaxBackups";
+    protected final static String JOURNAL_SYNC_DATA = "journalSyncData";
     protected final static String JOURNAL_ADAPTIVE_GROUP_WRITES = "journalAdaptiveGroupWrites";
     protected final static String JOURNAL_MAX_GROUP_WAIT_MSEC = "journalMaxGroupWaitMSec";
     protected final static String JOURNAL_BUFFERED_WRITES_THRESHOLD = "journalBufferedWritesThreshold";
@@ -1534,6 +1535,28 @@ public class ServerConfiguration extends AbstractConfiguration {
      */
     public int getSkipListArenaMaxAllocSize() {
         return getInt(SKIP_LIST_MAX_ALLOC_ENTRY, 128 * 1024);
+    }
+
+    /**
+     * Should the data be fsynced on journal before acknowledgment
+     *
+     * Default is true
+     *
+     * @return
+     */
+    public boolean getJournalSyncData() {
+        return getBoolean(JOURNAL_SYNC_DATA, true);
+    }
+
+    /**
+     * Enable or disable journal syncs
+     *
+     * @param syncData whether to sync data on disk before acknowledgement
+     * @return server configuration object
+     */
+    public ServerConfiguration setJournalSyncData(boolean syncData) {
+        setProperty(JOURNAL_SYNC_DATA, syncData);
+        return this;
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalNoSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalNoSyncTest.java
@@ -1,0 +1,63 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import java.util.Enumeration;
+
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BookieJournalNoSyncTest extends BookKeeperClusterTestCase {
+
+    public BookieJournalNoSyncTest() {
+        super(1);
+
+        baseConf.setJournalSyncData(false);
+    }
+
+    @Test
+    public void testWriteToJournal() throws Exception {
+        LedgerHandle lh = bkc.createLedger(1, 1, DigestType.CRC32, new byte[0]);
+
+        int N = 10;
+
+        long ledgerId = lh.getId();
+
+        for (int i = 0; i < N; i++) {
+            lh.addEntry(("entry-" + i).getBytes());
+        }
+
+        restartBookies();
+
+        LedgerHandle readLh = bkc.openLedger(ledgerId, DigestType.CRC32, new byte[0]);
+
+        Enumeration<LedgerEntry> entries = readLh.readEntries(0, N - 1);
+        for (int i = 0; i < N; i++) {
+            LedgerEntry entry = entries.nextElement();
+            Assert.assertEquals("entry-" + i, new String(entry.getEntry()));
+        }
+    }
+
+}


### PR DESCRIPTION
Context in #753 

For deployments where a RAID battery-backed cache is not available and where durability is not a requirements, we should allow bookies to rely on page cache and relax durability.