### PR TITLE
Issue 765: Add `isClosed()` to ReadHandle

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -362,6 +362,11 @@ public class LedgerHandle implements WriteHandle {
         return metadata.isClosed();
     }
 
+    @Override
+    public boolean isSealed() {
+        return isClosed();
+    }
+
     void asyncCloseInternal(final CloseCallback cb, final Object ctx, final int rc) {
         try {
             doAsyncCloseInternal(cb, ctx, rc);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -356,15 +356,11 @@ public class LedgerHandle implements WriteHandle {
     }
 
     /**
-     * Has the ledger been closed?
+     * {@inheritDoc}
      */
+    @Override
     public synchronized boolean isClosed() {
         return metadata.isClosed();
-    }
-
-    @Override
-    public boolean isSealed() {
-        return isClosed();
     }
 
     void asyncCloseInternal(final CloseCallback cb, final Object ctx, final int rc) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
@@ -127,7 +127,7 @@ public interface ReadHandle extends Handle {
      *
      * @return true if the ledger is sealed, otherwise false.
      */
-    boolean isSealed();
+    boolean isClosed();
 
     /**
      * Asynchronous read specific entry and the latest last add confirmed.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
@@ -116,6 +116,20 @@ public interface ReadHandle extends Handle {
     long getLength();
 
     /**
+     * Returns whether the ledger is sealed or not.
+     *
+     * <p>A ledger is sealed when either the client explicitly closes it ({@link WriteHandle#close()} or
+     * {@link WriteAdvHandle#close()}) or another client explicitly open and recovery it
+     * {@link OpenBuilder#withRecovery(boolean)}.
+     *
+     * <p>This method only checks the metadata cached locally. The metadata can be not update-to-date because
+     * the metadata notification is delayed.
+     *
+     * @return true if the ledger is sealed, otherwise false.
+     */
+    boolean isSealed();
+
+    /**
      * Asynchronous read specific entry and the latest last add confirmed.
      * If the next entryId is less than known last add confirmed, the call will read next entry directly.
      * If the next entryId is ahead of known last add confirmed, the call will issue a long poll read

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
@@ -199,7 +199,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
                     .withRecovery(false)
                     .withLedgerId(lId)
                     .execute())) {
-                assertFalse(reader.isSealed());
+                assertFalse(reader.isClosed());
             }
         }
     }
@@ -226,7 +226,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
             .withRecovery(false)
             .withLedgerId(lId)
             .execute())) {
-            assertTrue(reader.isSealed());
+            assertTrue(reader.isClosed());
             assertEquals(2, reader.getLastAddConfirmed());
             assertEquals(3 * data.length, reader.getLength());
             assertEquals(2, result(reader.readLastAddConfirmed()).intValue());
@@ -264,7 +264,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
                 .withRecovery(true)
                 .withLedgerId(lId)
                 .execute())) {
-                assertTrue(reader.isSealed());
+                assertTrue(reader.isClosed());
                 assertEquals(1L, reader.getLastAddConfirmed());
             }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

add `isClosed` to ReadHandle, so distributedlog can use this for implementing readers.