### PR TITLE
Tests wait for client to see started bookie

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -497,13 +497,13 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                     .setNameFormat("BKClientMetaDataPollScheduler-%d");
             this.bookieInfoScheduler = Executors.newSingleThreadScheduledExecutor(tFBuilder.build());
             this.bookieInfoReader = new BookieInfoReader(this, conf, this.bookieInfoScheduler);
-            this.bookieWatcher.readBookiesBlocking();
+            this.bookieWatcher.initialBlockingBookieRead();
             this.bookieInfoReader.start();
         } else {
             LOG.info("Weighted ledger placement is not enabled");
             this.bookieInfoScheduler = null;
             this.bookieInfoReader = new BookieInfoReader(this, conf, null);
-            this.bookieWatcher.readBookiesBlocking();
+            this.bookieWatcher.initialBlockingBookieRead();
         }
 
         // initialize ledger manager

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcher.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcher.java
@@ -146,8 +146,8 @@ class BookieWatcher {
         CompletableFuture<?> writable;
         CompletableFuture<?> readonly;
         synchronized (this) {
-            if (initialReadonlyBookiesFuture == null
-                && initialWritableBookiesFuture == null) {
+            if (initialReadonlyBookiesFuture == null) {
+                assert initialWritableBookiesFuture == null;
 
                 writable = this.registrationClient.watchWritableBookies(
                             bookies -> processWritableBookiesChanged(bookies.getValue()));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationClient.java
@@ -87,8 +87,10 @@ public interface RegistrationClient extends AutoCloseable {
      * <p>The topology changes of bookies will be propagated to the provided <i>listener</i>.
      *
      * @param listener listener to receive the topology changes of bookies.
+     * @return a future which completes when the bookies have been read for
+     *         the first time
      */
-    void watchWritableBookies(RegistrationListener listener);
+    CompletableFuture<?> watchWritableBookies(RegistrationListener listener);
 
     /**
      * Unwatch the changes of bookies.
@@ -103,8 +105,10 @@ public interface RegistrationClient extends AutoCloseable {
      * <p>The topology changes of bookies will be propagated to the provided <i>listener</i>.
      *
      * @param listener listener to receive the topology changes of bookies.
+     * @return a future which completes when the bookies have been read for
+     *         the first time
      */
-    void watchReadOnlyBookies(RegistrationListener listener);
+    CompletableFuture<?> watchReadOnlyBookies(RegistrationListener listener);
 
     /**
      * Unwatch the changes of bookies.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationClient.java
@@ -90,7 +90,7 @@ public interface RegistrationClient extends AutoCloseable {
      * @return a future which completes when the bookies have been read for
      *         the first time
      */
-    CompletableFuture<?> watchWritableBookies(RegistrationListener listener);
+    CompletableFuture<Void> watchWritableBookies(RegistrationListener listener);
 
     /**
      * Unwatch the changes of bookies.
@@ -108,7 +108,7 @@ public interface RegistrationClient extends AutoCloseable {
      * @return a future which completes when the bookies have been read for
      *         the first time
      */
-    CompletableFuture<?> watchReadOnlyBookies(RegistrationListener listener);
+    CompletableFuture<Void> watchReadOnlyBookies(RegistrationListener listener);
 
     /**
      * Unwatch the changes of bookies.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -77,10 +77,9 @@ public class ZKRegistrationClient implements RegistrationClient {
         private boolean closed = false;
         private Set<BookieSocketAddress> bookies = null;
         private Version version = Version.NEW;
-        private final CompletableFuture<Set<BookieSocketAddress>> firstRunFuture;
+        private final CompletableFuture<Void> firstRunFuture;
 
-        WatchTask(String regPath,
-                  CompletableFuture<Set<BookieSocketAddress>> firstRunFuture) {
+        WatchTask(String regPath, CompletableFuture<Void> firstRunFuture) {
             this.regPath = regPath;
             this.listeners = new CopyOnWriteArraySet<>();
             this.firstRunFuture = firstRunFuture;
@@ -145,7 +144,7 @@ public class ZKRegistrationClient implements RegistrationClient {
                     listener.onBookiesChanged(bookieSet);
                 }
             }
-            firstRunFuture.complete(bookieSet.getValue());
+            FutureUtils.complete(firstRunFuture, null);
         }
 
         @Override
@@ -283,7 +282,7 @@ public class ZKRegistrationClient implements RegistrationClient {
 
     @Override
     public synchronized CompletableFuture<?> watchWritableBookies(RegistrationListener listener) {
-        CompletableFuture<Set<BookieSocketAddress>> f = new CompletableFuture<>();
+        CompletableFuture<Void> f = new CompletableFuture<>();
         if (null == watchWritableBookiesTask) {
             watchWritableBookiesTask = new WatchTask(bookieRegistrationPath, f);
         }
@@ -310,7 +309,7 @@ public class ZKRegistrationClient implements RegistrationClient {
 
     @Override
     public synchronized CompletableFuture<?> watchReadOnlyBookies(RegistrationListener listener) {
-        CompletableFuture<Set<BookieSocketAddress>> f = new CompletableFuture<>();
+        CompletableFuture<Void> f = new CompletableFuture<>();
         if (null == watchReadOnlyBookiesTask) {
             watchReadOnlyBookiesTask = new WatchTask(bookieReadonlyRegistrationPath, f);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -281,7 +281,7 @@ public class ZKRegistrationClient implements RegistrationClient {
 
 
     @Override
-    public synchronized CompletableFuture<?> watchWritableBookies(RegistrationListener listener) {
+    public synchronized CompletableFuture<Void> watchWritableBookies(RegistrationListener listener) {
         CompletableFuture<Void> f = new CompletableFuture<>();
         if (null == watchWritableBookiesTask) {
             watchWritableBookiesTask = new WatchTask(bookieRegistrationPath, f);
@@ -308,7 +308,7 @@ public class ZKRegistrationClient implements RegistrationClient {
     }
 
     @Override
-    public synchronized CompletableFuture<?> watchReadOnlyBookies(RegistrationListener listener) {
+    public synchronized CompletableFuture<Void> watchReadOnlyBookies(RegistrationListener listener) {
         CompletableFuture<Void> f = new CompletableFuture<>();
         if (null == watchReadOnlyBookiesTask) {
             watchReadOnlyBookiesTask = new WatchTask(bookieReadonlyRegistrationPath, f);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -77,9 +77,10 @@ public class ZKRegistrationClient implements RegistrationClient {
         private boolean closed = false;
         private Set<BookieSocketAddress> bookies = null;
         private Version version = Version.NEW;
-        private final CompletableFuture<Void> firstRunFuture;
+        private final CompletableFuture<Set<BookieSocketAddress>> firstRunFuture;
 
-        WatchTask(String regPath, CompletableFuture<Void> firstRunFuture) {
+        WatchTask(String regPath,
+                  CompletableFuture<Set<BookieSocketAddress>> firstRunFuture) {
             this.regPath = regPath;
             this.listeners = new CopyOnWriteArraySet<>();
             this.firstRunFuture = firstRunFuture;
@@ -144,7 +145,7 @@ public class ZKRegistrationClient implements RegistrationClient {
                     listener.onBookiesChanged(bookieSet);
                 }
             }
-            firstRunFuture.complete(null);
+            firstRunFuture.complete(bookieSet.getValue());
         }
 
         @Override
@@ -282,7 +283,7 @@ public class ZKRegistrationClient implements RegistrationClient {
 
     @Override
     public synchronized CompletableFuture<?> watchWritableBookies(RegistrationListener listener) {
-        CompletableFuture<Void> f = new CompletableFuture<>();
+        CompletableFuture<Set<BookieSocketAddress>> f = new CompletableFuture<>();
         if (null == watchWritableBookiesTask) {
             watchWritableBookiesTask = new WatchTask(bookieRegistrationPath, f);
         }
@@ -309,7 +310,7 @@ public class ZKRegistrationClient implements RegistrationClient {
 
     @Override
     public synchronized CompletableFuture<?> watchReadOnlyBookies(RegistrationListener listener) {
-        CompletableFuture<Void> f = new CompletableFuture<>();
+        CompletableFuture<Set<BookieSocketAddress>> f = new CompletableFuture<>();
         if (null == watchReadOnlyBookiesTask) {
             watchReadOnlyBookiesTask = new WatchTask(bookieReadonlyRegistrationPath, f);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
@@ -23,13 +23,13 @@ package org.apache.bookkeeper.client;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.discover.RegistrationClient.RegistrationListener;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
-import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 
@@ -56,22 +56,12 @@ public class BookKeeperTestClient extends BookKeeper {
         return bookieClient;
     }
 
-    /**
-     * Wait for the bookie to appear in any set
-     */
-    public CompletableFuture<?> waitForBookie(BookieSocketAddress b)
-            throws Exception {
-        return CompletableFuture.anyOf(
-                waitForReadOnlyBookie(b),
-                waitForWritableBookie(b));
-    }
-
-    public CompletableFuture<?> waitForReadOnlyBookie(BookieSocketAddress b)
+    public Future<?> waitForReadOnlyBookie(BookieSocketAddress b)
             throws Exception {
         return waitForBookieInSet(b, false);
     }
 
-    public CompletableFuture<?> waitForWritableBookie(BookieSocketAddress b)
+    public Future<?> waitForWritableBookie(BookieSocketAddress b)
             throws Exception {
         return waitForBookieInSet(b, true);
     }
@@ -81,7 +71,7 @@ public class BookKeeperTestClient extends BookKeeper {
      * or the read only set of bookies. Also ensure that it doesn't exist
      * in the other set before completing.
      */
-    private CompletableFuture<?> waitForBookieInSet(BookieSocketAddress b,
+    private Future<?> waitForBookieInSet(BookieSocketAddress b,
                                                        boolean writable) {
         log.info("Wait for {} to become {}",
                  b, writable ? "writable" : "readonly");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
@@ -22,8 +22,14 @@ package org.apache.bookkeeper.client;
  */
 
 import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.discover.RegistrationClient.RegistrationListener;
+import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
+import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 
@@ -31,6 +37,7 @@ import org.apache.zookeeper.ZooKeeper;
  * Test BookKeeperClient which allows access to members we don't
  * wish to expose in the public API.
  */
+@Slf4j
 public class BookKeeperTestClient extends BookKeeper {
     public BookKeeperTestClient(ClientConfiguration conf)
             throws IOException, InterruptedException, BKException {
@@ -50,13 +57,53 @@ public class BookKeeperTestClient extends BookKeeper {
     }
 
     /**
-     * Force a read to zookeeper to get list of bookies.
-     *
-     * @throws InterruptedException
-     * @throws KeeperException
+     * Wait for the bookie to appear in any set
      */
-    public void readBookiesBlocking()
-            throws InterruptedException, BKException {
-        bookieWatcher.readBookiesBlocking();
+    public CompletableFuture<?> waitForBookie(BookieSocketAddress b)
+            throws Exception {
+        return CompletableFuture.anyOf(
+                waitForReadOnlyBookie(b),
+                waitForWritableBookie(b));
+    }
+
+    public CompletableFuture<?> waitForReadOnlyBookie(BookieSocketAddress b)
+            throws Exception {
+        return waitForBookieInSet(b, false);
+    }
+
+    public CompletableFuture<?> waitForWritableBookie(BookieSocketAddress b)
+            throws Exception {
+        return waitForBookieInSet(b, true);
+    }
+
+    /**
+     * Wait for bookie to appear in either the writable set of bookies,
+     * or the read only set of bookies. Also ensure that it doesn't exist
+     * in the other set before completing.
+     */
+    private CompletableFuture<?> waitForBookieInSet(BookieSocketAddress b,
+                                                       boolean writable) {
+        log.info("Wait for {} to become {}",
+                 b, writable ? "writable" : "readonly");
+
+        CompletableFuture<Void> readOnlyFuture = new CompletableFuture<>();
+        CompletableFuture<Void> writableFuture = new CompletableFuture<>();
+
+        RegistrationListener readOnlyListener = (bookies) -> {
+            boolean contains = bookies.getValue().contains(b);
+            if ((!writable && contains) || (writable && !contains)) {
+                readOnlyFuture.complete(null);
+            }
+        };
+        RegistrationListener writableListener = (bookies) -> {
+            boolean contains = bookies.getValue().contains(b);
+            if ((writable && contains) || (!writable && !contains)) {
+                writableFuture.complete(null);
+            }
+        };
+
+        regClient.watchWritableBookies(writableListener);
+        regClient.watchReadOnlyBookies(readOnlyListener);
+        return CompletableFuture.allOf(writableFuture, readOnlyFuture);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -563,12 +563,15 @@ public abstract class BookKeeperClusterTestCase {
         if (bkc == null) {
             bkc = new BookKeeperTestClient(baseClientConf);
         }
-        Future<?> waitForBookie = bkc.waitForBookie(address);
+
+        Future<?> waitForBookie = conf.isForceReadOnlyBookie()
+            ? bkc.waitForReadOnlyBookie(address)
+            : bkc.waitForWritableBookie(address);
 
         server.start();
 
         waitForBookie.get(30, TimeUnit.SECONDS);
-        LOG.info("New bookie, {}, has been created.", address);
+        LOG.info("New bookie '{}' has been created.", address);
 
         try {
             startAutoRecovery(server, conf);
@@ -597,12 +600,14 @@ public abstract class BookKeeperClusterTestCase {
         if (bkc == null) {
             bkc = new BookKeeperTestClient(baseClientConf);
         }
-        Future<?> waitForBookie = bkc.waitForBookie(address);
+        Future<?> waitForBookie = conf.isForceReadOnlyBookie()
+            ? bkc.waitForReadOnlyBookie(address)
+            : bkc.waitForWritableBookie(address);
 
         server.start();
 
         waitForBookie.get(30, TimeUnit.SECONDS);
-        LOG.info("New bookie, {}, has been created.", address);
+        LOG.info("New bookie '{}' has been created.", address);
 
         try {
             startAutoRecovery(server, conf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.bookie.Bookie;
@@ -558,26 +559,16 @@ public abstract class BookKeeperClusterTestCase {
     protected BookieServer startBookie(ServerConfiguration conf)
             throws Exception {
         BookieServer server = new BookieServer(conf);
-        server.start();
-
+        BookieSocketAddress address = Bookie.getBookieAddress(conf);
         if (bkc == null) {
             bkc = new BookKeeperTestClient(baseClientConf);
         }
+        Future<?> waitForBookie = bkc.waitForBookie(address);
 
-        int port = conf.getBookiePort();
-        String host = InetAddress.getLocalHost().getHostAddress();
-        if (conf.getUseHostNameAsBookieID()) {
-            host = InetAddress.getLocalHost().getCanonicalHostName();
-        }
-        
-        while (conf.isForceReadOnlyBookie()
-            && bkc.getZkHandle().exists(conf.getZkLedgersRootPath() +"/available/readonly/" + host + ":" + port,
-            false) == null) {
-            Thread.sleep(100);
-        }
+        server.start();
 
-        bkc.readBookiesBlocking();
-        LOG.info("New bookie on port " + port + " has been created.");
+        waitForBookie.get(30, TimeUnit.SECONDS);
+        LOG.info("New bookie, {}, has been created.", address);
 
         try {
             startAutoRecovery(server, conf);
@@ -601,24 +592,18 @@ public abstract class BookKeeperClusterTestCase {
                 return b;
             }
         };
-        server.start();
 
+        BookieSocketAddress address = Bookie.getBookieAddress(conf);
         if (bkc == null) {
             bkc = new BookKeeperTestClient(baseClientConf);
         }
+        Future<?> waitForBookie = bkc.waitForBookie(address);
 
-        int port = conf.getBookiePort();
-        String host = InetAddress.getLocalHost().getHostAddress();
-        if (conf.getUseHostNameAsBookieID()) {
-            host = InetAddress.getLocalHost().getCanonicalHostName();
-        }
-        while (bkc.getZkHandle().exists(
-                conf.getZkLedgersRootPath() + "/available/" + host + ":" + port, false) == null) {
-            Thread.sleep(500);
-        }
+        server.start();
 
-        bkc.readBookiesBlocking();
-        LOG.info("New bookie on port " + port + " has been created.");
+        waitForBookie.get(30, TimeUnit.SECONDS);
+        LOG.info("New bookie, {}, has been created.", address);
+
         try {
             startAutoRecovery(server, conf);
         } catch (CompatibilityException ce) {


### PR DESCRIPTION
Up until now we were only waiting for the bookie to exist in the
bookie list, after which we triggered a read. However, when the
registration changes went in, the read wasn't actually populating the
mechanism used to select bookies, so we ended up momentarily having
unusable bookkeeper clients until the correct read triggered. This
resulted in flakiness in random tests.

This change makes it so we wait until the client has seen a bookie
before startBookie will return. It also makes sure that reading the
bookie list actually populates the bookie selection mechanism.