### PR TITLE
Issue 784: LedgerEntries#close should not throw checked exception

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -52,5 +52,6 @@ public interface LedgerEntries
     /**
      * Close to release the resources held by this instance.
      */
+    @Override
     void close();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -42,10 +42,15 @@ public interface LedgerEntries
      * Calling this method does not modify the reference count of the ByteBuf in the returned LedgerEntry objects.
      * The caller who calls {@link #iterator()} should make sure that they do not call ByteBuf.release() on the
      * LedgerEntry objects to avoid a double free.
-     * All reference counts will be decremented when the containing LedgerEntries object is closed.
+     * All reference counts will be decremented when the containing LedgerEntries object is closed via {@link #close()}.
      *
      * @return an iterator of LedgerEntry objects
      */
     @Override
     Iterator<LedgerEntry> iterator();
+
+    /**
+     * Close to release the resources held by this instance.
+     */
+    void close();
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

override `close()` in LedgerEntries to make it not throw checked exception.