### PR TITLE
Shade bookkeeper-common into bookkeeper-server

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -210,6 +210,7 @@
               <shadeTestJar>true</shadeTestJar>
               <artifactSet>
                 <includes>
+                  <include>org.apache.bookkeeper:bookkeeper-common</include>
                   <include>org.apache.bookkeeper:bookkeeper-proto</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>com.google.guava:guava</include>


### PR DESCRIPTION
bookkeeper-server extends some interfaces from bookkeeper-common which
in turn use guava. As guava is shaded and relocated, we need to shade
the common module also, so that it can find the guava classes.

I hit this problem running localbookie from a locally build source directory. The write path worked fine, but it triggered a NoSuchMethod exception when trying to read a ledger.