### PR TITLE
ISSUE 230: Enable checkstyle for more packages

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
@@ -20,43 +20,42 @@
  */
 package org.apache.bookkeeper.replication;
 
+import static com.google.common.base.Charsets.UTF_8;
+import static org.apache.bookkeeper.replication.ReplicationStats.ELECTION_ATTEMPTS;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.TextFormat;
+
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.io.Serializable;
-import java.io.IOException;
-
-import org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat;
-import com.google.common.annotations.VisibleForTesting;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.BookKeeperConstants;
+import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
-import com.google.protobuf.TextFormat;
-import static com.google.common.base.Charsets.UTF_8;
-
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.bookkeeper.replication.ReplicationStats.ELECTION_ATTEMPTS;
-import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.zookeeper.data.ACL;
 
 /**
  * Performing auditor election using Apache ZooKeeper. Using ZooKeeper as a
@@ -97,7 +96,7 @@ public class AuditorElector {
 
 
     /**
-     * AuditorElector for performing the auditor election
+     * AuditorElector for performing the auditor election.
      *
      * @param bookieId
      *            - bookie identifier, comprises HostAddress:Port
@@ -114,7 +113,7 @@ public class AuditorElector {
     }
 
     /**
-     * AuditorElector for performing the auditor election
+     * AuditorElector for performing the auditor election.
      *
      * @param bookieId
      *            - bookie identifier, comprises HostAddress:Port
@@ -141,7 +140,7 @@ public class AuditorElector {
         executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
                 @Override
                 public Thread newThread(Runnable r) {
-                    return new Thread(r, "AuditorElector-"+bookieId);
+                    return new Thread(r, "AuditorElector-" + bookieId);
                 }
             });
     }
@@ -310,7 +309,7 @@ public class AuditorElector {
     }
 
     /**
-     * Query zookeeper for the currently elected auditor
+     * Query zookeeper for the currently elected auditor.
      * @return the bookie id of the current auditor
      */
     public static BookieSocketAddress getCurrentAuditor(ServerConfiguration conf, ZooKeeper zk)
