### PR TITLE
ISSUE #230: Enable Checkstyle on the proto package

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BKStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BKStats.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Bookie Server Stats
+ * Bookie Server Stats.
  */
 public class BKStats {
     private static final Logger LOG = LoggerFactory.getLogger(BKStats.class);
@@ -38,7 +38,7 @@ public class BKStats {
     }
 
     /**
-     * A read view of stats, also used in CompositeViewData to expose to JMX
+     * A read view of stats, also used in CompositeViewData to expose to JMX.
      */
     public static class OpStatData {
         private final long maxLatency, minLatency;
@@ -84,10 +84,10 @@ public class BKStats {
     }
 
     /**
-     * Operation Statistics
+     * Operation Statistics.
      */
     public static class OpStats {
-        static final int NUM_BUCKETS = 3*9 + 2;
+        static final int NUM_BUCKETS = 3 * 9 + 2;
 
         long maxLatency = 0;
         long minLatency = Long.MAX_VALUE;
@@ -99,16 +99,16 @@ public class BKStats {
         OpStats() {}
 
         /**
-         * Increment number of failed operations
+         * Increment number of failed operations.
          */
-        synchronized public void incrementFailedOps() {
+        public synchronized void incrementFailedOps() {
             ++numFailedOps;
         }
 
         /**
-         * Update Latency
+         * Update Latency.
          */
-        synchronized public void updateLatency(long latency) {
+        public synchronized void updateLatency(long latency) {
             if (latency < 0) {
                 // less than 0ms . Ideally this should not happen.
                 // We have seen this latency negative in some cases due to the
@@ -127,11 +127,11 @@ public class BKStats {
             }
             int bucket;
             if (latency <= 100) { // less than 100ms
-                bucket = (int)(latency / 10);
+                bucket = (int) (latency / 10);
             } else if (latency <= 1000) { // 100ms ~ 1000ms
-                bucket = 1 * 9 + (int)(latency / 100);
+                bucket = 1 * 9 + (int) (latency / 100);
             } else if (latency <= 10000) { // 1s ~ 10s
-                bucket = 2 * 9 + (int)(latency / 1000);
+                bucket = 2 * 9 + (int) (latency / 1000);
             } else { // more than 10s
                 bucket = 3 * 9 + 1;
             }
@@ -141,7 +141,7 @@ public class BKStats {
         public OpStatData toOpStatData() {
             double avgLatency = numSuccessOps > 0 ? totalLatency / numSuccessOps : 0.0f;
             StringBuilder sb = new StringBuilder();
-            for (int i=0; i<NUM_BUCKETS; i++) {
+            for (int i = 0; i < NUM_BUCKETS; i++) {
                 sb.append(latencyBuckets[i]);
                 if (i != NUM_BUCKETS - 1) {
                     sb.append(',');
@@ -152,7 +152,7 @@ public class BKStats {
         }
 
         /**
-         * Diff with base opstats
+         * Diff with base opstats.
          *
          * @param base
          *        base opstats
@@ -172,10 +172,9 @@ public class BKStats {
         }
 
         /**
-         * Copy stats from other OpStats
+         * Copy stats from other OpStats.
          *
          * @param other other op stats
-         * @return void
          */
         public synchronized void copyOf(OpStats other) {
             this.maxLatency = other.maxLatency;
@@ -196,13 +195,13 @@ public class BKStats {
     OpStats[] stats = new OpStats[NUM_STATS];
 
     private BKStats() {
-        for (int i=0; i<NUM_STATS; i++) {
+        for (int i = 0; i < NUM_STATS; i++) {
             stats[i] = new OpStats();
         }
     }
 
     /**
-     * Stats of operations
+     * Stats of operations.
      *
      * @return op stats
      */
@@ -211,7 +210,7 @@ public class BKStats {
     }
 
     /**
-     * Set stats of a specified operation
+     * Set stats of a specified operation.
      *
      * @param type operation type
      * @param stat operation stats
@@ -221,27 +220,26 @@ public class BKStats {
     }
 
     /**
-     * Diff with base stats
+     * Diff with base stats.
      *
      * @param base base stats
      * @return diff stats
      */
     public BKStats diff(BKStats base) {
         BKStats diff = new BKStats();
-        for (int i=0; i<NUM_STATS; i++) {
+        for (int i = 0; i < NUM_STATS; i++) {
             diff.setOpStats(i, stats[i].diff(base.getOpStats(i)));
         }
         return diff;
     }
 
     /**
-     * Copy stats from other stats
+     * Copy stats from other stats.
      *
      * @param other other stats
-     * @return void
      */
     public void copyOf(BKStats other) {
-        for (int i=0; i<NUM_STATS; i++) {
+        for (int i = 0; i < NUM_STATS; i++) {
             stats[i].copyOf(other.getOpStats(i));
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -20,22 +20,8 @@
  */
 package org.apache.bookkeeper.proto;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.bookkeeper.bookie.Bookie;
-import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.auth.BookieAuthProvider;
-import org.apache.bookkeeper.auth.AuthProviderFactoryFactory;
-import org.apache.bookkeeper.processor.RequestProcessor;
-import org.apache.commons.lang.SystemUtils;
-import org.apache.zookeeper.KeeperException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ExtensionRegistry;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -64,25 +50,40 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslHandler;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.Collection;
-import java.util.Collections;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.net.ssl.SSLPeerUnverifiedException;
+
+import org.apache.bookkeeper.auth.AuthProviderFactoryFactory;
 import org.apache.bookkeeper.auth.BookKeeperPrincipal;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.bookkeeper.auth.BookieAuthProvider;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.processor.RequestProcessor;
+import org.apache.commons.lang.SystemUtils;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Netty server for serving bookie requests
+ * Netty server for serving bookie requests.
  */
 class BookieNettyServer {
 
-    private final static Logger LOG = LoggerFactory.getLogger(BookieNettyServer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BookieNettyServer.class);
 
     final int maxFrameSize;
     final ServerConfiguration conf;
@@ -296,7 +297,8 @@ class BookieNettyServer {
                         }
                     }
 
-                    BookieSideConnectionPeerContextHandler contextHandler = new BookieSideConnectionPeerContextHandler();
+                    BookieSideConnectionPeerContextHandler contextHandler =
+                        new BookieSideConnectionPeerContextHandler();
                     ChannelPipeline pipeline = ch.pipeline();
 
                     pipeline.addLast("lengthbaseddecoder", new LengthFieldBasedFrameDecoder(maxFrameSize, 0, 4, 0, 4));
@@ -304,10 +306,12 @@ class BookieNettyServer {
 
                     pipeline.addLast("bookieProtoDecoder", new BookieProtoEncoding.RequestDecoder(registry));
                     pipeline.addLast("bookieProtoEncoder", new BookieProtoEncoding.ResponseEncoder(registry));
-                    pipeline.addLast("bookieAuthHandler", new AuthHandler.ServerSideHandler(contextHandler.getConnectionPeer(), authProviderFactory));
+                    pipeline.addLast("bookieAuthHandler", new AuthHandler.ServerSideHandler(
+                                contextHandler.getConnectionPeer(), authProviderFactory));
 
                     ChannelInboundHandler requestHandler = isRunning.get()
-                            ? new BookieRequestHandler(conf, requestProcessor, allChannels) : new RejectRequestHandler();
+                            ? new BookieRequestHandler(conf, requestProcessor, allChannels)
+                            : new RejectRequestHandler();
                     pipeline.addLast("bookieRequestHandler", requestHandler);
 
                     pipeline.addLast("contextHandler", contextHandler);
@@ -351,7 +355,8 @@ class BookieNettyServer {
                         }
                     }
 
-                    BookieSideConnectionPeerContextHandler contextHandler = new BookieSideConnectionPeerContextHandler();
+                    BookieSideConnectionPeerContextHandler contextHandler =
+                        new BookieSideConnectionPeerContextHandler();
                     ChannelPipeline pipeline = ch.pipeline();
 
                     pipeline.addLast("lengthbaseddecoder", new LengthFieldBasedFrameDecoder(maxFrameSize, 0, 4, 0, 4));
@@ -359,10 +364,12 @@ class BookieNettyServer {
 
                     pipeline.addLast("bookieProtoDecoder", new BookieProtoEncoding.RequestDecoder(registry));
                     pipeline.addLast("bookieProtoEncoder", new BookieProtoEncoding.ResponseEncoder(registry));
-                    pipeline.addLast("bookieAuthHandler", new AuthHandler.ServerSideHandler(contextHandler.getConnectionPeer(), authProviderFactory));
+                    pipeline.addLast("bookieAuthHandler", new AuthHandler.ServerSideHandler(
+                                contextHandler.getConnectionPeer(), authProviderFactory));
 
                     ChannelInboundHandler requestHandler = isRunning.get()
-                            ? new BookieRequestHandler(conf, requestProcessor, allChannels) : new RejectRequestHandler();
+                            ? new BookieRequestHandler(conf, requestProcessor, allChannels)
+                            : new RejectRequestHandler();
                     pipeline.addLast("bookieRequestHandler", requestHandler);
 
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.proto;
-
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,12 +18,12 @@ package org.apache.bookkeeper.proto;
  * under the License.
  *
  */
+package org.apache.bookkeeper.proto;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
-import io.netty.util.ReferenceCounted;
 
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
 
@@ -40,22 +38,22 @@ public interface BookieProtocol {
     /**
      * Lowest protocol version which will work with the bookie.
      */
-    public static final byte LOWEST_COMPAT_PROTOCOL_VERSION = 0;
+    byte LOWEST_COMPAT_PROTOCOL_VERSION = 0;
 
     /**
      * Current version of the protocol, which client will use.
      */
-    public static final byte CURRENT_PROTOCOL_VERSION = 2;
+    byte CURRENT_PROTOCOL_VERSION = 2;
 
     /**
      * Entry Entry ID. To be used when no valid entry id can be assigned.
      */
-    public static final long INVALID_ENTRY_ID = -1;
+    long INVALID_ENTRY_ID = -1;
 
     /**
-     * Entry identifier representing a request to obtain the last add entry confirmed
+     * Entry identifier representing a request to obtain the last add entry confirmed.
      */
-    public static final long LAST_ADD_CONFIRMED = -1;
+    long LAST_ADD_CONFIRMED = -1;
 
     /**
      * The length of the master key in add packets. This
@@ -63,7 +61,7 @@ public interface BookieProtocol {
      * is always generated using the MacDigestManager regardless
      * of whether Mac is being used for the digest or not
      */
-    public static final int MASTER_KEY_LENGTH = 20;
+    int MASTER_KEY_LENGTH = 20;
 
     /**
      * The first int of a packet is the header.
@@ -72,10 +70,10 @@ public interface BookieProtocol {
      * and just had an int representing the opCode as the
      * first int. This handles that case also.
      */
-    final static class PacketHeader {
+    final class PacketHeader {
         public static int toInt(byte version, byte opCode, short flags) {
             if (version == 0) {
-                return (int)opCode;
+                return (int) opCode;
             } else {
                 return ((version & 0xFF) << 24)
                     | ((opCode & 0xFF) << 16)
@@ -84,7 +82,7 @@ public interface BookieProtocol {
         }
 
         public static byte getVersion(int packetHeader) {
-            return (byte)(packetHeader >> 24);
+            return (byte) (packetHeader >> 24);
         }
 
         public static byte getOpCode(int packetHeader) {
@@ -92,16 +90,16 @@ public interface BookieProtocol {
             if (version == 0) {
                 return (byte) packetHeader;
             } else {
-                return (byte)((packetHeader >> 16) & 0xFF);
+                return (byte) ((packetHeader >> 16) & 0xFF);
             }
         }
 
         public static short getFlags(int packetHeader) {
-            byte version = (byte)(packetHeader >> 24);
+            byte version = (byte) (packetHeader >> 24);
             if (version == 0) {
                 return 0;
             } else {
-                return (short)(packetHeader & 0xFFFF);
+                return (short) (packetHeader & 0xFFFF);
             }
         }
     }
@@ -112,7 +110,7 @@ public interface BookieProtocol {
      * error code followed by the 8-byte ledger number and 8-byte entry number
      * of the entry written.
      */
-    public static final byte ADDENTRY = 1;
+    byte ADDENTRY = 1;
     /**
      * The Read entry request payload will be the ledger number and entry number
      * to read. (The ledger number is an 8-byte integer and the entry number is
@@ -122,69 +120,72 @@ public interface BookieProtocol {
      * requested. (Note that the first sixteen bytes of the entry happen to be
      * the ledger number and entry number as well.)
      */
-    public static final byte READENTRY = 2;
+    byte READENTRY = 2;
 
     /**
      * Auth message. This code is for passing auth messages between the auth
      * providers on the client and bookie. The message payload is determined
      * by the auth providers themselves.
      */
-    public static final byte AUTH = 3;
-    public static final byte READ_LAC = 4;
-    public static final byte WRITE_LAC = 5;
-    public static final byte GET_BOOKIE_INFO = 6;
+    byte AUTH = 3;
+    byte READ_LAC = 4;
+    byte WRITE_LAC = 5;
+    byte GET_BOOKIE_INFO = 6;
 
     /**
-     * The error code that indicates success
+     * The error code that indicates success.
      */
-    public static final int EOK = 0;
+    int EOK = 0;
     /**
-     * The error code that indicates that the ledger does not exist
+     * The error code that indicates that the ledger does not exist.
      */
-    public static final int ENOLEDGER = 1;
+    int ENOLEDGER = 1;
     /**
-     * The error code that indicates that the requested entry does not exist
+     * The error code that indicates that the requested entry does not exist.
      */
-    public static final int ENOENTRY = 2;
+    int ENOENTRY = 2;
     /**
-     * The error code that indicates an invalid request type
+     * The error code that indicates an invalid request type.
      */
-    public static final int EBADREQ = 100;
+    int EBADREQ = 100;
     /**
-     * General error occurred at the server
+     * General error occurred at the server.
      */
-    public static final int EIO = 101;
+    int EIO = 101;
 
     /**
-     * Unauthorized access to ledger
+     * Unauthorized access to ledger.
      */
-    public static final int EUA = 102;
+    int EUA = 102;
 
     /**
-     * The server version is incompatible with the client
+     * The server version is incompatible with the client.
      */
-    public static final int EBADVERSION = 103;
+    int EBADVERSION = 103;
 
     /**
-     * Attempt to write to fenced ledger
+     * Attempt to write to fenced ledger.
      */
-    public static final int EFENCED = 104;
+    int EFENCED = 104;
 
     /**
-     * The server is running as read-only mode
+     * The server is running as read-only mode.
      */
-    public static final int EREADONLY = 105;
+    int EREADONLY = 105;
 
     /**
-     * Too many concurrent requests
+     * Too many concurrent requests.
      */
-    public static final int ETOOMANYREQUESTS = 106;
+    int ETOOMANYREQUESTS = 106;
 
-    public static final short FLAG_NONE = 0x0;
-    public static final short FLAG_DO_FENCING = 0x0001;
-    public static final short FLAG_RECOVERY_ADD = 0x0002;
+    short FLAG_NONE = 0x0;
+    short FLAG_DO_FENCING = 0x0001;
+    short FLAG_RECOVERY_ADD = 0x0002;
 
-    static class Request {
+    /**
+     * A Bookie request object.
+     */
+    class Request {
         byte protocolVersion;
         byte opCode;
         long ledgerId;
@@ -239,7 +240,10 @@ public interface BookieProtocol {
         public void recycle() {}
     }
 
-    static class AddRequest extends Request {
+    /**
+     * A Request that adds data.
+     */
+    class AddRequest extends Request {
         ByteBuf data;
 
         static AddRequest create(byte protocolVersion, long ledgerId,
@@ -289,7 +293,10 @@ public interface BookieProtocol {
         }
     }
 
-    static class ReadRequest extends Request {
+    /**
+     * A Request that reads data.
+     */
+    class ReadRequest extends Request {
         ReadRequest(byte protocolVersion, long ledgerId, long entryId, short flags) {
             init(protocolVersion, READENTRY, ledgerId, entryId, flags, null);
         }
@@ -304,7 +311,10 @@ public interface BookieProtocol {
         }
     }
 
-    static class AuthRequest extends Request {
+    /**
+     * An authentication request.
+     */
+    class AuthRequest extends Request {
         final AuthMessage authMessage;
 
         AuthRequest(byte protocolVersion, AuthMessage authMessage) {
@@ -317,7 +327,10 @@ public interface BookieProtocol {
         }
     }
 
-    static abstract class Response {
+    /**
+     * A response object.
+     */
+    abstract class Response {
         byte protocolVersion;
         byte opCode;
         int errorCode;
@@ -362,7 +375,10 @@ public interface BookieProtocol {
         abstract void recycle();
     }
 
-    static class ReadResponse extends Response {
+    /**
+     * A request that reads data.
+     */
+    class ReadResponse extends Response {
         final ByteBuf data;
 
         ReadResponse(byte protocolVersion, int errorCode, long ledgerId, long entryId) {
@@ -387,7 +403,10 @@ public interface BookieProtocol {
         }
     }
 
-    static class AddResponse extends Response {
+    /**
+     * A response that adds data.
+     */
+    class AddResponse extends Response {
         static AddResponse create(byte protocolVersion, int errorCode, long ledgerId, long entryId) {
             AddResponse response = RECYCLER.get();
             response.init(protocolVersion, ADDENTRY, errorCode, ledgerId, entryId);
@@ -410,7 +429,10 @@ public interface BookieProtocol {
         }
     }
 
-    static class ErrorResponse extends Response {
+    /**
+     * An error response.
+     */
+    class ErrorResponse extends Response {
         ErrorResponse(byte protocolVersion, byte opCode, int errorCode,
                       long ledgerId, long entryId) {
             init(protocolVersion, opCode, errorCode, ledgerId, entryId);
@@ -420,7 +442,10 @@ public interface BookieProtocol {
         }
     }
 
-    static class AuthResponse extends Response {
+    /**
+     * A response with an authentication message.
+     */
+    class AuthResponse extends Response {
         final AuthMessage authMessage;
 
         AuthResponse(byte protocolVersion, AuthMessage authMessage) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestHandler.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestHandler.java
@@ -20,6 +20,9 @@
  */
 package org.apache.bookkeeper.proto;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.group.ChannelGroup;
 
 import java.nio.channels.ClosedChannelException;
 
@@ -28,16 +31,12 @@ import org.apache.bookkeeper.processor.RequestProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.group.ChannelGroup;
-
 /**
- * Serverside handler for bookkeeper requests
+ * Serverside handler for bookkeeper requests.
  */
 class BookieRequestHandler extends ChannelInboundHandlerAdapter {
 
-    private final static Logger LOG = LoggerFactory.getLogger(BookieRequestHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BookieRequestHandler.class);
     private final RequestProcessor requestProcessor;
     private final ChannelGroup allChannels;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -57,7 +57,7 @@ public class BookieServer {
     private volatile boolean running = false;
     Bookie bookie;
     DeathWatcher deathWatcher;
-    private final static Logger LOG = LoggerFactory.getLogger(BookieServer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BookieServer.class);
 
     int exitCode = ExitCode.OK;
 
@@ -97,9 +97,9 @@ public class BookieServer {
 
     protected Bookie newBookie(ServerConfiguration conf)
         throws IOException, KeeperException, InterruptedException, BookieException {
-        return conf.isForceReadOnlyBookie() ?
-                new ReadOnlyBookie(conf, statsLogger.scope(BOOKIE_SCOPE)) :
-                new Bookie(conf, statsLogger.scope(BOOKIE_SCOPE));
+        return conf.isForceReadOnlyBookie()
+            ? new ReadOnlyBookie(conf, statsLogger.scope(BOOKIE_SCOPE))
+            : new Bookie(conf, statsLogger.scope(BOOKIE_SCOPE));
     }
 
     public void start() throws IOException, UnavailableException, InterruptedException, BKException {
@@ -127,7 +127,7 @@ public class BookieServer {
     }
 
     /**
-     * Suspend processing of requests in the bookie (for testing)
+     * Suspend processing of requests in the bookie (for testing).
      */
     @VisibleForTesting
     public void suspendProcessing() {
@@ -138,7 +138,7 @@ public class BookieServer {
     }
 
     /**
-     * Resume processing requests in the bookie (for testing)
+     * Resume processing requests in the bookie (for testing).
      */
     @VisibleForTesting
     public void resumeProcessing() {
@@ -181,7 +181,7 @@ public class BookieServer {
     }
 
     /**
-     * A thread to watch whether bookie & nioserver is still alive
+     * A thread to watch whether bookie and nioserver are still alive.
      */
     private class DeathWatcher extends BookieCriticalThread {
 
@@ -194,7 +194,7 @@ public class BookieServer {
 
         @Override
         public void run() {
-            while(true) {
+            while (true) {
                 try {
                     Thread.sleep(watchInterval);
                 } catch (InterruptedException ie) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
@@ -22,15 +22,17 @@
 package org.apache.bookkeeper.proto;
 
 import io.netty.buffer.ByteBuf;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.LedgerMetadata;
-import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
@@ -67,26 +69,44 @@ public class BookkeeperInternalCallbacks {
         void onChanged(long ledgerId, LedgerMetadata metadata);
     }
 
+    /**
+     * A writer callback interface.
+     */
     public interface WriteCallback {
         void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx);
     }
 
+    /**
+     * A last-add-confirmed (LAC) reader callback interface.
+     */
     public interface ReadLacCallback {
         void readLacComplete(int rc, long ledgerId, ByteBuf lac, ByteBuf buffer, Object ctx);
     }
 
+    /**
+     * A last-add-confirmed (LAC) writer callback interface.
+     */
     public interface WriteLacCallback {
         void writeLacComplete(int rc, long ledgerId, BookieSocketAddress addr, Object ctx);
     }
 
+    /**
+     * A callback interface for a STARTTLS command.
+     */
     public interface StartTLSCallback {
         void startTLSComplete(int rc, Object ctx);
     }
 
+    /**
+     * A generic callback interface.
+     */
     public interface GenericCallback<T> {
         void operationComplete(int rc, T result);
     }
-    
+
+    /**
+     * A callback implementation with an internal timer.
+     */
     public static class TimedGenericCallback<T> implements GenericCallback<T> {
 
         final GenericCallback<T> cb;
@@ -112,6 +132,9 @@ public class BookkeeperInternalCallbacks {
         }
     }
 
+    /**
+     * Declaration of a callback interface for the Last Add Confirmed context of a reader.
+     */
     public interface ReadEntryCallbackCtx {
         void setLastAddConfirmed(long lac);
         long getLastAddConfirmed();
@@ -145,7 +168,10 @@ public class BookkeeperInternalCallbacks {
          */
         void onEntryComplete(int rc, LedgerHandle lh, LedgerEntry entry, Object ctx);
     }
-    
+
+    /**
+     * This is a callback interface for fetching metadata about a bookie.
+     */
     public interface GetBookieInfoCallback {
         void getBookieInfoComplete(int rc, BookieInfo bInfo, Object ctx);
     }
@@ -231,18 +257,18 @@ public class BookkeeperInternalCallbacks {
     }
 
     /**
-     * Processor to process a specific element
+     * Processor to process a specific element.
      */
-    public static interface Processor<T> {
+    public interface Processor<T> {
         /**
-         * Process a specific element
+         * Process a specific element.
          *
          * @param data
          *          data to process
          * @param cb
          *          Callback to invoke when process has been done.
          */
-        public void process(T data, AsyncCallback.VoidCallback cb);
+        void process(T data, AsyncCallback.VoidCallback cb);
     }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ConnectionPeer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ConnectionPeer.java
@@ -25,45 +25,45 @@ import java.util.Collection;
 import org.apache.bookkeeper.auth.BookKeeperPrincipal;
 
 /**
- * Represents the connection to a BookKeeper client, from the Bookie side 
+ * Represents the connection to a BookKeeper client, from the Bookie side.
  */
 public interface ConnectionPeer {
 
     /**
-     * Address from which originated the connection
+     * Address from which originated the connection.
      * @return
      */
-    public SocketAddress getRemoteAddr();
+    SocketAddress getRemoteAddr();
 
     /**
-     * Additional principals bound to the connection, like TLS certificates
+     * Additional principals bound to the connection, like TLS certificates.
      * @return
      */
-    public Collection<Object> getProtocolPrincipals();
+    Collection<Object> getProtocolPrincipals();
 
     /**
-     * Utility function to be used from AuthProviders to drop the connection
+     * Utility function to be used from AuthProviders to drop the connection.
      */
-    public void disconnect();
+    void disconnect();
 
     /**
-     * Returns the user which is bound to the connection
+     * Returns the user which is bound to the connection.
      * @return the principal or null if no auth takes place
      * or the auth plugin did not call {@link #setAuthorizedId(org.apache.bookkeeper.auth.BookKeeperPrincipal)}
      * @see  #setAuthorizedId(org.apache.bookkeeper.auth.BookKeeperPrincipal)
      */
-    public BookKeeperPrincipal getAuthorizedId();
+    BookKeeperPrincipal getAuthorizedId();
 
     /**
-     * Assign a principal to the current connection
+     * Assign a principal to the current connection.
      * @param principal the id of the user
      * @see #getAuthorizedId()
      */
-    public void setAuthorizedId(BookKeeperPrincipal principal);
+    void setAuthorizedId(BookKeeperPrincipal principal);
 
     /**
-     * This flag returns true if a 'secure' channel in use, like TLS
+     * This flag returns true if a 'secure' channel in use, like TLS.
      * @return true if the channel is 'secure'
      */
-    public boolean isSecure();
+    boolean isSecure();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/DefaultPerChannelBookieClientPool.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/DefaultPerChannelBookieClientPool.java
@@ -20,6 +20,9 @@
  */
 package org.apache.bookkeeper.proto;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -31,10 +34,6 @@ import org.apache.bookkeeper.tls.SecurityProviderFactoryFactory;
 import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-import java.util.concurrent.atomic.AtomicInteger;
-import com.google.common.base.Preconditions;
 
 /**
  *  Provide a simple round-robin style channel pool. We could improve it later to do more
@@ -59,7 +58,7 @@ class DefaultPerChannelBookieClientPool implements PerChannelBookieClientPool,
     DefaultPerChannelBookieClientPool(ClientConfiguration conf, PerChannelBookieClientFactory factory,
                                       BookieSocketAddress address,
                                       int coreSize) throws SecurityException {
-        Preconditions.checkArgument(coreSize > 0);
+        checkArgument(coreSize > 0);
         this.factory = factory;
         this.address = address;
         this.conf = conf;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetBookieInfoProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetBookieInfoProcessorV3.java
@@ -20,6 +20,8 @@
  */
 package org.apache.bookkeeper.proto;
 
+import io.netty.channel.Channel;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -32,10 +34,11 @@ import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.channel.Channel;
-
+/**
+ * A processor class for v3 bookie metadata packets.
+ */
 public class GetBookieInfoProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
-    private final static Logger LOG = LoggerFactory.getLogger(GetBookieInfoProcessorV3.class);
+    private static final Logger LOG = LoggerFactory.getLogger(GetBookieInfoProcessorV3.class);
 
     public GetBookieInfoProcessorV3(Request request, Channel channel,
                                      BookieRequestProcessor requestProcessor) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LocalBookiesRegistry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LocalBookiesRegistry.java
@@ -24,23 +24,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 
 /**
- * Local registry for embedded Bookies
+ * Local registry for embedded Bookies.
  */
 public class LocalBookiesRegistry {
-    
-    private final static ConcurrentHashMap<BookieSocketAddress,Boolean> localBookiesRegistry
-            = new ConcurrentHashMap<>();
-    
-    static void registerLocalBookieAddress(BookieSocketAddress address) {        
-        localBookiesRegistry.put(address,Boolean.TRUE);
+
+    private static final ConcurrentHashMap<BookieSocketAddress, Boolean> localBookiesRegistry =
+        new ConcurrentHashMap<>();
+
+    static void registerLocalBookieAddress(BookieSocketAddress address) {
+        localBookiesRegistry.put(address, Boolean.TRUE);
     }
     static void unregisterLocalBookieAddress(BookieSocketAddress address) {
-        if (address!= null) {
+        if (address != null) {
             localBookiesRegistry.remove(address);
         }
     }
-    public static boolean isLocalBookie(BookieSocketAddress address) {        
+    public static boolean isLocalBookie(BookieSocketAddress address) {
         return localBookiesRegistry.containsKey(address);
     }
-    
+
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.proto;
 
+import io.netty.channel.Channel;
+
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.proto.BookieProtocol.Request;
@@ -26,10 +28,11 @@ import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.channel.Channel;
-
+/**
+ * A base class for bookeeper packet processors.
+ */
 abstract class PacketProcessorBase extends SafeRunnable {
-    private final static Logger logger = LoggerFactory.getLogger(PacketProcessorBase.class);
+    private static final Logger logger = LoggerFactory.getLogger(PacketProcessorBase.class);
     Request request;
     Channel channel;
     BookieRequestProcessor requestProcessor;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
@@ -33,6 +33,9 @@ import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.SafeRunnable;
 
+/**
+ * A base class for bookkeeper protocol v3 packet processors.
+ */
 public abstract class PacketProcessorBaseV3 extends SafeRunnable {
 
     final Request request;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClientPool.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClientPool.java
@@ -41,7 +41,7 @@ interface PerChannelBookieClientPool {
     void obtain(GenericCallback<PerChannelBookieClient> callback, long key);
 
     /**
-     * record any read/write error on {@link PerChannelBookieClientPool}
+     * record any read/write error on {@link PerChannelBookieClientPool}.
      */
     void recordError();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -20,8 +20,8 @@ package org.apache.bookkeeper.proto;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.util.Recycler;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.ReferenceCountUtil;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class ReadEntryProcessor extends PacketProcessorBase {
-    private final static Logger LOG = LoggerFactory.getLogger(ReadEntryProcessor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ReadEntryProcessor.class);
 
     public static ReadEntryProcessor create(Request request, Channel channel,
                               BookieRequestProcessor requestProcessor) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -42,17 +42,17 @@ import org.slf4j.LoggerFactory;
 
 class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
 
-    private final static Logger LOG = LoggerFactory.getLogger(ReadEntryProcessorV3.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ReadEntryProcessorV3.class);
 
     protected Stopwatch lastPhaseStartTime;
     private final ExecutorService fenceThreadPool;
 
     private SettableFuture<Boolean> fenceResult = null;
-    
+
     protected final ReadRequest readRequest;
     protected final long ledgerId;
     protected final long entryId;
-    
+
     // Stats
     protected final OpStatsLogger readStats;
     protected final OpStatsLogger reqStats;
@@ -75,7 +75,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
             this.readStats = requestProcessor.readEntryStats;
             this.reqStats = requestProcessor.readRequestStats;
         }
-        
+
         this.fenceThreadPool = fenceThreadPool;
         lastPhaseStartTime = Stopwatch.createStarted();
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
@@ -20,6 +20,12 @@
  */
 package org.apache.bookkeeper.proto;
 
+import com.google.protobuf.ByteString;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.util.ReferenceCountUtil;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -33,14 +39,11 @@ import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.protobuf.ByteString;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
-import io.netty.util.ReferenceCountUtil;
-
+/**
+ * A read processor for v3 last add confirmed messages.
+ */
 class ReadLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
-    private final static Logger logger = LoggerFactory.getLogger(ReadLacProcessorV3.class);
+    private static final Logger logger = LoggerFactory.getLogger(ReadLacProcessorV3.class);
 
     public ReadLacProcessorV3(Request request, Channel channel,
                              BookieRequestProcessor requestProcessor) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ServerStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ServerStats.java
@@ -16,6 +16,9 @@ package org.apache.bookkeeper.proto;
 
 import org.apache.bookkeeper.util.MathUtils;
 
+/**
+ * A class to hold server statistics.
+ */
 public class ServerStats {
     private static ServerStats instance = new ServerStats();
     private long packetsSent;
@@ -25,7 +28,7 @@ public class ServerStats {
     private long totalLatency = 0;
     private long count = 0;
 
-    static public ServerStats getInstance() {
+    public static ServerStats getInstance() {
         return instance;
     }
 
@@ -33,26 +36,26 @@ public class ServerStats {
     }
 
     // getters
-    synchronized public long getMinLatency() {
+    public synchronized long getMinLatency() {
         return (minLatency == Long.MAX_VALUE) ? 0 : minLatency;
     }
 
-    synchronized public long getAvgLatency() {
-        if (count != 0)
+    public synchronized long getAvgLatency() {
+        if (count != 0) {
             return totalLatency / count;
+        }
         return 0;
     }
 
-    synchronized public long getMaxLatency() {
+    public synchronized long getMaxLatency() {
         return maxLatency;
     }
 
-
-    synchronized public long getPacketsReceived() {
+    public synchronized long getPacketsReceived() {
         return packetsReceived;
     }
 
-    synchronized public long getPacketsSent() {
+    public synchronized long getPacketsSent() {
         return packetsSent;
     }
 
@@ -77,24 +80,24 @@ public class ServerStats {
         }
     }
 
-    synchronized public void resetLatency() {
+    public synchronized void resetLatency() {
         totalLatency = count = maxLatency = 0;
         minLatency = Long.MAX_VALUE;
     }
 
-    synchronized public void resetMaxLatency() {
+    public synchronized void resetMaxLatency() {
         maxLatency = getMinLatency();
     }
 
-    synchronized public void incrementPacketsReceived() {
+    public synchronized void incrementPacketsReceived() {
         packetsReceived++;
     }
 
-    synchronized public void incrementPacketsSent() {
+    public synchronized void incrementPacketsSent() {
         packetsSent++;
     }
 
-    synchronized public void resetRequestCounters() {
+    public synchronized void resetRequestCounters() {
         packetsReceived = packetsSent = 0;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -34,11 +34,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Processes add entry requests
+ * Processes add entry requests.
  */
 class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
 
-    private final static Logger LOG = LoggerFactory.getLogger(WriteEntryProcessor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(WriteEntryProcessor.class);
 
     long startTimeNanos;
 
@@ -123,7 +123,7 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
         return String.format("WriteEntry(%d, %d)",
                              request.getLedgerId(), request.getEntryId());
     }
-    
+
     private void recycle() {
         reset();
         recyclerHandle.recycle(this);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
@@ -39,7 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
-    private final static Logger logger = LoggerFactory.getLogger(WriteEntryProcessorV3.class);
+    private static final Logger logger = LoggerFactory.getLogger(WriteEntryProcessorV3.class);
 
     public WriteEntryProcessorV3(Request request, Channel channel,
                                  BookieRequestProcessor requestProcessor) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -20,25 +20,25 @@
  */
 package org.apache.bookkeeper.proto;
 
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest;
-import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.Response;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.WriteLacResponse;
 import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
-
 class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
-    private final static Logger logger = LoggerFactory.getLogger(WriteLacProcessorV3.class);
+    private static final Logger logger = LoggerFactory.getLogger(WriteLacProcessorV3.class);
 
     public WriteLacProcessorV3(Request request, Channel channel,
                              BookieRequestProcessor requestProcessor) {
@@ -90,9 +90,11 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
         // If everything is okay, we return null so that the calling function
         // dosn't return a response back to the caller.
         if (status.equals(StatusCode.EOK)) {
-            requestProcessor.writeLacStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
+            requestProcessor.writeLacStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),
+                    TimeUnit.NANOSECONDS);
         } else {
-            requestProcessor.writeLacStats.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
+            requestProcessor.writeLacStats.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos),
+                    TimeUnit.NANOSECONDS);
         }
         writeLacResponse.setStatus(status);
         return writeLacResponse.build();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/package-info.java
@@ -1,5 +1,4 @@
-/**
- *
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,13 +15,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-package org.apache.bookkeeper.proto;
 
 /**
- * Represents the connection to a Bookie, from the client side.
+ * Classes related to the Bookkeeper protocol.
  */
-public interface ClientConnectionPeer extends ConnectionPeer {
-
-}
+package org.apache.bookkeeper.proto;

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -28,7 +28,6 @@
     <suppress checks=".*" files=".*[\\/]meta[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]metastore[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]net[\\/].*"/>
-    <suppress checks=".*" files=".*[\\/]proto[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]replication[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]sasl[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]test[\\/].*"/>


### PR DESCRIPTION
This is part of #230 and adds Checkstyle verification to the proto
package in bookeeper-server.

The changes here should generally be non-controversial, but I would like to highlight one change for particular review. In the `PerChannelBookieClient` class, there is a `public static final` field called `txnIdGenerator`. The checkstyle rules require that such public fields are ALL_CAPS. So one option would be to change that field to `TX_ID_GENERATOR` (this would be a change to the public API).

The relevant diff is here: https://github.com/apache/bookkeeper/compare/master...acoburn:checkstyle_proto?expand=1#diff-e50ee2c1aec1539ea185a94605b0e550R143

However, that field is never used outside this class, so the other option is to make the field private and keep the name as-is. (Making the field private is also a change to the public API)

I chose the second option because the field seemed more like an internal field. If, however, the field should be left public, I can add a commit that changes the name to `TX_ID_GENERATOR` so that it passes the checkstyle rules.