### PR TITLE
Issue 780:   change BK_statsProviderClass in to NullStatsProvider in Docker file

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -37,10 +37,13 @@ export BK_journalDirectory=${BK_journalDirectory:-${BK_DATA_DIR}/journal}
 export BK_ledgerDirectories=${BK_ledgerDirectories:-${BK_DATA_DIR}/ledgers}
 export BK_indexDirectories=${BK_indexDirectories:-${BK_DATA_DIR}/index}
 
+export BK_statsProviderClass=org.apache.bookkeeper.stats.NullStatsProvider
+
 echo "BK_bookiePort bookie service port is $BK_bookiePort"
 echo "BK_zkServers is $BK_zkServers"
 echo "BK_DATA_DIR is $BK_DATA_DIR"
 echo "BK_CLUSTER_ROOT_PATH is $BK_CLUSTER_ROOT_PATH"
+echo "BK_statsProviderClass is $BK_statsProviderClass"
 
 
 mkdir -p "${BK_journalDirectory}" "${BK_ledgerDirectories}" "${BK_indexDirectories}"


### PR DESCRIPTION
Descriptions of the changes in this PR:
In issue #732, we changed Makefile for Docker:
BK_statsProviderClass=org.apache.bookkeeper.stats.NullStatsProvider
to avoid error:
java.lang.ClassNotFoundException: org.apache.bookkeeper.stats.PrometheusMetricsProvider

The reason is that 4.5.1 doesn't ship the providers, so we hard code it to the null providers.

It is more safe to change the default env in Dockerfile instead of Makefile. So that user use the default 4.5.1 Docker will not meet error.

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
> 
> - [x] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [x] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [x] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
