### PR TITLE
Open should run recovery by default

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -218,7 +218,7 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
 
     static final class OpenBuilderImpl implements OpenBuilder {
 
-        private boolean builderRecovery = false;
+        private boolean builderRecovery = true;
         private Long builderLedgerId;
         private byte[] builderPassword;
         private org.apache.bookkeeper.client.api.DigestType builderDigestType

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/OpenBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/OpenBuilder.java
@@ -44,7 +44,7 @@ public interface OpenBuilder extends OpBuilder<ReadHandle> {
 
     /**
      * Define to open the ledger in recovery mode or in readonly mode. In recovery mode the ledger will be fenced and
-     * the writer of the ledger will be prevented from issuing other writes to the ledger. It defaults to 'false'
+     * the writer of the ledger will be prevented from issuing other writes to the ledger. It defaults to 'true'
      *
      * @param recovery recovery mode
      *


### PR DESCRIPTION
This is how it has always been and is the safer option. Non-recovery
open is for tailing, which isn't the primary usecase for open. The
primary usecase is to recover state before writing new state, and this
requires that we fence and recover the ledger.
