### PR TITLE
ISSUE 230: Add Checkstyle to some packages

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/InMemoryMetaStore.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/InMemoryMetaStore.java
@@ -22,6 +22,9 @@ import java.util.Map;
 
 import org.apache.commons.configuration.Configuration;
 
+/**
+ * An in-memory implementation of the MetaStore interface.
+ */
 public class InMemoryMetaStore implements MetaStore {
 
     static final int CUR_VERSION = 1;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/InMemoryMetastoreCursor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/InMemoryMetastoreCursor.java
@@ -19,6 +19,8 @@ package org.apache.bookkeeper.metastore;
 
 import static org.apache.bookkeeper.metastore.InMemoryMetastoreTable.cloneValue;
 
+import com.google.common.collect.ImmutableSortedMap;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -30,8 +32,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.bookkeeper.metastore.MSException.Code;
 import org.apache.bookkeeper.versioning.Versioned;
-
-import com.google.common.collect.ImmutableSortedMap;
 
 class InMemoryMetastoreCursor implements MetastoreCursor {
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MSException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MSException.java
@@ -21,13 +21,16 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Marker for metastore exceptions.
+ */
 @SuppressWarnings("serial")
 public abstract class MSException extends Exception {
 
     /**
-     * return codes
+     * Return codes.
      */
-    public static enum Code {
+    public enum Code {
         OK (0, "OK"),
         BadVersion (-1, "Version conflict"),
         NoKey (-2, "Key does not exist"),
@@ -39,8 +42,7 @@ public abstract class MSException extends Exception {
         ServiceDown (-102, "Metadata service is down"),
         OperationFailure(-103, "Operaion failed on metadata storage server side");
 
-        private static final Map<Integer, Code> codes
-            = new HashMap<Integer, Code>();
+        private static final Map<Integer, Code> codes = new HashMap<Integer, Code>();
 
         static {
             for (Code c : EnumSet.allOf(Code.class)) {
@@ -131,6 +133,9 @@ public abstract class MSException extends Exception {
         }
     }
 
+    /**
+     * A BadVersion exception.
+     */
     public static class BadVersionException extends MSException {
         public BadVersionException(String errMsg) {
             super(Code.BadVersion, errMsg);
@@ -141,6 +146,9 @@ public abstract class MSException extends Exception {
         }
     }
 
+    /**
+     * Exception in cases where there is no key.
+     */
     public static class NoKeyException extends MSException {
         public NoKeyException(String errMsg) {
             super(Code.NoKey, errMsg);
@@ -151,7 +159,9 @@ public abstract class MSException extends Exception {
         }
     }
 
-    // Exception would be thrown in a cursor if no entries found
+    /**
+     * Exception would be thrown in a cursor if no entries found.
+     */
     public static class NoEntriesException extends MSException {
         public NoEntriesException(String errMsg) {
             super(Code.NoEntries, errMsg);
@@ -162,6 +172,9 @@ public abstract class MSException extends Exception {
         }
     }
 
+    /**
+     * Key Exists Exception.
+     */
     public static class KeyExistsException extends MSException {
         public KeyExistsException(String errMsg) {
             super(Code.KeyExists, errMsg);
@@ -172,6 +185,9 @@ public abstract class MSException extends Exception {
         }
     }
 
+    /**
+     * Metastore interruption exception.
+     */
     public static class MSInterruptedException extends MSException {
         public MSInterruptedException(String errMsg) {
             super(Code.InterruptedException, errMsg);
@@ -182,6 +198,9 @@ public abstract class MSException extends Exception {
         }
     }
 
+    /**
+     * Illegal operation exception.
+     */
     public static class IllegalOpException extends MSException {
         public IllegalOpException(String errMsg) {
             super(Code.IllegalOp, errMsg);
@@ -192,6 +211,9 @@ public abstract class MSException extends Exception {
         }
     }
 
+    /**
+     * Service down exception.
+     */
     public static class ServiceDownException extends MSException {
         public ServiceDownException(String errMsg) {
             super(Code.ServiceDown, errMsg);
@@ -202,6 +224,9 @@ public abstract class MSException extends Exception {
         }
     }
 
+    /**
+     * Operation failure exception.
+     */
     public static class OperationFailureException extends MSException {
         public OperationFailureException(String errMsg) {
             super(Code.OperationFailure, errMsg);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MSWatchedEvent.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MSWatchedEvent.java
@@ -17,21 +17,27 @@
  */
 package org.apache.bookkeeper.metastore;
 
+/**
+ * A metastore watched event.
+ */
 public class MSWatchedEvent {
+    /**
+     * The metastore event type.
+     */
     public enum EventType {CHANGED, REMOVED}
-    
+
     String key;
     EventType type;
-    
+
     public MSWatchedEvent(String key, EventType type) {
         this.key = key;
         this.type = type;
     }
-    
+
     public EventType getType() {
         return type;
     }
-    
+
     public String getKey(){
         return key;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetaStore.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetaStore.java
@@ -28,14 +28,14 @@ public interface MetaStore {
      *
      * @return the plugin name.
      */
-    public String getName();
+    String getName();
 
     /**
      * Get the plugin verison.
      *
      * @return the plugin version.
      */
-    public int getVersion();
+    int getVersion();
 
     /**
      * Initialize the meta store.
@@ -46,13 +46,12 @@ public interface MetaStore {
      *          Version to initialize the metastore
      * @throws MetastoreException when failed to initialize
      */
-    public void init(Configuration config, int msVersion)
-    throws MetastoreException;
+    void init(Configuration config, int msVersion) throws MetastoreException;
 
     /**
      * Close the meta store.
      */
-    public void close();
+    void close();
 
     /**
      * Create a metastore table.
@@ -62,8 +61,7 @@ public interface MetaStore {
      * @return a metastore table
      * @throws MetastoreException when failed to create the metastore table.
      */
-    public MetastoreTable createTable(String name)
-    throws MetastoreException;
+    MetastoreTable createTable(String name) throws MetastoreException;
 
     /**
      * Create a scannable metastore table.
@@ -73,7 +71,6 @@ public interface MetaStore {
      * @return a metastore scannable table
      * @throws MetastoreException when failed to create the metastore table.
      */
-    public MetastoreScannableTable createScannableTable(String name)
-    throws MetastoreException;
+    MetastoreScannableTable createScannableTable(String name) throws MetastoreException;
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreCallback.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreCallback.java
@@ -17,9 +17,12 @@
  */
 package org.apache.bookkeeper.metastore;
 
+/**
+ * Metastore callback.
+ */
 public interface MetastoreCallback<T> {
     /**
      * @see MSException.Code
      */
-    public void complete(int rc, T value, Object ctx);
+    void complete(int rc, T value, Object ctx);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreCursor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreCursor.java
@@ -21,9 +21,12 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 
+/**
+ * A Metastore Cursor.
+ */
 public interface MetastoreCursor extends Closeable {
 
-    public static MetastoreCursor EMPTY_CURSOR = new MetastoreCursor() {
+    MetastoreCursor EMPTY_CURSOR = new MetastoreCursor() {
         @Override
         public boolean hasMoreEntries() {
             return false;
@@ -46,7 +49,10 @@ public interface MetastoreCursor extends Closeable {
         }
     };
 
-    public static interface ReadEntriesCallback extends
+    /**
+     * A callback for reading entries.
+     */
+    interface ReadEntriesCallback extends
         MetastoreCallback<Iterator<MetastoreTableItem>> {
     }
 
@@ -55,7 +61,7 @@ public interface MetastoreCursor extends Closeable {
      *
      * @return true if there is entries left, false otherwise.
      */
-    public boolean hasMoreEntries();
+    boolean hasMoreEntries();
 
     /**
      * Read entries from the cursor, up to the specified <code>numEntries</code>.
@@ -66,8 +72,7 @@ public interface MetastoreCursor extends Closeable {
      * @return the iterator of returned entries.
      * @throws MSException when failed to read entries from the cursor.
      */
-    public Iterator<MetastoreTableItem> readEntries(int numEntries)
-    throws MSException;
+    Iterator<MetastoreTableItem> readEntries(int numEntries) throws MSException;
 
     /**
      * Asynchronously read entries from the cursor, up to the specified <code>numEntries</code>.
@@ -80,5 +85,5 @@ public interface MetastoreCursor extends Closeable {
      * @param ctx
      *            opaque context
      */
-    public void asyncReadEntries(int numEntries, ReadEntriesCallback callback, Object ctx);
+    void asyncReadEntries(int numEntries, ReadEntriesCallback callback, Object ctx);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreException.java
@@ -17,6 +17,9 @@
  */
 package org.apache.bookkeeper.metastore;
 
+/**
+ * A marker for Metastore exceptions.
+ */
 @SuppressWarnings("serial")
 public class MetastoreException extends Exception {
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreFactory.java
@@ -19,6 +19,9 @@ package org.apache.bookkeeper.metastore;
 
 import org.apache.bookkeeper.util.ReflectionUtils;
 
+/**
+ *  Metastore Factory.
+ */
 public class MetastoreFactory {
 
     public static MetaStore createMetaStore(String name)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreScannableTable.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreScannableTable.java
@@ -19,14 +19,19 @@ package org.apache.bookkeeper.metastore;
 
 import java.util.Set;
 
+/**
+ * Metastore Scannable Table.
+ */
 public interface MetastoreScannableTable extends MetastoreTable {
 
     // Used by cursor, etc when they want to start at the beginning of a table
-    public static final String EMPTY_START_KEY = null;
+    String EMPTY_START_KEY = null;
     // Last row in a table.
-    public static final String EMPTY_END_KEY = null;
-    // the order to loop over a table
-    public static enum Order {
+    String EMPTY_END_KEY = null;
+    /**
+     * The order to loop over a table.
+     */
+    enum Order {
         ASC,
         DESC
     }
@@ -35,12 +40,10 @@ public interface MetastoreScannableTable extends MetastoreTable {
      * Open a cursor to loop over the entries belonging to a key range,
      * which returns all fields for each entry.
      *
-     * <p>
-     * Return Code:<br/>
+     * <p>Return Code:<br/>
      * {@link MSException.Code.OK}: an opened cursor<br/>
      * {@link MSException.Code.IllegalOp}/{@link MSException.Code.ServiceDown}:
      * other issues
-     * </p>
      *
      * @param firstKey
      *            Key to start scanning. If it is {@link EMPTY_START_KEY}, it starts
@@ -59,7 +62,7 @@ public interface MetastoreScannableTable extends MetastoreTable {
      * @param ctx
      *            Callback context
      */
-    public void openCursor(String firstKey, boolean firstInclusive,
+    void openCursor(String firstKey, boolean firstInclusive,
                            String lastKey, boolean lastInclusive,
                            Order order,
                            MetastoreCallback<MetastoreCursor> cb,
@@ -69,12 +72,10 @@ public interface MetastoreScannableTable extends MetastoreTable {
      * Open a cursor to loop over the entries belonging to a key range,
      * which returns the specified <code>fields</code> for each entry.
      *
-     * <p>
-     * Return Code:<br/>
+     * <p>Return Code:<br/>
      * {@link MSException.Code.OK}: an opened cursor<br/>
      * {@link MSException.Code.IllegalOp}/{@link MSException.Code.ServiceDown}:
      * other issues
-     * </p>
      *
      * @param firstKey
      *            Key to start scanning. If it is {@link EMPTY_START_KEY}, it starts
@@ -95,7 +96,7 @@ public interface MetastoreScannableTable extends MetastoreTable {
      * @param ctx
      *            Callback context
      */
-    public void openCursor(String firstKey, boolean firstInclusive,
+    void openCursor(String firstKey, boolean firstInclusive,
                            String lastKey, boolean lastInclusive,
                            Order order, Set<String> fields,
                            MetastoreCallback<MetastoreCursor> cb,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreTable.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreTable.java
@@ -22,19 +22,22 @@ import java.util.Set;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
 
+/**
+ * Metastore Table interface.
+ */
 public interface MetastoreTable {
 
     // select all fields when reading or scanning entries
-    public static final Set<String> ALL_FIELDS = null;
+    Set<String> ALL_FIELDS = null;
     // select non fields to return when reading/scanning entries
-    public static final Set<String> NON_FIELDS = Collections.emptySet();
+    Set<String> NON_FIELDS = Collections.emptySet();
 
     /**
      * Get table name.
      *
      * @return table name
      */
-    public String getName();
+    String getName();
 
     /**
      * Get all fields of a key.
@@ -53,7 +56,7 @@ public interface MetastoreTable {
      * @param ctx
      *          Callback context
      */
-    public void get(String key, MetastoreCallback<Versioned<Value>> cb, Object ctx);
+    void get(String key, MetastoreCallback<Versioned<Value>> cb, Object ctx);
 
     /**
      * Get all fields of a key.
@@ -74,8 +77,8 @@ public interface MetastoreTable {
      * @param ctx
      *          Callback context
      */
-    public void get(String key, MetastoreWatcher watcher, MetastoreCallback<Versioned<Value>> cb, Object ctx);
-    
+    void get(String key, MetastoreWatcher watcher, MetastoreCallback<Versioned<Value>> cb, Object ctx);
+
     /**
      * Get specified fields of a key.
      *
@@ -95,8 +98,7 @@ public interface MetastoreTable {
      * @param ctx
      *          Callback context
      */
-    public void get(String key, Set<String> fields,
-                    MetastoreCallback<Versioned<Value>> cb, Object ctx);
+    void get(String key, Set<String> fields, MetastoreCallback<Versioned<Value>> cb, Object ctx);
 
     /**
      * Update a key according to its version.
@@ -110,7 +112,7 @@ public interface MetastoreTable {
      * <li>{@link MSException.Code.IllegalOp}/{@link MSException.Code.ServiceDown}: other issues</li>
      * </ul></p>
      *
-     * The key is updated only when the version matches its current version.
+     * <p>The key is updated only when the version matches its current version.
      * In particular, if the provided version is:<ul>
      * <li>{@link Version.ANY}: update the data without comparing its version.
      *      <b>Note this usage is not encouraged since it may mess up data consistency.</b></li>
@@ -129,12 +131,12 @@ public interface MetastoreTable {
      * @param ctx
      *          Callback context
      */
-    public void put(String key, Value value, Version version, MetastoreCallback<Version> cb, Object ctx);
+    void put(String key, Value value, Version version, MetastoreCallback<Version> cb, Object ctx);
 
     /**
      * Remove a key by its version.
      *
-     * The key is removed only when the version matches its current version.
+     * <p>The key is removed only when the version matches its current version.
      * If <code>version</code> is {@link Version.ANY}, the key would be removed directly.
      *
      * <p>
@@ -154,8 +156,7 @@ public interface MetastoreTable {
      * @param ctx
      *          Callback context
      */
-    public void remove(String key, Version version,
-                       MetastoreCallback<Void> cb, Object ctx);
+    void remove(String key, Version version, MetastoreCallback<Void> cb, Object ctx);
 
     /**
      * Open a cursor to loop over all the entries of the table,
@@ -168,7 +169,7 @@ public interface MetastoreTable {
      * @param ctx
      *          Callback context
      */
-    public void openCursor(MetastoreCallback<MetastoreCursor> cb, Object ctx);
+    void openCursor(MetastoreCallback<MetastoreCursor> cb, Object ctx);
 
     /**
      * Open a cursor to loop over all the entries of the table,
@@ -183,11 +184,10 @@ public interface MetastoreTable {
      * @param ctx
      *          Callback context
      */
-    public void openCursor(Set<String> fields,
-                           MetastoreCallback<MetastoreCursor> cb, Object ctx);
+    void openCursor(Set<String> fields, MetastoreCallback<MetastoreCursor> cb, Object ctx);
 
     /**
      * Close the table.
      */
-    public void close();
+    void close();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreTableItem.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreTableItem.java
@@ -62,7 +62,7 @@ public class MetastoreTableItem {
     /**
      * Set the value of the item.
      *
-     * @return value of the item.
+     * @param value of the item.
      */
     public void setValue(Versioned<Value> value) {
         this.value = value;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreUtils.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MetastoreUtils {
 
-    protected final static Logger logger = LoggerFactory.getLogger(MetastoreUtils.class);
+    private static final Logger logger = LoggerFactory.getLogger(MetastoreUtils.class);
 
     static class MultiMetastoreCallback<T> implements MetastoreCallback<T> {
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreWatcher.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/MetastoreWatcher.java
@@ -17,6 +17,9 @@
  */
 package org.apache.bookkeeper.metastore;
 
+/**
+ * Metastore watcher.
+ */
 public interface MetastoreWatcher {
-    public void process(MSWatchedEvent e);
+    void process(MSWatchedEvent e);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/Value.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/Value.java
@@ -17,24 +17,26 @@
  */
 package org.apache.bookkeeper.metastore;
 
-import com.google.common.primitives.UnsignedBytes;
-import com.google.common.hash.Hasher;
+import static com.google.common.base.Charsets.UTF_8;
+import static org.apache.bookkeeper.metastore.MetastoreTable.ALL_FIELDS;
+
 import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+import com.google.common.primitives.UnsignedBytes;
 
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.Collections;
 
-import static com.google.common.base.Charsets.UTF_8;
-
-import static org.apache.bookkeeper.metastore.MetastoreTable.ALL_FIELDS;
-
+/**
+ * A metastore value.
+ */
 public class Value {
-    static final Comparator<byte[]> comparator =
+    private static final Comparator<byte[]> comparator =
         UnsignedBytes.lexicographicalComparator();
 
     protected Map<String, byte[]> fields;
@@ -107,7 +109,7 @@ public class Value {
         if (fields.size() != other.fields.size()) {
             return false;
         }
-        for (Map.Entry<String,byte[]> entry : fields.entrySet()) {
+        for (Map.Entry<String, byte[]> entry : fields.entrySet()) {
             String f = entry.getKey();
             byte[] v1 = entry.getValue();
             byte[] v2 = other.fields.get(f);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/package-info.java
@@ -1,5 +1,4 @@
-/**
- *
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,19 +15,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-package org.apache.bookkeeper.net;
 
 /**
- * Common Configuration Keys.
+ * MetaStore-related classes.
  */
-public interface CommonConfigurationKeys {
-
-    // script file name to resolve network topology
-    String NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY = "networkTopologyScriptFileName";
-    // number of arguments that network topology resolve script used
-    String NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_KEY = "networkTopologyScriptNumberArgs";
-    // default value of NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_KEY
-    int NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_DEFAULT = 100;
-}
+package org.apache.bookkeeper.metastore;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.bookkeeper.net;
 
 import java.util.HashSet;
@@ -26,13 +25,13 @@ import org.apache.bookkeeper.conf.Configurable;
 import org.apache.commons.configuration.Configuration;
 
 /**
- * This is a base class for DNS to Switch mappings. <p/> It is not mandatory to
- * derive {@link DNSToSwitchMapping} implementations from it, but it is strongly
+ * This is a base class for DNS to Switch mappings.
+ *
+ * <p>It is not mandatory to derive {@link DNSToSwitchMapping} implementations from it, but it is strongly
  * recommended, as it makes it easy for the Hadoop developers to add new methods
  * to this base class that are automatically picked up by all implementations.
- * <p/>
  *
- * This class does not extend the <code>Configured</code>
+ * <p>This class does not extend the <code>Configured</code>
  * base class, and should not be changed to do so, as it causes problems
  * for subclasses. The constructor of the <code>Configured</code> calls
  * the  {@link #setConf(Configuration)} method, which will call into the
@@ -44,7 +43,7 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
     private Configuration conf;
 
     /**
-     * Create an unconfigured instance
+     * Create an unconfigured instance.
      */
     protected AbstractDNSToSwitchMapping() {
     }
@@ -73,12 +72,9 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
      * multi-rack. Subclasses may override this with methods that are more aware
      * of their topologies.
      *
-     * <p/>
-     *
-     * This method is used when parts of Hadoop need know whether to apply
+     * <p>This method is used when parts of Hadoop need know whether to apply
      * single rack vs multi-rack policies, such as during block placement.
      * Such algorithms behave differently if they are on multi-switch systems.
-     * </p>
      *
      * @return true if the mapping thinks that it is on a single switch
      */
@@ -87,7 +83,7 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
     }
 
     /**
-     * Get a copy of the map (for diagnostics)
+     * Get a copy of the map (for diagnostics).
      * @return a clone of the map or null for none known
      */
     public Map<String, String> getSwitchMap() {
@@ -127,9 +123,10 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
     /**
      * Query for a {@link DNSToSwitchMapping} instance being on a single
      * switch.
-     * <p/>
-     * This predicate simply assumes that all mappings not derived from
+     *
+     * <p>This predicate simply assumes that all mappings not derived from
      * this class are multi-switch.
+     *
      * @param mapping the mapping to query
      * @return true if the base class says it is single switch, or the mapping
      * is not derived from this class.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
@@ -20,18 +20,18 @@
  */
 package org.apache.bookkeeper.net;
 
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
+import static org.apache.bookkeeper.util.BookKeeperConstants.COLON;
 
 import io.netty.channel.local.LocalAddress;
 
-import static org.apache.bookkeeper.util.BookKeeperConstants.COLON;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 
 /**
  * This is a data wrapper class that is an InetSocketAddress, it would use the hostname
  * provided in constructors directly.
- * <p>
- * The string representation of a BookieSocketAddress is : <hostname>:<port>
+ *
+ * <p>The string representation of a BookieSocketAddress is : &lt;hostname&gt;:&lt;port&gt;
  */
 public class BookieSocketAddress {
 
@@ -78,7 +78,7 @@ public class BookieSocketAddress {
     }
 
     /**
-     * Maps the socketAddress to a "local" address
+     * Maps the socketAddress to a "local" address.
      */
     public LocalAddress getLocalAddress() {
         return new LocalAddress(socketAddress.toString());
@@ -95,8 +95,9 @@ public class BookieSocketAddress {
     // Implement an equals method comparing two BookiSocketAddress objects.
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof BookieSocketAddress))
+        if (!(obj instanceof BookieSocketAddress)) {
             return false;
+        }
         BookieSocketAddress that = (BookieSocketAddress) obj;
         return this.hostname.equals(that.hostname) && (this.port == that.port);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/CachedDNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/CachedDNSToSwitchMapping.java
@@ -34,12 +34,12 @@ public class CachedDNSToSwitchMapping extends AbstractDNSToSwitchMapping {
   private Map<String, String> cache = new ConcurrentHashMap<String, String>();
 
   /**
-   * The uncached mapping
+   * The uncached mapping.
    */
   protected final DNSToSwitchMapping rawMapping;
 
   /**
-   * cache a raw DNS mapping
+   * Cache a raw DNS mapping.
    * @param rawMapping the raw mapping to cache
    */
   public CachedDNSToSwitchMapping(DNSToSwitchMapping rawMapping) {
@@ -79,7 +79,7 @@ public class CachedDNSToSwitchMapping extends AbstractDNSToSwitchMapping {
       List<String> resolvedHosts) {
     // Cache the result
     if (resolvedHosts != null) {
-      for (int i=0; i<uncachedHosts.size(); i++) {
+      for (int i = 0; i < uncachedHosts.size(); i++) {
         cache.put(uncachedHosts.get(i), resolvedHosts.get(i));
       }
     }
@@ -131,7 +131,7 @@ public class CachedDNSToSwitchMapping extends AbstractDNSToSwitchMapping {
    */
   @Override
   public Map<String, String> getSwitchMap() {
-    Map<String, String > switchMap = new HashMap<String, String>(cache);
+    Map<String, String> switchMap = new HashMap<String, String>(cache);
     return switchMap;
   }
 
@@ -143,7 +143,7 @@ public class CachedDNSToSwitchMapping extends AbstractDNSToSwitchMapping {
 
   /**
    * Delegate the switch topology query to the raw mapping, via
-   * {@link AbstractDNSToSwitchMapping#isMappingSingleSwitch(DNSToSwitchMapping)}
+   * {@link AbstractDNSToSwitchMapping#isMappingSingleSwitch(DNSToSwitchMapping)}.
    * @return true iff the raw mapper is considered single-switch.
    */
   @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNS.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNS.java
@@ -18,9 +18,6 @@
 // This code has been copied from hadoop-common 2.0.4-alpha
 package org.apache.bookkeeper.net;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -34,6 +31,9 @@ import javax.naming.NamingException;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A class that provides direct and reverse lookup functionalities, allowing
@@ -69,7 +69,7 @@ public class DNS {
         // This is formed by reversing the IP numbers and appending in-addr.arpa
         //
         String[] parts = hostIp.getHostAddress().split("\\.");
-        if(parts.length !=4) {
+        if (parts.length != 4) {
             //Not proper address. May be IPv6
             throw new NamingException("IPV6");
         }
@@ -80,9 +80,9 @@ public class DNS {
         Attributes attribute;
         try {
             attribute = ictx.getAttributes("dns://"               // Use "dns:///" if the default
-                    + ((ns == null) ? "" : ns) +
+                    + ((ns == null) ? "" : ns)
                     // nameserver is to be used
-                    "/" + reverseIP, new String[]{"PTR"});
+                    + "/" + reverseIP, new String[]{"PTR"});
         } finally {
             ictx.close();
         }
@@ -130,7 +130,7 @@ public class DNS {
     }
 
     /**
-     * Like {@link DNS#getIPs(String, boolean), but returns all
+     * Like {@link DNS#getIPs(String, boolean)}, but returns all
      * IPs associated with the given interface and its subinterfaces.
      */
     public static String[] getIPs(String strInterface)
@@ -164,8 +164,7 @@ public class DNS {
                 netIf = getSubinterface(strInterface);
             }
         } catch (SocketException e) {
-            LOG.warn("I/O error finding interface " + strInterface +
-                    ": " + e.getMessage());
+            LOG.warn("I/O error finding interface {}: {}", strInterface, e.getMessage());
             return new String[]{cachedHostAddress};
         }
         if (netIf == null) {
@@ -208,7 +207,7 @@ public class DNS {
 
     /**
      * Returns all the host names associated by the provided nameserver with the
-     * address bound to the specified network interface
+     * address bound to the specified network interface.
      *
      * @param strInterface The name of the network interface or subinterface to query
      *                     (e.g. eth0 or eth0:0)
@@ -240,7 +239,7 @@ public class DNS {
 
     /**
      * Determine the local hostname; retrieving it from cache if it is known
-     * If we cannot determine our host name, return "localhost"
+     * If we cannot determine our host name, return "localhost".
      *
      * @return the local hostname or "localhost"
      */
@@ -280,8 +279,8 @@ public class DNS {
             } catch (UnknownHostException noLocalHostAddressException) {
                 //at this point, deep trouble
                 LOG.error("Unable to determine local loopback address "
-                        + "of \"" + LOCALHOST + "\" " +
-                        "-this system's network configuration is unsupported", e);
+                        + "of \"" + LOCALHOST + "\" "
+                        + "-this system's network configuration is unsupported", e);
                 address = null;
             }
         }
@@ -290,7 +289,7 @@ public class DNS {
 
     /**
      * Returns all the host names associated by the default nameserver with the
-     * address bound to the specified network interface
+     * address bound to the specified network interface.
      *
      * @param strInterface The name of the network interface to query (e.g. eth0)
      * @return The list of host names associated with IPs bound to the network
@@ -304,7 +303,7 @@ public class DNS {
 
     /**
      * Returns the default (first) host name associated by the provided
-     * nameserver with the address bound to the specified network interface
+     * nameserver with the address bound to the specified network interface.
      *
      * @param strInterface The name of the network interface to query (e.g. eth0)
      * @param nameserver   The DNS host name
@@ -328,7 +327,7 @@ public class DNS {
 
     /**
      * Returns the default (first) host name associated by the default
-     * nameserver with the address bound to the specified network interface
+     * nameserver with the address bound to the specified network interface.
      *
      * @param strInterface The name of the network interface to query (e.g. eth0).
      *                     Must not be null.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
@@ -17,9 +17,9 @@
  */
 package org.apache.bookkeeper.net;
 
-import java.util.List;
-
 import com.google.common.annotations.Beta;
+
+import java.util.List;
 
 /**
  * An interface that must be implemented to allow pluggable
@@ -38,9 +38,8 @@ public interface DNSToSwitchMapping {
      * Note the hostname/ip-address is not part of the returned path.
      * The network topology of the cluster would determine the number of
      * components in the network path.
-     * <p/>
      *
-     * If a name cannot be resolved to a rack, the implementation
+     * <p>If a name cannot be resolved to a rack, the implementation
      * should return {@link NetworkTopology#DEFAULT_REGION_AND_RACK}. This
      * is what the bundled implementations do, though it is not a formal requirement
      *
@@ -48,21 +47,21 @@ public interface DNSToSwitchMapping {
      * @return list of resolved network paths.
      * If <i>names</i> is empty, the returned list is also empty
      */
-    public List<String> resolve(List<String> names);
+    List<String> resolve(List<String> names);
 
     /**
      * Reload all of the cached mappings.
      *
-     * If there is a cache, this method will clear it, so that future accesses
+     * <p>If there is a cache, this method will clear it, so that future accesses
      * will get a chance to see the new data.
      */
-    public void reloadCachedMappings();
+    void reloadCachedMappings();
 
     /**
      * Hints what to use with implementation when InetSocketAddress is converted
      * to String:
      * hostname (addr.getHostName(), default)
-     * or IP address (addr.getAddress().getHostAddress())
+     * or IP address (addr.getAddress().getHostAddress()).
      * @return true if hostname, false if IP address. Default is true.
       */
     default boolean useHostName() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
@@ -17,6 +17,9 @@
  */
 package org.apache.bookkeeper.net;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -24,10 +27,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Network Utilities.
+ */
 public class NetUtils {
     private static final Logger logger = LoggerFactory.getLogger(NetUtils.class);
 
@@ -68,15 +73,14 @@ public class NetUtils {
 
         if (dnsResolver.useHostName()) {
             names.add(addr.getHostName());
-        }
-        else {
+        } else {
             names.add(addr.getAddress().getHostAddress());
         }
 
         // resolve network addresses
         List<String> rNames = dnsResolver.resolve(names);
-        Preconditions.checkNotNull(rNames, "DNS Resolver should not return null response.");
-        Preconditions.checkState(rNames.size() == 1, "Expected exactly one element");
+        checkNotNull(rNames, "DNS Resolver should not return null response.");
+        checkState(rNames.size() == 1, "Expected exactly one element");
 
         return rNames.get(0);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopology.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopology.java
@@ -20,16 +20,16 @@ package org.apache.bookkeeper.net;
 import java.util.Set;
 
 /**
- * Network Topology Interface
+ * Network Topology Interface.
  */
 public interface NetworkTopology {
 
-    public final static String DEFAULT_REGION = "/default-region";
-    public final static String DEFAULT_RACK = "/default-rack";
-    public final static String DEFAULT_REGION_AND_RACK = DEFAULT_REGION + DEFAULT_RACK;
+    String DEFAULT_REGION = "/default-region";
+    String DEFAULT_RACK = "/default-rack";
+    String DEFAULT_REGION_AND_RACK = DEFAULT_REGION + DEFAULT_RACK;
 
     /**
-     * Add a node to the network topology
+     * Add a node to the network topology.
      *
      * @param node
      *          add the node to network topology
@@ -37,7 +37,7 @@ public interface NetworkTopology {
     void add(Node node);
 
     /**
-     * Remove a node from nework topology
+     * Remove a node from nework topology.
      *
      * @param node
      *          remove the node from network topology
@@ -54,7 +54,7 @@ public interface NetworkTopology {
     boolean contains(Node node);
 
     /**
-     * Retrieve a node from the network topology
+     * Retrieve a node from the network topology.
      * @param loc
      * @return
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/Node.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/Node.java
@@ -31,34 +31,37 @@ import com.google.common.annotations.Beta;
 @Beta
 public interface Node {
     /** @return the string representation of this node's network location at the specified level in the hierarchy*/
-    public String getNetworkLocation(int level);
+    String getNetworkLocation(int level);
 
     /** @return the string representation of this node's network location */
-    public String getNetworkLocation();
+    String getNetworkLocation();
 
-    /** Set this node's network location
+    /**
+     * Set this node's network location.
      * @param location the location
      */
-    public void setNetworkLocation(String location);
+    void setNetworkLocation(String location);
 
     /** @return this node's name */
-    public String getName();
+    String getName();
 
     /** @return this node's parent */
-    public Node getParent();
+    Node getParent();
 
-    /** Set this node's parent
+    /**
+     * Set this node's parent.
      * @param parent the parent
      */
-    public void setParent(Node parent);
+    void setParent(Node parent);
 
     /** @return this node's level in the tree.
      * E.g. the root of a tree returns 0 and its children return 1
      */
-    public int getLevel();
+    int getLevel();
 
-    /** Set this node's level in the tree
+    /**
+     * Set this node's level in the tree.
      * @param i the level
      */
-    public void setLevel(int i);
+    void setLevel(int i);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NodeBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NodeBase.java
@@ -17,27 +17,36 @@
  */
 package org.apache.bookkeeper.net;
 
-/** A base class that implements interface Node
- *
+/**
+ * A base class that implements interface Node.
  */
 public class NodeBase implements Node {
-    /** Path separator {@value} */
-    public final static char PATH_SEPARATOR = '/';
-    /** Path separator as a string {@value} */
-    public final static String PATH_SEPARATOR_STR = "/";
-    /** string representation of root {@value} */
-    public final static String ROOT = "";
+    /**
+     * Path separator {@value}.
+     */
+    public static final char PATH_SEPARATOR = '/';
+    /**
+     * Path separator as a string {@value}.
+     */
+    public static final String PATH_SEPARATOR_STR = "/";
+    /**
+     * String representation of root {@value}.
+     */
+    public static final String ROOT = "";
 
     protected String name; //host:port#
     protected String location; //string representation of this node's location
     protected int level; //which level of the tree the node resides
     protected Node parent; //its parent
 
-    /** Default constructor */
+    /**
+     * Default constructor.
+     */
     public NodeBase() {
     }
 
-    /** Construct a node from its path
+    /**
+     * Construct a node from its path.
      * @param path
      *   a concatenation of this node's location, the path seperator, and its name
      */
@@ -51,7 +60,8 @@ public class NodeBase implements Node {
         }
     }
 
-    /** Construct a node from its name and its location
+    /**
+     * Construct a node from its name and its location.
      * @param name this node's name (can be null, must not contain {@link #PATH_SEPARATOR})
      * @param location this node's location
      */
@@ -59,7 +69,8 @@ public class NodeBase implements Node {
         set(name, normalize(location));
     }
 
-    /** Construct a node from its name and its location
+    /**
+     * Construct a node from its name and its location.
      * @param name this node's name (can be null, must not contain {@link #PATH_SEPARATOR})
      * @param location this node's location
      * @param parent this node's parent node
@@ -72,13 +83,14 @@ public class NodeBase implements Node {
     }
 
     /**
-     * set this node's name and location
+     * Set this node's name and location.
      * @param name the (nullable) name -which cannot contain the {@link #PATH_SEPARATOR}
      * @param location the location
      */
     private void set(String name, String location) {
-        if (name != null && name.contains(PATH_SEPARATOR_STR))
+        if (name != null && name.contains(PATH_SEPARATOR_STR)) {
             throw new IllegalArgumentException("Network location name contains /: " + name);
+        }
         this.name = (name == null) ? "" : name;
         this.location = location;
     }
@@ -95,7 +107,8 @@ public class NodeBase implements Node {
         return location;
     }
 
-    /** Set this node's network location
+    /**
+     * Set this node's network location.
      * @param location the location
      */
     @Override
@@ -104,7 +117,7 @@ public class NodeBase implements Node {
     }
 
     /**
-     * Get the path of a node
+     * Get the path of a node.
      * @param node a non-null node
      * @return the path of a node
      */
@@ -118,7 +131,8 @@ public class NodeBase implements Node {
         return getPath(this);
     }
 
-    /** Normalize a path by stripping off any trailing {@link #PATH_SEPARATOR}
+    /**
+     * Normalize a path by stripping off any trailing {@link #PATH_SEPARATOR}.
      * @param path path to normalize.
      * @return the normalised path
      * If <i>path</i>is null or empty {@link #ROOT} is returned
@@ -126,8 +140,9 @@ public class NodeBase implements Node {
      * is not {@link #PATH_SEPARATOR}
      */
     public static String normalize(String path) {
-        if (path == null || path.length() == 0)
+        if (path == null || path.length() == 0) {
             return ROOT;
+        }
 
         if (path.charAt(0) != PATH_SEPARATOR) {
             throw new IllegalArgumentException("Network Location path does not start with " + PATH_SEPARATOR_STR + ": "
@@ -147,7 +162,8 @@ public class NodeBase implements Node {
         return parent;
     }
 
-    /** Set this node's parent
+    /**
+     * Set this node's parent.
      * @param parent the parent
      */
     @Override
@@ -163,7 +179,8 @@ public class NodeBase implements Node {
         return level;
     }
 
-    /** Set this node's level in the tree
+    /**
+     * Set this node's level in the tree.
      * @param level the level
      */
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/ScriptBasedMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/ScriptBasedMapping.java
@@ -45,34 +45,34 @@ import org.apache.commons.logging.LogFactory;
 public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
 
     /**
-     * Minimum number of arguments: {@value}
+     * Minimum number of arguments: {@value}.
      */
     static final int MIN_ALLOWABLE_ARGS = 1;
 
     /**
-     * Default number of arguments: {@value}
+     * Default number of arguments: {@value}.
      */
     static final int DEFAULT_ARG_COUNT = CommonConfigurationKeys.NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_DEFAULT;
 
     /**
-     * key to the script filename {@value}
+     * Key to the script filename {@value}.
      */
     static final String SCRIPT_FILENAME_KEY = CommonConfigurationKeys.NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY;
     /**
-     * key to the argument count that the script supports
-     * {@value}
+     * Key to the argument count that the script supports
+     * {@value}.
      */
     static final String SCRIPT_ARG_COUNT_KEY = CommonConfigurationKeys.NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_KEY;
     /**
      * Text used in the {@link #toString()} method if there is no string
-     * {@value}
+     * {@value}.
      */
     public static final String NO_SCRIPT = "no script";
 
     /**
      * Create an instance with the default configuration.
-     * </p>
-     * Calling {@link #setConf(Configuration)} will trigger a
+     *
+     * <p>Calling {@link #setConf(Configuration)} will trigger a
      * re-evaluation of the configuration settings and so be used to
      * set up the mapping script.
      *
@@ -82,7 +82,7 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
     }
 
     /**
-     * Create an instance from the given configuration
+     * Create an instance from the given configuration.
      * @param conf configuration
      */
     public ScriptBasedMapping(Configuration conf) {
@@ -91,7 +91,7 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
     }
 
     /**
-     * Get the cached mapping and convert it to its real type
+     * Get the cached mapping and convert it to its real type.
      * @return the inner raw script mapping.
      */
     private RawScriptBasedMapping getRawMapping() {
@@ -110,8 +110,8 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
 
     /**
      * {@inheritDoc}
-     * <p/>
-     * This will get called in the superclass constructor, so a check is needed
+     *
+     * <p>This will get called in the superclass constructor, so a check is needed
      * to ensure that the raw mapping is defined before trying to relaying a null
      * configuration.
      * @param conf
@@ -124,7 +124,7 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
 
     /**
      * This is the uncached script mapping that is fed into the cache managed
-     * by the superclass {@link CachedDNSToSwitchMapping}
+     * by the superclass {@link CachedDNSToSwitchMapping}.
      */
     private static final class RawScriptBasedMapping extends AbstractDNSToSwitchMapping {
         private String scriptName;
@@ -132,7 +132,7 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
         private static final Log LOG = LogFactory.getLog(ScriptBasedMapping.class);
 
         /**
-         * Set the configuration and extract the configuration parameters of interest
+         * Set the configuration and extract the configuration parameters of interest.
          * @param conf the new configuration
          */
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/StabilizeNetworkTopology.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/StabilizeNetworkTopology.java
@@ -17,10 +17,6 @@
  */
 package org.apache.bookkeeper.net;
 
-import org.apache.bookkeeper.util.MathUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
@@ -29,6 +25,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.util.MathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is going to provide a stabilize network topology regarding to flapping zookeeper registration.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/package-info.java
@@ -1,5 +1,4 @@
-/**
- *
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,19 +15,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-package org.apache.bookkeeper.net;
 
 /**
- * Common Configuration Keys.
+ * Network-related classes.
  */
-public interface CommonConfigurationKeys {
-
-    // script file name to resolve network topology
-    String NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY = "networkTopologyScriptFileName";
-    // number of arguments that network topology resolve script used
-    String NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_KEY = "networkTopologyScriptNumberArgs";
-    // default value of NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_KEY
-    int NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_DEFAULT = 100;
-}
+package org.apache.bookkeeper.net;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/JAASCredentialsContainer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/JAASCredentialsContainer.java
@@ -24,6 +24,9 @@ import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
 
+/**
+ * JAAS Credentials Container.
+ */
 public interface JAASCredentialsContainer {
 
     Subject getSubject();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLBookieAuthProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLBookieAuthProvider.java
@@ -25,15 +25,19 @@ import java.util.regex.Pattern;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 import javax.security.sasl.SaslException;
+
 import org.apache.bookkeeper.auth.AuthCallbacks;
 import org.apache.bookkeeper.auth.AuthToken;
 import org.apache.bookkeeper.auth.BookieAuthProvider;
-import org.apache.bookkeeper.proto.BookieConnectionPeer;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.proto.BookieConnectionPeer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * SASL Bookie Authentication Provider.
+ */
 public class SASLBookieAuthProvider implements BookieAuthProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(SASLBookieAuthProvider.class);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLBookieAuthProviderFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLBookieAuthProviderFactory.java
@@ -23,6 +23,7 @@ package org.apache.bookkeeper.sasl;
 import java.io.IOException;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -37,15 +38,16 @@ import javax.security.auth.login.LoginException;
 import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.SaslException;
+
 import org.apache.bookkeeper.auth.AuthCallbacks;
-import org.apache.bookkeeper.proto.BookieConnectionPeer;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.proto.BookieConnectionPeer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * BookieAuthProvider which uses JDK-bundled SASL
+ * BookieAuthProvider which uses JDK-bundled SASL.
  */
 public class SASLBookieAuthProviderFactory implements org.apache.bookkeeper.auth.BookieAuthProvider.Factory,
     JAASCredentialsContainer {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLClientAuthProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLClientAuthProvider.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.security.auth.Subject;
 import javax.security.sasl.SaslException;
+
 import org.apache.bookkeeper.auth.AuthCallbacks;
 import org.apache.bookkeeper.auth.AuthToken;
 import org.apache.bookkeeper.auth.ClientAuthProvider;
@@ -33,6 +34,9 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.proto.ClientConnectionPeer;
 import org.slf4j.LoggerFactory;
 
+/**
+ * SASL Client Authentication Provider.
+ */
 public class SASLClientAuthProvider implements ClientAuthProvider {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SASLClientAuthProvider.class);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLClientProviderFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SASLClientProviderFactory.java
@@ -20,7 +20,14 @@
  */
 package org.apache.bookkeeper.sasl;
 
+import static org.apache.bookkeeper.conf.ClientConfiguration.CLIENT_ROLE_SYSTEM;
+import static org.apache.bookkeeper.sasl.SaslConstants.JAAS_AUDITOR_SECTION_NAME;
+import static org.apache.bookkeeper.sasl.SaslConstants.JAAS_CLIENT_SECTION_NAME;
+import static org.apache.bookkeeper.sasl.SaslConstants.JAAS_DEFAULT_AUDITOR_SECTION_NAME;
+import static org.apache.bookkeeper.sasl.SaslConstants.JAAS_DEFAULT_CLIENT_SECTION_NAME;
+
 import java.io.IOException;
+
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosTicket;
 import javax.security.auth.login.AppConfigurationEntry;
@@ -28,15 +35,16 @@ import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import javax.security.sasl.SaslException;
+
 import org.apache.bookkeeper.auth.AuthCallbacks;
 import org.apache.bookkeeper.auth.ClientAuthProvider;
-import org.apache.bookkeeper.proto.ClientConnectionPeer;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.proto.ClientConnectionPeer;
 import org.slf4j.LoggerFactory;
 
 /**
- * ClientAuthProvider which uses JDK-bundled SASL
+ * ClientAuthProvider which uses JDK-bundled SASL.
  */
 public class SASLClientProviderFactory implements
     org.apache.bookkeeper.auth.ClientAuthProvider.Factory, JAASCredentialsContainer {
@@ -60,10 +68,10 @@ public class SASLClientProviderFactory implements
             this.login = loginClient();
             this.subject = login.getSubject();
             this.isKrbTicket = !subject.getPrivateCredentials(KerberosTicket.class).isEmpty();
-            boolean systemRole = ClientConfiguration.CLIENT_ROLE_SYSTEM.equals(clientConfiguration.getClientRole());
+            boolean systemRole = CLIENT_ROLE_SYSTEM.equals(clientConfiguration.getClientRole());
             this.loginContextName = systemRole
-                ? clientConfiguration.getString(SaslConstants.JAAS_AUDITOR_SECTION_NAME, SaslConstants.JAAS_DEFAULT_AUDITOR_SECTION_NAME)
-                : clientConfiguration.getString(SaslConstants.JAAS_CLIENT_SECTION_NAME, SaslConstants.JAAS_DEFAULT_CLIENT_SECTION_NAME);
+                ? clientConfiguration.getString(JAAS_AUDITOR_SECTION_NAME, JAAS_DEFAULT_AUDITOR_SECTION_NAME)
+                : clientConfiguration.getString(JAAS_CLIENT_SECTION_NAME, JAAS_DEFAULT_CLIENT_SECTION_NAME);
             if (isKrbTicket) {
                 this.isUsingTicketCache = SaslConstants.isUsingTicketCache(loginContextName);
                 this.principal = SaslConstants.getPrincipal(loginContextName);
@@ -88,8 +96,8 @@ public class SASLClientProviderFactory implements
     private LoginContext loginClient() throws SaslException, LoginException {
         boolean systemRole = ClientConfiguration.CLIENT_ROLE_SYSTEM.equals(clientConfiguration.getClientRole());
         String configurationEntry = systemRole
-            ? clientConfiguration.getString(SaslConstants.JAAS_AUDITOR_SECTION_NAME, SaslConstants.JAAS_DEFAULT_AUDITOR_SECTION_NAME)
-            : clientConfiguration.getString(SaslConstants.JAAS_CLIENT_SECTION_NAME, SaslConstants.JAAS_DEFAULT_CLIENT_SECTION_NAME);
+            ? clientConfiguration.getString(JAAS_AUDITOR_SECTION_NAME, JAAS_DEFAULT_AUDITOR_SECTION_NAME)
+            : clientConfiguration.getString(JAAS_CLIENT_SECTION_NAME, JAAS_DEFAULT_CLIENT_SECTION_NAME);
         AppConfigurationEntry[] entries = Configuration.getConfiguration()
             .getAppConfigurationEntry(configurationEntry);
         if (entries == null) {
@@ -97,7 +105,8 @@ public class SASLClientProviderFactory implements
             return null;
         }
         try {
-            LoginContext loginContext = new LoginContext(configurationEntry, new SaslClientState.ClientCallbackHandler(null));
+            LoginContext loginContext = new LoginContext(configurationEntry,
+                    new SaslClientState.ClientCallbackHandler(null));
             loginContext.login();
             return loginContext;
         } catch (LoginException error) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslClientState.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslClientState.java
@@ -37,6 +37,9 @@ import javax.security.sasl.SaslException;
 import org.apache.zookeeper.server.auth.KerberosName;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A SASL Client State data object.
+ */
 public class SaslClientState {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SaslClientState.class);
@@ -100,8 +103,7 @@ public class SaslClientState {
         }
         if (clientSubject != null) {
             try {
-                final byte[] retval
-                    = Subject.doAs(clientSubject, new PrivilegedExceptionAction<byte[]>() {
+                final byte[] retval = Subject.doAs(clientSubject, new PrivilegedExceptionAction<byte[]>() {
                         @Override
                         public byte[] run() throws SaslException {
                             return saslClient.evaluateChallenge(saslToken);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslConstants.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslConstants.java
@@ -23,6 +23,9 @@ package org.apache.bookkeeper.sasl;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
+/**
+ * SASL Constants.
+ */
 public class SaslConstants {
 
     static final String PLUGIN_NAME = "sasl";
@@ -37,8 +40,8 @@ public class SaslConstants {
     public static final String JAAS_DEFAULT_CLIENT_SECTION_NAME = "BookKeeper";
 
     /**
-     * This is a regexp which limits the range of possible ids which can connect to the Bookie using SASL
-     * By default only clients whose id contains the word 'bookkeeper' are allowed to connect
+     * This is a regexp which limits the range of possible ids which can connect to the Bookie using SASL.
+     * By default only clients whose id contains the word 'bookkeeper' are allowed to connect.
      */
     public static final String JAAS_CLIENT_ALLOWED_IDS = "saslJaasClientAllowedIds";
     public static final String JAAS_CLIENT_ALLOWED_IDS_DEFAULT = ".*bookkeeper.*";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslServerState.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/SaslServerState.java
@@ -26,6 +26,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
+
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -40,12 +41,13 @@ import javax.security.sasl.RealmCallback;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
+
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.zookeeper.server.auth.KerberosName;
 import org.slf4j.LoggerFactory;
 
 /**
- * Server side Sasl implementation
+ * Server side Sasl implementation.
  */
 public class SaslServerState {
 
@@ -95,8 +97,8 @@ public class SaslServerState {
                         public SaslServer run() {
                             try {
                                 SaslServer saslServer;
-                                saslServer = Sasl.createSaslServer("GSSAPI", servicePrincipalName, serviceHostname, null,
-                                    callbackHandler);
+                                saslServer = Sasl.createSaslServer("GSSAPI", servicePrincipalName, serviceHostname,
+                                        null, callbackHandler);
                                 return saslServer;
                             } catch (SaslException e) {
                                 throw new RuntimeException(e);
@@ -144,13 +146,15 @@ public class SaslServerState {
         private String userName;
         private final Map<String, String> credentials = new HashMap<>();
 
-        public SaslServerCallbackHandler(Configuration configuration, ServerConfiguration serverConfiguration) throws IOException {
+        public SaslServerCallbackHandler(Configuration configuration, ServerConfiguration serverConfiguration)
+                throws IOException {
             String configurationEntry = serverConfiguration.getString(SaslConstants.JAAS_BOOKIE_SECTION_NAME,
                 SaslConstants.JAAS_DEFAULT_BOOKIE_SECTION_NAME);
             AppConfigurationEntry configurationEntries[] = configuration.getAppConfigurationEntry(configurationEntry);
 
             if (configurationEntries == null) {
-                String errorMessage = "Could not find a '" + configurationEntry + "' entry in this configuration: Server cannot start.";
+                String errorMessage = "Could not find a '" + configurationEntry
+                    + "' entry in this configuration: Server cannot start.";
 
                 throw new IOException(errorMessage);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/TGTRefreshThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/TGTRefreshThread.java
@@ -33,7 +33,9 @@ import org.apache.zookeeper.common.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// copied from Apache ZooKeeper TGT refresh logic
+/**
+ * TGT Refresh Thread. Copied from Apache ZooKeeper TGT refresh logic.
+ */
 class TGTRefreshThread extends Thread {
 
     private static final Logger LOG = LoggerFactory.getLogger(TGTRefreshThread.class);
@@ -77,7 +79,7 @@ class TGTRefreshThread extends Thread {
     // and try to renew the ticket.
     private static final float TICKET_RENEW_WINDOW = 0.80f;
     /**
-     * Percentage of random jitter added to the renewal time
+     * Percentage of random jitter added to the renewal time.
      */
     private static final float TICKET_RENEW_JITTER = 0.05f;
     // Regardless of TICKET_RENEW_WINDOW setting above and the ticket expiry time,
@@ -175,7 +177,8 @@ class TGTRefreshThread extends Thread {
                 break;
             }
             if (container.isUsingTicketCache()) {
-                String cmd = container.getConfiguration().getString(SaslConstants.KINIT_COMMAND, SaslConstants.KINIT_COMMAND_DEFAULT);
+                String cmd = container.getConfiguration().getString(SaslConstants.KINIT_COMMAND,
+                        SaslConstants.KINIT_COMMAND_DEFAULT);
                 String kinitArgs = "-R";
                 int retry = 1;
                 while (retry >= 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/sasl/package-info.java
@@ -1,5 +1,4 @@
-/**
- *
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,19 +15,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-package org.apache.bookkeeper.net;
 
 /**
- * Common Configuration Keys.
+ * SASL and JAAS Authentication classes.
  */
-public interface CommonConfigurationKeys {
-
-    // script file name to resolve network topology
-    String NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY = "networkTopologyScriptFileName";
-    // number of arguments that network topology resolve script used
-    String NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_KEY = "networkTopologyScriptNumberArgs";
-    // default value of NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_KEY
-    int NET_TOPOLOGY_SCRIPT_NUMBER_ARGS_DEFAULT = 100;
-}
+package org.apache.bookkeeper.sasl;

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -24,10 +24,7 @@
     <suppress checks=".*" files=".*[\\/]bookie[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]client[\\/](?:[^\\/]+$|(?!api)|(?!impl)[^\\/]+[\\/])"/>
     <suppress checks=".*" files=".*[\\/]http[\\/].*"/>
-    <suppress checks=".*" files=".*[\\/]metastore[\\/].*"/>
-    <suppress checks=".*" files=".*[\\/]net[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]replication[\\/].*"/>
-    <suppress checks=".*" files=".*[\\/]sasl[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]test[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]util[\\/].*"/>
 


### PR DESCRIPTION
This is part of #230 and adds checkstyle verification to the following
packages in bookkeeper-server:

  - metastore
  - net
  - sasl

Descriptions of the changes in this PR:

Most of the changes are entirely stylistic, but there were a few minor functional changes:

  - In `metastore.MetastoreUtils`, the protected `logger` field was changed to `private` (it is not accessed from outside the class).
  - In `metastore.Value`, the package-protected `comparator` field was changed to `private` (it, too, is not accessed outside the class).
  
