### PR TITLE
Fix bin/bookkeeper to work with release

### DIFF
--- a/bookkeeper-server/bin/bookkeeper
+++ b/bookkeeper-server/bin/bookkeeper
@@ -71,13 +71,15 @@ fi
 
 find-server-jar() {
   DIR=$1
-  cd $DIR
-  for f in *.jar; do
-    if [[ $f =~ ^bookkeeper-server-[0-9\\.]*(-SNAPSHOT)?.jar$ ]]; then
-      echo $DIR/$f
-        return
-    fi
-  done
+  if [ -d $DIR ]; then
+    cd $DIR
+    for f in *.jar; do
+      if [[ $f =~ ^(org.apache.bookkeeper-)?bookkeeper-server-[0-9\\.]*(-SNAPSHOT)?.jar$ ]]; then
+        echo $DIR/$f
+          return
+      fi
+    done
+  fi
 }
 
 RELEASE_JAR=$(find-server-jar ${BK_HOME})


### PR DESCRIPTION
Part of the assembly process prepends the package name to the
bookkeeper-server, which wasn't taken into account by
bin/bookkeeper. This change takes it into account.

It also stops the script from printing a warning if a directory
doesn't exist.
