### PR TITLE
Explicitly search for bookkeeper-server jar

### DIFF
--- a/bookkeeper-server/bin/bookkeeper
+++ b/bookkeeper-server/bin/bookkeeper
@@ -71,18 +71,18 @@ else
 fi
 
 # exclude tests jar
-RELEASE_JAR=$(ls ${BK_HOME}/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1)
+RELEASE_JAR=$(ls ${BK_HOME}/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | grep -v sources | tail -1)
 if [ -n "${RELEASE_JAR}" ]; then
   BOOKIE_JAR=${RELEASE_JAR}
 else
-  RELEASE_JAR=$(ls ${BK_HOME}/lib/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1)
+  RELEASE_JAR=$(ls ${BK_HOME}/lib/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | grep -v sources | tail -1)
   if [ -n "${RELEASE_JAR}" ]; then
     BOOKIE_JAR=${RELEASE_JAR}
   fi
 fi
 
 # exclude tests jar
-BUILT_JAR=$(ls ${BK_HOME}/target/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1)
+BUILT_JAR=$(ls ${BK_HOME}/target/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | grep -v sources | tail -1)
 
 if [ -z "${BUILT_JAR}" ] && [ -z "${BOOKIE_JAR}" ]; then
   echo "Couldn't find bookkeeper jar."

--- a/bookkeeper-server/bin/bookkeeper
+++ b/bookkeeper-server/bin/bookkeeper
@@ -70,19 +70,28 @@ else
   JAVA=$JAVA_HOME/bin/java
 fi
 
-# exclude tests jar
-RELEASE_JAR=$(ls ${BK_HOME}/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | grep -v sources | tail -1)
+find-server-jar() {
+  DIR=$1
+  cd $DIR
+  for f in *.jar; do
+    if [[ $f =~ ^bookkeeper-server-[0-9\\.]*(-SNAPSHOT)?.jar$ ]]; then
+      echo $DIR/$f
+        return
+    fi
+  done
+}
+
+RELEASE_JAR=$(find-server-jar ${BK_HOME})
 if [ -n "${RELEASE_JAR}" ]; then
   BOOKIE_JAR=${RELEASE_JAR}
 else
-  RELEASE_JAR=$(ls ${BK_HOME}/lib/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | grep -v sources | tail -1)
+  RELEASE_JAR=$(find-server-jar ${BK_HOME}/lib)
   if [ -n "${RELEASE_JAR}" ]; then
     BOOKIE_JAR=${RELEASE_JAR}
   fi
 fi
 
-# exclude tests jar
-BUILT_JAR=$(ls ${BK_HOME}/target/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | grep -v sources | tail -1)
+BUILT_JAR=$(find-server-jar ${BK_HOME}/target)
 
 if [ -z "${BUILT_JAR}" ] && [ -z "${BOOKIE_JAR}" ]; then
   echo "Couldn't find bookkeeper jar."
@@ -96,7 +105,7 @@ if [ -z "${BUILT_JAR}" ] && [ -z "${BOOKIE_JAR}" ]; then
       ;;
   esac
 
-  BUILT_JAR=$(ls ${BK_HOME}/target/*bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1)
+  BUILT_JAR=$(find-server-jar ${BK_HOME}/target)
   if [ -n "${BUILT_JAR}" ]; then
     BOOKIE_JAR=$BUILT_JAR
   fi


### PR DESCRIPTION
Rather than listing all jars, and excluding some exceptions, search for
jars which match a specific pattern, namely:

  bookkeeper-server-[version].jar

Where [version] may include numbers, dots and optionally -SNAPSHOT.

