### PR TITLE
Issue 230: Enable Checkstyle on the tls package

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityException.java
@@ -17,6 +17,9 @@
  */
 package org.apache.bookkeeper.tls;
 
+/**
+ * Signals that a security-related exception has occurred.
+ */
 public class SecurityException extends Exception {
     public SecurityException() {}
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityHandlerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityHandlerFactory.java
@@ -17,19 +17,27 @@
  */
 package org.apache.bookkeeper.tls;
 
-import org.apache.bookkeeper.conf.AbstractConfiguration;
-
 import io.netty.handler.ssl.SslHandler;
 
+import org.apache.bookkeeper.conf.AbstractConfiguration;
+
+/**
+ * A factory to manage the security handlers.
+ */
 public interface SecurityHandlerFactory {
-    public enum NodeType {
+
+    /**
+     * The security handler type.
+     */
+    enum NodeType {
         Unknown,
         Client,
         Server,
     }
 
-    public abstract String getHandlerName();
+    String getHandlerName();
 
-    public abstract void init(NodeType type, AbstractConfiguration conf) throws SecurityException;
-    public SslHandler newTLSHandler();
+    void init(NodeType type, AbstractConfiguration conf) throws SecurityException;
+
+    SslHandler newTLSHandler();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityProviderFactoryFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityProviderFactoryFactory.java
@@ -20,8 +20,11 @@ package org.apache.bookkeeper.tls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A factory to manage security provider factories.
+ */
 public abstract class SecurityProviderFactoryFactory {
-    private final static Logger LOG = LoggerFactory.getLogger(SecurityProviderFactoryFactory.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SecurityProviderFactoryFactory.class);
 
     public static SecurityHandlerFactory getSecurityProviderFactory(String securityHandler)
             throws SecurityException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
@@ -17,13 +17,6 @@
  */
 package org.apache.bookkeeper.tls;
 
-import org.apache.bookkeeper.conf.AbstractConfiguration;
-import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Strings;
 
 import io.netty.buffer.PooledByteBufAllocator;
@@ -46,9 +39,19 @@ import java.security.cert.CertificateException;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 
+import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A factory to manage TLS contexts.
+ */
 public class TLSContextFactory implements SecurityHandlerFactory {
-    private final static Logger LOG = LoggerFactory.getLogger(TLSContextFactory.class);
-    private final static String TLSCONTEXT_HANDLER_NAME = "tls";
+    private static final Logger LOG = LoggerFactory.getLogger(TLSContextFactory.class);
+    private static final String TLSCONTEXT_HANDLER_NAME = "tls";
     private String[] protocols;
     private String[] ciphers;
     private SslContext sslContext;
@@ -148,12 +151,12 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         return SslProvider.JDK;
     }
 
-    private void createClientContext(AbstractConfiguration conf) throws SecurityException, KeyStoreException, NoSuchAlgorithmException,
-            CertificateException, IOException, UnrecoverableKeyException {
+    private void createClientContext(AbstractConfiguration conf) throws SecurityException, KeyStoreException,
+            NoSuchAlgorithmException, CertificateException, IOException, UnrecoverableKeyException {
         final SslContextBuilder sslContextBuilder;
         final ClientConfiguration clientConf;
         final SslProvider provider;
-        final boolean Authentication;
+        final boolean authentication;
 
         KeyManagerFactory kmf = null;
         TrustManagerFactory tmf = null;
@@ -165,12 +168,12 @@ public class TLSContextFactory implements SecurityHandlerFactory {
 
         clientConf = (ClientConfiguration) conf;
         provider = getTLSProvider(clientConf.getTLSProvider());
-        Authentication = clientConf.getTLSClientAuthentication();
+        authentication = clientConf.getTLSClientAuthentication();
 
         tmf = initTrustManagerFactory(clientConf.getTLSTrustStoreType(), clientConf.getTLSTrustStore(),
                 clientConf.getTLSTrustStorePasswordPath());
 
-        if (Authentication) {
+        if (authentication) {
             kmf = initKeyManagerFactory(clientConf.getTLSKeyStoreType(), clientConf.getTLSKeyStore(),
                     clientConf.getTLSKeyStorePasswordPath());
         }
@@ -185,19 +188,19 @@ public class TLSContextFactory implements SecurityHandlerFactory {
                                             .clientAuth(ClientAuth.REQUIRE);
 
         /* if mutual authentication is enabled */
-        if (Authentication) {
+        if (authentication) {
             sslContextBuilder.keyManager(kmf);
         }
 
         sslContext = sslContextBuilder.build();
     }
 
-    private void createServerContext(AbstractConfiguration conf) throws SecurityException, KeyStoreException, NoSuchAlgorithmException,
-            CertificateException, IOException, UnrecoverableKeyException {
+    private void createServerContext(AbstractConfiguration conf) throws SecurityException, KeyStoreException,
+            NoSuchAlgorithmException, CertificateException, IOException, UnrecoverableKeyException {
         final SslContextBuilder sslContextBuilder;
         final ServerConfiguration serverConf;
         final SslProvider provider;
-        final boolean Authentication;
+        final boolean authentication;
 
         KeyManagerFactory kmf = null;
         TrustManagerFactory tmf = null;
@@ -209,12 +212,12 @@ public class TLSContextFactory implements SecurityHandlerFactory {
 
         serverConf = (ServerConfiguration) conf;
         provider = getTLSProvider(serverConf.getTLSProvider());
-        Authentication = serverConf.getTLSClientAuthentication();
+        authentication = serverConf.getTLSClientAuthentication();
 
         kmf = initKeyManagerFactory(serverConf.getTLSKeyStoreType(), serverConf.getTLSKeyStore(),
                 serverConf.getTLSKeyStorePasswordPath());
 
-        if (Authentication) {
+        if (authentication) {
             tmf = initTrustManagerFactory(serverConf.getTLSTrustStoreType(), serverConf.getTLSTrustStore(),
                     serverConf.getTLSTrustStorePasswordPath());
         }
@@ -228,7 +231,7 @@ public class TLSContextFactory implements SecurityHandlerFactory {
                                             .startTls(true);
 
         /* if mutual authentication is enabled */
-        if (Authentication) {
+        if (authentication) {
             sslContextBuilder.trustManager(tmf)
                             .clientAuth(ClientAuth.REQUIRE);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Security and TLS-related classes.
+ */
+package org.apache.bookkeeper.tls;

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -32,7 +32,6 @@
     <suppress checks=".*" files=".*[\\/]replication[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]sasl[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]test[\\/].*"/>
-    <suppress checks=".*" files=".*[\\/]tls[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]util[\\/].*"/>
 
     <!-- suppress all checks in the generated directories -->


### PR DESCRIPTION
This is part of #230 and adds Checkstyle verification to the TLS package in `bookkeeper-server`.