@@ -335,7 +334,7 @@ public class AuditorElector {
     }
 
     /**
-     * Shutting down AuditorElector
+     * Shutting down AuditorElector.
      */
     public void shutdown() throws InterruptedException {
         synchronized (this) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -20,21 +20,26 @@
  */
 package org.apache.bookkeeper.replication;
 
+import static org.apache.bookkeeper.replication.ReplicationStats.AUDITOR_SCOPE;
+import static org.apache.bookkeeper.replication.ReplicationStats.REPLICATION_WORKER_SCOPE;
+
 import com.google.common.annotations.VisibleForTesting;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieCriticalThread;
 import org.apache.bookkeeper.bookie.ExitCode;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.server.http.BKHttpServiceProvider;
 import org.apache.bookkeeper.http.HttpServer;
 import org.apache.bookkeeper.http.HttpServerLoader;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
+import org.apache.bookkeeper.server.http.BKHttpServiceProvider;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
@@ -51,11 +56,8 @@ import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.bookkeeper.replication.ReplicationStats.AUDITOR_SCOPE;
-import static org.apache.bookkeeper.replication.ReplicationStats.REPLICATION_WORKER_SCOPE;
-
 /**
- * Class to start/stop the AutoRecovery daemons Auditor and ReplicationWorker
+ * Class to start/stop the AutoRecovery daemons Auditor and ReplicationWorker.
  */
 public class AutoRecoveryMain {
     private static final Logger LOG = LoggerFactory
@@ -107,8 +109,8 @@ public class AutoRecoveryMain {
         deathWatcher = new AutoRecoveryDeathWatcher(this);
     }
 
-    public AutoRecoveryMain(ServerConfiguration conf, ZooKeeper zk) throws IOException, InterruptedException, KeeperException,
-            UnavailableException, CompatibilityException {
+    public AutoRecoveryMain(ServerConfiguration conf, ZooKeeper zk) throws IOException, InterruptedException,
+           KeeperException, UnavailableException, CompatibilityException {
         this.conf = conf;
         this.zk = zk;
         auditorElector = new AuditorElector(Bookie.getBookieAddress(conf).toString(), conf, zk);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/BookieLedgerIndexer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/BookieLedgerIndexer.java
@@ -61,8 +61,7 @@ public class BookieLedgerIndexer {
     public Map<String, Set<Long>> getBookieToLedgerIndex()
             throws BKAuditException {
         // bookie vs ledgers map
-        final ConcurrentHashMap<String, Set<Long>> bookie2ledgersMap
-            = new ConcurrentHashMap<String, Set<Long>>();
+        final ConcurrentHashMap<String, Set<Long>> bookie2ledgersMap = new ConcurrentHashMap<String, Set<Long>>();
         final CountDownLatch ledgerCollectorLatch = new CountDownLatch(1);
 
         Processor<Long> ledgerProcessor = new Processor<Long>() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationEnableCb.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationEnableCb.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Callback which is getting notified when the replication process is enabled
+ * Callback which is getting notified when the replication process is enabled.
  */
 public class ReplicationEnableCb implements GenericCallback<Void> {
 
@@ -45,7 +45,7 @@ public class ReplicationEnableCb implements GenericCallback<Void> {
 
     /**
      * This is a blocking call and causes the current thread to wait until the
-     * replication process is enabled
+     * replication process is enabled.
      *
      * @throws InterruptedException
      *             interrupted while waiting

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationException.java
@@ -19,7 +19,7 @@
 package org.apache.bookkeeper.replication;
 
 /**
- * Exceptions for use within the replication service
+ * Exceptions for use within the replication service.
  */
 public abstract class ReplicationException extends Exception {
     protected ReplicationException(String message, Throwable cause) {
@@ -31,7 +31,7 @@ public abstract class ReplicationException extends Exception {
     }
 
     /**
-     * The replication service has become unavailable
+     * The replication service has become unavailable.
      */
     public static class UnavailableException extends ReplicationException {
         private static final long serialVersionUID = 31872209L;
@@ -62,7 +62,7 @@ public abstract class ReplicationException extends Exception {
     }
 
     /**
-     * Exception while auditing bookie-ledgers
+     * Exception while auditing bookie-ledgers.
     */
     public static class BKAuditException extends ReplicationException {
         private static final long serialVersionUID = 95551905L;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationStats.java
@@ -20,31 +20,34 @@
  */
 package org.apache.bookkeeper.replication;
 
+/**
+ * Replication statistics.
+ */
 public interface ReplicationStats {
 
-    public final static String REPLICATION_SCOPE = "replication";
+    String REPLICATION_SCOPE = "replication";
 
-    public final static String AUDITOR_SCOPE = "auditor";
-    public final static String ELECTION_ATTEMPTS = "election_attempts";
-    public final static String NUM_UNDER_REPLICATED_LEDGERS = "NUM_UNDER_REPLICATED_LEDGERS";
-    public final static String URL_PUBLISH_TIME_FOR_LOST_BOOKIE = "URL_PUBLISH_TIME_FOR_LOST_BOOKIE";
-    public final static String BOOKIE_TO_LEDGERS_MAP_CREATION_TIME = "BOOKIE_TO_LEDGERS_MAP_CREATION_TIME";
-    public final static String CHECK_ALL_LEDGERS_TIME = "CHECK_ALL_LEDGERS_TIME";
-    public final static String NUM_FRAGMENTS_PER_LEDGER = "NUM_FRAGMENTS_PER_LEDGER";
-    public final static String NUM_BOOKIES_PER_LEDGER = "NUM_BOOKIES_PER_LEDGER";
-    public final static String NUM_LEDGERS_CHECKED = "NUM_LEDGERS_CHECKED";
-    public final static String NUM_BOOKIE_AUDITS_DELAYED = "NUM_BOOKIE_AUDITS_DELAYED";
-    public final static String NUM_DELAYED_BOOKIE_AUDITS_DELAYES_CANCELLED = "NUM_DELAYED_BOOKIE_AUDITS_CANCELLED";
+    String AUDITOR_SCOPE = "auditor";
+    String ELECTION_ATTEMPTS = "election_attempts";
+    String NUM_UNDER_REPLICATED_LEDGERS = "NUM_UNDER_REPLICATED_LEDGERS";
+    String URL_PUBLISH_TIME_FOR_LOST_BOOKIE = "URL_PUBLISH_TIME_FOR_LOST_BOOKIE";
+    String BOOKIE_TO_LEDGERS_MAP_CREATION_TIME = "BOOKIE_TO_LEDGERS_MAP_CREATION_TIME";
+    String CHECK_ALL_LEDGERS_TIME = "CHECK_ALL_LEDGERS_TIME";
+    String NUM_FRAGMENTS_PER_LEDGER = "NUM_FRAGMENTS_PER_LEDGER";
+    String NUM_BOOKIES_PER_LEDGER = "NUM_BOOKIES_PER_LEDGER";
+    String NUM_LEDGERS_CHECKED = "NUM_LEDGERS_CHECKED";
+    String NUM_BOOKIE_AUDITS_DELAYED = "NUM_BOOKIE_AUDITS_DELAYED";
+    String NUM_DELAYED_BOOKIE_AUDITS_DELAYES_CANCELLED = "NUM_DELAYED_BOOKIE_AUDITS_CANCELLED";
 
-    public final static String REPLICATION_WORKER_SCOPE = "replication_worker";
-    public final static String REREPLICATE_OP = "rereplicate";
-    public final static String NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED = "NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED";
-    public final static String NUM_ENTRIES_READ = "NUM_ENTRIES_READ";
-    public final static String NUM_BYTES_READ = "NUM_BYTES_READ";
-    public final static String NUM_ENTRIES_WRITTEN = "NUM_ENTRIES_WRITTEN";
-    public final static String NUM_BYTES_WRITTEN = "NUM_BYTES_WRITTEN";
-    public final static String REPLICATE_EXCEPTION = "exceptions";
+    String REPLICATION_WORKER_SCOPE = "replication_worker";
+    String REREPLICATE_OP = "rereplicate";
+    String NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED = "NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED";
+    String NUM_ENTRIES_READ = "NUM_ENTRIES_READ";
+    String NUM_BYTES_READ = "NUM_BYTES_READ";
+    String NUM_ENTRIES_WRITTEN = "NUM_ENTRIES_WRITTEN";
+    String NUM_BYTES_WRITTEN = "NUM_BYTES_WRITTEN";
+    String REPLICATE_EXCEPTION = "exceptions";
 
-    public final static String BK_CLIENT_SCOPE = "bk_client";
+    String BK_CLIENT_SCOPE = "bk_client";
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Classes for replicating Bookkeeper data.
+ */
+package org.apache.bookkeeper.replication;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ConfigurationService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ConfigurationService.java
@@ -18,7 +18,8 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -38,7 +39,7 @@ public class ConfigurationService implements HttpEndpointService {
     protected ServerConfiguration conf;
 
     public ConfigurationService(ServerConfiguration conf) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
     }
 
@@ -53,14 +54,14 @@ public class ConfigurationService implements HttpEndpointService {
             return response;
         } else if (HttpServer.Method.PUT == request.getMethod()) {
             String requestBody = request.getBody();
-            if(null == requestBody) {
+            if (null == requestBody) {
                 response.setCode(HttpServer.StatusCode.NOT_FOUND);
                 response.setBody("Request body not found. should contains k-v pairs");
                 return response;
             }
             @SuppressWarnings("unchecked")
             HashMap<String, Object> configMap = JsonUtil.fromJson(requestBody, HashMap.class);
-            for(Map.Entry<String, Object> entry: configMap.entrySet()) {
+            for (Map.Entry<String, Object> entry: configMap.entrySet()) {
                 conf.setProperty(entry.getKey(), entry.getValue());
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/DecommissionService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/DecommissionService.java
@@ -18,9 +18,11 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
+
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
@@ -46,7 +48,7 @@ public class DecommissionService implements HttpEndpointService {
 
 
     public DecommissionService(ServerConfiguration conf, BookKeeperAdmin bka, ExecutorService executor) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.bka = bka;
         this.executor = executor;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/DeleteLedgerService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/DeleteLedgerService.java
@@ -18,7 +18,8 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Map;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -42,7 +43,7 @@ public class DeleteLedgerService implements HttpEndpointService {
     protected ServerConfiguration conf;
 
     public DeleteLedgerService(ServerConfiguration conf) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ExpandStorageService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ExpandStorageService.java
@@ -18,11 +18,14 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.Lists;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -51,7 +54,7 @@ public class ExpandStorageService implements HttpEndpointService {
     private ZooKeeper zk;
 
     public ExpandStorageService(ServerConfiguration conf, ZooKeeper zk) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.zk = zk;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLastLogMarkService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLastLogMarkService.java
@@ -18,12 +18,15 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.bookkeeper.bookie.Journal;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
 import org.apache.bookkeeper.bookie.LogMark;
@@ -41,9 +44,9 @@ import org.slf4j.LoggerFactory;
  * HttpEndpointService that handle Bookkeeper get last log mark related http request.
  * The GET method will get the last log position of each journal.
  *
- * output would be like this:
+ * <p>output would be like this:
  *  {
- *    "<Journal_id>" : "<Pos>",
+ *    "&lt;Journal_id&gt;" : "&lt;Pos&gt;",
  *    ...
  *  }
  */
@@ -54,7 +57,7 @@ public class GetLastLogMarkService implements HttpEndpointService {
     protected ServerConfiguration conf;
 
     public GetLastLogMarkService(ServerConfiguration conf) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
     }
 
@@ -67,7 +70,7 @@ public class GetLastLogMarkService implements HttpEndpointService {
                 /**
                  * output:
                  *  {
-                 *    "<Journal_id>" : "<Pos>",
+                 *    "&lt;Journal_id&gt;" : "&lt;Pos&gt;",
                  *    ...
                  *  }
                  */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLedgerMetaService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLedgerMetaService.java
@@ -19,8 +19,8 @@
 package org.apache.bookkeeper.server.http.service;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import org.apache.bookkeeper.client.LedgerMetadata;
@@ -48,7 +48,7 @@ public class GetLedgerMetaService implements HttpEndpointService {
     protected ZooKeeper zk;
 
     public GetLedgerMetaService(ServerConfiguration conf, ZooKeeper zk) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.zk = zk;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookieInfoService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookieInfoService.java
@@ -18,12 +18,15 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.Maps;
+
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookieInfoReader;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -40,7 +43,7 @@ import org.slf4j.LoggerFactory;
 /**
  * HttpEndpointService that handle Bookkeeper list bookie info related http request.
  *
- * The GET method will get the disk usage of all bookies in this bookkeeper cluster.
+ * <p>The GET method will get the disk usage of all bookies in this bookkeeper cluster.
  * Output would be like this:
  *  {
  *    "bookieAddress" : {free: xxx, total: xxx}",
@@ -56,7 +59,7 @@ public class ListBookieInfoService implements HttpEndpointService {
     protected ServerConfiguration conf;
 
     public ListBookieInfoService(ServerConfiguration conf) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookiesService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookiesService.java
@@ -18,11 +18,14 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.Maps;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
@@ -46,7 +49,7 @@ public class ListBookiesService implements HttpEndpointService {
     protected BookKeeperAdmin bka;
 
     public ListBookiesService(ServerConfiguration conf, BookKeeperAdmin bka) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.bka = bka;
     }
@@ -60,13 +63,13 @@ public class ListBookiesService implements HttpEndpointService {
 
             Map<String, String> params = request.getParams();
             // default print rw
-            boolean readOnly = (params != null) &&
-              params.containsKey("type") &&
-              params.get("type").equals("ro");
+            boolean readOnly = (params != null)
+                && params.containsKey("type")
+                && params.get("type").equals("ro");
             // default not print hostname
-            boolean printHostname = (params != null) &&
-              params.containsKey("print_hostnames") &&
-              params.get("print_hostnames").equals("true");
+            boolean printHostname = (params != null)
+                && params.containsKey("print_hostnames")
+                && params.get("print_hostnames").equals("true");
 
             if (readOnly) {
                 bookies.addAll(bka.getReadOnlyBookies());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListDiskFilesService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListDiskFilesService.java
@@ -18,13 +18,15 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.bookkeeper.bookie.BookieShell.listFilesAndSort;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
 import org.apache.bookkeeper.http.service.HttpEndpointService;
@@ -37,7 +39,7 @@ import org.slf4j.LoggerFactory;
 /**
  * HttpEndpointService that handle Bookkeeper list disk files related http request.
  *
- * The GET method will list all bookie files of type journal|entrylog|index in this bookie.
+ * <p>The GET method will list all bookie files of type journal|entrylog|index in this bookie.
  * The output would be like this:
  *  {
  *    "journal files" : "filename1 \t ...",
@@ -52,7 +54,7 @@ public class ListDiskFilesService implements HttpEndpointService {
     protected ServerConfiguration conf;
 
     public ListDiskFilesService(ServerConfiguration conf) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
     }
 
@@ -72,14 +74,14 @@ public class ListDiskFilesService implements HttpEndpointService {
              */
             Map<String, String> output = Maps.newHashMap();
 
-            boolean journal = params != null &&
-                params.containsKey("file_type")
+            boolean journal = params != null
+                && params.containsKey("file_type")
                 && params.get("file_type").equals("journal");
-            boolean entrylog = params != null &&
-                params.containsKey("file_type")
+            boolean entrylog = params != null
+                && params.containsKey("file_type")
                 && params.get("file_type").equals("entrylog");
-            boolean index = params != null &&
-                params.containsKey("file_type")
+            boolean index = params != null
+                && params.containsKey("file_type")
                 && params.get("file_type").equals("index");
             boolean all = false;
 
@@ -102,7 +104,7 @@ public class ListDiskFilesService implements HttpEndpointService {
                 List<File> ledgerFiles = listFilesAndSort(ledgerDirs, "log");
                 StringBuffer files = new StringBuffer();
                 for (File ledgerFile : ledgerFiles) {
-                    files.append(ledgerFile.getName()+ "\t");
+                    files.append(ledgerFile.getName() + "\t");
                 }
                 output.put("entrylog files", files.toString());
             }
@@ -112,7 +114,7 @@ public class ListDiskFilesService implements HttpEndpointService {
                 List<File> indexFiles = listFilesAndSort(indexDirs, "idx");
                 StringBuffer files = new StringBuffer();
                 for (File indexFile : indexFiles) {
-                    files.append(indexFile.getName()+ "\t");
+                    files.append(indexFile.getName() + "\t");
                 }
                 output.put("index files", files.toString());
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListUnderReplicatedLedgerService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListUnderReplicatedLedgerService.java
@@ -18,12 +18,15 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.Lists;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
 import org.apache.bookkeeper.http.service.HttpEndpointService;
@@ -40,7 +43,7 @@ import org.slf4j.LoggerFactory;
 /**
  * HttpEndpointService that handle Bookkeeper list under replicated ledger related http request.
  *
- * The GET method will list all ledger_ids of under replicated ledger.
+ * <p>The GET method will list all ledger_ids of under replicated ledger.
  * User can filer wanted ledger by set parameter "missingreplica" and "excludingmissingreplica"
  */
 public class ListUnderReplicatedLedgerService implements HttpEndpointService {
@@ -51,7 +54,7 @@ public class ListUnderReplicatedLedgerService implements HttpEndpointService {
     protected ZooKeeper zk;
 
     public ListUnderReplicatedLedgerService(ServerConfiguration conf, ZooKeeper zk) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.zk = zk;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/LostBookieRecoveryDelayService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/LostBookieRecoveryDelayService.java
@@ -18,8 +18,10 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.HashMap;
+
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
@@ -33,7 +35,7 @@ import org.slf4j.LoggerFactory;
 /**
  * HttpEndpointService that handle Bookkeeper lost bookie recovery delay parameter related http request.
  *
- * The GET method will get the value of parameter lostBookieRecoveryDelay,
+ * <p>The GET method will get the value of parameter lostBookieRecoveryDelay,
  * while the PUT method will set the value of parameter lostBookieRecoveryDelay,
  */
 public class LostBookieRecoveryDelayService implements HttpEndpointService {
@@ -44,7 +46,7 @@ public class LostBookieRecoveryDelayService implements HttpEndpointService {
     protected BookKeeperAdmin bka;
 
     public LostBookieRecoveryDelayService(ServerConfiguration conf, BookKeeperAdmin bka) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.bka = bka;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ReadLedgerEntryService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ReadLedgerEntryService.java
@@ -19,9 +19,10 @@
 package org.apache.bookkeeper.server.http.service;
 
 import static com.google.common.base.Charsets.US_ASCII;
+import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+
 import java.util.Iterator;
 import java.util.Map;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
 /**
  * HttpEndpointService that handle Bookkeeper read ledger entry related http request.
  *
- * The GET method will print all entry content of wanted entry.
+ * <p>The GET method will print all entry content of wanted entry.
  * User should set wanted "ledger_id", and can choose only print out wanted entry
  * by set parameter "start_entry_id", "end_entry_id" and "page".
  */
@@ -50,7 +51,7 @@ public class ReadLedgerEntryService implements HttpEndpointService {
     protected BookKeeperAdmin bka;
 
     public ReadLedgerEntryService(ServerConfiguration conf, BookKeeperAdmin bka) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.bka = bka;
     }
@@ -78,7 +79,7 @@ public class ReadLedgerEntryService implements HttpEndpointService {
 
             // Page index should start from 1;
             Integer pageIndex = params.containsKey("page") ? Integer.parseInt(params.get("page")) : -1;
-            if(pageIndex > 0) {
+            if (pageIndex > 0) {
                 // start and end ledger index for wanted page.
                 Long startIndexInPage = (pageIndex - 1) * ENTRIES_PER_PAE;
                 Long endIndexInPage = startIndexInPage + ENTRIES_PER_PAE - 1;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerAuditService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerAuditService.java
@@ -18,7 +18,8 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
@@ -40,7 +41,7 @@ public class TriggerAuditService implements HttpEndpointService {
     protected BookKeeperAdmin bka;
 
     public TriggerAuditService(ServerConfiguration conf, BookKeeperAdmin bka) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.bka = bka;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/WhoIsAuditorService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/WhoIsAuditorService.java
@@ -18,7 +18,8 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
 import org.apache.bookkeeper.http.service.HttpEndpointService;
@@ -33,7 +34,7 @@ import org.slf4j.LoggerFactory;
 /**
  * HttpEndpointService that handle Bookkeeper who is auditor related http request.
  *
- * The GET method will get the auditor bookie address
+ * <p>The GET method will get the auditor bookie address
  */
 public class WhoIsAuditorService implements HttpEndpointService {
 
@@ -43,7 +44,7 @@ public class WhoIsAuditorService implements HttpEndpointService {
     protected ZooKeeper zk;
 
     public WhoIsAuditorService(ServerConfiguration conf, ZooKeeper zk) {
-        Preconditions.checkNotNull(conf);
+        checkNotNull(conf);
         this.conf = conf;
         this.zk = zk;
     }

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -23,10 +23,8 @@
     <!-- suppress packages by packages -->
     <suppress checks=".*" files=".*[\\/]bookie[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]client[\\/](?:[^\\/]+$|(?!api)|(?!impl)[^\\/]+[\\/])"/>
-    <suppress checks=".*" files=".*[\\/]http[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]metastore[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]net[\\/].*"/>
-    <suppress checks=".*" files=".*[\\/]replication[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]sasl[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]test[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]util[\\/].*"/>


### PR DESCRIPTION
Part of #230, this enables the checkstyle plugin for the `replication` and
`server.http.service` packages.

Descriptions of the changes in this PR:

Most of the changes here are merely cosmetic. The only change of any significance is in the `RecoveryBookieService.RecoveryRequestJsonBody` class in which the JSON object fields had to be changed in order to conform to the Checkstyle rules: `bookie_src` to `bookieSrc` and `delete_cookie` to `deleteCookie`. Using a Jackson annotation (`@JsonProperty`), however, means that these field names continue to be parsed and serialized as `bookie_src` and `delete_cookie`, respectively.