### PR TITLE
Issue 763: Javadoc layout should reflect new modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,14 +244,18 @@
               <packages>org.apache.bookkeeper.client:org.apache.bookkeeper.common.annotation:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature</packages>
             </group>
             <group>
+              <title>Bookkeeper Client (New Fluent API - Experimental)</title>
+              <packages>org.apache.bookkeeper.client.api</packages>
+            </group>
+            <group>
               <title>Bookkeeper Stats API</title>
-              <!-- currently codahale and prometheus are placed under `stats` package unfortunately.
-                   we might consider rename them to their own packages in future. -->
+              <!-- currently codahale is placed under `stats` package unfortunately.
+                   we might consider rename them to their own packages in future. {@link https://github.com/apache/bookkeeper/issues/762} -->
               <packages>org.apache.bookkeeper.stats</packages>
             </group>
             <group>
               <title>Bookkeeper Stats Providers</title>
-              <packages>org.apache.bookkeeper.stats.twitter.finagle:org.apache.bookkeeper.stats.twitter.ostrich:org.apache.bookkeeper.stats.twitter.science</packages>
+              <packages>org.apache.bookkeeper.stats.twitter.finagle:org.apache.bookkeeper.stats.twitter.ostrich:org.apache.bookkeeper.stats.twitter.science:org.apache.bookkeeper.stats.prometheus</packages>
             </group>
           </groups>
           <doctitle>BookKeeper Java API (version ${project.version})</doctitle>


### PR DESCRIPTION
Descriptions of the changes in this PR:

- add `org.apache.bookkeeper.client.api` in `BookKeeper Client (New Fluent API - Experimental)`
- move prometheus package to `BookKeeper Stats Providers`
