### PR TITLE
Don't require password to create or open ledgers

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -222,7 +222,7 @@ class LedgerCreateOp implements GenericCallback<Void> {
         private int builderEnsembleSize = 3;
         private int builderAckQuorumSize = 2;
         private int builderWriteQuorumSize = 2;
-        private byte[] builderPassword;
+        private byte[] builderPassword = new byte[0];
         private org.apache.bookkeeper.client.api.DigestType builderDigestType
             = org.apache.bookkeeper.client.api.DigestType.CRC32;
         private Map<String, byte[]> builderCustomMetadata = Collections.emptyMap();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -220,7 +220,7 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
 
         private boolean builderRecovery = false;
         private Long builderLedgerId;
-        private byte[] builderPassword;
+        private byte[] builderPassword = new byte[0];
         private org.apache.bookkeeper.client.api.DigestType builderDigestType
                 = org.apache.bookkeeper.client.api.DigestType.CRC32;
         private final BookKeeper bk;


### PR DESCRIPTION
The new fluent api shouldn't require a password to create or open a
ledger. The password is only an extra check to avoid accidentally
overwriting data, and the scenarios where this would happen are very
rare, so it's of limited utility. It's not security.
