### PR TITLE
Don't print out redundant JMX notice

### DIFF
--- a/bookkeeper-server/bin/bookkeeper
+++ b/bookkeeper-server/bin/bookkeeper
@@ -40,7 +40,6 @@ fi
 
 if [ "x$JMXDISABLE" = "x" ]
 then
-  echo "JMX enabled by default" >&2
   # for some reason these two options are necessary on jdk6 on Ubuntu
   #   accord to the docs they are not necessary, but otw jconsole cannot
   #   do a local attach


### PR DESCRIPTION
Users don't really care that JMX is enabled by default, so don't print
it out.