### PR TITLE
ISSUE 230: Enable Checkstyle on the conf package

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -35,66 +35,65 @@ import org.apache.commons.configuration.SystemConfiguration;
  */
 public abstract class AbstractConfiguration extends CompositeConfiguration {
 
-    public static final String READ_SYSTEM_PROPERTIES_PROPERTY
-                            = "org.apache.bookkeeper.conf.readsystemproperties";
-    /**
-     * Enable the use of System Properties, which was the default behaviour till 4.4.0
-     */
-    private static final boolean READ_SYSTEM_PROPERTIES
-                                    = Boolean.getBoolean(READ_SYSTEM_PROPERTIES_PROPERTY);
+    public static final String READ_SYSTEM_PROPERTIES_PROPERTY = "org.apache.bookkeeper.conf.readsystemproperties";
 
-    protected static final ClassLoader defaultLoader;
+    /**
+     * Enable the use of System Properties, which was the default behaviour till 4.4.0.
+     */
+    private static final boolean READ_SYSTEM_PROPERTIES = Boolean.getBoolean(READ_SYSTEM_PROPERTIES_PROPERTY);
+
+    protected static final ClassLoader DEFAULT_LOADER;
     static {
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         if (null == loader) {
             loader = AbstractConfiguration.class.getClassLoader();
         }
-        defaultLoader = loader;
+        DEFAULT_LOADER = loader;
     }
 
     // Ledger Manager
-    protected final static String LEDGER_MANAGER_TYPE = "ledgerManagerType";
-    protected final static String LEDGER_MANAGER_FACTORY_CLASS = "ledgerManagerFactoryClass";
-    protected final static String ZK_LEDGERS_ROOT_PATH = "zkLedgersRootPath";
-    protected final static String ZK_REQUEST_RATE_LIMIT = "zkRequestRateLimit";
-    protected final static String AVAILABLE_NODE = "available";
-    protected final static String REREPLICATION_ENTRY_BATCH_SIZE = "rereplicationEntryBatchSize";
+    protected static final String LEDGER_MANAGER_TYPE = "ledgerManagerType";
+    protected static final String LEDGER_MANAGER_FACTORY_CLASS = "ledgerManagerFactoryClass";
+    protected static final String ZK_LEDGERS_ROOT_PATH = "zkLedgersRootPath";
+    protected static final String ZK_REQUEST_RATE_LIMIT = "zkRequestRateLimit";
+    protected static final String AVAILABLE_NODE = "available";
+    protected static final String REREPLICATION_ENTRY_BATCH_SIZE = "rereplicationEntryBatchSize";
 
     // Metastore settings, only being used when LEDGER_MANAGER_FACTORY_CLASS is MSLedgerManagerFactory
-    protected final static String METASTORE_IMPL_CLASS = "metastoreImplClass";
-    protected final static String METASTORE_MAX_ENTRIES_PER_SCAN = "metastoreMaxEntriesPerScan";
+    protected static final String METASTORE_IMPL_CLASS = "metastoreImplClass";
+    protected static final String METASTORE_MAX_ENTRIES_PER_SCAN = "metastoreMaxEntriesPerScan";
 
     // Common TLS configuration
     // TLS Provider (JDK or OpenSSL)
-    protected final static String TLS_PROVIDER = "tlsProvider";
+    protected static final String TLS_PROVIDER = "tlsProvider";
 
     // TLS provider factory class name
-    protected final static String TLS_PROVIDER_FACTORY_CLASS = "tlsProviderFactoryClass";
+    protected static final String TLS_PROVIDER_FACTORY_CLASS = "tlsProviderFactoryClass";
 
     // Enable authentication of the other connection end point (mutual authentication)
-    protected final static String TLS_CLIENT_AUTHENTICATION = "tlsClientAuthentication";
+    protected static final String TLS_CLIENT_AUTHENTICATION = "tlsClientAuthentication";
 
     /**
      * This list will be passed to {@link SSLEngine#setEnabledCipherSuites(java.lang.String[]) }.
      * Please refer to official JDK JavaDocs
     */
-    protected final static String TLS_ENABLED_CIPHER_SUITES = "tlsEnabledCipherSuites";
+    protected static final String TLS_ENABLED_CIPHER_SUITES = "tlsEnabledCipherSuites";
 
     /**
      * This list will be passed to {@link SSLEngine#setEnabledProtocols(java.lang.String[]) }.
      * Please refer to official JDK JavaDocs
     */
-    protected final static String TLS_ENABLED_PROTOCOLS = "tlsEnabledProtocols";
+    protected static final String TLS_ENABLED_PROTOCOLS = "tlsEnabledProtocols";
 
     //Netty configuration
-    protected final static String NETTY_MAX_FRAME_SIZE = "nettyMaxFrameSizeBytes";
-    protected final static int DEFAULT_NETTY_MAX_FRAME_SIZE = 5 * 1024 * 1024; // 5MB
+    protected static final String NETTY_MAX_FRAME_SIZE = "nettyMaxFrameSizeBytes";
+    protected static final int DEFAULT_NETTY_MAX_FRAME_SIZE = 5 * 1024 * 1024; // 5MB
 
     // Zookeeper ACL settings
-    protected final static String ZK_ENABLE_SECURITY = "zkEnableSecurity";
+    protected static final String ZK_ENABLE_SECURITY = "zkEnableSecurity";
 
     // Kluge for compatibility testing. Never set this outside tests.
-    public final static String LEDGER_MANAGER_FACTORY_DISABLE_CLASS_CHECK = "ledgerManagerFactoryDisableClassCheck";
+    public static final String LEDGER_MANAGER_FACTORY_DISABLE_CLASS_CHECK = "ledgerManagerFactoryDisableClassCheck";
 
     protected AbstractConfiguration() {
         super();
@@ -121,7 +120,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * You can load configuration from other configuration
+     * You can load configuration from other configuration.
      *
      * @param baseConf
      *          Other Configuration
@@ -143,7 +142,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
      */
     @Deprecated
     public void setLedgerManagerType(String lmType) {
-        setProperty(LEDGER_MANAGER_TYPE, lmType); 
+        setProperty(LEDGER_MANAGER_TYPE, lmType);
     }
 
     /**
@@ -187,7 +186,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
         throws ConfigurationException {
         return ReflectionUtils.getClass(this, LEDGER_MANAGER_FACTORY_CLASS,
                                         null, LedgerManagerFactory.class,
-                                        defaultLoader);
+                                        DEFAULT_LOADER);
     }
 
     /**
@@ -228,7 +227,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Are z-node created with strict ACLs
+     * Are z-node created with strict ACLs.
      *
      * @return usage of secure ZooKeeper ACLs
      */
@@ -237,7 +236,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Set the usage of ACLs of new z-nodes
+     * Set the usage of ACLs of new z-nodes.
      *
      * @param zkEnableSecurity
      */
@@ -246,7 +245,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Get the node under which available bookies are stored
+     * Get the node under which available bookies are stored.
      *
      * @return Node under which available bookies are stored.
      */
@@ -266,7 +265,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Get the re-replication entry batch size
+     * Get the re-replication entry batch size.
      */
     public long getRereplicationEntryBatchSize() {
         return getLong(REREPLICATION_ENTRY_BATCH_SIZE, 10);
@@ -318,7 +317,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
         if (null == getProperty(configProperty)) {
             return defaultValue;
         } else {
-            return (Feature)getProperty(configProperty);
+            return (Feature) getProperty(configProperty);
         }
     }
 
@@ -391,8 +390,8 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Get TLS Provider (JDK or OpenSSL)
-     * 
+     * Get TLS Provider (JDK or OpenSSL).
+     *
      * @return the TLS provider to use in creating TLS Context
      */
     public String getTLSProvider() {
@@ -400,8 +399,8 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Set TLS Provider (JDK or OpenSSL)
-     * 
+     * Set TLS Provider (JDK or OpenSSL).
+     *
      * @param provider
      *            TLS Provider type
      * @return Client Configuration
@@ -412,8 +411,8 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Whether the client will send an TLS certificate on TLS-handshake
-     * 
+     * Whether the client will send an TLS certificate on TLS-handshake.
+     *
      * @see #setTLSAuthentication(boolean)
      * @return whether TLS is enabled on the bookie or not.
      */
@@ -422,8 +421,8 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Specify whether the client will send an TLS certificate on TLS-handshake
-     * 
+     * Specify whether the client will send an TLS certificate on TLS-handshake.
+     *
      * @param enabled
      *            Whether to send a certificate or not
      * @return client configuration
@@ -448,7 +447,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Get the list of enabled TLS cipher suites
+     * Get the list of enabled TLS cipher suites.
      *
      * @return this list of enabled TLS cipher suites
      *
@@ -473,7 +472,7 @@ public abstract class AbstractConfiguration extends CompositeConfiguration {
     }
 
     /**
-     * Get the list of enabled TLS protocols
+     * Get the list of enabled TLS protocols.
      *
      * @return the list of enabled TLS protocols.
      *

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -43,127 +43,130 @@ import org.apache.commons.lang.StringUtils;
 public class ClientConfiguration extends AbstractConfiguration {
 
     // Zookeeper Parameters
-    protected final static String ZK_TIMEOUT = "zkTimeout";
-    protected final static String ZK_SERVERS = "zkServers";
+    protected static final String ZK_TIMEOUT = "zkTimeout";
+    protected static final String ZK_SERVERS = "zkServers";
 
     // Throttle value
-    protected final static String THROTTLE = "throttle";
+    protected static final String THROTTLE = "throttle";
 
     // Digest Type
-    protected final static String DIGEST_TYPE = "digestType";
-    protected final static String ENABLE_DIGEST_TYPE_AUTODETECTION = "enableDigestTypeAutodetection";
+    protected static final String DIGEST_TYPE = "digestType";
+    protected static final String ENABLE_DIGEST_TYPE_AUTODETECTION = "enableDigestTypeAutodetection";
 
     // Passwd
-    protected final static String PASSWD = "passwd";
+    protected static final String PASSWD = "passwd";
 
     // NIO Parameters
-    protected final static String CLIENT_TCP_NODELAY = "clientTcpNoDelay";
-    protected final static String CLIENT_SOCK_KEEPALIVE = "clientSockKeepalive";
-    protected final static String CLIENT_SENDBUFFER_SIZE = "clientSendBufferSize";
-    protected final static String CLIENT_RECEIVEBUFFER_SIZE = "clientReceiveBufferSize";
-    protected final static String CLIENT_WRITEBUFFER_LOW_WATER_MARK = "clientWriteBufferLowWaterMark";
-    protected final static String CLIENT_WRITEBUFFER_HIGH_WATER_MARK = "clientWriteBufferHighWaterMark";
-    protected final static String CLIENT_CONNECT_TIMEOUT_MILLIS = "clientConnectTimeoutMillis";
-    protected final static String NUM_CHANNELS_PER_BOOKIE = "numChannelsPerBookie";
-    protected final static String USE_V2_WIRE_PROTOCOL = "useV2WireProtocol";
-    protected final static String NETTY_USE_POOLED_BUFFERS = "nettyUsePooledBuffers";
+    protected static final String CLIENT_TCP_NODELAY = "clientTcpNoDelay";
+    protected static final String CLIENT_SOCK_KEEPALIVE = "clientSockKeepalive";
+    protected static final String CLIENT_SENDBUFFER_SIZE = "clientSendBufferSize";
+    protected static final String CLIENT_RECEIVEBUFFER_SIZE = "clientReceiveBufferSize";
+    protected static final String CLIENT_WRITEBUFFER_LOW_WATER_MARK = "clientWriteBufferLowWaterMark";
+    protected static final String CLIENT_WRITEBUFFER_HIGH_WATER_MARK = "clientWriteBufferHighWaterMark";
+    protected static final String CLIENT_CONNECT_TIMEOUT_MILLIS = "clientConnectTimeoutMillis";
+    protected static final String NUM_CHANNELS_PER_BOOKIE = "numChannelsPerBookie";
+    protected static final String USE_V2_WIRE_PROTOCOL = "useV2WireProtocol";
+    protected static final String NETTY_USE_POOLED_BUFFERS = "nettyUsePooledBuffers";
 
     // Read Parameters
-    protected final static String READ_TIMEOUT = "readTimeout";
-    protected final static String SPECULATIVE_READ_TIMEOUT = "speculativeReadTimeout";
-    protected final static String FIRST_SPECULATIVE_READ_TIMEOUT = "firstSpeculativeReadTimeout";
-    protected final static String MAX_SPECULATIVE_READ_TIMEOUT = "maxSpeculativeReadTimeout";
-    protected final static String SPECULATIVE_READ_TIMEOUT_BACKOFF_MULTIPLIER = "speculativeReadTimeoutBackoffMultiplier";
-    protected final static String FIRST_SPECULATIVE_READ_LAC_TIMEOUT = "firstSpeculativeReadLACTimeout";
-    protected final static String MAX_SPECULATIVE_READ_LAC_TIMEOUT = "maxSpeculativeReadLACTimeout";
-    protected final static String SPECULATIVE_READ_LAC_TIMEOUT_BACKOFF_MULTIPLIER = "speculativeReadLACTimeoutBackoffMultiplier";
-    protected final static String ENABLE_PARALLEL_RECOVERY_READ = "enableParallelRecoveryRead";
-    protected final static String RECOVERY_READ_BATCH_SIZE = "recoveryReadBatchSize";
-    protected final static String REORDER_READ_SEQUENCE_ENABLED = "reorderReadSequenceEnabled";
+    protected static final String READ_TIMEOUT = "readTimeout";
+    protected static final String SPECULATIVE_READ_TIMEOUT = "speculativeReadTimeout";
+    protected static final String FIRST_SPECULATIVE_READ_TIMEOUT = "firstSpeculativeReadTimeout";
+    protected static final String MAX_SPECULATIVE_READ_TIMEOUT = "maxSpeculativeReadTimeout";
+    protected static final String SPECULATIVE_READ_TIMEOUT_BACKOFF_MULTIPLIER =
+        "speculativeReadTimeoutBackoffMultiplier";
+    protected static final String FIRST_SPECULATIVE_READ_LAC_TIMEOUT = "firstSpeculativeReadLACTimeout";
+    protected static final String MAX_SPECULATIVE_READ_LAC_TIMEOUT = "maxSpeculativeReadLACTimeout";
+    protected static final String SPECULATIVE_READ_LAC_TIMEOUT_BACKOFF_MULTIPLIER =
+        "speculativeReadLACTimeoutBackoffMultiplier";
+    protected static final String ENABLE_PARALLEL_RECOVERY_READ = "enableParallelRecoveryRead";
+    protected static final String RECOVERY_READ_BATCH_SIZE = "recoveryReadBatchSize";
+    protected static final String REORDER_READ_SEQUENCE_ENABLED = "reorderReadSequenceEnabled";
     // Add Parameters
-    protected final static String DELAY_ENSEMBLE_CHANGE = "delayEnsembleChange";
+    protected static final String DELAY_ENSEMBLE_CHANGE = "delayEnsembleChange";
     // Timeout Setting
-    protected final static String ADD_ENTRY_TIMEOUT_SEC = "addEntryTimeoutSec";
-    protected final static String ADD_ENTRY_QUORUM_TIMEOUT_SEC = "addEntryQuorumTimeoutSec";
-    protected final static String READ_ENTRY_TIMEOUT_SEC = "readEntryTimeoutSec";
-    protected final static String TIMEOUT_TASK_INTERVAL_MILLIS = "timeoutTaskIntervalMillis";
-    protected final static String EXPLICIT_LAC_INTERVAL = "explicitLacInterval";
-    protected final static String PCBC_TIMEOUT_TIMER_TICK_DURATION_MS = "pcbcTimeoutTimerTickDurationMs";
-    protected final static String PCBC_TIMEOUT_TIMER_NUM_TICKS = "pcbcTimeoutTimerNumTicks";
-    protected final static String TIMEOUT_TIMER_TICK_DURATION_MS = "timeoutTimerTickDurationMs";
-    protected final static String TIMEOUT_TIMER_NUM_TICKS = "timeoutTimerNumTicks";
+    protected static final String ADD_ENTRY_TIMEOUT_SEC = "addEntryTimeoutSec";
+    protected static final String ADD_ENTRY_QUORUM_TIMEOUT_SEC = "addEntryQuorumTimeoutSec";
+    protected static final String READ_ENTRY_TIMEOUT_SEC = "readEntryTimeoutSec";
+    protected static final String TIMEOUT_TASK_INTERVAL_MILLIS = "timeoutTaskIntervalMillis";
+    protected static final String EXPLICIT_LAC_INTERVAL = "explicitLacInterval";
+    protected static final String PCBC_TIMEOUT_TIMER_TICK_DURATION_MS = "pcbcTimeoutTimerTickDurationMs";
+    protected static final String PCBC_TIMEOUT_TIMER_NUM_TICKS = "pcbcTimeoutTimerNumTicks";
+    protected static final String TIMEOUT_TIMER_TICK_DURATION_MS = "timeoutTimerTickDurationMs";
+    protected static final String TIMEOUT_TIMER_NUM_TICKS = "timeoutTimerNumTicks";
 
     // Bookie health check settings
-    protected final static String BOOKIE_HEALTH_CHECK_ENABLED = "bookieHealthCheckEnabled";
-    protected final static String BOOKIE_HEALTH_CHECK_INTERVAL_SECONDS = "bookieHealthCheckIntervalSeconds";
-    protected final static String BOOKIE_ERROR_THRESHOLD_PER_INTERVAL = "bookieErrorThresholdPerInterval";
-    protected final static String BOOKIE_QUARANTINE_TIME_SECONDS = "bookieQuarantineTimeSeconds";
+    protected static final String BOOKIE_HEALTH_CHECK_ENABLED = "bookieHealthCheckEnabled";
+    protected static final String BOOKIE_HEALTH_CHECK_INTERVAL_SECONDS = "bookieHealthCheckIntervalSeconds";
+    protected static final String BOOKIE_ERROR_THRESHOLD_PER_INTERVAL = "bookieErrorThresholdPerInterval";
+    protected static final String BOOKIE_QUARANTINE_TIME_SECONDS = "bookieQuarantineTimeSeconds";
 
     // Bookie info poll interval
-    protected final static String DISK_WEIGHT_BASED_PLACEMENT_ENABLED = "diskWeightBasedPlacementEnabled";
-    protected final static String GET_BOOKIE_INFO_INTERVAL_SECONDS = "getBookieInfoIntervalSeconds";
-    protected final static String GET_BOOKIE_INFO_RETRY_INTERVAL_SECONDS = "getBookieInfoRetryIntervalSeconds";
-    protected final static String BOOKIE_MAX_MULTIPLE_FOR_WEIGHTED_PLACEMENT = "bookieMaxMultipleForWeightBasedPlacement";
-    protected final static String GET_BOOKIE_INFO_TIMEOUT_SECS = "getBookieInfoTimeoutSecs";
-    protected final static String START_TLS_TIMEOUT_SECS = "startTLSTimeoutSecs";
+    protected static final String DISK_WEIGHT_BASED_PLACEMENT_ENABLED = "diskWeightBasedPlacementEnabled";
+    protected static final String GET_BOOKIE_INFO_INTERVAL_SECONDS = "getBookieInfoIntervalSeconds";
+    protected static final String GET_BOOKIE_INFO_RETRY_INTERVAL_SECONDS = "getBookieInfoRetryIntervalSeconds";
+    protected static final String BOOKIE_MAX_MULTIPLE_FOR_WEIGHTED_PLACEMENT =
+        "bookieMaxMultipleForWeightBasedPlacement";
+    protected static final String GET_BOOKIE_INFO_TIMEOUT_SECS = "getBookieInfoTimeoutSecs";
+    protected static final String START_TLS_TIMEOUT_SECS = "startTLSTimeoutSecs";
 
     // Number Woker Threads
-    protected final static String NUM_WORKER_THREADS = "numWorkerThreads";
+    protected static final String NUM_WORKER_THREADS = "numWorkerThreads";
 
     // Ensemble Placement Policy
-    protected final static String ENSEMBLE_PLACEMENT_POLICY = "ensemblePlacementPolicy";
-    protected final static String NETWORK_TOPOLOGY_STABILIZE_PERIOD_SECONDS = "networkTopologyStabilizePeriodSeconds";
+    protected static final String ENSEMBLE_PLACEMENT_POLICY = "ensemblePlacementPolicy";
+    protected static final String NETWORK_TOPOLOGY_STABILIZE_PERIOD_SECONDS = "networkTopologyStabilizePeriodSeconds";
 
     // Ledger Metadata Parameters
     protected static final String STORE_SYSTEMTIME_AS_LEDGER_CREATION_TIME = "storeSystemTimeAsLedgerCreationTime";
 
     // Stats
-    protected final static String ENABLE_TASK_EXECUTION_STATS = "enableTaskExecutionStats";
-    protected final static String TASK_EXECUTION_WARN_TIME_MICROS = "taskExecutionWarnTimeMicros";
+    protected static final String ENABLE_TASK_EXECUTION_STATS = "enableTaskExecutionStats";
+    protected static final String TASK_EXECUTION_WARN_TIME_MICROS = "taskExecutionWarnTimeMicros";
 
     // Failure History Settings
-    protected final static String ENABLE_BOOKIE_FAILURE_TRACKING = "enableBookieFailureTracking";
-    protected final static String BOOKIE_FAILURE_HISTORY_EXPIRATION_MS = "bookieFailureHistoryExpirationMSec";
+    protected static final String ENABLE_BOOKIE_FAILURE_TRACKING = "enableBookieFailureTracking";
+    protected static final String BOOKIE_FAILURE_HISTORY_EXPIRATION_MS = "bookieFailureHistoryExpirationMSec";
 
     // Names of dynamic features
-    protected final static String DISABLE_ENSEMBLE_CHANGE_FEATURE_NAME = "disableEnsembleChangeFeatureName";
+    protected static final String DISABLE_ENSEMBLE_CHANGE_FEATURE_NAME = "disableEnsembleChangeFeatureName";
 
     // Role of the client
-    protected final static String CLIENT_ROLE = "clientRole";
+    protected static final String CLIENT_ROLE = "clientRole";
 
     /**
-     * This client will act as a standard client
+     * This client will act as a standard client.
      */
-    public final static String CLIENT_ROLE_STANDARD = "standard";
+    public static final String CLIENT_ROLE_STANDARD = "standard";
 
     /**
-     * This client will act as a system client, like the {@link Auditor}
+     * This client will act as a system client, like the {@link Auditor}.
      */
-    public final static String CLIENT_ROLE_SYSTEM = "system";
+    public static final String CLIENT_ROLE_SYSTEM = "system";
 
     // Client auth provider factory class name. It must be configured on Bookies to for the Auditor
-    protected final static String CLIENT_AUTH_PROVIDER_FACTORY_CLASS = "clientAuthProviderFactoryClass";
+    protected static final String CLIENT_AUTH_PROVIDER_FACTORY_CLASS = "clientAuthProviderFactoryClass";
 
     // Client TLS
-    protected final static String TLS_KEYSTORE_TYPE = "clientKeyStoreType";
-    protected final static String TLS_KEYSTORE = "clientKeyStore";
-    protected final static String TLS_KEYSTORE_PASSWORD_PATH = "clientKeyStorePasswordPath";
-    protected final static String TLS_TRUSTSTORE_TYPE = "clientTrustStoreType";
-    protected final static String TLS_TRUSTSTORE = "clientTrustStore";
-    protected final static String TLS_TRUSTSTORE_PASSWORD_PATH = "clientTrustStorePasswordPath";
+    protected static final String TLS_KEYSTORE_TYPE = "clientKeyStoreType";
+    protected static final String TLS_KEYSTORE = "clientKeyStore";
+    protected static final String TLS_KEYSTORE_PASSWORD_PATH = "clientKeyStorePasswordPath";
+    protected static final String TLS_TRUSTSTORE_TYPE = "clientTrustStoreType";
+    protected static final String TLS_TRUSTSTORE = "clientTrustStore";
+    protected static final String TLS_TRUSTSTORE_PASSWORD_PATH = "clientTrustStorePasswordPath";
 
     // Registration Client
-    protected final static String REGISTRATION_CLIENT_CLASS = "registrationClientClass";
+    protected static final String REGISTRATION_CLIENT_CLASS = "registrationClientClass";
 
     /**
-     * Construct a default client-side configuration
+     * Construct a default client-side configuration.
      */
     public ClientConfiguration() {
         super();
     }
 
     /**
-     * Construct a client-side configuration using a base configuration
+     * Construct a client-side configuration using a base configuration.
      *
      * @param conf
      *          Base configuration
@@ -174,7 +177,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get throttle value
+     * Get throttle value.
      *
      * @return throttle value
      * @see #setThrottleValue
@@ -186,12 +189,12 @@ public class ClientConfiguration extends AbstractConfiguration {
     /**
      * Set throttle value.
      *
-     * Since BookKeeper process requests in asynchronous way, it will holds
+     * <p>Since BookKeeper process requests in asynchronous way, it will holds
      * those pending request in queue. You may easily run it out of memory
      * if producing too many requests than the capability of bookie servers can handle.
      * To prevent that from happening, you can set a throttle value here.
      *
-     * Setting the throttle value to 0, will disable any throttling.
+     * <p>Setting the throttle value to 0, will disable any throttling.
      *
      * @param throttle
      *          Throttle Value
@@ -204,7 +207,8 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Get autodetection of digest type.
-     * Ignores provided digestType, if enabled and uses one from ledger metadata instead.
+     *
+     * <p>Ignores provided digestType, if enabled and uses one from ledger metadata instead.
      * Incompatible with ledger created by bookie versions < 4.2
      *
      * @return flag to enable/disable autodetection of digest type.
@@ -224,9 +228,9 @@ public class ClientConfiguration extends AbstractConfiguration {
         this.setProperty(ENABLE_DIGEST_TYPE_AUTODETECTION, enable);
         return this;
     }
-    
+
     /**
-     * Get digest type used in bookkeeper admin
+     * Get digest type used in bookkeeper admin.
      *
      * @return digest type
      * @see #setBookieRecoveryDigestType
@@ -238,7 +242,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     /**
      * Set digest type used in bookkeeper admin.
      *
-     * Digest Type and Passwd used to open ledgers for admin tool
+     * <p>Digest Type and Passwd used to open ledgers for admin tool
      * For now, assume that all ledgers were created with the same DigestType
      * and password. In the future, this admin tool will need to know for each
      * ledger, what was the DigestType and password used to create it before it
@@ -255,7 +259,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get passwd used in bookkeeper admin
+     * Get passwd used in bookkeeper admin.
      *
      * @return password
      * @see #setBookieRecoveryPasswd
@@ -267,7 +271,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     /**
      * Set passwd used in bookkeeper admin.
      *
-     * Digest Type and Passwd used to open ledgers for admin tool
+     * <p>Digest Type and Passwd used to open ledgers for admin tool
      * For now, assume that all ledgers were created with the same DigestType
      * and password. In the future, this admin tool will need to know for each
      * ledger, what was the DigestType and password used to create it before it
@@ -296,7 +300,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     /**
      * Set socket nodelay setting.
      *
-     * This settings is used to enabled/disabled Nagle's algorithm, which is a means of
+     * <p>This settings is used to enabled/disabled Nagle's algorithm, which is a means of
      * improving the efficiency of TCP/IP networks by reducing the number of packets
      * that need to be sent over the network. If you are sending many small messages,
      * such that more than one can fit in a single IP packet, setting client.tcpnodelay
@@ -314,8 +318,8 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * get socket keepalive
-     * 
+     * get socket keepalive.
+     *
      * @return socket keepalive setting
      */
     public boolean getClientSockKeepalive() {
@@ -324,9 +328,9 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Set socket keepalive setting.
-     * 
-     * This setting is used to send keep-alive messages on connection-oriented sockets.
-     * 
+     *
+     * <p>This setting is used to send keep-alive messages on connection-oriented sockets.
+     *
      * @param keepalive
      *            KeepAlive setting
      * @return client configuration
@@ -506,7 +510,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Use older Bookkeeper wire protocol (no protobuf)
+     * Use older Bookkeeper wire protocol (no protobuf).
      *
      * @return whether or not to use older Bookkeeper wire protocol (no protobuf)
      */
@@ -515,7 +519,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set whether or not to use older Bookkeeper wire protocol (no protobuf)
+     * Set whether or not to use older Bookkeeper wire protocol (no protobuf).
      *
      * @param useV2WireProtocol
      *          whether or not to use older Bookkeeper wire protocol (no protobuf)
@@ -527,7 +531,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get zookeeper servers to connect
+     * Get zookeeper servers to connect.
      *
      * @return zookeeper servers
      */
@@ -540,7 +544,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set zookeeper servers to connect
+     * Set zookeeper servers to connect.
      *
      * @param zkServers
      *          ZooKeeper servers to connect
@@ -551,7 +555,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get zookeeper timeout
+     * Get zookeeper timeout.
      *
      * @return zookeeper client timeout
      */
@@ -560,7 +564,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set zookeeper timeout
+     * Set zookeeper timeout.
      *
      * @param zkTimeout
      *          ZooKeeper client timeout
@@ -576,7 +580,7 @@ public class ClientConfiguration extends AbstractConfiguration {
      * seconds we wait without hearing a response from a bookie
      * before we consider it failed.
      *
-     * The default is 5 seconds.
+     * <p>The default is 5 seconds.
      *
      * @return the current read timeout in seconds
      * @deprecated use {@link #getReadEntryTimeout()} or {@link #getAddEntryTimeout()} instead
@@ -603,7 +607,7 @@ public class ClientConfiguration extends AbstractConfiguration {
      * Get the timeout for add request. This is the number of seconds we wait without hearing
      * a response for add request from a bookie before we consider it failed.
      *
-     * The default value is 5 second for backwards compatibility.
+     * <p>The default value is 5 second for backwards compatibility.
      *
      * @return add entry timeout.
      */
@@ -678,7 +682,7 @@ public class ClientConfiguration extends AbstractConfiguration {
      * TimeoutTask. This value is in milliseconds. Every X milliseconds, the timeout task
      * will be executed and it will error out entries that have timed out.
      *
-     * We do it more aggressive to not accumulate pending requests due to slow responses.
+     * <p>We do it more aggressive to not accumulate pending requests due to slow responses.
      * @return the interval at which request timeouts will be checked
      */
     @Deprecated
@@ -808,10 +812,10 @@ public class ClientConfiguration extends AbstractConfiguration {
      * A speculative entry read is sent to the next replica bookie before
      * an error or response has been received for the previous entry read request.
      *
-     * A speculative entry read is only sent if we have not heard from the current
+     * <p>A speculative entry read is only sent if we have not heard from the current
      * replica bookie during the entire read operation which may comprise of many entries.
      *
-     * Speculative reads allow the client to avoid having to wait for the connect timeout
+     * <p>Speculative reads allow the client to avoid having to wait for the connect timeout
      * in the case that a bookie has failed. It induces higher load on the network and on
      * bookies. This should be taken into account before changing this configuration value.
      *
@@ -826,7 +830,7 @@ public class ClientConfiguration extends AbstractConfiguration {
      * Set the speculative read timeout. A lower timeout will reduce read latency in the
      * case of a failed bookie, while increasing the load on bookies and the network.
      *
-     * The default is 2000 milliseconds. A value of 0 will disable speculative reads
+     * <p>The default is 2000 milliseconds. A value of 0 will disable speculative reads
      * completely.
      *
      * @see #getSpeculativeReadTimeout()
@@ -860,7 +864,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Multipler to use when determining time between successive speculative read requests
+     * Multipler to use when determining time between successive speculative read requests.
      *
      * @return speculative read timeout backoff multiplier.
      */
@@ -869,19 +873,20 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the multipler to use when determining time between successive speculative read requests
+     * Set the multipler to use when determining time between successive speculative read requests.
      *
      * @param speculativeReadTimeoutBackoffMultiplier
      *          multipler to use when determining time between successive speculative read requests.
      * @return client configuration.
      */
-    public ClientConfiguration setSpeculativeReadTimeoutBackoffMultiplier(float speculativeReadTimeoutBackoffMultiplier) {
+    public ClientConfiguration setSpeculativeReadTimeoutBackoffMultiplier(
+            float speculativeReadTimeoutBackoffMultiplier) {
         setProperty(SPECULATIVE_READ_TIMEOUT_BACKOFF_MULTIPLIER, speculativeReadTimeoutBackoffMultiplier);
         return this;
     }
 
     /**
-     * Multipler to use when determining time between successive speculative read LAC requests
+     * Multipler to use when determining time between successive speculative read LAC requests.
      *
      * @return speculative read LAC timeout backoff multiplier.
      */
@@ -890,13 +895,14 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the multipler to use when determining time between successive speculative read LAC requests
+     * Set the multipler to use when determining time between successive speculative read LAC requests.
      *
      * @param speculativeReadLACTimeoutBackoffMultiplier
      *          multipler to use when determining time between successive speculative read LAC requests.
      * @return client configuration.
      */
-    public ClientConfiguration setSpeculativeReadLACTimeoutBackoffMultiplier(float speculativeReadLACTimeoutBackoffMultiplier) {
+    public ClientConfiguration setSpeculativeReadLACTimeoutBackoffMultiplier(
+            float speculativeReadLACTimeoutBackoffMultiplier) {
         setProperty(SPECULATIVE_READ_LAC_TIMEOUT_BACKOFF_MULTIPLIER, speculativeReadLACTimeoutBackoffMultiplier);
         return this;
     }
@@ -928,10 +934,10 @@ public class ClientConfiguration extends AbstractConfiguration {
      * A speculative entry request is sent to the next replica bookie before
      * an error or response has been received for the previous entry read request.
      *
-     * A speculative entry read is only sent if we have not heard from the current
+     * <p>A speculative entry read is only sent if we have not heard from the current
      * replica bookie during the entire read operation which may comprise of many entries.
      *
-     * Speculative requests allow the client to avoid having to wait for the connect timeout
+     * <p>Speculative requests allow the client to avoid having to wait for the connect timeout
      * in the case that a bookie has failed. It induces higher load on the network and on
      * bookies. This should be taken into account before changing this configuration value.
      *
@@ -958,7 +964,7 @@ public class ClientConfiguration extends AbstractConfiguration {
      * A lower timeout will reduce read latency in the case of a failed bookie,
      * while increasing the load on bookies and the network.
      *
-     * The default is 1500 milliseconds. A value of 0 will disable speculative reads
+     * <p>The default is 1500 milliseconds. A value of 0 will disable speculative reads
      * completely.
      *
      * @see #getSpeculativeReadTimeout()
@@ -1062,7 +1068,7 @@ public class ClientConfiguration extends AbstractConfiguration {
         return ReflectionUtils.getClass(this, ENSEMBLE_PLACEMENT_POLICY,
                 RackawareEnsemblePlacementPolicy.class,
                 EnsemblePlacementPolicy.class,
-                                        defaultLoader);
+                                        DEFAULT_LOADER);
     }
 
     /**
@@ -1157,7 +1163,7 @@ public class ClientConfiguration extends AbstractConfiguration {
      * quarantined period, the client will try not to use this bookie when creating new ensembles.
      * </p>
      *
-     * By default, the bookie health check is <b>disabled</b>.
+     * <p>By default, the bookie health check is <b>disabled</b>.
      *
      * @return client configuration
      */
@@ -1250,14 +1256,14 @@ public class ClientConfiguration extends AbstractConfiguration {
         super.setNettyMaxFrameSizeBytes(maxSize);
         return this;
     }
- 
+
     /**
      * Get the time interval between successive calls for bookie get info. Default is 24 hours.
      *
      * @return
      */
     public int getGetBookieInfoIntervalSeconds() {
-        return getInt(GET_BOOKIE_INFO_INTERVAL_SECONDS, 24*60*60);
+        return getInt(GET_BOOKIE_INFO_INTERVAL_SECONDS, 24 * 60 * 60);
     }
 
     /**
@@ -1271,7 +1277,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Return whether disk weight based placement policy is enabled
+     * Return whether disk weight based placement policy is enabled.
      * @return
      */
     public boolean getDiskWeightBasedPlacementEnabled() {
@@ -1279,7 +1285,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Returns the max multiple to use for nodes with very high weight
+     * Returns the max multiple to use for nodes with very high weight.
      * @return max multiple
      */
     public int getBookieMaxWeightMultipleForWeightBasedPlacement() {
@@ -1287,7 +1293,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Return the timeout value for getBookieInfo request
+     * Return the timeout value for getBookieInfo request.
      * @return
      */
     public int getBookieInfoTimeout() {
@@ -1295,7 +1301,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Return the timeout value for startTLS request
+     * Return the timeout value for startTLS request.
      * @return
      */
     public int getStartTLSTimeout() {
@@ -1326,8 +1332,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the time interval between retries on unsuccessful GetInfo requests
-     *
+     * Set the time interval between retries on unsuccessful GetInfo requests.
      *
      * @param interval
      * @param unit
@@ -1339,7 +1344,8 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the max multiple to use for nodes with very high weight
+     * Set the max multiple to use for nodes with very high weight.
+     *
      * @param multiple
      * @return client configuration
      */
@@ -1349,7 +1355,8 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the timeout value in secs for the GET_BOOKIE_INFO request
+     * Set the timeout value in secs for the GET_BOOKIE_INFO request.
+     *
      * @param timeout
      * @return client configuration
      */
@@ -1359,7 +1366,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the timeout value in secs for the START_TLS request
+     * Set the timeout value in secs for the START_TLS request.
      * @param timeout
      * @return client configuration
      */
@@ -1369,7 +1376,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the client role
+     * Set the client role.
      *
      * @param role defines how the client will act
      * @return client configuration
@@ -1383,14 +1390,14 @@ public class ClientConfiguration extends AbstractConfiguration {
             case CLIENT_ROLE_SYSTEM:
                 break;
             default:
-                throw new IllegalArgumentException("invalid role "+role);
+                throw new IllegalArgumentException("invalid role " + role);
         }
         setProperty(CLIENT_ROLE, role);
         return this;
     }
 
     /**
-     * Get the role of the client
+     * Get the role of the client.
      *
      * @return the type of client
      */
@@ -1400,7 +1407,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Get the keystore type for client. Default is JKS.
-     * 
+     *
      * @return
      */
     public String getTLSKeyStoreType() {
@@ -1410,7 +1417,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Set the keystore type for client.
-     * 
+     *
      * @return
      */
     public ClientConfiguration setTLSKeyStoreType(String arg) {
@@ -1420,7 +1427,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Get the keystore path for the client.
-     * 
+     *
      * @return
      */
     public String getTLSKeyStore() {
@@ -1429,7 +1436,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Set the keystore path for the client.
-     * 
+     *
      * @return
      */
     public ClientConfiguration setTLSKeyStore(String arg) {
@@ -1439,7 +1446,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Get the path to file containing keystore password, if the client keystore is password protected. Default is null.
-     * 
+     *
      * @return
      */
     public String getTLSKeyStorePasswordPath() {
@@ -1448,7 +1455,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Set the path to file containing keystore password, if the client keystore is password protected.
-     * 
+     *
      * @return
      */
     public ClientConfiguration setTLSKeyStorePasswordPath(String arg) {
@@ -1458,7 +1465,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Get the truststore type for client. Default is JKS.
-     * 
+     *
      * @return
      */
     public String getTLSTrustStoreType() {
@@ -1467,7 +1474,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Set the truststore type for client.
-     * 
+     *
      * @return
      */
     public ClientConfiguration setTLSTrustStoreType(String arg) {
@@ -1477,7 +1484,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Get the truststore path for the client.
-     * 
+     *
      * @return
      */
     public String getTLSTrustStore() {
@@ -1486,7 +1493,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Set the truststore path for the client.
-     * 
+     *
      * @return
      */
     public ClientConfiguration setTLSTrustStore(String arg) {
@@ -1497,7 +1504,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     /**
      * Get the path to file containing truststore password, if the client truststore is password protected. Default is
      * null.
-     * 
+     *
      * @return
      */
     public String getTLSTrustStorePasswordPath() {
@@ -1506,7 +1513,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Set the path to file containing truststore password, if the client truststore is password protected.
-     * 
+     *
      * @return
      */
     public ClientConfiguration setTLSTrustStorePasswordPath(String arg) {
@@ -1541,7 +1548,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Whether to enable bookie failure tracking
+     * Whether to enable bookie failure tracking.
      *
      * @return flag to enable/disable bookie failure tracking
      */
@@ -1573,7 +1580,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     /**
      * Set the bookie failure tracking expiration timeout.
      *
-     * @param timeout
+     * @param expirationMSec
      *          bookie failure tracking expiration timeout.
      * @return client configuration.
      */
@@ -1583,7 +1590,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get the name of the dynamic feature that disables ensemble change
+     * Get the name of the dynamic feature that disables ensemble change.
      *
      * @return name of the dynamic feature that disables ensemble change
      */
@@ -1592,7 +1599,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the name of the dynamic feature that disables ensemble change
+     * Set the name of the dynamic feature that disables ensemble change.
      *
      * @param disableEnsembleChangeFeatureName
      *          name of the dynamic feature that disables ensemble change
@@ -1605,7 +1612,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
 
     /**
-     * Option to use Netty Pooled ByteBufs
+     * Option to use Netty Pooled ByteBufs.
      *
      * @return the value of the option
      */
@@ -1615,7 +1622,7 @@ public class ClientConfiguration extends AbstractConfiguration {
 
     /**
      * Enable/Disable the usage of Pooled Netty buffers. While using v2 wire protocol the application will be
-     * responsible for releasing ByteBufs returned by BookKeeper
+     * responsible for releasing ByteBufs returned by BookKeeper.
      *
      * @param enabled
      *          if enabled BookKeeper will use default Pooled Netty Buffer allocator
@@ -1630,7 +1637,7 @@ public class ClientConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set registration manager class
+     * Set registration manager class.
      *
      * @param regClientClass
      *            ClientClass
@@ -1650,7 +1657,7 @@ public class ClientConfiguration extends AbstractConfiguration {
             throws ConfigurationException {
         return ReflectionUtils.getClass(this, REGISTRATION_CLIENT_CLASS,
                 ZKRegistrationClient.class, RegistrationClient.class,
-                defaultLoader);
+                DEFAULT_LOADER);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -17,11 +17,12 @@
  */
 package org.apache.bookkeeper.conf;
 
+import com.google.common.annotations.Beta;
+
 import java.io.File;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.annotations.Beta;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.bookie.SortedLedgerStorage;
@@ -39,161 +40,161 @@ import org.apache.commons.lang.StringUtils;
  */
 public class ServerConfiguration extends AbstractConfiguration {
     // Entry Log Parameters
-    protected final static String ENTRY_LOG_SIZE_LIMIT = "logSizeLimit";
-    protected final static String ENTRY_LOG_FILE_PREALLOCATION_ENABLED = "entryLogFilePreallocationEnabled";
-    protected final static String MINOR_COMPACTION_INTERVAL = "minorCompactionInterval";
-    protected final static String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
-    protected final static String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";
-    protected final static String MAJOR_COMPACTION_THRESHOLD = "majorCompactionThreshold";
-    protected final static String IS_THROTTLE_BY_BYTES = "isThrottleByBytes";
-    protected final static String COMPACTION_MAX_OUTSTANDING_REQUESTS
-        = "compactionMaxOutstandingRequests";
-    protected final static String COMPACTION_RATE = "compactionRate";
-    protected final static String COMPACTION_RATE_BY_ENTRIES = "compactionRateByEntries";
-    protected final static String COMPACTION_RATE_BY_BYTES = "compactionRateByBytes";
+    protected static final String ENTRY_LOG_SIZE_LIMIT = "logSizeLimit";
+    protected static final String ENTRY_LOG_FILE_PREALLOCATION_ENABLED = "entryLogFilePreallocationEnabled";
+    protected static final String MINOR_COMPACTION_INTERVAL = "minorCompactionInterval";
+    protected static final String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
+    protected static final String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";
+    protected static final String MAJOR_COMPACTION_THRESHOLD = "majorCompactionThreshold";
+    protected static final String IS_THROTTLE_BY_BYTES = "isThrottleByBytes";
+    protected static final String COMPACTION_MAX_OUTSTANDING_REQUESTS = "compactionMaxOutstandingRequests";
+    protected static final String COMPACTION_RATE = "compactionRate";
+    protected static final String COMPACTION_RATE_BY_ENTRIES = "compactionRateByEntries";
+    protected static final String COMPACTION_RATE_BY_BYTES = "compactionRateByBytes";
 
     // Gc Parameters
-    protected final static String GC_WAIT_TIME = "gcWaitTime";
-    protected final static String IS_FORCE_GC_ALLOW_WHEN_NO_SPACE = "isForceGCAllowWhenNoSpace";
-    protected final static String GC_OVERREPLICATED_LEDGER_WAIT_TIME = "gcOverreplicatedLedgerWaitTime";
-    protected final static String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
+    protected static final String GC_WAIT_TIME = "gcWaitTime";
+    protected static final String IS_FORCE_GC_ALLOW_WHEN_NO_SPACE = "isForceGCAllowWhenNoSpace";
+    protected static final String GC_OVERREPLICATED_LEDGER_WAIT_TIME = "gcOverreplicatedLedgerWaitTime";
+    protected static final String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
     // Sync Parameters
-    protected final static String FLUSH_INTERVAL = "flushInterval";
-    protected final static String FLUSH_ENTRYLOG_INTERVAL_BYTES = "flushEntrylogBytes";
+    protected static final String FLUSH_INTERVAL = "flushInterval";
+    protected static final String FLUSH_ENTRYLOG_INTERVAL_BYTES = "flushEntrylogBytes";
     // Bookie death watch interval
-    protected final static String DEATH_WATCH_INTERVAL = "bookieDeathWatchInterval";
+    protected static final String DEATH_WATCH_INTERVAL = "bookieDeathWatchInterval";
     // Ledger Cache Parameters
-    protected final static String OPEN_FILE_LIMIT = "openFileLimit";
-    protected final static String PAGE_LIMIT = "pageLimit";
-    protected final static String PAGE_SIZE = "pageSize";
-    protected final static String FILEINFO_CACHE_INITIAL_CAPACITY = "fileInfoCacheInitialCapacity";
-    protected final static String FILEINFO_MAX_IDLE_TIME = "fileInfoMaxIdleTime";
+    protected static final String OPEN_FILE_LIMIT = "openFileLimit";
+    protected static final String PAGE_LIMIT = "pageLimit";
+    protected static final String PAGE_SIZE = "pageSize";
+    protected static final String FILEINFO_CACHE_INITIAL_CAPACITY = "fileInfoCacheInitialCapacity";
+    protected static final String FILEINFO_MAX_IDLE_TIME = "fileInfoMaxIdleTime";
     // Journal Parameters
-    protected final static String MAX_JOURNAL_SIZE = "journalMaxSizeMB";
-    protected final static String MAX_BACKUP_JOURNALS = "journalMaxBackups";
-    protected final static String JOURNAL_SYNC_DATA = "journalSyncData";
-    protected final static String JOURNAL_ADAPTIVE_GROUP_WRITES = "journalAdaptiveGroupWrites";
-    protected final static String JOURNAL_MAX_GROUP_WAIT_MSEC = "journalMaxGroupWaitMSec";
-    protected final static String JOURNAL_BUFFERED_WRITES_THRESHOLD = "journalBufferedWritesThreshold";
-    protected final static String JOURNAL_BUFFERED_ENTRIES_THRESHOLD = "journalBufferedEntriesThreshold";
-    protected final static String JOURNAL_FLUSH_WHEN_QUEUE_EMPTY = "journalFlushWhenQueueEmpty";
-    protected final static String JOURNAL_REMOVE_FROM_PAGE_CACHE = "journalRemoveFromPageCache";
-    protected final static String JOURNAL_PRE_ALLOC_SIZE = "journalPreAllocSizeMB";
-    protected final static String JOURNAL_WRITE_BUFFER_SIZE = "journalWriteBufferSizeKB";
-    protected final static String JOURNAL_ALIGNMENT_SIZE = "journalAlignmentSize";
-    protected final static String NUM_JOURNAL_CALLBACK_THREADS = "numJournalCallbackThreads";
-    protected final static String JOURNAL_FORMAT_VERSION_TO_WRITE = "journalFormatVersionToWrite";
+    protected static final String MAX_JOURNAL_SIZE = "journalMaxSizeMB";
+    protected static final String MAX_BACKUP_JOURNALS = "journalMaxBackups";
+    protected static final String JOURNAL_SYNC_DATA = "journalSyncData";
+    protected static final String JOURNAL_ADAPTIVE_GROUP_WRITES = "journalAdaptiveGroupWrites";
+    protected static final String JOURNAL_MAX_GROUP_WAIT_MSEC = "journalMaxGroupWaitMSec";
+    protected static final String JOURNAL_BUFFERED_WRITES_THRESHOLD = "journalBufferedWritesThreshold";
+    protected static final String JOURNAL_BUFFERED_ENTRIES_THRESHOLD = "journalBufferedEntriesThreshold";
+    protected static final String JOURNAL_FLUSH_WHEN_QUEUE_EMPTY = "journalFlushWhenQueueEmpty";
+    protected static final String JOURNAL_REMOVE_FROM_PAGE_CACHE = "journalRemoveFromPageCache";
+    protected static final String JOURNAL_PRE_ALLOC_SIZE = "journalPreAllocSizeMB";
+    protected static final String JOURNAL_WRITE_BUFFER_SIZE = "journalWriteBufferSizeKB";
+    protected static final String JOURNAL_ALIGNMENT_SIZE = "journalAlignmentSize";
+    protected static final String NUM_JOURNAL_CALLBACK_THREADS = "numJournalCallbackThreads";
+    protected static final String JOURNAL_FORMAT_VERSION_TO_WRITE = "journalFormatVersionToWrite";
     // Bookie Parameters
-    protected final static String BOOKIE_PORT = "bookiePort";
-    protected final static String LISTENING_INTERFACE = "listeningInterface";
-    protected final static String ALLOW_LOOPBACK = "allowLoopback";
-    protected final static String ADVERTISED_ADDRESS = "advertisedAddress";
-    protected final static String ALLOW_EPHEMERAL_PORTS = "allowEphemeralPorts";
+    protected static final String BOOKIE_PORT = "bookiePort";
+    protected static final String LISTENING_INTERFACE = "listeningInterface";
+    protected static final String ALLOW_LOOPBACK = "allowLoopback";
+    protected static final String ADVERTISED_ADDRESS = "advertisedAddress";
+    protected static final String ALLOW_EPHEMERAL_PORTS = "allowEphemeralPorts";
 
-    protected final static String JOURNAL_DIR = "journalDirectory";
-    protected final static String JOURNAL_DIRS = "journalDirectories";
-    protected final static String LEDGER_DIRS = "ledgerDirectories";
-    protected final static String INDEX_DIRS = "indexDirectories";
-    protected final static String ALLOW_STORAGE_EXPANSION = "allowStorageExpansion";
+    protected static final String JOURNAL_DIR = "journalDirectory";
+    protected static final String JOURNAL_DIRS = "journalDirectories";
+    protected static final String LEDGER_DIRS = "ledgerDirectories";
+    protected static final String INDEX_DIRS = "indexDirectories";
+    protected static final String ALLOW_STORAGE_EXPANSION = "allowStorageExpansion";
     // NIO Parameters
-    protected final static String SERVER_TCP_NODELAY = "serverTcpNoDelay";
-    protected final static String SERVER_SOCK_KEEPALIVE = "serverSockKeepalive";
-    protected final static String SERVER_SOCK_LINGER = "serverTcpLinger";
+    protected static final String SERVER_TCP_NODELAY = "serverTcpNoDelay";
+    protected static final String SERVER_SOCK_KEEPALIVE = "serverSockKeepalive";
+    protected static final String SERVER_SOCK_LINGER = "serverTcpLinger";
 
     // Zookeeper Parameters
-    protected final static String ZK_TIMEOUT = "zkTimeout";
-    protected final static String ZK_SERVERS = "zkServers";
-    protected final static String ZK_RETRY_BACKOFF_START_MS = "zkRetryBackoffStartMs";
-    protected final static String ZK_RETRY_BACKOFF_MAX_MS = "zkRetryBackoffMaxMs";
-    protected final static String OPEN_LEDGER_REREPLICATION_GRACE_PERIOD = "openLedgerRereplicationGracePeriod";
+    protected static final String ZK_TIMEOUT = "zkTimeout";
+    protected static final String ZK_SERVERS = "zkServers";
+    protected static final String ZK_RETRY_BACKOFF_START_MS = "zkRetryBackoffStartMs";
+    protected static final String ZK_RETRY_BACKOFF_MAX_MS = "zkRetryBackoffMaxMs";
+    protected static final String OPEN_LEDGER_REREPLICATION_GRACE_PERIOD = "openLedgerRereplicationGracePeriod";
     //ReadOnly mode support on all disk full
-    protected final static String READ_ONLY_MODE_ENABLED = "readOnlyModeEnabled";
+    protected static final String READ_ONLY_MODE_ENABLED = "readOnlyModeEnabled";
     //Whether the bookie is force started in ReadOnly mode
-    protected final static String FORCE_READ_ONLY_BOOKIE = "forceReadOnlyBookie";
+    protected static final String FORCE_READ_ONLY_BOOKIE = "forceReadOnlyBookie";
     //Whether to persist the bookie status
-    protected final static String PERSIST_BOOKIE_STATUS_ENABLED = "persistBookieStatusEnabled";
+    protected static final String PERSIST_BOOKIE_STATUS_ENABLED = "persistBookieStatusEnabled";
     //Disk utilization
-    protected final static String DISK_USAGE_THRESHOLD = "diskUsageThreshold";
-    protected final static String DISK_USAGE_WARN_THRESHOLD = "diskUsageWarnThreshold";
-    protected final static String DISK_USAGE_LWM_THRESHOLD = "diskUsageLwmThreshold";
-    protected final static String DISK_CHECK_INTERVAL = "diskCheckInterval";
+    protected static final String DISK_USAGE_THRESHOLD = "diskUsageThreshold";
+    protected static final String DISK_USAGE_WARN_THRESHOLD = "diskUsageWarnThreshold";
+    protected static final String DISK_USAGE_LWM_THRESHOLD = "diskUsageLwmThreshold";
+    protected static final String DISK_CHECK_INTERVAL = "diskCheckInterval";
 
     // Replication parameters
-    protected final static String AUDITOR_PERIODIC_CHECK_INTERVAL = "auditorPeriodicCheckInterval";
-    protected final static String AUDITOR_PERIODIC_BOOKIE_CHECK_INTERVAL = "auditorPeriodicBookieCheckInterval";
-    protected final static String AUTO_RECOVERY_DAEMON_ENABLED = "autoRecoveryDaemonEnabled";
-    protected final static String LOST_BOOKIE_RECOVERY_DELAY = "lostBookieRecoveryDelay";
-    protected final static String RW_REREPLICATE_BACKOFF_MS = "rwRereplicateBackoffMs";
+    protected static final String AUDITOR_PERIODIC_CHECK_INTERVAL = "auditorPeriodicCheckInterval";
+    protected static final String AUDITOR_PERIODIC_BOOKIE_CHECK_INTERVAL = "auditorPeriodicBookieCheckInterval";
+    protected static final String AUTO_RECOVERY_DAEMON_ENABLED = "autoRecoveryDaemonEnabled";
+    protected static final String LOST_BOOKIE_RECOVERY_DELAY = "lostBookieRecoveryDelay";
+    protected static final String RW_REREPLICATE_BACKOFF_MS = "rwRereplicateBackoffMs";
 
     // Worker Thread parameters.
-    protected final static String NUM_ADD_WORKER_THREADS = "numAddWorkerThreads";
-    protected final static String NUM_READ_WORKER_THREADS = "numReadWorkerThreads";
-    protected final static String MAX_PENDING_READ_REQUESTS_PER_THREAD = "maxPendingReadRequestsPerThread";
-    protected final static String MAX_PENDING_ADD_REQUESTS_PER_THREAD = "maxPendingAddRequestsPerThread";
-    protected final static String NUM_LONG_POLL_WORKER_THREADS = "numLongPollWorkerThreads";
+    protected static final String NUM_ADD_WORKER_THREADS = "numAddWorkerThreads";
+    protected static final String NUM_READ_WORKER_THREADS = "numReadWorkerThreads";
+    protected static final String MAX_PENDING_READ_REQUESTS_PER_THREAD = "maxPendingReadRequestsPerThread";
+    protected static final String MAX_PENDING_ADD_REQUESTS_PER_THREAD = "maxPendingAddRequestsPerThread";
+    protected static final String NUM_LONG_POLL_WORKER_THREADS = "numLongPollWorkerThreads";
 
     // Long poll parameters
-    protected final static String REQUEST_TIMER_TICK_DURATION_MILLISEC = "requestTimerTickDurationMs";
-    protected final static String REQUEST_TIMER_NO_OF_TICKS = "requestTimerNumTicks";
+    protected static final String REQUEST_TIMER_TICK_DURATION_MILLISEC = "requestTimerTickDurationMs";
+    protected static final String REQUEST_TIMER_NO_OF_TICKS = "requestTimerNumTicks";
 
-    protected final static String READ_BUFFER_SIZE = "readBufferSizeBytes";
-    protected final static String WRITE_BUFFER_SIZE = "writeBufferSizeBytes";
+    protected static final String READ_BUFFER_SIZE = "readBufferSizeBytes";
+    protected static final String WRITE_BUFFER_SIZE = "writeBufferSizeBytes";
     // Whether the bookie should use its hostname or ipaddress for the
     // registration.
-    protected final static String USE_HOST_NAME_AS_BOOKIE_ID = "useHostNameAsBookieID";
-    protected final static String ENABLE_LOCAL_TRANSPORT = "enableLocalTransport";
-    protected final static String DISABLE_SERVER_SOCKET_BIND = "disableServerSocketBind";
+    protected static final String USE_HOST_NAME_AS_BOOKIE_ID = "useHostNameAsBookieID";
+    protected static final String ENABLE_LOCAL_TRANSPORT = "enableLocalTransport";
+    protected static final String DISABLE_SERVER_SOCKET_BIND = "disableServerSocketBind";
 
-    protected final static String SORTED_LEDGER_STORAGE_ENABLED = "sortedLedgerStorageEnabled";
-    protected final static String SKIP_LIST_SIZE_LIMIT = "skipListSizeLimit";
-    protected final static String SKIP_LIST_CHUNK_SIZE_ENTRY = "skipListArenaChunkSize";
-    protected final static String SKIP_LIST_MAX_ALLOC_ENTRY = "skipListArenaMaxAllocSize";
+    protected static final String SORTED_LEDGER_STORAGE_ENABLED = "sortedLedgerStorageEnabled";
+    protected static final String SKIP_LIST_SIZE_LIMIT = "skipListSizeLimit";
+    protected static final String SKIP_LIST_CHUNK_SIZE_ENTRY = "skipListArenaChunkSize";
+    protected static final String SKIP_LIST_MAX_ALLOC_ENTRY = "skipListArenaMaxAllocSize";
 
     // Statistics Parameters
-    protected final static String ENABLE_STATISTICS = "enableStatistics";
-    protected final static String STATS_PROVIDER_CLASS = "statsProviderClass";
+    protected static final String ENABLE_STATISTICS = "enableStatistics";
+    protected static final String STATS_PROVIDER_CLASS = "statsProviderClass";
 
-    protected final static String LEDGER_STORAGE_CLASS = "ledgerStorageClass";
+    protected static final String LEDGER_STORAGE_CLASS = "ledgerStorageClass";
 
     // Rx adaptive ByteBuf allocator parameters
-    protected final static String BYTEBUF_ALLOCATOR_SIZE_INITIAL = "byteBufAllocatorSizeInitial";
-    protected final static String BYTEBUF_ALLOCATOR_SIZE_MIN = "byteBufAllocatorSizeMin";
-    protected final static String BYTEBUF_ALLOCATOR_SIZE_MAX = "byteBufAllocatorSizeMax";
+    protected static final String BYTEBUF_ALLOCATOR_SIZE_INITIAL = "byteBufAllocatorSizeInitial";
+    protected static final String BYTEBUF_ALLOCATOR_SIZE_MIN = "byteBufAllocatorSizeMin";
+    protected static final String BYTEBUF_ALLOCATOR_SIZE_MAX = "byteBufAllocatorSizeMax";
 
     // Bookie auth provider factory class name
-    protected final static String BOOKIE_AUTH_PROVIDER_FACTORY_CLASS = "bookieAuthProviderFactoryClass";
+    protected static final String BOOKIE_AUTH_PROVIDER_FACTORY_CLASS = "bookieAuthProviderFactoryClass";
 
-    protected final static String MIN_USABLESIZE_FOR_INDEXFILE_CREATION = "minUsableSizeForIndexFileCreation";
+    protected static final String MIN_USABLESIZE_FOR_INDEXFILE_CREATION = "minUsableSizeForIndexFileCreation";
 
-    protected final static String ALLOW_MULTIPLEDIRS_UNDER_SAME_DISKPARTITION = "allowMultipleDirsUnderSameDiskPartition";
+    protected static final String ALLOW_MULTIPLEDIRS_UNDER_SAME_DISKPARTITION =
+        "allowMultipleDirsUnderSameDiskPartition";
 
     // Http Server parameters
-    protected final static String HTTP_SERVER_ENABLED = "httpServerEnabled";
-    protected final static String HTTP_SERVER_PORT = "httpServerPort";
+    protected static final String HTTP_SERVER_ENABLED = "httpServerEnabled";
+    protected static final String HTTP_SERVER_PORT = "httpServerPort";
 
     // TLS parameters
-    protected final static String TLS_KEYSTORE_TYPE = "tlsKeyStoreType";
-    protected final static String TLS_KEYSTORE = "tlsKeyStore";
-    protected final static String TLS_KEYSTORE_PASSWORD_PATH = "tlsKeyStorePasswordPath";
-    protected final static String TLS_TRUSTSTORE_TYPE = "tlsTrustStoreType";
-    protected final static String TLS_TRUSTSTORE = "tlsTrustStore";
-    protected final static String TLS_TRUSTSTORE_PASSWORD_PATH = "tlsTrustStorePasswordPath";
+    protected static final String TLS_KEYSTORE_TYPE = "tlsKeyStoreType";
+    protected static final String TLS_KEYSTORE = "tlsKeyStore";
+    protected static final String TLS_KEYSTORE_PASSWORD_PATH = "tlsKeyStorePasswordPath";
+    protected static final String TLS_TRUSTSTORE_TYPE = "tlsTrustStoreType";
+    protected static final String TLS_TRUSTSTORE = "tlsTrustStore";
+    protected static final String TLS_TRUSTSTORE_PASSWORD_PATH = "tlsTrustStorePasswordPath";
 
     // Lifecycle Components
-    protected final static String EXTRA_SERVER_COMPONENTS = "extraServerComponents";
+    protected static final String EXTRA_SERVER_COMPONENTS = "extraServerComponents";
 
     // Registration
-    protected final static String REGISTRATION_MANAGER_CLASS = "registrationManagerClass";
+    protected static final String REGISTRATION_MANAGER_CLASS = "registrationManagerClass";
 
     /**
-     * Construct a default configuration object
+     * Construct a default configuration object.
      */
     public ServerConfiguration() {
         super();
     }
 
     /**
-     * Construct a configuration based on other configuration
+     * Construct a configuration based on other configuration.
      *
      * @param conf
      *          Other configuration
@@ -204,7 +205,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get entry logger size limitation
+     * Get entry logger size limitation.
      *
      * @return entry logger size limitation
      */
@@ -213,7 +214,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set entry logger size limitation
+     * Set entry logger size limitation.
      *
      * @param logSizeLimit
      *          new log size limitation
@@ -257,7 +258,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set garbage collection wait time
+     * Set garbage collection wait time.
      *
      * @param gcWaitTime
      *          gc wait time
@@ -269,8 +270,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get wait time in millis for garbage collection of overreplicated ledgers
-     * 
+     * Get wait time in millis for garbage collection of overreplicated ledgers.
+     *
      * @return gc wait time
      */
     public long getGcOverreplicatedLedgerWaitTimeMillis() {
@@ -279,14 +280,14 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set wait time for garbage collection of overreplicated ledgers. Default: 1 day
-     * 
-     * A ledger can be overreplicated under the following circumstances:
+     *
+     * <p>A ledger can be overreplicated under the following circumstances:
      * 1. The ledger with few entries has bk1 and bk2 as its ensemble.
      * 2. bk1 crashes.
      * 3. bk3 replicates the ledger from bk2 and updates the ensemble to bk2 and bk3.
      * 4. bk1 comes back up.
      * 5. Now there are 3 copies of the ledger.
-     *  
+     *
      * @param gcWaitTime
      * @return server configuration
      */
@@ -318,7 +319,7 @@ public class ServerConfiguration extends AbstractConfiguration {
      * Get flush interval. Default value is 10 second. It isn't useful to decrease
      * this value, since ledger storage only checkpoints when an entry logger file
      * is rolled.
-     * 
+     *
      * @return flush interval
      */
     public int getFlushInterval() {
@@ -326,7 +327,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set flush interval
+     * Set flush interval.
      *
      * @param flushInterval
      *          Flush Interval
@@ -339,13 +340,13 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set entry log flush interval in bytes.
-     * 
-     * Default is 0. 0 or less disables this feature and effectively flush
+     *
+     * <p>Default is 0. 0 or less disables this feature and effectively flush
      * happens on log rotation.
      *
-     * Flushing in smaller chunks but more frequently reduces spikes in disk
+     * <p>Flushing in smaller chunks but more frequently reduces spikes in disk
      * I/O. Flushing too frequently may also affect performance negatively.
-     * 
+     *
      * @return Entry log flush interval in bytes
      */
     public long getFlushIntervalInBytes() {
@@ -353,7 +354,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set entry log flush interval in bytes
+     * Set entry log flush interval in bytes.
      *
      * @param flushInterval in bytes
      * @return server configuration
@@ -362,10 +363,10 @@ public class ServerConfiguration extends AbstractConfiguration {
         this.setProperty(FLUSH_ENTRYLOG_INTERVAL_BYTES, Long.toString(flushInterval));
         return this;
     }
-    
-    
+
+
     /**
-     * Get bookie death watch interval
+     * Get bookie death watch interval.
      *
      * @return watch interval
      */
@@ -395,7 +396,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get limitation number of index pages in ledger cache
+     * Get limitation number of index pages in ledger cache.
      *
      * @return max number of index pages in ledger cache
      */
@@ -416,7 +417,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get page size
+     * Get page size.
      *
      * @return page size in ledger cache
      */
@@ -425,7 +426,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set page size
+     * Set page size.
      *
      * @see #getPageSize()
      *
@@ -489,7 +490,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Max journal file size
+     * Max journal file size.
      *
      * @return max journal file size
      */
@@ -498,7 +499,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set new max journal file size
+     * Set new max journal file size.
      *
      * @param maxJournalSize
      *          new max journal file size
@@ -510,7 +511,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * How much space should we pre-allocate at a time in the journal
+     * How much space should we pre-allocate at a time in the journal.
      *
      * @return journal pre-allocation size in MB
      */
@@ -519,7 +520,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Size of the write buffers used for the journal
+     * Size of the write buffers used for the journal.
      *
      * @return journal write buffer size in KB
      */
@@ -528,7 +529,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Max number of older journal files kept
+     * Max number of older journal files kept.
      *
      * @return max number of older journal files to kept
      */
@@ -537,7 +538,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set max number of older journal files to kept
+     * Set max number of older journal files to kept.
      *
      * @param maxBackupJournals
      *          Max number of older journal files
@@ -592,7 +593,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get bookie port that bookie server listen on
+     * Get bookie port that bookie server listen on.
      *
      * @return bookie port
      */
@@ -601,7 +602,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set new bookie port that bookie server listen on
+     * Set new bookie port that bookie server listen on.
      *
      * @param port
      *          Port to listen on
@@ -639,10 +640,10 @@ public class ServerConfiguration extends AbstractConfiguration {
      * Is the bookie allowed to use a loopback interface as its primary
      * interface(i.e. the interface it uses to establish its identity)?
      *
-     * By default, loopback interfaces are not allowed as the primary
+     * <p>By default, loopback interfaces are not allowed as the primary
      * interface.
      *
-     * Using a loopback interface as the primary interface usually indicates
+     * <p>Using a loopback interface as the primary interface usually indicates
      * a configuration error. For example, its fairly common in some VPS setups
      * to not configure a hostname, or to have the hostname resolve to
      * 127.0.0.1. If this is the case, then all bookies in the cluster will
@@ -673,7 +674,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Get the configured advertised address for the bookie.
      *
-     * If present, this setting will take precedence over the
+     * <p>If present, this setting will take precedence over the
      * {@link #setListeningInterface(String)} and
      * {@link #setUseHostNameAsBookieID(boolean)}.
      *
@@ -687,13 +688,13 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Configure the bookie to advertise a specific address.
      *
-     * By default, a bookie will advertise either its own IP or hostname,
+     * <p>By default, a bookie will advertise either its own IP or hostname,
      * depending on the {@link getUseHostNameAsBookieID()} setting.
      *
-     * When the advertised is set to a non-empty string, the bookie will
+     * <p>When the advertised is set to a non-empty string, the bookie will
      * register and advertise using this address.
      *
-     * If present, this setting will take precedence over the
+     * <p>If present, this setting will take precedence over the
      * {@link #setListeningInterface(String)} and
      * {@link #setUseHostNameAsBookieID(boolean)}.
      *
@@ -755,7 +756,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get dir names to store journal files
+     * Get dir names to store journal files.
      *
      * @return journal dir name
      */
@@ -768,7 +769,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get dir name to store journal files
+     * Get dir name to store journal files.
      *
      * @return journal dir name
      */
@@ -778,7 +779,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get dir name to store journal files
+     * Get dir name to store journal files.
      *
      * @return journal dir name
      */
@@ -788,7 +789,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
 
     /**
-     * Set dir name to store journal files
+     * Set dir name to store journal files.
      *
      * @param journalDir
      *          Dir to store journal files
@@ -800,7 +801,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set dir names to store journal files
+     * Set dir names to store journal files.
      *
      * @param journalDirs
      *          Dir to store journal files
@@ -812,21 +813,21 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get dirs to store journal files
+     * Get dirs to store journal files.
      *
      * @return journal dirs, if no journal dir provided return null
      */
     public File[] getJournalDirs() {
         String[] journalDirNames = getJournalDirNames();
         File[] journalDirs = new File[journalDirNames.length];
-        for(int i=0 ;i<journalDirNames.length; i++) {
+        for (int i = 0; i < journalDirNames.length; i++) {
             journalDirs[i] = new File(journalDirNames[i]);
         }
         return journalDirs;
     }
 
     /**
-     * Get dir names to store ledger data
+     * Get dir names to store ledger data.
      *
      * @return ledger dir names, if not provided return null
      */
@@ -835,7 +836,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get dir names to store ledger data
+     * Get dir names to store ledger data.
      *
      * @return ledger dir names, if not provided return null
      */
@@ -848,7 +849,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set dir names to store ledger data
+     * Set dir names to store ledger data.
      *
      * @param ledgerDirs
      *          Dir names to store ledger data
@@ -863,7 +864,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get dirs that stores ledger data
+     * Get dirs that stores ledger data.
      *
      * @return ledger dirs
      */
@@ -912,7 +913,7 @@ public class ServerConfiguration extends AbstractConfiguration {
             return null;
         }
         File[] idxDirs = new File[idxDirNames.length];
-        for (int i=0; i<idxDirNames.length; i++) {
+        for (int i = 0; i < idxDirNames.length; i++) {
             idxDirs[i] = new File(idxDirNames[i]);
         }
         return idxDirs;
@@ -928,7 +929,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set socket nodelay setting
+     * Set socket nodelay setting.
      *
      * @param noDelay
      *          NoDelay setting
@@ -950,10 +951,10 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set socket linger timeout on close.
-     * 
-     * When enabled, a close or shutdown will not return until all queued messages for the socket have been successfully
-     * sent or the linger timeout has been reached. Otherwise, the call returns immediately and the closing is done in
-     * the background.
+     *
+     * <p>When enabled, a close or shutdown will not return until all queued messages for the socket have been
+     * successfully sent or the linger timeout has been reached. Otherwise, the call returns immediately and the
+     * closing is done in the background.
      *
      * @param linger
      *            NoDelay setting
@@ -965,8 +966,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * get socket keepalive
-     * 
+     * Get socket keepalive.
+     *
      * @return socket keepalive setting
      */
     public boolean getServerSockKeepalive() {
@@ -975,9 +976,9 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set socket keepalive setting.
-     * 
-     * This setting is used to send keep-alive messages on connection-oriented sockets.
-     * 
+     *
+     * <p>This setting is used to send keep-alive messages on connection-oriented sockets.
+     *
      * @param keepalive
      *            KeepAlive setting
      * @return server configuration
@@ -988,7 +989,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get zookeeper servers to connect
+     * Get zookeeper servers to connect.
      *
      * @return zookeeper servers
      */
@@ -1001,7 +1002,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set zookeeper servers to connect
+     * Set zookeeper servers to connect.
      *
      * @param zkServers
      *          ZooKeeper servers to connect
@@ -1012,7 +1013,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get zookeeper timeout
+     * Get zookeeper timeout.
      *
      * @return zookeeper server timeout
      */
@@ -1021,7 +1022,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set zookeeper timeout
+     * Set zookeeper timeout.
      *
      * @param zkTimeout
      *          ZooKeeper server timeout
@@ -1075,7 +1076,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Is statistics enabled
+     * Is statistics enabled.
      *
      * @return is statistics enabled
      */
@@ -1084,7 +1085,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Turn on/off statistics
+     * Turn on/off statistics.
      *
      * @param enabled
      *          Whether statistics enabled or not.
@@ -1098,10 +1099,10 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Get threshold of minor compaction.
      *
-     * For those entry log files whose remaining size percentage reaches below
+     * <p>For those entry log files whose remaining size percentage reaches below
      * this threshold  will be compacted in a minor compaction.
      *
-     * If it is set to less than zero, the minor compaction is disabled.
+     * <p>If it is set to less than zero, the minor compaction is disabled.
      *
      * @return threshold of minor compaction
      */
@@ -1110,7 +1111,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set threshold of minor compaction
+     * Set threshold of minor compaction.
      *
      * @see #getMinorCompactionThreshold()
      *
@@ -1126,10 +1127,10 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Get threshold of major compaction.
      *
-     * For those entry log files whose remaining size percentage reaches below
+     * <p>For those entry log files whose remaining size percentage reaches below
      * this threshold  will be compacted in a major compaction.
      *
-     * If it is set to less than zero, the major compaction is disabled.
+     * <p>If it is set to less than zero, the major compaction is disabled.
      *
      * @return threshold of major compaction
      */
@@ -1154,7 +1155,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Get interval to run minor compaction, in seconds.
      *
-     * If it is set to less than zero, the minor compaction is disabled.
+     * <p>If it is set to less than zero, the minor compaction is disabled.
      *
      * @return threshold of minor compaction
      */
@@ -1163,7 +1164,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set interval to run minor compaction
+     * Set interval to run minor compaction.
      *
      * @see #getMinorCompactionInterval()
      *
@@ -1179,7 +1180,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Get interval to run major compaction, in seconds.
      *
-     * If it is set to less than zero, the major compaction is disabled.
+     * <p>If it is set to less than zero, the major compaction is disabled.
      *
      * @return high water mark
      */
@@ -1204,7 +1205,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Get whether force compaction is allowed when disk full or almost full.
      *
-     * Force GC may get some space back, but may also fill up disk space more
+     * <p>Force GC may get some space back, but may also fill up disk space more
      * quickly. This is because new log files are created before GC, while old
      * garbage log files deleted after GC.
      *
@@ -1232,7 +1233,7 @@ public class ServerConfiguration extends AbstractConfiguration {
      * fencing and rereplicating a ledger fragment which is still being written
      * to, on bookie failure.
      *
-     * The grace period allows the writer to detect the bookie failure, and and
+     * <p>The grace period allows the writer to detect the bookie failure, and and
      * start writing to another ledger fragment. If the writer writes nothing
      * during the grace period, the rereplication worker assumes that it has
      * crashed and therefore fences the ledger, preventing any further writes to
@@ -1259,7 +1260,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Get the number of bytes we should use as capacity for
-     * org.apache.bookkeeper.bookie.BufferedReadChannel
+     * org.apache.bookkeeper.bookie.BufferedReadChannel.
      * Default is 512 bytes
      * @return read buffer size
      */
@@ -1269,7 +1270,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set the number of bytes we should use as capacity for
-     * org.apache.bookkeeper.bookie.BufferedReadChannel
+     * org.apache.bookkeeper.bookie.BufferedReadChannel.
      *
      * @param readBufferSize
      *          Read Buffer Size
@@ -1302,7 +1303,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the number of threads that should handle long poll requests
+     * Set the number of threads that should handle long poll requests.
      *
      * @param numThreads
      *          number of threads to handle long poll requests.
@@ -1339,9 +1340,9 @@ public class ServerConfiguration extends AbstractConfiguration {
     public int getNumReadWorkerThreads() {
         return getInt(NUM_READ_WORKER_THREADS, 8);
     }
-    
+
     /**
-     * Set the tick duration in milliseconds
+     * Set the tick duration in milliseconds.
      *
      * @param tickDuration
      *          tick duration in milliseconds.
@@ -1353,8 +1354,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the max number of pending read requests for each read worker thread. After the quota is reached, new requests
-     * will be failed immediately
+     * Set the max number of pending read requests for each read worker thread. After the quota is reached,
+     * new requests will be failed immediately.
      *
      * @param maxPendingReadRequestsPerThread
      * @return server configuration
@@ -1366,7 +1367,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * If read workers threads are enabled, limit the number of pending requests, to avoid the executor queue to grow
-     * indefinitely (default: 10000 entries)
+     * indefinitely (default: 10000 entries).
      */
     public int getMaxPendingReadRequestPerThread() {
         return getInt(MAX_PENDING_READ_REQUESTS_PER_THREAD, 10000);
@@ -1374,7 +1375,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set the max number of pending add requests for each add worker thread. After the quota is reached, new requests
-     * will be failed immediately
+     * will be failed immediately.
      *
      * @param maxPendingAddRequestsPerThread
      * @return server configuration
@@ -1386,7 +1387,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * If add workers threads are enabled, limit the number of pending requests, to avoid the executor queue to grow
-     * indefinitely (default: 10000 entries)
+     * indefinitely (default: 10000 entries).
      */
     public int getMaxPendingAddRequestPerThread() {
         return getInt(MAX_PENDING_ADD_REQUESTS_PER_THREAD, 10000);
@@ -1466,7 +1467,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set sorted-ledger storage enabled or not
+     * Set sorted-ledger storage enabled or not.
      *
      * @deprecated Use {@link #setLedgerStorageClass(String)} to configure the implementation class
      * @param enabled
@@ -1477,7 +1478,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Check if sorted-ledger storage enabled (default true)
+     * Check if sorted-ledger storage enabled (default true).
      *
      * @return true if sorted ledger storage is enabled, false otherwise
      */
@@ -1486,7 +1487,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get skip list data size limitation (default 64MB)
+     * Get skip list data size limitation (default 64MB).
      *
      * @return skip list data size limitation
      */
@@ -1507,7 +1508,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Get the number of bytes we should use as chunk allocation for
-     * org.apache.bookkeeper.bookie.SkipListArena
+     * org.apache.bookkeeper.bookie.SkipListArena.
      * Default is 4 MB
      * @return the number of bytes to use for each chunk in the skiplist arena
      */
@@ -1517,7 +1518,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set the number of bytes we used as chunk allocation for
-     * org.apache.bookkeeper.bookie.SkipListArena
+     * org.apache.bookkeeper.bookie.SkipListArena.
      *
      * @param size chunk size.
      * @return server configuration object.
@@ -1538,9 +1539,9 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Should the data be fsynced on journal before acknowledgment
+     * Should the data be fsynced on journal before acknowledgment.
      *
-     * Default is true
+     * <p>Default is true
      *
      * @return
      */
@@ -1550,13 +1551,13 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Enable or disable journal syncs.
-     * <p>
-     * By default, data sync is enabled to guarantee durability of writes.
-     * <p>
-     * Beware: while disabling data sync in the Bookie journal might improve the bookie write performance, it will also
-     * introduce the possibility of data loss. With no sync, the journal entries are written in the OS page cache but
-     * not flushed to disk. In case of power failure, the affected bookie might lose the unflushed data. If the ledger
-     * is replicated to multiple bookies, the chances of data loss are reduced though still present.
+     *
+     * <p>By default, data sync is enabled to guarantee durability of writes.
+     *
+     * <p>Beware: while disabling data sync in the Bookie journal might improve the bookie write performance, it will
+     * also introduce the possibility of data loss. With no sync, the journal entries are written in the OS page cache
+     * but not flushed to disk. In case of power failure, the affected bookie might lose the unflushed data. If the
+     * ledger is replicated to multiple bookies, the chances of data loss are reduced though still present.
      *
      * @param syncData
      *            whether to sync data on disk before acknowledgement
@@ -1568,7 +1569,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Should we group journal force writes
+     * Should we group journal force writes.
      *
      * @return group journal force writes
      */
@@ -1577,7 +1578,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Enable/disable group journal force writes
+     * Enable/disable group journal force writes.
      *
      * @param enabled flag to enable/disable group journal force writes
      */
@@ -1596,7 +1597,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Sets the maximum latency to impose on a journal write to achieve grouping
+     * Sets the maximum latency to impose on a journal write to achieve grouping.
      *
      * @param journalMaxGroupWaitMSec
      *          maximum time to wait in milliseconds.
@@ -1608,7 +1609,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Maximum bytes to buffer to impose on a journal write to achieve grouping
+     * Maximum bytes to buffer to impose on a journal write to achieve grouping.
      *
      * @return max bytes to buffer
      */
@@ -1642,7 +1643,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set if we should flush the journal when queue is empty
+     * Set if we should flush the journal when queue is empty.
      */
     public ServerConfiguration setJournalFlushWhenQueueEmpty(boolean enabled) {
         setProperty(JOURNAL_FLUSH_WHEN_QUEUE_EMPTY, enabled);
@@ -1650,7 +1651,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Should we flush the journal when queue is empty
+     * Should we flush the journal when queue is empty.
      *
      * @return flush when queue is empty
      */
@@ -1704,7 +1705,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Whether to persist the bookie status so that when bookie server restarts,
-     * it will continue using the previous status
+     * it will continue using the previous status.
      *
      * @param enabled
      *            - true if persist the bookie status. Otherwise false.
@@ -1747,14 +1748,13 @@ public class ServerConfiguration extends AbstractConfiguration {
         return getFloat(DISK_USAGE_THRESHOLD, 0.95f);
     }
 
-    
     /**
-     * Set the disk free space low water mark threshold. 
+     * Set the disk free space low water mark threshold.
      * Disk is considered full when usage threshold is exceeded.
      * Disk returns back to non-full state when usage is below low water mark threshold.
-     * This prevents it from going back and forth between these states frequently 
-     * when concurrent writes and compaction are happening. This also prevent bookie from 
-     * switching frequently between read-only and read-writes states in the same cases.  
+     * This prevents it from going back and forth between these states frequently
+     * when concurrent writes and compaction are happening. This also prevent bookie from
+     * switching frequently between read-only and read-writes states in the same cases.
      *
      * @param threshold threshold to declare a disk full
      *
@@ -1766,7 +1766,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Returns disk free space low water mark threshold. By default it is the 
+     * Returns disk free space low water mark threshold. By default it is the
      * same as usage threshold (for backwards-compatibility).
      *
      * @return the percentage below which a disk will NOT be considered full
@@ -1775,9 +1775,8 @@ public class ServerConfiguration extends AbstractConfiguration {
         return getFloat(DISK_USAGE_LWM_THRESHOLD, getDiskUsageThreshold());
     }
 
-    
     /**
-     * Set the disk checker interval to monitor ledger disk space
+     * Set the disk checker interval to monitor ledger disk space.
      *
      * @param interval interval between disk checks for space.
      *
@@ -1789,7 +1788,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get the disk checker interval
+     * Get the disk checker interval.
      *
      * @return int
      */
@@ -1842,7 +1841,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Sets that whether the auto-recovery service can start along with Bookie
-     * server itself or not
+     * server itself or not.
      *
      * @param enabled
      *            - true if need to start auto-recovery service. Otherwise
@@ -1855,7 +1854,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get whether the Bookie itself can start auto-recovery service also or not
+     * Get whether the Bookie itself can start auto-recovery service also or not.
      *
      * @return true - if Bookie should start auto-recovery service along with
      *         it. false otherwise.
@@ -1899,7 +1898,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Sets that whether force start a bookie in readonly mode
+     * Sets that whether force start a bookie in readonly mode.
      *
      * @param enabled
      *            - true if need to start a bookie in read only mode. Otherwise
@@ -1912,7 +1911,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get whether the Bookie is force started in read only mode or not
+     * Get whether the Bookie is force started in read only mode or not.
      *
      * @return true - if need to start a bookie in read only mode. Otherwise
      *         false.
@@ -1922,7 +1921,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get whether use bytes to throttle garbage collector compaction or not
+     * Get whether use bytes to throttle garbage collector compaction or not.
      *
      * @return true  - use Bytes,
      *         false - use Entries.
@@ -1932,7 +1931,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set whether use bytes to throttle garbage collector compaction or not
+     * Set whether use bytes to throttle garbage collector compaction or not.
      *
      * @param byBytes true to use by bytes; false to use by entries
      *
@@ -1956,13 +1955,13 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Set the maximum number of entries which can be compacted without flushing.
      *
-     * When compacting, the entries are written to the entrylog and the new offsets
+     * <p>When compacting, the entries are written to the entrylog and the new offsets
      * are cached in memory. Once the entrylog is flushed the index is updated with
      * the new offsets. This parameter controls the number of entries added to the
      * entrylog before a flush is forced. A higher value for this parameter means
      * more memory will be used for offsets. Each offset consists of 3 longs.
      *
-     * This parameter should _not_ be modified unless you know what you're doing.
+     * <p>This parameter should _not_ be modified unless you know what you're doing.
      * The default is 100,000.
      *
      * @param maxOutstandingRequests number of entries to compact before flushing
@@ -2040,7 +2039,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Should we remove pages from page cache after force write
+     * Should we remove pages from page cache after force write.
      *
      * @return remove pages from cache
      */
@@ -2062,7 +2061,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /*
-     * Get the {@link LedgerStorage} implementation class name
+     * Get the {@link LedgerStorage} implementation class name.
      *
      * @return the class name
      */
@@ -2084,7 +2083,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set the {@link LedgerStorage} implementation class name
+     * Set the {@link LedgerStorage} implementation class name.
      *
      * @param ledgerStorageClass the class name
      * @return ServerConfiguration
@@ -2108,7 +2107,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Configure the bookie to use its hostname to register with the
-     * co-ordination service(eg: zookeeper) and in ledger metadata
+     * co-ordination service(eg: zookeeper) and in ledger metadata.
      *
      * @see #getUseHostNameAsBookieID
      * @param useHostName
@@ -2130,7 +2129,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Configure the bookie to listen for BookKeeper clients executed on the local JVM
+     * Configure the bookie to listen for BookKeeper clients executed on the local JVM.
      *
      * @see #isEnableLocalTransport
      * @param enableLocalTransport
@@ -2153,7 +2152,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Configure the bookie to disable bind on network interfaces,
-     * this bookie will be available only to BookKeeper clients executed on the local JVM
+     * this bookie will be available only to BookKeeper clients executed on the local JVM.
      *
      * @see #isDisableServerSocketBind
      * @param disableServerSocketBind
@@ -2175,7 +2174,7 @@ public class ServerConfiguration extends AbstractConfiguration {
         throws ConfigurationException {
         return ReflectionUtils.getClass(this, STATS_PROVIDER_CLASS,
                                         NullStatsProvider.class, StatsProvider.class,
-                                        defaultLoader);
+                                        DEFAULT_LOADER);
     }
 
     /**
@@ -2214,8 +2213,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get Recv ByteBuf allocator initial buf size
-     * 
+     * Get Recv ByteBuf allocator initial buf size.
+     *
      * @return initial byteBuf size
      */
     public int getRecvByteBufAllocatorSizeInitial() {
@@ -2223,8 +2222,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set Recv ByteBuf allocator initial buf size
-     * 
+     * Set Recv ByteBuf allocator initial buf size.
+     *
      * @param size
      *            buffer size
      */
@@ -2233,8 +2232,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get Recv ByteBuf allocator min buf size
-     * 
+     * Get Recv ByteBuf allocator min buf size.
+     *
      * @return min byteBuf size
      */
     public int getRecvByteBufAllocatorSizeMin() {
@@ -2242,8 +2241,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set Recv ByteBuf allocator min buf size
-     * 
+     * Set Recv ByteBuf allocator min buf size.
+     *
      * @param size
      *            buffer size
      */
@@ -2252,8 +2251,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get Recv ByteBuf allocator max buf size
-     * 
+     * Get Recv ByteBuf allocator max buf size.
+     *
      * @return max byteBuf size
      */
     public int getRecvByteBufAllocatorSizeMax() {
@@ -2261,8 +2260,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set Recv ByteBuf allocator max buf size
-     * 
+     * Set Recv ByteBuf allocator max buf size.
+     *
      * @param size
      *            buffer size
      */
@@ -2270,13 +2269,12 @@ public class ServerConfiguration extends AbstractConfiguration {
         setProperty(BYTEBUF_ALLOCATOR_SIZE_MAX, size);
     }
 
-    /*
+    /**
      * Set the bookie authentication provider factory class name.
-     * If this is not set, no authentication will be used
+     * If this is not set, no authentication will be used.
      *
      * @param factoryClass
      *          the bookie authentication provider factory class name
-     * @return void
      */
     public void setBookieAuthProviderFactoryClass(String factoryClass) {
         setProperty(BOOKIE_AUTH_PROVIDER_FACTORY_CLASS, factoryClass);
@@ -2312,7 +2310,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set the keystore type for client.
-     * 
+     *
      * @return
      */
     public ServerConfiguration setTLSKeyStoreType(String arg) {
@@ -2340,9 +2338,8 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Gets the minimum safe Usable size to be available in index directory for Bookie to create Index File while replaying
      * Get the path to file containing keystore password if the client keystore is password protected. Default is null.
-     * 
+     *
      * @return
      */
     public String getTLSKeyStorePasswordPath() {
@@ -2351,7 +2348,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set the path to file containing keystore password, if the client keystore is password protected.
-     * 
+     *
      * @return
      */
     public ServerConfiguration setTLSKeyStorePasswordPath(String arg) {
@@ -2361,7 +2358,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Get the keystore type for client. Default is JKS.
-     * 
+     *
      * @return
      */
     public String getTLSKeyStoreType() {
@@ -2370,7 +2367,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set the truststore type for client.
-     * 
+     *
      * @return
      */
     public ServerConfiguration setTLSTrustStoreType(String arg) {
@@ -2380,7 +2377,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Get the truststore path for the client.
-     * 
+     *
      * @return
      */
     public String getTLSTrustStore() {
@@ -2389,7 +2386,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set the truststore path for the client.
-     * 
+     *
      * @return
      */
     public ServerConfiguration setTLSTrustStore(String arg) {
@@ -2400,7 +2397,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     /**
      * Get the path to file containing truststore password if the client truststore is password protected. Default is
      * null.
-     * 
+     *
      * @return
      */
     public String getTLSTrustStorePasswordPath() {
@@ -2409,7 +2406,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Set the path to file containing truststore password, if the client truststore is password protected.
-     * 
+     *
      * @return
      */
     public ServerConfiguration setTLSTrustStorePasswordPath(String arg) {
@@ -2418,9 +2415,9 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Gets the minimum safe Usable size to be available in index directory for Bookie to create Index File while replaying 
-     * journal at the time of Bookie Start in Readonly Mode (in bytes)
-     * 
+     * Gets the minimum safe Usable size to be available in index directory for Bookie to create Index File while
+     * replaying journal at the time of Bookie Start in Readonly Mode (in bytes).
+     *
      * @return
      */
     public long getMinUsableSizeForIndexFileCreation() {
@@ -2428,9 +2425,9 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Sets the minimum safe Usable size to be available in index directory for Bookie to create Index File while replaying 
-     * journal at the time of Bookie Start in Readonly Mode (in bytes)
-     * 
+     * Sets the minimum safe Usable size to be available in index directory for Bookie to create Index File while
+     * replaying journal at the time of Bookie Start in Readonly Mode (in bytes).
+     *
      * @param minUsableSizeForIndexFileCreation
      * @return
      */
@@ -2441,7 +2438,7 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * returns whether it is allowed to have multiple ledger/index/journal
-     * Directories in the same filesystem diskpartition
+     * Directories in the same filesystem diskpartition.
      *
      * @return
      */
@@ -2451,10 +2448,10 @@ public class ServerConfiguration extends AbstractConfiguration {
 
     /**
      * Configure the Bookie to allow/disallow multiple ledger/index/journal
-     * directories in the same filesystem diskpartition
+     * directories in the same filesystem diskpartition.
      *
      * @param allow
-     * 
+     *
      * @return server configuration object.
      */
     public ServerConfiguration setAllowMultipleDirsUnderSameDiskPartition(boolean allow) {
@@ -2463,7 +2460,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get whether to start the http server or not
+     * Get whether to start the http server or not.
      *
      * @return true - if http server should start
      */
@@ -2472,7 +2469,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set whether to start the http server or not
+     * Set whether to start the http server or not.
      *
      * @param enabled
      *            - true if we should start http server
@@ -2484,7 +2481,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get the http server port
+     * Get the http server port.
      *
      * @return http server port
      */
@@ -2493,7 +2490,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set Http server port listening on
+     * Set Http server port listening on.
      *
      * @param port
      *          Port to listen on
@@ -2529,7 +2526,7 @@ public class ServerConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Set registration manager class
+     * Set registration manager class.
      *
      * @param regManagerClass
      *            ManagerClass
@@ -2548,7 +2545,7 @@ public class ServerConfiguration extends AbstractConfiguration {
             throws ConfigurationException {
         return ReflectionUtils.getClass(this, REGISTRATION_MANAGER_CLASS,
                 ZKRegistrationManager.class, RegistrationManager.class,
-                defaultLoader);
+                DEFAULT_LOADER);
     }
 
 }

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -23,7 +23,6 @@
     <!-- suppress packages by packages -->
     <suppress checks=".*" files=".*[\\/]bookie[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]client[\\/](?:[^\\/]+$|(?!api)|(?!impl)[^\\/]+[\\/])"/>
-    <suppress checks=".*" files=".*[\\/]conf[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]http[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]meta[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]metastore[\\/].*"/>


### PR DESCRIPTION
This is part of #230 and adds Checkstyle verification to the conf
package in bookkeeper-server.

As with #792, most of the changes here should be non-controversial. However, as with #792, there is a constant field whose name needed to be renamed. `AbstractConfiguration` has a `protected static final` field called `defaultLoader`. This field is used in the two implementing classes, so keeping `protected` visibility seems right. So in this case, the field has been renamed to `DEFAULT_LOADER` while keeping the `protected static final` modifiers.

The changed line is: https://github.com/apache/bookkeeper/compare/master...acoburn:checkstyle_conf?expand=1#diff-b4f821552b13a688d62015e96092e08eR45