### PR TITLE
Issue 801: remove assembly plugin in root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,16 +286,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>${maven-assembly-plugin.version}</version>
-        <configuration>
-	  <tarLongFileMode>gnu</tarLongFileMode>
-          <descriptors>
-            <descriptor>src/assemble/src.xml</descriptor>
-          </descriptors>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <version>0.12</version>


### PR DESCRIPTION
Descriptions of the changes in this PR:
mvn release:prepare cmd will fail, for the wrong assembly plugin in root pom. This change remove it, for it has already in bookkeeper-dist/pom.

