### PR TITLE
ISSUE #230: Enable checkstyle on bookie and client

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -48,8 +48,8 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -438,8 +438,7 @@ public class Bookie extends BookieCriticalThread {
             //    if it doesn't exist in registration manager, this bookie is a new bookie, otherwise it is
             //    an old bookie.
             List<BookieSocketAddress> possibleBookieIds = possibleBookieIds(conf);
-            final Versioned<Cookie> rmCookie
-                = readAndVerifyCookieFromRegistrationManager(
+            final Versioned<Cookie> rmCookie = readAndVerifyCookieFromRegistrationManager(
                         masterCookie, rm, possibleBookieIds, allowExpansion);
 
             // 4. check if the cookie appear in all the directories.
@@ -979,8 +978,7 @@ public class Bookie extends BookieCriticalThread {
     }
 
     private void doRegisterBookie(boolean isReadOnly) throws IOException {
-        if (null == registrationManager ||
-            ((ZKRegistrationManager) this.registrationManager).getZk() == null) {
+        if (null == registrationManager || ((ZKRegistrationManager) this.registrationManager).getZk() == null) {
             // registration manager is null, means not register itself to zk.
             // ZooKeeper is null existing only for testing.
             LOG.info("null zk while do register");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1874,7 +1874,7 @@ public class BookieShell implements Tool {
             };
             try {
                 updateLedgerOp.updateBookieIdInLedgers(oldBookieId, newBookieId, rate, limit, progressable);
-            } catch (BKException | IOException e) {
+            } catch (IOException e) {
                 LOG.error("Failed to update ledger metadata", e);
                 return -1;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStatus.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStatus.java
@@ -48,7 +48,7 @@ public class BookieStatus {
         READ_WRITE;
     }
 
-    private final static long INVALID_UPDATE_TIME = -1;
+    private static final long INVALID_UPDATE_TIME = -1;
 
     private int layoutVersion;
     private long lastUpdateTime;
@@ -92,7 +92,7 @@ public class BookieStatus {
     }
 
     /**
-     * Write bookie status to multiple directories in best effort
+     * Write bookie status to multiple directories in best effort.
      *
      * @param directories list of directories to write to
      *
@@ -105,11 +105,11 @@ public class BookieStatus {
                 writeToFile(statusFile, toString());
                 success = true;
             } catch (IOException e) {
-                LOG.warn("IOException while trying to write bookie status to directory {}." +
-                    " This is fine if not all directories are failed.", dir);
+                LOG.warn("IOException while trying to write bookie status to directory {}."
+                    + " This is fine if not all directories are failed.", dir);
             }
         }
-        if(success){
+        if (success) {
             LOG.info("Successfully persist bookie status {}", this.bookieMode);
         } else {
             LOG.warn("Failed to persist bookie status {}", this.bookieMode);
@@ -160,24 +160,24 @@ public class BookieStatus {
                     }
                 }
             } catch (IOException e) {
-                LOG.warn("IOException while trying to read bookie status from directory {}." +
-                    " This is fine if not all directories failed.", dir);
-            } catch (IllegalArgumentException e ){
-                LOG.warn("IllegalArgumentException while trying to read bookie status from directory {}." +
-                    " This is fine if not all directories failed.", dir);
+                LOG.warn("IOException while trying to read bookie status from directory {}."
+                    + " This is fine if not all directories failed.", dir);
+            } catch (IllegalArgumentException e) {
+                LOG.warn("IllegalArgumentException while trying to read bookie status from directory {}."
+                    + " This is fine if not all directories failed.", dir);
             }
         }
         if (success) {
             LOG.info("Successfully retrieve bookie status {} from disks.", getBookieMode());
         } else {
-            LOG.warn("Failed to retrieve bookie status from disks." +
-                    " Fall back to current or default bookie status: {}", getBookieMode());
+            LOG.warn("Failed to retrieve bookie status from disks."
+                    + " Fall back to current or default bookie status: {}", getBookieMode());
         }
     }
 
 
     /**
-     * Function to read the bookie status from a single file
+     * Function to read the bookie status from a single file.
      *
      * @param file file to read from
      * @return BookieStatus if not error, null if file not exist or any exception happens
@@ -188,7 +188,7 @@ public class BookieStatus {
         if (!file.exists()) {
             return null;
         }
-        
+
         try (BufferedReader reader = new BufferedReader(
             new InputStreamReader(new FileInputStream(file), UTF_8))) {
             return parse(reader);
@@ -196,7 +196,7 @@ public class BookieStatus {
     }
 
     /**
-     * Parse the bookie status object using appropriate layout version
+     * Parse the bookie status object using appropriate layout version.
      *
      * @param reader
      * @return BookieStatus if parse succeed, otherwise return null

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -26,12 +26,13 @@ import static com.google.common.base.Charsets.UTF_8;
 import static org.apache.bookkeeper.bookie.TransactionalEntryLogCompactor.COMPACTING_SUFFIX;
 import static org.apache.bookkeeper.util.BookKeeperConstants.MAX_LOG_SIZE_LIMIT;
 
+import com.google.common.collect.MapMaker;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
-import com.google.common.collect.MapMaker;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -116,7 +117,7 @@ public class EntryLogger {
     private volatile long leastUnflushedLogId;
 
     /**
-     * locks for compaction log
+     * locks for compaction log.
      */
     private final Object compactionLogLock = new Object();
 
@@ -387,7 +388,7 @@ public class EntryLogger {
     }
 
     /**
-     * Get the current log file for compaction
+     * Get the current log file for compaction.
      */
     File getCurCompactionLogFile() {
         synchronized (compactionLogLock) {
@@ -1342,7 +1343,7 @@ public class EntryLogger {
     }
 
     /**
-     * Convert log Id to hex string
+     * Convert log Id to hex string.
      */
     static String logId2HexString(long logId) {
         return Long.toHexString(logId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -25,7 +25,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -62,10 +62,9 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
     private static final Logger LOG = LoggerFactory.getLogger(Journal.class);
 
-    private static final RecyclableArrayList.Recycler<QueueEntry> entryListRecycler
-        = new RecyclableArrayList.Recycler<QueueEntry>();
-    private static final RecyclableArrayList<QueueEntry> EMPTY_ARRAY_LIST
-        = entryListRecycler.newInstance();
+    private static final RecyclableArrayList.Recycler<QueueEntry> entryListRecycler =
+        new RecyclableArrayList.Recycler<QueueEntry>();
+    private static final RecyclableArrayList<QueueEntry> EMPTY_ARRAY_LIST = entryListRecycler.newInstance();
 
     /**
      * Filter to pickup journals.
@@ -410,8 +409,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         return req;
     }
 
-    private final Recycler<ForceWriteRequest> forceWriteRequestsRecycler
-        = new Recycler<ForceWriteRequest>() {
+    private final Recycler<ForceWriteRequest> forceWriteRequestsRecycler = new Recycler<ForceWriteRequest>() {
                 protected ForceWriteRequest newObject(
                         Recycler.Handle<ForceWriteRequest> handle) {
                     return new ForceWriteRequest(handle);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -141,7 +141,6 @@ public interface LedgerStorage {
      *
      * @param checkpoint Check Point that {@link Checkpoint} proposed.
      * @throws IOException
-     * @return the checkpoint that the ledger storage finished.
      */
     void checkpoint(Checkpoint checkpoint) throws IOException;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LocalBookieEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LocalBookieEnsemblePlacementPolicy.java
@@ -23,7 +23,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -27,8 +27,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.util.concurrent.RateLimiter;
-
 import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
 import org.apache.bookkeeper.util.HardLink;
 import org.slf4j.Logger;
@@ -79,7 +77,8 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
             File[] compactedPhaseFiles = dir.listFiles(file -> file.getName().endsWith(COMPACTED_SUFFIX));
             if (compactedPhaseFiles != null) {
                 for (File compactedFile : compactedPhaseFiles) {
-                    LOG.info("Found compacted log file {} has partially flushed index, recovering index.", compactedFile);
+                    LOG.info("Found compacted log file {} has partially flushed index, recovering index.",
+                            compactedFile);
                     CompactionPhase updateIndex = new UpdateIndexPhase(compactedFile, true);
                     updateIndex.run();
                 }
@@ -116,7 +115,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
     }
 
     /**
-     * An abstract class that would be extended to be the actual transactional phases for compaction
+     * An abstract class that would be extended to be the actual transactional phases for compaction.
      */
     abstract static class CompactionPhase {
         private String phaseName = "";
@@ -151,8 +150,8 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
      * If after scanning, there's no data written, it means there's no valid entries to be compacted,
      * so we can remove 1.log directly, clear the offsets and end the compaction.
      * Otherwise, we should move on to the next phase.
-     * <p>
-     * If anything failed in this phase, we should delete the compaction log and clean the offsets.
+     *
+     * <p>If anything failed in this phase, we should delete the compaction log and clean the offsets.
      */
     class ScanEntryLogPhase extends CompactionPhase {
         private final EntryLogMetadata metadata;
@@ -179,8 +178,8 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                         long lid = entry.getLong();
                         long entryId = entry.getLong();
                         if (lid != ledgerId || entryId < -1) {
-                            LOG.warn("Scanning expected ledgerId {}, but found invalid entry " +
-                                    "with ledgerId {} entryId {} at offset {}",
+                            LOG.warn("Scanning expected ledgerId {}, but found invalid entry "
+                                    + "with ledgerId {} entryId {} at offset {}",
                                 new Object[]{ledgerId, lid, entryId, offset});
                             throw new IOException("Invalid entry found @ offset " + offset);
                         }
@@ -281,8 +280,8 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
      * where 3 is the new compaction logId and 1 is the old entry logId.
      * After the index the flushed successfully, a hardlink "3.log" file should be created,
      * and 3.log.1.compacted file should be deleted to indicate the phase is succeed.
-     * <p>
-     * This phase can also used to recover partially flushed index when we pass isInRecovery=true
+     *
+     * <p>This phase can also used to recover partially flushed index when we pass isInRecovery=true
      */
     class UpdateIndexPhase extends CompactionPhase {
         File compactedLogFile;
@@ -305,7 +304,8 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                 File dir = compactedLogFile.getParentFile();
                 String compactedFilename = compactedLogFile.getName();
                 // create a hard link "x.log" for file "x.log.y.compacted"
-                this.newEntryLogFile = new File(dir, compactedFilename.substring(0, compactedFilename.indexOf(".log") + 4));
+                this.newEntryLogFile = new File(dir, compactedFilename.substring(0,
+                            compactedFilename.indexOf(".log") + 4));
                 if (!newEntryLogFile.exists()) {
                     HardLink.createHardLink(compactedLogFile, newEntryLogFile);
                 }
@@ -360,8 +360,8 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                     long lid = entry.getLong();
                     long entryId = entry.getLong();
                     if (lid != ledgerId || entryId < -1) {
-                        LOG.warn("Scanning expected ledgerId {}, but found invalid entry " +
-                                "with ledgerId {} entryId {} at offset {}",
+                        LOG.warn("Scanning expected ledgerId {}, but found invalid entry "
+                                + "with ledgerId {} entryId {} at offset {}",
                             new Object[]{ledgerId, lid, entryId, offset});
                         throw new IOException("Invalid entry found @ offset " + offset);
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/AsyncCallback.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/AsyncCallback.java
@@ -36,7 +36,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface AddCallback {
         /**
-         * Callback declaration
+         * Callback declaration.
          *
          * @param rc
          *          return code
@@ -59,7 +59,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface AddLacCallback {
         /**
-         * Callback declaration
+         * Callback declaration.
          *
          * @param rc
          *          return code
@@ -80,7 +80,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface CloseCallback {
         /**
-         * Callback definition
+         * Callback definition.
          *
          * @param rc
          *          return code
@@ -101,7 +101,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface CreateCallback {
         /**
-         * Declaration of callback method
+         * Declaration of callback method.
          *
          * @param rc
          *          return status
@@ -122,7 +122,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface OpenCallback {
         /**
-         * Callback for asynchronous call to open ledger
+         * Callback for asynchronous call to open ledger.
          *
          * @param rc
          *          Return code
@@ -144,7 +144,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface ReadCallback {
         /**
-         * Callback declaration
+         * Callback declaration.
          *
          * @param rc
          *          return code
@@ -168,7 +168,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface DeleteCallback {
         /**
-         * Callback definition for delete operations
+         * Callback definition for delete operations.
          *
          * @param rc
          *          return code
@@ -187,7 +187,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface ReadLastConfirmedCallback {
         /**
-         * Callback definition for bookie recover operations
+         * Callback definition for bookie recover operations.
          *
          * @param rc Return code
          * @param lastConfirmed The entry id of the last confirmed write or
@@ -209,7 +209,7 @@ public interface AsyncCallback {
     interface ReadLastConfirmedAndEntryCallback {
         /**
          * Callback definition for bookie operation that allows reading the last add confirmed
-         * along with an entry within the last add confirmed range
+         * along with an entry within the last add confirmed range.
          *
          * @param rc Return code
          * @param lastConfirmed The entry id of the last confirmed write or
@@ -231,7 +231,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface RecoverCallback {
         /**
-         * Callback definition for bookie recover operations
+         * Callback definition for bookie recover operations.
          *
          * @param rc
          *          return code
@@ -240,7 +240,7 @@ public interface AsyncCallback {
          */
         void recoverComplete(int rc, Object ctx);
     }
-    
+
     /**
      * Async Callback for checking if a ledger is closed.
      *
@@ -250,7 +250,7 @@ public interface AsyncCallback {
     @InterfaceStability.Stable
     interface IsClosedCallback {
         /**
-         * Callback definition for isClosed operation
+         * Callback definition for isClosed operation.
          *
          * @param rc
          *          return code

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
@@ -33,7 +33,7 @@ public abstract class BKException extends org.apache.bookkeeper.client.api.BKExc
     }
 
     /**
-     * Create an exception from an error code
+     * Create an exception from an error code.
      * @param code return error code
      * @return corresponding exception
      */
@@ -115,197 +115,297 @@ public abstract class BKException extends org.apache.bookkeeper.client.api.BKExc
     public interface Code extends org.apache.bookkeeper.client.api.BKException.Code {
     }
 
+    /**
+     * Bookkeeper security exception.
+     */
     public static class BKSecurityException extends BKException {
         public BKSecurityException() {
             super(Code.SecurityException);
         }
     }
+
+    /**
+     * Bookkeeper read exception.
+     */
     public static class BKReadException extends BKException {
         public BKReadException() {
             super(Code.ReadException);
         }
     }
 
+    /**
+     * Bookkeeper no such entry exception.
+     */
     public static class BKNoSuchEntryException extends BKException {
         public BKNoSuchEntryException() {
             super(Code.NoSuchEntryException);
         }
     }
 
+    /**
+     * Bookkeeper quorum exception.
+     */
     public static class BKQuorumException extends BKException {
         public BKQuorumException() {
             super(Code.QuorumException);
         }
     }
 
+    /**
+     * Bookkeeper bookie exception.
+     */
     public static class BKBookieException extends BKException {
         public BKBookieException() {
             super(Code.NoBookieAvailableException);
         }
     }
 
+    /**
+     * Bookkeeper digest not initialized exception.
+     */
     public static class BKDigestNotInitializedException extends BKException {
         public BKDigestNotInitializedException() {
             super(Code.DigestNotInitializedException);
         }
     }
 
+    /**
+     * Bookkeeper digest match exception.
+     */
     public static class BKDigestMatchException extends BKException {
         public BKDigestMatchException() {
             super(Code.DigestMatchException);
         }
     }
 
+    /**
+     * Bookkeeper illegal operation exception.
+     */
     public static class BKIllegalOpException extends BKException {
         public BKIllegalOpException() {
             super(Code.IllegalOpException);
         }
     }
 
+    /**
+     * Bookkeeper add entry quorum timeout exception.
+     */
     public static class BKAddEntryQuorumTimeoutException extends BKException {
         public BKAddEntryQuorumTimeoutException() {
             super(Code.AddEntryQuorumTimeoutException);
         }
     }
 
+    /**
+     * Bookkeeper duplicate entry id exception.
+     */
     public static class BKDuplicateEntryIdException extends BKException {
         public BKDuplicateEntryIdException() {
             super(Code.DuplicateEntryIdException);
         }
     }
 
+    /**
+     * Bookkeeper unexpected condition exception.
+     */
     public static class BKUnexpectedConditionException extends BKException {
         public BKUnexpectedConditionException() {
             super(Code.UnexpectedConditionException);
         }
     }
 
+    /**
+     * Bookkeeper not enough bookies exception.
+     */
     public static class BKNotEnoughBookiesException extends BKException {
         public BKNotEnoughBookiesException() {
             super(Code.NotEnoughBookiesException);
         }
     }
 
+    /**
+     * Bookkeeper write exception.
+     */
     public static class BKWriteException extends BKException {
         public BKWriteException() {
             super(Code.WriteException);
         }
     }
 
+    /**
+     * Bookkeeper protocol version exception.
+     */
     public static class BKProtocolVersionException extends BKException {
         public BKProtocolVersionException() {
             super(Code.ProtocolVersionException);
         }
     }
 
+    /**
+     * Bookkeeper metadata version exception.
+     */
     public static class BKMetadataVersionException extends BKException {
         public BKMetadataVersionException() {
             super(Code.MetadataVersionException);
         }
     }
 
+    /**
+     * Bookkeeper no such ledger exists exception.
+     */
     public static class BKNoSuchLedgerExistsException extends BKException {
         public BKNoSuchLedgerExistsException() {
             super(Code.NoSuchLedgerExistsException);
         }
     }
 
+    /**
+     * Bookkeeper bookie handle not available exception.
+     */
     public static class BKBookieHandleNotAvailableException extends BKException {
         public BKBookieHandleNotAvailableException() {
             super(Code.BookieHandleNotAvailableException);
         }
     }
 
+    /**
+     * Zookeeper exception.
+     */
     public static class ZKException extends BKException {
         public ZKException() {
             super(Code.ZKException);
         }
     }
 
+    /**
+     * Metastore exception.
+     */
     public static class MetaStoreException extends BKException {
         public MetaStoreException() {
             super(Code.MetaStoreException);
         }
     }
 
+    /**
+     * Bookkeeper ledger exist exception.
+     */
     public static class BKLedgerExistException extends BKException {
         public BKLedgerExistException() {
             super(Code.LedgerExistException);
         }
     }
 
+    /**
+     * Bookkeeper ledger recovery exception.
+     */
     public static class BKLedgerRecoveryException extends BKException {
         public BKLedgerRecoveryException() {
             super(Code.LedgerRecoveryException);
         }
     }
 
+    /**
+     * Bookkeeper ledger closed exception.
+     */
     public static class BKLedgerClosedException extends BKException {
         public BKLedgerClosedException() {
             super(Code.LedgerClosedException);
         }
     }
 
+    /**
+     * Bookkeeper incorrect parameter exception.
+     */
     public static class BKIncorrectParameterException extends BKException {
         public BKIncorrectParameterException() {
             super(Code.IncorrectParameterException);
         }
     }
 
+    /**
+     * Bookkeeper interrupted exception.
+     */
     public static class BKInterruptedException extends BKException {
         public BKInterruptedException() {
             super(Code.InterruptedException);
         }
     }
 
+    /**
+     * Bookkeeper ledger fenced exception.
+     */
     public static class BKLedgerFencedException extends BKException {
         public BKLedgerFencedException() {
             super(Code.LedgerFencedException);
         }
     }
 
+    /**
+     * Bookkeeper unauthorized access exception.
+     */
     public static class BKUnauthorizedAccessException extends BKException {
         public BKUnauthorizedAccessException() {
             super(Code.UnauthorizedAccessException);
         }
     }
 
+    /**
+     * Bookkeeper unclosed fragment exception.
+     */
     public static class BKUnclosedFragmentException extends BKException {
         public BKUnclosedFragmentException() {
             super(Code.UnclosedFragmentException);
         }
     }
 
+    /**
+     * Bookkeeper write on readonly bookie exception.
+     */
     public static class BKWriteOnReadOnlyBookieException extends BKException {
         public BKWriteOnReadOnlyBookieException() {
             super(Code.WriteOnReadOnlyBookieException);
         }
     }
 
+    /**
+     * Bookkeeper too many requests exception.
+     */
     public static class BKTooManyRequestsException extends BKException {
         public BKTooManyRequestsException() {
             super(Code.TooManyRequestsException);
         }
     }
 
+    /**
+     * Bookkeeper replication exception.
+     */
     public static class BKReplicationException extends BKException {
         public BKReplicationException() {
             super(Code.ReplicationException);
         }
     }
 
+    /**
+     * Bookkeeper client closed exception.
+     */
     public static class BKClientClosedException extends BKException {
         public BKClientClosedException() {
             super(Code.ClientClosedException);
         }
     }
 
+    /**
+     * Bookkeeper timeout exception.
+     */
     public static class BKTimeoutException extends BKException {
         public BKTimeoutException() {
             super(Code.TimeoutException);
         }
     }
 
+    /**
+     * Bookkeeper ledger id overflow exception.
+     */
     public static class BKLedgerIdOverflowException extends BKException {
         public BKLedgerIdOverflowException() {
             super(Code.LedgerIdOverflowException);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -20,9 +20,10 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -276,7 +277,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         }
 
         /**
-         * Feature Provider
+         * Feature Provider.
          *
          * @param featureProvider
          * @return
@@ -287,7 +288,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         }
 
         public BookKeeper build() throws IOException, InterruptedException, BKException {
-            Preconditions.checkNotNull(statsLogger, "No stats logger provided");
+            checkNotNull(statsLogger, "No stats logger provided");
             return new BookKeeper(conf, zk, eventLoopGroup, statsLogger, dnsResolver, requestTimer, featureProvider);
         }
     }
@@ -332,7 +333,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     }
 
     private static ZooKeeper validateZooKeeper(ZooKeeper zk) throws NullPointerException, IOException {
-        Preconditions.checkNotNull(zk, "No zookeeper instance provided");
+        checkNotNull(zk, "No zookeeper instance provided");
         if (!zk.getState().isConnected()) {
             LOG.error("Unconnected zookeeper handle passed to bookkeeper");
             throw new IOException(KeeperException.create(KeeperException.Code.CONNECTIONLOSS));
@@ -342,7 +343,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
     private static EventLoopGroup validateEventLoopGroup(EventLoopGroup eventLoopGroup)
             throws NullPointerException {
-        Preconditions.checkNotNull(eventLoopGroup, "No Event Loop Group provided");
+        checkNotNull(eventLoopGroup, "No Event Loop Group provided");
         return eventLoopGroup;
     }
 
@@ -380,7 +381,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      *          An event loop group that will be used to create connections to the bookies
      * @throws IOException
      * @throws InterruptedException
-     * @throws KeeperException if the passed zk handle is not connected
+     * @throws BKException in the event of a bookkeeper connection error
      */
     public BookKeeper(ClientConfiguration conf, ZooKeeper zk, EventLoopGroup eventLoopGroup)
             throws IOException, InterruptedException, BKException {
@@ -479,7 +480,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
         if (conf.getFirstSpeculativeReadLACTimeout() > 0) {
             this.readLACSpeculativeRequestPolicy =
-                    Optional.of((SpeculativeRequestExecutionPolicy)(new DefaultSpeculativeRequestExecutionPolicy(
+                    Optional.of((SpeculativeRequestExecutionPolicy) (new DefaultSpeculativeRequestExecutionPolicy(
                         conf.getFirstSpeculativeReadLACTimeout(),
                         conf.getMaxSpeculativeReadLACTimeout(),
                         conf.getSpeculativeReadLACTimeoutBackoffMultiplier())));
@@ -709,8 +710,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     public void asyncCreateLedger(final int ensSize,
                                   final int writeQuorumSize,
                                   final DigestType digestType,
-                                  final byte[] passwd, final CreateCallback cb, final Object ctx)
-    {
+                                  final byte[] passwd, final CreateCallback cb, final Object ctx) {
         asyncCreateLedger(ensSize, writeQuorumSize, writeQuorumSize, digestType, passwd, cb, ctx, null);
     }
 
@@ -719,13 +719,13 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      * a separate write quorum and ack quorum size. The write quorum must be larger than
      * the ack quorum.
      *
-     * Separating the write and the ack quorum allows the BookKeeper client to continue
+     * <p>Separating the write and the ack quorum allows the BookKeeper client to continue
      * writing when a bookie has failed but the failure has not yet been detected. Detecting
      * a bookie has failed can take a number of seconds, as configured by the read timeout
      * {@link ClientConfiguration#getReadTimeout()}. Once the bookie failure is detected,
      * that bookie will be removed from the ensemble.
      *
-     * The other parameters match those of {@link #asyncCreateLedger(int, int, DigestType, byte[],
+     * <p>The other parameters match those of {@link #asyncCreateLedger(int, int, DigestType, byte[],
      *                                      AsyncCallback.CreateCallback, Object)}
      *
      * @param ensSize
@@ -923,13 +923,13 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      * a separate write quorum and ack quorum size. The write quorum must be larger than
      * the ack quorum.
      *
-     * Separating the write and the ack quorum allows the BookKeeper client to continue
+     * <p>Separating the write and the ack quorum allows the BookKeeper client to continue
      * writing when a bookie has failed but the failure has not yet been detected. Detecting
      * a bookie has failed can take a number of seconds, as configured by the read timeout
      * {@link ClientConfiguration#getReadTimeout()}. Once the bookie failure is detected,
      * that bookie will be removed from the ensemble.
      *
-     * The other parameters match those of {@link #asyncCreateLedger(int, int, DigestType, byte[],
+     * <p>The other parameters match those of {@link #asyncCreateLedger(int, int, DigestType, byte[],
      *                                      AsyncCallback.CreateCallback, Object)}
      *
      * @param ensSize
@@ -962,7 +962,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                 return;
             }
             new LedgerCreateOp(BookKeeper.this, ensSize, writeQuorumSize,
-                               ackQuorumSize, digestType, passwd, cb, ctx, customMetadata).initiateAdv((long)(-1));
+                               ackQuorumSize, digestType, passwd, cb, ctx, customMetadata).initiateAdv((long) (-1));
         } finally {
             closeLock.readLock().unlock();
         }
@@ -991,7 +991,8 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                                         int ackQuorumSize,
                                         DigestType digestType,
                                         byte passwd[],
-                                        final Map<String, byte[]> customMetadata) throws InterruptedException, BKException{
+                                        final Map<String, byte[]> customMetadata)
+            throws InterruptedException, BKException {
         CompletableFuture<LedgerHandleAdv> future = new CompletableFuture<>();
         SyncCreateAdvCallback result = new SyncCreateAdvCallback(future);
 
@@ -1023,13 +1024,13 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      * a separate write quorum and ack quorum size. The write quorum must be larger than
      * the ack quorum.
      *
-     * Separating the write and the ack quorum allows the BookKeeper client to continue
+     * <p>Separating the write and the ack quorum allows the BookKeeper client to continue
      * writing when a bookie has failed but the failure has not yet been detected. Detecting
      * a bookie has failed can take a number of seconds, as configured by the read timeout
      * {@link ClientConfiguration#getReadTimeout()}. Once the bookie failure is detected,
      * that bookie will be removed from the ensemble.
      *
-     * The other parameters match those of {@link #asyncCreateLedger(long, int, int, DigestType, byte[],
+     * <p>The other parameters match those of {@link #asyncCreateLedger(long, int, int, DigestType, byte[],
      *                                      AsyncCallback.CreateCallback, Object)}
      *
      * @param ledgerId
@@ -1079,17 +1080,17 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     /**
      * Open existing ledger asynchronously for reading.
      *
-     * Opening a ledger with this method invokes fencing and recovery on the ledger
+     * <p>Opening a ledger with this method invokes fencing and recovery on the ledger
      * if the ledger has not been closed. Fencing will block all other clients from
      * writing to the ledger. Recovery will make sure that the ledger is closed
      * before reading from it.
      *
-     * Recovery also makes sure that any entries which reached one bookie, but not a
+     * <p>Recovery also makes sure that any entries which reached one bookie, but not a
      * quorum, will be replicated to a quorum of bookies. This occurs in cases were
      * the writer of a ledger crashes after sending a write request to one bookie but
      * before being able to send it to the rest of the bookies in the quorum.
      *
-     * If the ledger is already closed, neither fencing nor recovery will be applied.
+     * <p>If the ledger is already closed, neither fencing nor recovery will be applied.
      *
      * @see LedgerHandle#asyncClose
      *
@@ -1124,14 +1125,14 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      * of the writer and the ledger is not open in a safe manner, invoking the
      * recovery procedure.
      *
-     * Opening a ledger without recovery does not fence the ledger. As such, other
+     * <p>Opening a ledger without recovery does not fence the ledger. As such, other
      * clients can continue to write to the ledger.
      *
-     * This method returns a read only ledger handle. It will not be possible
+     * <p>This method returns a read only ledger handle. It will not be possible
      * to add entries to the ledger. Any attempt to add entries will throw an
      * exception.
      *
-     * Reads from the returned ledger will be able to read entries up until
+     * <p>Reads from the returned ledger will be able to read entries up until
      * the lastConfirmedEntry at the point in time at which the ledger was opened.
      * If an attempt is made to read beyond the ledger handle's LAC, an attempt is made
      * to get the latest LAC from bookies or metadata, and if the entry_id of the read request
@@ -1162,7 +1163,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
 
     /**
-     * Synchronous open ledger call
+     * Synchronous open ledger call.
      *
      * @see #asyncOpenLedger
      * @param lId
@@ -1189,7 +1190,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     }
 
     /**
-     * Synchronous, unsafe open ledger call
+     * Synchronous, unsafe open ledger call.
      *
      * @see #asyncOpenLedgerNoRecovery
      * @param lId
@@ -1247,7 +1248,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      * @param lId
      *            ledgerId
      * @throws InterruptedException
-     * @throws BKException.BKNoSuchLedgerExistsException if the ledger doesn't exist
      * @throws BKException
      */
     @SuppressWarnings("unchecked")
@@ -1376,14 +1376,15 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         this.regClient.close();
     }
 
-    private final void initOpLoggers(StatsLogger stats) {
+    private void initOpLoggers(StatsLogger stats) {
         createOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.CREATE_OP);
         deleteOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.DELETE_OP);
         openOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.OPEN_OP);
         recoverOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.RECOVER_OP);
         readOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_OP);
         readLacAndEntryOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY);
-        readLacAndEntryRespLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE);
+        readLacAndEntryRespLogger = stats.getOpStatsLogger(
+                BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE);
         addOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.ADD_OP);
         writeLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.WRITE_LAC_OP);
         readLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAC_OP);
@@ -1391,18 +1392,42 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         recoverReadEntriesStats = stats.getOpStatsLogger(BookKeeperClientStats.LEDGER_RECOVER_READ_ENTRIES);
     }
 
-    OpStatsLogger getCreateOpLogger() { return createOpLogger; }
-    OpStatsLogger getOpenOpLogger() { return openOpLogger; }
-    OpStatsLogger getDeleteOpLogger() { return deleteOpLogger; }
-    OpStatsLogger getRecoverOpLogger() { return recoverOpLogger; }
-    OpStatsLogger getReadOpLogger() { return readOpLogger; }
-    OpStatsLogger getReadLacAndEntryOpLogger() { return readLacAndEntryOpLogger; }
-    OpStatsLogger getReadLacAndEntryRespLogger() { return readLacAndEntryRespLogger; }
-    OpStatsLogger getAddOpLogger() { return addOpLogger; }
-    OpStatsLogger getWriteLacOpLogger() { return writeLacOpLogger; }
-    OpStatsLogger getReadLacOpLogger() { return readLacOpLogger; }
-    OpStatsLogger getRecoverAddCountLogger() { return recoverAddEntriesStats; }
-    OpStatsLogger getRecoverReadCountLogger() { return recoverReadEntriesStats; }
+    OpStatsLogger getCreateOpLogger() {
+        return createOpLogger;
+    }
+    OpStatsLogger getOpenOpLogger() {
+        return openOpLogger;
+    }
+    OpStatsLogger getDeleteOpLogger() {
+        return deleteOpLogger;
+    }
+    OpStatsLogger getRecoverOpLogger() {
+        return recoverOpLogger;
+    }
+    OpStatsLogger getReadOpLogger() {
+        return readOpLogger;
+    }
+    OpStatsLogger getReadLacAndEntryOpLogger() {
+        return readLacAndEntryOpLogger;
+    }
+    OpStatsLogger getReadLacAndEntryRespLogger() {
+        return readLacAndEntryRespLogger;
+    }
+    OpStatsLogger getAddOpLogger() {
+        return addOpLogger;
+    }
+    OpStatsLogger getWriteLacOpLogger() {
+        return writeLacOpLogger;
+    }
+    OpStatsLogger getReadLacOpLogger() {
+        return readLacOpLogger;
+    }
+    OpStatsLogger getRecoverAddCountLogger() {
+        return recoverAddEntriesStats;
+    }
+    OpStatsLogger getRecoverReadCountLogger() {
+        return recoverReadEntriesStats;
+    }
 
     static EventLoopGroup getDefaultEventLoopGroup() {
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("bookkeeper-io-%s").build();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -25,43 +25,43 @@ package org.apache.bookkeeper.client;
  * List of constants for defining client stats names.
  */
 public interface BookKeeperClientStats {
-    public final static String CLIENT_SCOPE = "bookkeeper_client";
+    String CLIENT_SCOPE = "bookkeeper_client";
 
     // Metadata Operations
 
-    public final static String CREATE_OP = "LEDGER_CREATE";
-    public final static String DELETE_OP = "LEDGER_DELETE";
-    public final static String OPEN_OP = "LEDGER_OPEN";
-    public final static String RECOVER_OP = "LEDGER_RECOVER";
-    public final static String LEDGER_RECOVER_READ_ENTRIES = "LEDGER_RECOVER_READ_ENTRIES";
-    public final static String LEDGER_RECOVER_ADD_ENTRIES = "LEDGER_RECOVER_ADD_ENTRIES";
+    String CREATE_OP = "LEDGER_CREATE";
+    String DELETE_OP = "LEDGER_DELETE";
+    String OPEN_OP = "LEDGER_OPEN";
+    String RECOVER_OP = "LEDGER_RECOVER";
+    String LEDGER_RECOVER_READ_ENTRIES = "LEDGER_RECOVER_READ_ENTRIES";
+    String LEDGER_RECOVER_ADD_ENTRIES = "LEDGER_RECOVER_ADD_ENTRIES";
 
     // Data Operations
 
-    public final static String ADD_OP = "ADD_ENTRY";
-    public final static String READ_OP = "READ_ENTRY";
-    public final static String WRITE_LAC_OP = "WRITE_LAC";
-    public final static String READ_LAC_OP = "READ_LAC";
-    public final static String READ_LAST_CONFIRMED_AND_ENTRY = "READ_LAST_CONFIRMED_AND_ENTRY";
-    public final static String READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE = "READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE";
-    public final static String PENDING_ADDS = "NUM_PENDING_ADD";
-    public final static String ENSEMBLE_CHANGES = "NUM_ENSEMBLE_CHANGE";
-    public final static String LAC_UPDATE_HITS = "LAC_UPDATE_HITS";
-    public final static String LAC_UPDATE_MISSES = "LAC_UPDATE_MISSES";
-    public final static String GET_BOOKIE_INFO_OP = "GET_BOOKIE_INFO";
+    String ADD_OP = "ADD_ENTRY";
+    String READ_OP = "READ_ENTRY";
+    String WRITE_LAC_OP = "WRITE_LAC";
+    String READ_LAC_OP = "READ_LAC";
+    String READ_LAST_CONFIRMED_AND_ENTRY = "READ_LAST_CONFIRMED_AND_ENTRY";
+    String READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE = "READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE";
+    String PENDING_ADDS = "NUM_PENDING_ADD";
+    String ENSEMBLE_CHANGES = "NUM_ENSEMBLE_CHANGE";
+    String LAC_UPDATE_HITS = "LAC_UPDATE_HITS";
+    String LAC_UPDATE_MISSES = "LAC_UPDATE_MISSES";
+    String GET_BOOKIE_INFO_OP = "GET_BOOKIE_INFO";
 
     // per channel stats
-    public final static String CHANNEL_SCOPE = "per_channel_bookie_client";
+    String CHANNEL_SCOPE = "per_channel_bookie_client";
 
-    public final static String CHANNEL_READ_OP = "READ_ENTRY";
-    public final static String CHANNEL_TIMEOUT_READ = "TIMEOUT_READ_ENTRY";
-    public final static String CHANNEL_ADD_OP = "ADD_ENTRY";
-    public final static String CHANNEL_TIMEOUT_ADD = "TIMEOUT_ADD_ENTRY";
-    public final static String CHANNEL_WRITE_LAC_OP = "WRITE_LAC";
-    public final static String CHANNEL_TIMEOUT_WRITE_LAC = "TIMEOUT_WRITE_LAC";
-    public final static String CHANNEL_READ_LAC_OP = "READ_LAC";
-    public final static String CHANNEL_TIMEOUT_READ_LAC = "TIMEOUT_READ_LAC";
-    public final static String TIMEOUT_GET_BOOKIE_INFO = "TIMEOUT_GET_BOOKIE_INFO";
-    public final static String CHANNEL_START_TLS_OP = "START_TLS";
-    public final static String CHANNEL_TIMEOUT_START_TLS_OP = "TIMEOUT_START_TLS";
+    String CHANNEL_READ_OP = "READ_ENTRY";
+    String CHANNEL_TIMEOUT_READ = "TIMEOUT_READ_ENTRY";
+    String CHANNEL_ADD_OP = "ADD_ENTRY";
+    String CHANNEL_TIMEOUT_ADD = "TIMEOUT_ADD_ENTRY";
+    String CHANNEL_WRITE_LAC_OP = "WRITE_LAC";
+    String CHANNEL_TIMEOUT_WRITE_LAC = "TIMEOUT_WRITE_LAC";
+    String CHANNEL_READ_LAC_OP = "READ_LAC";
+    String CHANNEL_TIMEOUT_READ_LAC = "TIMEOUT_READ_LAC";
+    String TIMEOUT_GET_BOOKIE_INFO = "TIMEOUT_GET_BOOKIE_INFO";
+    String CHANNEL_START_TLS_OP = "START_TLS";
+    String CHANNEL_TIMEOUT_START_TLS_OP = "TIMEOUT_START_TLS";
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
@@ -46,9 +46,9 @@ import org.slf4j.LoggerFactory;
  */
 public class BookieInfoReader {
     private static final Logger LOG = LoggerFactory.getLogger(BookieInfoReader.class);
-    private static final long GET_BOOKIE_INFO_REQUEST_FLAGS
-        = BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE |
-                               BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE;
+    private static final long GET_BOOKIE_INFO_REQUEST_FLAGS =
+        BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE
+                               | BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE;
 
     private final ScheduledExecutorService scheduler;
     private final BookKeeper bk;
@@ -123,7 +123,7 @@ public class BookieInfoReader {
         }
 
         /**
-         * Returns info for bookie, null if not known
+         * Returns info for bookie, null if not known.
          *
          * @param bookie bookie for which to get info
          * @return Info for bookie, null otherwise
@@ -133,7 +133,7 @@ public class BookieInfoReader {
         }
 
         /**
-         * Removes bookie from bookieInfoMap
+         * Removes bookie from bookieInfoMap.
          *
          * @param bookie bookie on which we observed an error
          */
@@ -142,7 +142,7 @@ public class BookieInfoReader {
         }
 
         /**
-         * Report new info on bookie
+         * Report new info on bookie.
          *
          * @param bookie bookie for which we obtained new info
          * @param info the new info
@@ -152,7 +152,7 @@ public class BookieInfoReader {
         }
 
         /**
-         * Get bookie info map
+         * Get bookie info map.
          */
         public Map<BookieSocketAddress, BookieInfo> getBookieMap() {
             return infoMap;
@@ -179,7 +179,7 @@ public class BookieInfoReader {
         }
 
         /**
-         * Mark pending operation FULL and return true if there is no in-progress operation
+         * Mark pending operation FULL and return true if there is no in-progress operation.
          *
          * @return True if we should execute a scan, False if there is already one running
          */
@@ -189,7 +189,7 @@ public class BookieInfoReader {
         }
 
         /**
-         * Mark pending operation PARTIAL if not full and return true if there is no in-progress operation
+         * Mark pending operation PARTIAL if not full and return true if there is no in-progress operation.
          *
          * @return True if we should execute a scan, False if there is already one running
          */
@@ -201,7 +201,7 @@ public class BookieInfoReader {
         }
 
         /**
-         * Gets and clears queuedType
+         * Gets and clears queuedType.
          */
         public State getAndClearQueuedType() {
             State ret = queuedType;
@@ -211,7 +211,7 @@ public class BookieInfoReader {
 
         /**
          * If queuedType != UNQUEUED, returns true, leaves running equal to true
-         * Otherwise, returns false and sets running to false
+         * Otherwise, returns false and sets running to false.
          */
         public boolean completeUnlessQueued() {
             if (queuedType == State.UNQUEUED) {
@@ -277,7 +277,7 @@ public class BookieInfoReader {
     }
 
     /**
-     * Method to allow tests to block until bookie info is available
+     * Method to allow tests to block until bookie info is available.
      *
      * @param bookie to lookup
      * @return None if absent, free disk space if present
@@ -322,8 +322,8 @@ public class BookieInfoReader {
         }
 
         BookieClient bkc = bk.getBookieClient();
-        final long requested = BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE |
-                               BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE;
+        final long requested = BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE
+                               | BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE;
         totalSent = 0;
         completedCnt = 0;
         errorCnt = 0;
@@ -395,10 +395,11 @@ public class BookieInfoReader {
         BookieClient bkc = bk.getBookieClient();
         final AtomicInteger totalSent = new AtomicInteger();
         final AtomicInteger totalCompleted = new AtomicInteger();
-        final ConcurrentMap<BookieSocketAddress, BookieInfo> map = new ConcurrentHashMap<BookieSocketAddress, BookieInfo>();
+        final ConcurrentMap<BookieSocketAddress, BookieInfo> map =
+            new ConcurrentHashMap<BookieSocketAddress, BookieInfo>();
         final CountDownLatch latch = new CountDownLatch(1);
-        long requested = BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE |
-                         BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE;
+        long requested = BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE
+                         | BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE;
 
         Collection<BookieSocketAddress> bookies;
         bookies = bk.bookieWatcher.getBookies();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultEnsemblePlacementPolicy.java
@@ -17,16 +17,18 @@
  */
 package org.apache.bookkeeper.client;
 
+import io.netty.util.HashedWheelTimer;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import io.netty.util.HashedWheelTimer;
-import java.util.Optional;
+
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.client.WeightedRandomSelection.WeightedObject;
@@ -60,7 +62,9 @@ public class DefaultEnsemblePlacementPolicy implements EnsemblePlacementPolicy {
     }
 
     @Override
-    public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize, int quorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Set<BookieSocketAddress> excludeBookies) throws BKNotEnoughBookiesException {
+    public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize, int quorumSize, int ackQuorumSize,
+            Map<String, byte[]> customMetadata, Set<BookieSocketAddress> excludeBookies)
+            throws BKNotEnoughBookiesException {
         ArrayList<BookieSocketAddress> newBookies = new ArrayList<BookieSocketAddress>(ensembleSize);
         if (ensembleSize <= 0) {
             return newBookies;
@@ -109,7 +113,10 @@ public class DefaultEnsemblePlacementPolicy implements EnsemblePlacementPolicy {
     }
 
     @Override
-    public BookieSocketAddress replaceBookie(int ensembleSize, int writeQuorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Collection<BookieSocketAddress> currentEnsemble, BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies) throws BKNotEnoughBookiesException {
+    public BookieSocketAddress replaceBookie(int ensembleSize, int writeQuorumSize, int ackQuorumSize,
+            Map<String, byte[]> customMetadata, Collection<BookieSocketAddress> currentEnsemble,
+            BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies)
+            throws BKNotEnoughBookiesException {
         excludeBookies.addAll(currentEnsemble);
         ArrayList<BookieSocketAddress> addresses = newEnsemble(1, 1, 1, customMetadata, excludeBookies);
         return addresses.get(0);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
@@ -20,13 +20,13 @@
  */
 package org.apache.bookkeeper.client;
 
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +43,8 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
     final int maxSpeculativeRequestTimeout;
     final float backoffMultiplier;
 
-    public DefaultSpeculativeRequestExecutionPolicy(int firstSpeculativeRequestTimeout, int maxSpeculativeRequestTimeout, float backoffMultiplier) {
+    public DefaultSpeculativeRequestExecutionPolicy(int firstSpeculativeRequestTimeout,
+            int maxSpeculativeRequestTimeout, float backoffMultiplier) {
         this.firstSpeculativeRequestTimeout = firstSpeculativeRequestTimeout;
         this.maxSpeculativeRequestTimeout = maxSpeculativeRequestTimeout;
         this.backoffMultiplier = backoffMultiplier;
@@ -53,19 +54,20 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
         }
 
         // Prevent potential over flow
-        if (Math.round((double)maxSpeculativeRequestTimeout * (double)backoffMultiplier) > Integer.MAX_VALUE) {
+        if (Math.round((double) maxSpeculativeRequestTimeout * (double) backoffMultiplier) > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Invalid values for maxSpeculativeRequestTimeout and backoffMultiplier");
         }
     }
 
     /**
-     * Initialize the speculative request execution policy
+     * Initialize the speculative request execution policy.
      *
      * @param scheduler The scheduler service to issue the speculative request
      * @param requestExecutor The executor is used to issue the actual speculative requests
      */
     @Override
-    public void initiateSpeculativeRequest(final ScheduledExecutorService scheduler, final SpeculativeRequestExecutor requestExecutor) {
+    public void initiateSpeculativeRequest(final ScheduledExecutorService scheduler,
+            final SpeculativeRequestExecutor requestExecutor) {
         scheduleSpeculativeRead(scheduler, requestExecutor, firstSpeculativeRequestTimeout);
     }
 
@@ -81,12 +83,13 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
                         // we want this handler to run immediately after we push the big red button!
                         public void onSuccess(Boolean issueNextRequest) {
                             if (issueNextRequest) {
-                                scheduleSpeculativeRead(scheduler, requestExecutor, Math.min(maxSpeculativeRequestTimeout,
-                                    Math.round((float)speculativeRequestTimeout * backoffMultiplier)));
+                                scheduleSpeculativeRead(scheduler, requestExecutor,
+                                        Math.min(maxSpeculativeRequestTimeout,
+                                        Math.round((float) speculativeRequestTimeout * backoffMultiplier)));
                             } else {
-                                if(LOG.isTraceEnabled()) {
-                                    LOG.trace("Stopped issuing speculative requests for {}, " +
-                                        "speculativeReadTimeout = {}", requestExecutor, speculativeRequestTimeout);
+                                if (LOG.isTraceEnabled()) {
+                                    LOG.trace("Stopped issuing speculative requests for {}, "
+                                        + "speculativeReadTimeout = {}", requestExecutor, speculativeRequestTimeout);
                                 }
                             }
                         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DigestManager.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 
 abstract class DigestManager {
-    static final Logger logger = LoggerFactory.getLogger(DigestManager.class);
+    private static final Logger logger = LoggerFactory.getLogger(DigestManager.class);
 
     static final int METADATA_LENGTH = 32;
     static final int LAC_METADATA_LENGTH = 16;
@@ -62,7 +62,8 @@ abstract class DigestManager {
         macCodeLength = getMacCodeLength();
     }
 
-    static DigestManager instantiate(long ledgerId, byte[] passwd, DigestType digestType) throws GeneralSecurityException {
+    static DigestManager instantiate(long ledgerId, byte[] passwd, DigestType digestType)
+            throws GeneralSecurityException {
         switch(digestType) {
         case MAC:
             return new MacDigestManager(ledgerId, passwd);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
@@ -17,14 +17,14 @@
  */
 package org.apache.bookkeeper.client;
 
-import org.apache.bookkeeper.net.BookieSocketAddress;
-
 import java.util.Map;
+
+import org.apache.bookkeeper.net.BookieSocketAddress;
 
 /**
  * This interface determins how entries are distributed among bookies.
  *
- * Every entry gets replicated to some number of replicas. The first replica for
+ * <p>Every entry gets replicated to some number of replicas. The first replica for
  * an entry is given a replicaIndex of 0, and so on. To distribute write load,
  * not all entries go to all bookies. Given an entry-id and replica index, an
  * {@link DistributionSchedule} determines which bookie that replica should go
@@ -39,38 +39,38 @@ public interface DistributionSchedule {
      * The set consists of a list of indices which can be
      * used to lookup the bookie in the ensemble.
      */
-    public interface WriteSet {
+    interface WriteSet {
         /**
          * The number of indexes in the write set.
          */
-        public int size();
+        int size();
 
         /**
          * Whether the set contains the given index.
          */
-        public boolean contains(int i);
+        boolean contains(int i);
 
         /**
          * Get the index at index i.
          */
-        public int get(int i);
+        int get(int i);
 
         /**
          * Set the index at index i.
          * @return the previous value at that index.
          */
-        public int set(int i, int index);
+        int set(int i, int index);
 
         /**
-         * Sort the indices
+         * Sort the indices.
          */
-        public void sort();
+        void sort();
 
         /**
          * Index of a specified bookie index.
          * -1 if not found.
          */
-        public int indexOf(int index);
+        int indexOf(int index);
 
         /**
          * If we want a write set to cover all bookies in an ensemble
@@ -78,30 +78,34 @@ public interface DistributionSchedule {
          * write set. This method appends those which are missing to the
          * end of the write set.
          */
-        public void addMissingIndices(int maxIndex);
+        void addMissingIndices(int maxIndex);
 
         /**
          * Move an index from one position to another,
          * shifting the other indices accordingly.
          */
-        public void moveAndShift(int from, int to);
+        void moveAndShift(int from, int to);
 
         /**
          * Recycle write set object when not in use.
          */
-        public void recycle();
+        void recycle();
 
         /**
          * Make a deep copy of this write set.
          */
-        public WriteSet copy();
+        WriteSet copy();
     }
 
-    public static WriteSet NULL_WRITE_SET = new WriteSet() {
+    WriteSet NULL_WRITE_SET = new WriteSet() {
             @Override
-            public int size() { return 0; }
+            public int size() {
+                return 0;
+            }
             @Override
-            public boolean contains(int i) { return false; }
+            public boolean contains(int i) {
+                return false;
+            }
             @Override
             public int get(int i) {
                 throw new ArrayIndexOutOfBoundsException();
@@ -113,7 +117,9 @@ public interface DistributionSchedule {
             @Override
             public void sort() {}
             @Override
-            public int indexOf(int index) { return -1; }
+            public int indexOf(int index) {
+                return -1;
+            }
             @Override
             public void addMissingIndices(int maxIndex) {
                 throw new ArrayIndexOutOfBoundsException();
@@ -125,13 +131,15 @@ public interface DistributionSchedule {
             @Override
             public void recycle() {}
             @Override
-            public WriteSet copy() { return this; }
+            public WriteSet copy() {
+                return this;
+            }
         };
 
     /**
-     * return the set of bookie indices to send the message to
+     * Return the set of bookie indices to send the message to.
      */
-    public WriteSet getWriteSet(long entryId);
+    WriteSet getWriteSet(long entryId);
 
 
     /**
@@ -139,12 +147,12 @@ public interface DistributionSchedule {
      * a response must be received so that an entry can be
      * considered to be replicated on a quorum.
      */
-    public interface AckSet {
+    interface AckSet {
         /**
-         * Add a bookie response and check if quorum has been met
+         * Add a bookie response and check if quorum has been met.
          * @return true if quorum has been met, false otherwise
          */
-        public boolean completeBookieAndCheck(int bookieIndexHeardFrom);
+        boolean completeBookieAndCheck(int bookieIndexHeardFrom);
 
         /**
          * Received failure response from a bookie and check if ack quorum
@@ -156,40 +164,40 @@ public interface DistributionSchedule {
          *          bookie address
          * @return true if ack quorum is broken, false otherwise.
          */
-        public boolean failBookieAndCheck(int bookieIndexHeardFrom, BookieSocketAddress address);
+        boolean failBookieAndCheck(int bookieIndexHeardFrom, BookieSocketAddress address);
 
         /**
          * Return the list of bookies that already failed.
          *
          * @return the list of bookies that already failed.
          */
-        public Map<Integer, BookieSocketAddress> getFailedBookies();
+        Map<Integer, BookieSocketAddress> getFailedBookies();
 
         /**
          * Invalidate a previous bookie response.
          * Used for reissuing write requests.
          */
-        public boolean removeBookieAndCheck(int bookie);
+        boolean removeBookieAndCheck(int bookie);
 
         /**
-         * Recycle this ack set when not used anymore
+         * Recycle this ack set when not used anymore.
          */
-        public void recycle();
+        void recycle();
     }
 
     /**
-     * Returns an ackset object, responses should be checked against this
+     * Returns an ackset object, responses should be checked against this.
      */
-    public AckSet getAckSet();
+    AckSet getAckSet();
 
 
     /**
      * Interface to keep track of which bookies in an ensemble, an action
      * has been performed for.
      */
-    public interface QuorumCoverageSet {
+    interface QuorumCoverageSet {
         /**
-         * Add a bookie to the result set
+         * Add a bookie to the result set.
          *
          * @param bookieIndexHeardFrom Bookie we've just heard from
          */
@@ -203,10 +211,10 @@ public interface DistributionSchedule {
         boolean checkCovered();
     }
 
-    public QuorumCoverageSet getCoverageSet();
+    QuorumCoverageSet getCoverageSet();
 
     /**
-     * Whether entry presents on given bookie index
+     * Whether entry presents on given bookie index.
      *
      * @param entryId
      *            - entryId to check the presence on given bookie index
@@ -215,5 +223,5 @@ public interface DistributionSchedule {
      *            of the entry
      * @return true if it has entry otherwise false.
      */
-    public boolean hasEntry(long entryId, int bookieIndex);
+    boolean hasEntry(long entryId, int bookieIndex);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
@@ -42,8 +42,8 @@ import org.apache.bookkeeper.stats.StatsLogger;
  *
  * <h2>How does it work?</h2>
  *
- * This interface basically covers three parts:
- * <p><ul>
+ * <p>This interface basically covers three parts:
+ * <ul>
  * <li>Initialization and uninitialization</li>
  * <li>How to choose bookies to place data</li>
  * <li>How to choose bookies to do speculative reads</li>
@@ -127,7 +127,7 @@ import org.apache.bookkeeper.stats.StatsLogger;
  *   bk1  bk2  bk3  bk4
  * </pre>
  *
- * <p> The network location of each bookie is resolved by a {@link DNSToSwitchMapping}. The {@link DNSToSwitchMapping}
+ * <p>The network location of each bookie is resolved by a {@link DNSToSwitchMapping}. The {@link DNSToSwitchMapping}
  * resolves a list of DNS-names or IP-addresses into a list of network locations. The network location that is returned
  * must be a network path of the form `/region/rack`, where `/` is the root, and `region` is the region id representing
  * the data center where `rack` is located. The network topology of the bookie cluster would determine the number of
@@ -137,7 +137,7 @@ import org.apache.bookkeeper.stats.StatsLogger;
  * <p>{@link RackawareEnsemblePlacementPolicy} basically just chooses bookies from different racks in the built
  * network topology. It guarantees that a write quorum will cover at least two racks. It expects the network locations
  * resolved by {@link DNSToSwitchMapping} have at least 2 levels. For example, network location paths like
- * {@code /dc1/rack0} and {@code /dc1/row1/rack0} are okay, but {@link /rack0} is not acceptable.
+ * {@code /dc1/rack0} and {@code /dc1/row1/rack0} are okay, but {@code /rack0} is not acceptable.
  *
  * <p>{@link RegionAwareEnsemblePlacementPolicy} is a hierarchical placement policy, which it chooses
  * equal-sized bookies from regions, and within each region it uses {@link RackawareEnsemblePlacementPolicy} to choose
@@ -206,16 +206,16 @@ public interface EnsemblePlacementPolicy {
      *
      * @since 4.5
      */
-    public EnsemblePlacementPolicy initialize(ClientConfiguration conf,
-                                              Optional<DNSToSwitchMapping> optionalDnsResolver,
-                                              HashedWheelTimer hashedWheelTimer,
-                                              FeatureProvider featureProvider,
-                                              StatsLogger statsLogger);
+    EnsemblePlacementPolicy initialize(ClientConfiguration conf,
+                                       Optional<DNSToSwitchMapping> optionalDnsResolver,
+                                       HashedWheelTimer hashedWheelTimer,
+                                       FeatureProvider featureProvider,
+                                       StatsLogger statsLogger);
 
     /**
-     * Uninitialize the policy
+     * Uninitialize the policy.
      */
-    public void uninitalize();
+    void uninitalize();
 
     /**
      * A consistent view of the cluster (what bookies are available as writable, what bookies are available as
@@ -231,8 +231,8 @@ public interface EnsemblePlacementPolicy {
      *          All the bookies in the cluster available for readonly.
      * @return the dead bookies during this cluster change.
      */
-    public Set<BookieSocketAddress> onClusterChanged(Set<BookieSocketAddress> writableBookies,
-                                                     Set<BookieSocketAddress> readOnlyBookies);
+    Set<BookieSocketAddress> onClusterChanged(Set<BookieSocketAddress> writableBookies,
+                                              Set<BookieSocketAddress> readOnlyBookies);
 
     /**
      * Choose <i>numBookies</i> bookies for ensemble. If the count is more than the number of available
@@ -254,13 +254,13 @@ public interface EnsemblePlacementPolicy {
      *                       provides in {@link BookKeeper#createLedger(int, int, int, BookKeeper.DigestType, byte[])}
      * @param excludeBookies Bookies that should not be considered as targets.
      * @throws BKNotEnoughBookiesException if not enough bookies available.
-     * @return the java.util.ArrayList<org.apache.bookkeeper.net.BookieSocketAddress>
+     * @return the ArrayList&lt;org.apache.bookkeeper.net.BookieSocketAddress&gt;
      */
-    public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize,
-                                                      int writeQuorumSize,
-                                                      int ackQuorumSize,
-                                                      Map<String, byte[]> customMetadata,
-                                                      Set<BookieSocketAddress> excludeBookies)
+    ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize,
+                                               int writeQuorumSize,
+                                               int ackQuorumSize,
+                                               Map<String, byte[]> customMetadata,
+                                               Set<BookieSocketAddress> excludeBookies)
         throws BKNotEnoughBookiesException;
 
     /**
@@ -280,13 +280,13 @@ public interface EnsemblePlacementPolicy {
      * @throws BKNotEnoughBookiesException
      * @return the org.apache.bookkeeper.net.BookieSocketAddress
      */
-    public BookieSocketAddress replaceBookie(int ensembleSize,
-                                             int writeQuorumSize,
-                                             int ackQuorumSize,
-                                             Map<String, byte[]> customMetadata,
-                                             Collection<BookieSocketAddress> currentEnsemble,
-                                             BookieSocketAddress bookieToReplace,
-                                             Set<BookieSocketAddress> excludeBookies)
+    BookieSocketAddress replaceBookie(int ensembleSize,
+                                      int writeQuorumSize,
+                                      int ackQuorumSize,
+                                      Map<String, byte[]> customMetadata,
+                                      Collection<BookieSocketAddress> currentEnsemble,
+                                      BookieSocketAddress bookieToReplace,
+                                      Set<BookieSocketAddress> excludeBookies)
         throws BKNotEnoughBookiesException;
 
     /**
@@ -303,7 +303,7 @@ public interface EnsemblePlacementPolicy {
      *         writeSet.
      * @since 4.5
      */
-    public DistributionSchedule.WriteSet reorderReadSequence(
+    DistributionSchedule.WriteSet reorderReadSequence(
             ArrayList<BookieSocketAddress> ensemble,
             Map<BookieSocketAddress, Long> bookieFailureHistory,
             DistributionSchedule.WriteSet writeSet);
@@ -323,18 +323,18 @@ public interface EnsemblePlacementPolicy {
      *         writeSet.
      * @since 4.5
      */
-    public DistributionSchedule.WriteSet reorderReadLACSequence(
+    DistributionSchedule.WriteSet reorderReadLACSequence(
             ArrayList<BookieSocketAddress> ensemble,
             Map<BookieSocketAddress, Long> bookieFailureHistory,
             DistributionSchedule.WriteSet writeSet);
 
     /**
      * Send the bookie info details.
-     * 
+     *
      * @param bookieInfoMap
      *          A map that has the bookie to BookieInfo
      * @since 4.5
      */
-    default public void updateBookieInfo(Map<BookieSocketAddress, BookieInfo> bookieInfoMap) {
+    default void updateBookieInfo(Map<BookieSocketAddress, BookieInfo> bookieInfoMap) {
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ExplicitLacFlushPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ExplicitLacFlushPolicy.java
@@ -20,6 +20,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import io.netty.buffer.ByteBuf;
+
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -29,14 +31,12 @@ import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.buffer.ByteBuf;
-
 interface ExplicitLacFlushPolicy {
     void stopExplicitLacFlush();
 
     void updatePiggyBackedLac(long piggyBackedLac);
 
-    static final ExplicitLacFlushPolicy VOID_EXPLICITLAC_FLUSH_POLICY = new ExplicitLacFlushPolicy() {
+    ExplicitLacFlushPolicy VOID_EXPLICITLAC_FLUSH_POLICY = new ExplicitLacFlushPolicy() {
         @Override
         public void stopExplicitLacFlush() {
             // void method
@@ -49,7 +49,7 @@ interface ExplicitLacFlushPolicy {
     };
 
     class ExplicitLacFlushPolicyImpl implements ExplicitLacFlushPolicy {
-        final static Logger LOG = LoggerFactory.getLogger(ExplicitLacFlushPolicyImpl.class);
+        static final Logger LOG = LoggerFactory.getLogger(ExplicitLacFlushPolicyImpl.class);
 
         volatile long piggyBackedLac = LedgerHandle.INVALID_ENTRY_ID;
         volatile long explicitLac = LedgerHandle.INVALID_ENTRY_ID;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ITopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ITopologyAwareEnsemblePlacementPolicy.java
@@ -17,13 +17,13 @@
  */
 package org.apache.bookkeeper.client;
 
+import java.util.ArrayList;
+import java.util.Set;
+
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.net.Node;
-
-import java.util.ArrayList;
-import java.util.Set;
 
 /**
  * Interface for topology aware ensemble placement policy.
@@ -39,37 +39,37 @@ public interface ITopologyAwareEnsemblePlacementPolicy<T extends Node> extends E
     /**
      * Predicate used when choosing an ensemble.
      */
-    static interface Predicate<T extends Node> {
+    interface Predicate<T extends Node> {
         boolean apply(T candidate, Ensemble<T> chosenBookies);
     }
 
     /**
      * Ensemble used to hold the result of an ensemble selected for placement.
      */
-    static interface Ensemble<T extends Node> {
+    interface Ensemble<T extends Node> {
 
         /**
          * Append the new bookie node to the ensemble only if the ensemble doesnt
-         * already contain the same bookie
+         * already contain the same bookie.
          *
          * @param node
          *          new candidate bookie node.
          * @return
          *          true if the node was added
          */
-        public boolean addNode(T node);
+        boolean addNode(T node);
 
         /**
          * @return list of addresses representing the ensemble
          */
-        public ArrayList<BookieSocketAddress> toList();
+        ArrayList<BookieSocketAddress> toList();
 
         /**
-         * Validates if an ensemble is valid
+         * Validates if an ensemble is valid.
          *
          * @return true if the ensemble is valid; false otherwise
          */
-        public boolean validate();
+        boolean validate();
 
     }
 
@@ -127,7 +127,7 @@ public interface ITopologyAwareEnsemblePlacementPolicy<T extends Node> extends E
     void handleBookiesThatLeft(Set<BookieSocketAddress> leftBookies);
 
     /**
-     * Handle bookies that joined
+     * Handle bookies that joined.
      *
      * @param joinedBookies
      *          bookies that joined.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * <p>NOTE: This class is tended to be used by this project only. External users should not rely on it directly.
  */
 public class LedgerChecker {
-    private final static Logger LOG = LoggerFactory.getLogger(LedgerChecker.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LedgerChecker.class);
 
     public final BookieClient bookieClient;
 
@@ -52,7 +52,7 @@ public class LedgerChecker {
     /**
      * This will collect all the entry read call backs and finally it will give
      * call back to previous call back API which is waiting for it once it meets
-     * the expected call backs from down
+     * the expected call backs from down.
      */
     private static class ReadManyEntriesCallback implements ReadEntryCallback {
         AtomicBoolean completed = new AtomicBoolean(false);
@@ -134,7 +134,7 @@ public class LedgerChecker {
     }
 
     /**
-     * Verify a ledger fragment to collect bad bookies
+     * Verify a ledger fragment to collect bad bookies.
      *
      * @param fragment
      *          fragment to verify
@@ -220,8 +220,7 @@ public class LedgerChecker {
 
         public void readEntryComplete(int rc, long ledgerId, long entryId,
                                       ByteBuf buffer, Object ctx) {
-            if (BKException.Code.NoSuchEntryException != rc &&
-                BKException.Code.NoSuchLedgerExistsException != rc) {
+            if (BKException.Code.NoSuchEntryException != rc && BKException.Code.NoSuchLedgerExistsException != rc) {
                 entryMayExist.set(true);
             }
 
@@ -234,7 +233,7 @@ public class LedgerChecker {
     /**
      * This will collect all the fragment read call backs and finally it will
      * give call back to above call back API which is waiting for it once it
-     * meets the expected call backs from down
+     * meets the expected call backs from down.
      */
     private static class FullLedgerCallback implements
             GenericCallback<LedgerFragment> {
@@ -322,8 +321,7 @@ public class LedgerChecker {
             if (curEntryId == lastEntry) {
                 final long entryToRead = curEntryId;
 
-                final EntryExistsCallback eecb
-                    = new EntryExistsCallback(lh.getLedgerMetadata().getWriteQuorumSize(),
+                final EntryExistsCallback eecb = new EntryExistsCallback(lh.getLedgerMetadata().getWriteQuorumSize(),
                                               new GenericCallback<Boolean>() {
                                                   public void operationComplete(int rc, Boolean result) {
                                                       if (result) {
@@ -333,8 +331,7 @@ public class LedgerChecker {
                                                   }
                                               });
 
-                DistributionSchedule.WriteSet writeSet
-                    = lh.getDistributionSchedule().getWriteSet(entryToRead);
+                DistributionSchedule.WriteSet writeSet = lh.getDistributionSchedule().getWriteSet(entryToRead);
                 for (int i = 0; i < writeSet.size(); i++) {
                     BookieSocketAddress addr = curEnsemble.get(writeSet.get(i));
                     bookieClient.readEntry(addr, lh.getId(), entryToRead, eecb, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -47,7 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Encapsulates asynchronous ledger create operation
+ * Encapsulates asynchronous ledger create operation.
  *
  */
 class LedgerCreateOp implements GenericCallback<Void> {
@@ -68,7 +68,7 @@ class LedgerCreateOp implements GenericCallback<Void> {
     boolean generateLedgerId = true;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param bk
      *       BookKeeper object
@@ -110,7 +110,7 @@ class LedgerCreateOp implements GenericCallback<Void> {
     }
 
     /**
-     * Initiates the operation
+     * Initiates the operation.
      */
     public void initiate() {
         // allocate ensemble first
@@ -223,8 +223,8 @@ class LedgerCreateOp implements GenericCallback<Void> {
         private int builderAckQuorumSize = 2;
         private int builderWriteQuorumSize = 2;
         private byte[] builderPassword;
-        private org.apache.bookkeeper.client.api.DigestType builderDigestType
-            = org.apache.bookkeeper.client.api.DigestType.CRC32;
+        private org.apache.bookkeeper.client.api.DigestType builderDigestType =
+            org.apache.bookkeeper.client.api.DigestType.CRC32;
         private Map<String, byte[]> builderCustomMetadata = Collections.emptyMap();
 
         CreateBuilderImpl(BookKeeper bk) {
@@ -279,7 +279,8 @@ class LedgerCreateOp implements GenericCallback<Void> {
             }
 
             if (builderAckQuorumSize > builderWriteQuorumSize) {
-                LOG.error("invalid ackQuorumSize {} > writeQuorumSize {}", builderAckQuorumSize, builderWriteQuorumSize);
+                LOG.error("invalid ackQuorumSize {} > writeQuorumSize {}", builderAckQuorumSize,
+                        builderWriteQuorumSize);
                 return false;
             }
 
@@ -364,7 +365,8 @@ class LedgerCreateOp implements GenericCallback<Void> {
                 return false;
             }
             if (builderLedgerId != null && builderLedgerId < 0) {
-                LOG.error("invalid ledgerId {} < 0. Do not set en explicit value if you want automatic generation", builderLedgerId);
+                LOG.error("invalid ledgerId {} < 0. Do not set en explicit value if you want automatic generation",
+                        builderLedgerId);
                 return false;
             }
             return true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerDeleteOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerDeleteOp.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Encapsulates asynchronous ledger delete operation
+ * Encapsulates asynchronous ledger delete operation.
  *
  */
 class LedgerDeleteOp extends OrderedSafeGenericCallback<Void> {
@@ -51,7 +51,7 @@ class LedgerDeleteOp extends OrderedSafeGenericCallback<Void> {
     final OpStatsLogger deleteOpLogger;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param bk
      *            BookKeeper object
@@ -73,7 +73,7 @@ class LedgerDeleteOp extends OrderedSafeGenericCallback<Void> {
     }
 
     /**
-     * Initiates the operation
+     * Initiates the operation.
      */
     public void initiate() {
         // Asynchronously delete the ledger from meta manager

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerEntry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerEntry.java
@@ -20,10 +20,13 @@
  */
 package org.apache.bookkeeper.client;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkState;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
+
 import java.io.InputStream;
+
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 
@@ -62,12 +65,12 @@ public class LedgerEntry {
      * Returns the content of the entry.
      * This method can be called only once. While using v2 wire protocol this method will automatically release
      * the internal ByteBuf
-     * 
+     *
      * @return the content of the entry
      * @throws IllegalStateException if this method is called twice
      */
     public byte[] getEntry() {
-        Preconditions.checkState(null != data, "entry content can be accessed only once");
+        checkState(null != data, "entry content can be accessed only once");
         byte[] entry = new byte[data.readableBytes()];
         data.readBytes(entry);
         data.release();
@@ -85,7 +88,7 @@ public class LedgerEntry {
      * @throws IllegalStateException if this method is called twice
      */
     public InputStream getEntryInputStream() {
-        Preconditions.checkState(null != data, "entry content can be accessed only once");
+        checkState(null != data, "entry content can be accessed only once");
         ByteBufInputStream res = new ByteBufInputStream(data);
         data = null;
         return res;
@@ -94,7 +97,7 @@ public class LedgerEntry {
     /**
      * Return the internal buffer that contains the entry payload.
      *
-     * Note: Using v2 wire protocol it is responsibility of the caller to ensure to release the buffer after usage.
+     * <p>Note: Using v2 wire protocol it is responsibility of the caller to ensure to release the buffer after usage.
      *
      * @return a ByteBuf which contains the data
      *
@@ -103,8 +106,7 @@ public class LedgerEntry {
      * or {@link #getEntryInputStream()}.
      */
     public ByteBuf getEntryBuffer() {
-        Preconditions.checkState(null != data, "entry content has been retrieved" +
-            " by #getEntry or #getEntryInputStream");
+        checkState(null != data, "entry content has been retrieved by #getEntry or #getEntryInputStream");
         return data;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
@@ -30,7 +30,7 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
  * Represents the entries of a segment of a ledger which are stored on subset of
  * bookies in the segments bookie ensemble.
  *
- * Used for checking and recovery
+ * <p>Used for checking and recovery
  */
 public class LedgerFragment {
     private final Set<Integer> bookieIndexes;
@@ -105,7 +105,7 @@ public class LedgerFragment {
     }
 
     /**
-     * Gets the failedBookie address
+     * Gets the failedBookie address.
      */
     public BookieSocketAddress getAddress(int bookieIndex) {
         return ensemble.get(bookieIndex);
@@ -120,7 +120,7 @@ public class LedgerFragment {
     }
 
     /**
-     * Gets the failedBookie index
+     * Gets the failedBookie index.
      */
     public Set<Integer> getBookiesIndexes() {
         return bookieIndexes;
@@ -202,7 +202,7 @@ public class LedgerFragment {
     }
 
     /**
-     * Gets the ensemble of fragment
+     * Gets the ensemble of fragment.
      *
      * @return the ensemble for the segment which this fragment is a part of
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This is the helper class for replicating the fragments from one bookie to
- * another
+ * another.
  */
 public class LedgerFragmentReplicator {
 
@@ -76,7 +76,7 @@ public class LedgerFragmentReplicator {
         this(bkc, NullStatsLogger.INSTANCE);
     }
 
-    private final static Logger LOG = LoggerFactory
+    private static final Logger LOG = LoggerFactory
             .getLogger(LedgerFragmentReplicator.class);
 
     private void replicateFragmentInternal(final LedgerHandle lh,
@@ -141,7 +141,7 @@ public class LedgerFragmentReplicator {
      * then it re-replicates that batched entry fragments one by one. After
      * re-replication of all batched entry fragments, it will update the
      * ensemble info with new Bookie once
-     * 
+     *
      * @param lh
      *            LedgerHandle for the ledger
      * @param lf
@@ -165,7 +165,9 @@ public class LedgerFragmentReplicator {
                 ledgerFragmentMcb, targetBookieAddresses);
     }
 
-    /** Replicate the batched entry fragments one after other */
+    /**
+     * Replicate the batched entry fragments one after other.
+     */
     private void replicateNextBatch(final LedgerHandle lh,
             final Iterator<LedgerFragment> fragments,
             final AsyncCallback.VoidCallback ledgerFragmentMcb,
@@ -200,7 +202,7 @@ public class LedgerFragmentReplicator {
     /**
      * Split the full fragment into batched entry fragments by keeping
      * rereplicationEntryBatchSize of entries in each one and can treat them as
-     * sub fragments
+     * sub fragments.
      */
     static Set<LedgerFragment> splitIntoSubFragments(LedgerHandle lh,
             LedgerFragment ledgerFragment, long rereplicationEntryBatchSize) {
@@ -281,8 +283,7 @@ public class LedgerFragmentReplicator {
                         LOG.debug("Success writing ledger id {}, entry id {} to a new bookie {}!",
                                   new Object[] { ledgerId, entryId, addr });
                     }
-                    if (numCompleted.incrementAndGet() == newBookies.size() &&
-                        completed.compareAndSet(false, true)) {
+                    if (numCompleted.incrementAndGet() == newBookies.size() && completed.compareAndSet(false, true)) {
                         ledgerFragmentEntryMcb.processResult(rc, null, null);
                     }
                 }
@@ -359,7 +360,9 @@ public class LedgerFragmentReplicator {
         }
     }
 
-    /** Updates the ensemble with newBookie and notify the ensembleUpdatedCb */
+    /**
+     * Updates the ensemble with newBookie and notify the ensembleUpdatedCb.
+     */
     private static void updateEnsembleInfo(
             AsyncCallback.VoidCallback ensembleUpdatedCb, long fragmentStartId,
             LedgerHandle lh, Map<BookieSocketAddress, BookieSocketAddress> oldBookie2NewBookie) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -21,8 +21,8 @@
 
 package org.apache.bookkeeper.client;
 
-import static org.apache.bookkeeper.common.concurrent.FutureUtils.createFuture;
-import static org.apache.bookkeeper.common.concurrent.FutureUtils.completeExceptionally;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import java.io.Serializable;
 import java.security.GeneralSecurityException;
@@ -31,15 +31,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.SyncCallbackUtils.SyncAddCallback;
+import org.apache.bookkeeper.client.api.WriteAdvHandle;
 import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import org.apache.bookkeeper.client.api.WriteAdvHandle;
 
 /**
  * Ledger Advanced handle extends {@link LedgerHandle} to provide API to add entries with
@@ -47,7 +46,7 @@ import org.apache.bookkeeper.client.api.WriteAdvHandle;
  * ledger being written.
  */
 public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
-    final static Logger LOG = LoggerFactory.getLogger(LedgerHandleAdv.class);
+    static final Logger LOG = LoggerFactory.getLogger(LedgerHandleAdv.class);
 
     static class PendingOpsComparator implements Comparator<PendingAddOp>, Serializable {
         public int compare(PendingAddOp o1, PendingAddOp o2) {
@@ -227,7 +226,7 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
     }
 
     /**
-     * LedgerHandleAdv will not allow addEntry without providing an entryId
+     * LedgerHandleAdv will not allow addEntry without providing an entryId.
      */
     @Override
     public void asyncAddEntry(ByteBuf data, AddCallback cb, Object ctx) {
@@ -235,7 +234,7 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
     }
 
     /**
-     * LedgerHandleAdv will not allow addEntry without providing an entryId
+     * LedgerHandleAdv will not allow addEntry without providing an entryId.
      */
     @Override
     public void asyncAddEntry(final byte[] data, final int offset, final int length,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -118,8 +118,8 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
         this.lastEntryId = LedgerHandle.INVALID_ENTRY_ID;
         this.metadataFormatVersion = CURRENT_METADATA_FORMAT_VERSION;
 
-        this.digestType = digestType.equals(BookKeeper.DigestType.MAC) ?
-            LedgerMetadataFormat.DigestType.HMAC : LedgerMetadataFormat.DigestType.CRC32;
+        this.digestType = digestType.equals(BookKeeper.DigestType.MAC)
+            ? LedgerMetadataFormat.DigestType.HMAC : LedgerMetadataFormat.DigestType.CRC32;
         this.password = Arrays.copyOf(password, password.length);
         this.hasPassword = true;
         if (customMetadata != null) {
@@ -297,7 +297,7 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
 
     /**
      * the entry id greater than the given entry-id at which the next ensemble change takes
-     * place
+     * place.
      *
      * @param entryId
      * @return the entry id of the next ensemble change (-1 if no further ensemble changes)
@@ -336,8 +336,9 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
         }
 
         if (customMetadata != null) {
-            LedgerMetadataFormat.cMetadataMapEntry.Builder cMetadataBuilder = LedgerMetadataFormat.cMetadataMapEntry.newBuilder();
-            for (Map.Entry<String,byte[]> entry : customMetadata.entrySet()) {
+            LedgerMetadataFormat.cMetadataMapEntry.Builder cMetadataBuilder =
+                LedgerMetadataFormat.cMetadataMapEntry.newBuilder();
+            for (Map.Entry<String, byte[]> entry : customMetadata.entrySet()) {
                 cMetadataBuilder.setKey(entry.getKey()).setValue(ByteString.copyFrom(entry.getValue()));
                 builder.addCustomMetadata(cMetadataBuilder.build());
             }
@@ -355,7 +356,7 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
     }
 
     /**
-     * Generates a byte array of this object
+     * Generates a byte array of this object.
      *
      * @return the metadata serialized into a byte array
      */
@@ -400,7 +401,7 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
     }
 
     /**
-     * Parses a given byte array and transforms into a LedgerConfig object
+     * Parses a given byte array and transforms into a LedgerConfig object.
      *
      * @param bytes
      *            byte array to parse
@@ -572,15 +573,16 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
     }
 
     /**
-     * Routine to compare two Map<String, byte[]>; Since the values in the map are byte[], we can't use Map.equals
+     * Routine to compare two {@code Map<String, byte[]>}; Since the values in the map are {@code byte[]}, we can't use
+     * {@code Map.equals}.
      * @param first
      *          The first map
      * @param second
      *          The second map to compare with
-     * @return true if the 2 maps contain the exact set of <K,V> pairs.
+     * @return true if the 2 maps contain the exact set of {@code <K,V>} pairs.
      */
     public static boolean areByteArrayValMapsEqual(Map<String, byte[]> first, Map<String, byte[]> second) {
-        if(first == null && second == null) {
+        if (first == null && second == null) {
             return true;
         }
 
@@ -615,15 +617,15 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
          *  opened the ledger, can't resolve this conflict.
          */
 
-        if (metadataFormatVersion != newMeta.metadataFormatVersion ||
-            ensembleSize != newMeta.ensembleSize ||
-            writeQuorumSize != newMeta.writeQuorumSize ||
-            ackQuorumSize != newMeta.ackQuorumSize ||
-            length != newMeta.length ||
-            state != newMeta.state ||
-            !digestType.equals(newMeta.digestType) ||
-            !Arrays.equals(password, newMeta.password) ||
-            !LedgerMetadata.areByteArrayValMapsEqual(customMetadata, newMeta.customMetadata)) {
+        if (metadataFormatVersion != newMeta.metadataFormatVersion
+            || ensembleSize != newMeta.ensembleSize
+            || writeQuorumSize != newMeta.writeQuorumSize
+            || ackQuorumSize != newMeta.ackQuorumSize
+            || length != newMeta.length
+            || state != newMeta.state
+            || !digestType.equals(newMeta.digestType)
+            || !Arrays.equals(password, newMeta.password)
+            || !LedgerMetadata.areByteArrayValMapsEqual(customMetadata, newMeta.customMetadata)) {
             return true;
         }
 
@@ -651,7 +653,7 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
             // using recovery tool.
             Iterator<Long> keyIter = ensembles.keySet().iterator();
             Iterator<Long> newMetaKeyIter = newMeta.ensembles.keySet().iterator();
-            for (int i=0; i<newMeta.ensembles.size(); i++) {
+            for (int i = 0; i < newMeta.ensembles.size(); i++) {
                 Long curKey = keyIter.next();
                 Long newMetaKey = newMetaKeyIter.next();
                 if (!curKey.equals(newMetaKey)) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -23,11 +23,12 @@ package org.apache.bookkeeper.client;
 
 import static org.apache.bookkeeper.client.BookKeeper.DigestType.fromApiDigestType;
 
+import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.security.GeneralSecurityException;
+
 import org.apache.bookkeeper.client.AsyncCallback.OpenCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadLastConfirmedCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -42,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Encapsulates the ledger open operation
+ * Encapsulates the ledger open operation.
  *
  */
 class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
@@ -58,7 +59,7 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
     boolean administrativeOpen = false;
     long startTime;
     final OpStatsLogger openOpLogger;
-    
+
     final DigestType suggestedDigestType;
     final boolean enableDigestAutodetection;
 
@@ -98,7 +99,7 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
     }
 
     /**
-     * Inititates the ledger open operation
+     * Inititates the ledger open operation.
      */
     public void initiate() {
         startTime = MathUtils.nowInNano();
@@ -110,7 +111,7 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
     }
 
     /**
-     * Inititates the ledger open operation without recovery
+     * Inititates the ledger open operation without recovery.
      */
     public void initiateWithoutRecovery() {
         this.doRecovery = false;
@@ -129,10 +130,10 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
         }
 
         final byte[] passwd;
-        DigestType digestType = enableDigestAutodetection 
+        DigestType digestType = enableDigestAutodetection
                                     ? fromApiDigestType(metadata.getDigestType())
                                     : suggestedDigestType;
-										
+
         /* For an administrative open, the default passwords
          * are read from the configuration, but if the metadata
          * already contains passwords, use these instead. */
@@ -223,8 +224,8 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
         private boolean builderRecovery = false;
         private Long builderLedgerId;
         private byte[] builderPassword;
-        private org.apache.bookkeeper.client.api.DigestType builderDigestType
-                = org.apache.bookkeeper.client.api.DigestType.CRC32;
+        private org.apache.bookkeeper.client.api.DigestType builderDigestType =
+            org.apache.bookkeeper.client.api.DigestType.CRC32;
         private final BookKeeper bk;
 
         OpenBuilderImpl(BookKeeper bookkeeper) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/MacDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/MacDigestManager.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * <p>NOTE: This class is tended to be used by this project only. External users should not rely on it directly.
  */
 public class MacDigestManager extends DigestManager {
-    private final static Logger LOG = LoggerFactory.getLogger(MacDigestManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MacDigestManager.class);
 
     public static final String DIGEST_ALGORITHM = "SHA-1";
     public static final String KEY_ALGORITHM = "HmacSHA1";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -18,6 +18,9 @@
 package org.apache.bookkeeper.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableMap;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
@@ -25,11 +28,10 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 
-import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieProtocol;
@@ -37,10 +39,8 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.SafeRunnable;
-import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.concurrent.RejectedExecutionException;
 
 /**
  * This represents a pending add operation. When it has got success from all
@@ -52,7 +52,7 @@ import java.util.concurrent.RejectedExecutionException;
  *
  */
 class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
-    private final static Logger LOG = LoggerFactory.getLogger(PendingAddOp.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PendingAddOp.class);
 
     ByteBuf payload;
     ByteBuf toSend;
@@ -126,8 +126,8 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
     void sendWriteRequest(int bookieIndex) {
         int flags = isRecoveryAdd ? BookieProtocol.FLAG_RECOVERY_ADD : BookieProtocol.FLAG_NONE;
 
-        lh.bk.getBookieClient().addEntry(lh.metadata.currentEnsemble.get(bookieIndex), lh.ledgerId, lh.ledgerKey, entryId, toSend,
-                this, bookieIndex, flags);
+        lh.bk.getBookieClient().addEntry(lh.metadata.currentEnsemble.get(bookieIndex), lh.ledgerId, lh.ledgerKey,
+                entryId, toSend, this, bookieIndex, flags);
         ++pendingWriteRequests;
     }
 
@@ -177,8 +177,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
         // completes.
         //
         // We call sendAddSuccessCallback when unsetting t cover this case.
-        DistributionSchedule.WriteSet writeSet
-            = lh.distributionSchedule.getWriteSet(entryId);
+        DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSet(entryId);
         try {
             if (!writeSet.contains(bookieIndex)) {
                 lh.sendAddSuccessCallbacks();
@@ -209,7 +208,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
     }
 
     /**
-     * Initiate the add operation
+     * Initiate the add operation.
      */
     public void safeRun() {
         hasRun = true;
@@ -235,8 +234,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
                 payload);
 
         // Iterate over set and trigger the sendWriteRequests
-        DistributionSchedule.WriteSet writeSet
-            = lh.distributionSchedule.getWriteSet(entryId);
+        DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSet(entryId);
         try {
             for (int i = 0; i < writeSet.size(); i++) {
                 sendWriteRequest(writeSet.get(i));
@@ -272,11 +270,12 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
             //
             // E.g. entry x is going to complete.
             //
-            // 1) entry x + k hits a failure. lh.handleBookieFailure increases blockAddCompletions to 1, for ensemble change
+            // 1) entry x + k hits a failure. lh.handleBookieFailure increases blockAddCompletions to 1, for ensemble
+            //    change
             // 2) entry x receives all responses, sets completed to true but fails to send success callback because
             //    blockAddCompletions is 1
-            // 3) ensemble change completed. lh unset success starting from x to x+k, but since the unset doesn't break ackSet
-            //    constraint. #removeBookieAndCheck doesn't set completed back to false.
+            // 3) ensemble change completed. lh unset success starting from x to x+k, but since the unset doesn't break
+            //    ackSet constraint. #removeBookieAndCheck doesn't set completed back to false.
             // 4) so when the retry request on new bookie completes, it finds the pending op is already completed.
             //    we have to trigger #sendAddSuccessCallbacks
             //
@@ -307,7 +306,8 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
             return;
         default:
             if (lh.bk.delayEnsembleChange) {
-                if (ackSet.failBookieAndCheck(bookieIndex, addr) || rc == BKException.Code.WriteOnReadOnlyBookieException) {
+                if (ackSet.failBookieAndCheck(bookieIndex, addr)
+                        || rc == BKException.Code.WriteOnReadOnlyBookieException) {
                     Map<Integer, BookieSocketAddress> failedBookies = ackSet.getFailedBookies();
                     LOG.warn("Failed to write entry ({}, {}) to bookies {}, handling failures.",
                              new Object[] { ledgerId, entryId, failedBookies });
@@ -315,8 +315,8 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
                     lh.handleBookieFailure(failedBookies);
                 } else {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Failed to write entry ({}, {}) to bookie ({}, {})," +
-                                  " but it didn't break ack quorum, delaying ensemble change : {}",
+                        LOG.debug("Failed to write entry ({}, {}) to bookie ({}, {}),"
+                                  + " but it didn't break ack quorum, delaying ensemble change : {}",
                                   new Object[] { ledgerId, entryId, bookieIndex, addr, BKException.getMessage(rc) });
                     }
                 }
@@ -379,7 +379,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback, TimerTask {
     @Override
     public boolean equals(Object o) {
        if (o instanceof PendingAddOp) {
-           return (this.entryId == ((PendingAddOp)o).entryId);
+           return (this.entryId == ((PendingAddOp) o).entryId);
        }
        return (this == o);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
@@ -17,25 +17,25 @@
  */
 package org.apache.bookkeeper.client;
 
+import io.netty.buffer.ByteBuf;
+
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.client.DigestManager.RecoveryData;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadLacCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.buffer.ByteBuf;
-
 /**
  * This represents a pending ReadLac operation.
  *
- * LAC is stored in two places on bookies.
+ * <p>LAC is stored in two places on bookies.
  * 1. WriteLac operation sends Explicit LAC and is stored in memory on each bookie.
  * 2. Each AddEntry operation piggy-backs LAC which is stored on bookie's disk.
  *
- * This operation returns both of those entries and we pick the latest LAC out of
+ * <p>This operation returns both of those entries and we pick the latest LAC out of
  * available answers.
  *
- * This is an optional protocol operations to facilitate tailing readers
+ * <p>This is an optional protocol operations to facilitate tailing readers
  * to be up to date with the writer. This is best effort to get latest LAC
  * from bookies, and doesn't affect the correctness of the protocol.
  */
@@ -54,7 +54,7 @@ class PendingReadLacOp implements ReadLacCallback {
      * Wrapper to get Lac from the request
      */
     interface LacCallback {
-        public void getLacComplete(int rc, long lac);
+        void getLacComplete(int rc, long lac);
     }
 
     PendingReadLacOp(LedgerHandle lh, LacCallback cb) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
@@ -17,9 +17,9 @@
  */
 package org.apache.bookkeeper.client;
 
+import io.netty.buffer.ByteBuf;
+
 import java.util.BitSet;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.apache.bookkeeper.client.AsyncCallback.AddLacCallback;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -28,19 +28,17 @@ import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.buffer.ByteBuf;
-
 /**
  * This represents a pending WriteLac operation. When it has got
  * success from Ack Quorum bookies, sends success back to the application,
  * otherwise failure is sent back to the caller.
  *
- * This is an optional protocol operations to facilitate tailing readers
+ * <p>This is an optional protocol operations to facilitate tailing readers
  * to be up to date with the writer. This is best effort to get latest LAC
  * from bookies, and doesn't affect the correctness of the protocol.
  */
 class PendingWriteLacOp implements WriteLacCallback {
-    private final static Logger LOG = LoggerFactory.getLogger(PendingWriteLacOp.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PendingWriteLacOp.class);
     ByteBuf toSend;
     AddLacCallback cb;
     long lac;
@@ -79,8 +77,7 @@ class PendingWriteLacOp implements WriteLacCallback {
 
     void initiate(ByteBuf toSend) {
         this.toSend = toSend;
-        DistributionSchedule.WriteSet writeSet
-            = lh.distributionSchedule.getWriteSet(lac);
+        DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSet(lac);
         try {
             for (int i = 0; i < writeSet.size(); i++) {
                 sendWriteLacRequest(writeSet.get(i));
@@ -114,8 +111,8 @@ class PendingWriteLacOp implements WriteLacCallback {
         } else {
             LOG.warn("WriteLac did not succeed: Ledger {} on {}", new Object[] { ledgerId, addr });
         }
-        
-        if(receivedResponseSet.isEmpty()){
+
+        if (receivedResponseSet.isEmpty()){
             completed = true;
             cb.addLacComplete(lastSeenError, lh, ctx);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
@@ -17,9 +17,10 @@
  */
 package org.apache.bookkeeper.client;
 
+import io.netty.util.HashedWheelTimer;
+
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,8 +28,6 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.net.DNSToSwitchMapping;
 import org.apache.bookkeeper.net.Node;
 import org.apache.bookkeeper.stats.StatsLogger;
-
-import io.netty.util.HashedWheelTimer;
 
 /**
  * A placement policy implementation use rack information for placing ensembles.
@@ -77,7 +76,8 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
     }
 
     @Override
-    public Set<BookieSocketAddress> onClusterChanged(Set<BookieSocketAddress> writableBookies, Set<BookieSocketAddress> readOnlyBookies) {
+    public Set<BookieSocketAddress> onClusterChanged(Set<BookieSocketAddress> writableBookies,
+            Set<BookieSocketAddress> readOnlyBookies) {
         Set<BookieSocketAddress> deadBookies = super.onClusterChanged(writableBookies, readOnlyBookies);
         if (null != slave) {
             deadBookies = slave.onClusterChanged(writableBookies, readOnlyBookies);
@@ -86,8 +86,8 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
     }
 
     @Override
-    public ArrayList<BookieSocketAddress> newEnsemble(
-        int ensembleSize, int writeQuorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Set<BookieSocketAddress> excludeBookies)
+    public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize, int writeQuorumSize, int ackQuorumSize,
+            Map<String, byte[]> customMetadata, Set<BookieSocketAddress> excludeBookies)
             throws BKException.BKNotEnoughBookiesException {
         try {
             return super.newEnsemble(ensembleSize, writeQuorumSize, ackQuorumSize, customMetadata, excludeBookies);
@@ -101,8 +101,9 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
     }
 
     @Override
-    public BookieSocketAddress replaceBookie(
-        int ensembleSize, int writeQuorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Collection<BookieSocketAddress> currentEnsemble, BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies)
+    public BookieSocketAddress replaceBookie(int ensembleSize, int writeQuorumSize, int ackQuorumSize,
+            Map<String, byte[]> customMetadata, Collection<BookieSocketAddress> currentEnsemble,
+            BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies)
             throws BKException.BKNotEnoughBookiesException {
        try {
             return super.replaceBookie(ensembleSize, writeQuorumSize, ackQuorumSize, customMetadata,
@@ -111,7 +112,7 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
             if (slave == null) {
                 throw bnebe;
             } else {
-                return slave.replaceBookie(ensembleSize, writeQuorumSize, ackQuorumSize,customMetadata,
+                return slave.replaceBookie(ensembleSize, writeQuorumSize, ackQuorumSize, customMetadata,
                         currentEnsemble, bookieToReplace, excludeBookies);
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
@@ -22,8 +22,8 @@ import io.netty.util.ReferenceCountUtil;
 
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.client.DigestManager.RecoveryData;
-import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.proto.BookieProtocol;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,10 +43,10 @@ class ReadLastConfirmedOp implements ReadEntryCallback {
     final DistributionSchedule.QuorumCoverageSet coverageSet;
 
     /**
-     * Wrapper to get all recovered data from the request
+     * Wrapper to get all recovered data from the request.
      */
     interface LastConfirmedDataCallback {
-        public void readLastConfirmedDataComplete(int rc, RecoveryData data);
+        void readLastConfirmedDataComplete(int rc, RecoveryData data);
     }
 
     public ReadLastConfirmedOp(LedgerHandle lh, LastConfirmedDataCallback cb) {
@@ -133,7 +133,7 @@ class ReadLastConfirmedOp implements ReadEntryCallback {
 
         if (numResponsesPending == 0 && !completed) {
             // Have got all responses back but was still not enough, just fail the operation
-            LOG.error("While readLastConfirmed ledger: " + ledgerId + " did not hear success responses from all quorums");
+            LOG.error("While readLastConfirmed ledger: {} did not hear success responses from all quorums", ledgerId);
             cb.readLastConfirmedDataComplete(lastSeenError, maxRecoveredData);
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -17,25 +17,24 @@
  */
 package org.apache.bookkeeper.client;
 
-import java.util.Arrays;
+import io.netty.util.HashedWheelTimer;
+
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import io.netty.util.HashedWheelTimer;
-import java.util.Optional;
+
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.feature.Feature;
 import org.apache.bookkeeper.feature.FeatureProvider;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.net.DNSToSwitchMapping;
-import org.apache.bookkeeper.net.NetUtils;
 import org.apache.bookkeeper.net.NetworkTopology;
 import org.apache.bookkeeper.net.Node;
 import org.apache.bookkeeper.net.NodeBase;
@@ -55,9 +54,11 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
 
     public static final String REPP_REGIONS_TO_WRITE = "reppRegionsToWrite";
     public static final String REPP_MINIMUM_REGIONS_FOR_DURABILITY = "reppMinimumRegionsForDurability";
-    public static final String REPP_ENABLE_DURABILITY_ENFORCEMENT_IN_REPLACE = "reppEnableDurabilityEnforcementInReplace";
+    public static final String REPP_ENABLE_DURABILITY_ENFORCEMENT_IN_REPLACE =
+        "reppEnableDurabilityEnforcementInReplace";
     public static final String REPP_DISABLE_DURABILITY_FEATURE_NAME = "reppDisableDurabilityFeatureName";
-    public static final String REPP_DISALLOW_BOOKIE_PLACEMENT_IN_REGION_FEATURE_NAME = "reppDisallowBookiePlacementInRegionFeatureName";
+    public static final String REPP_DISALLOW_BOOKIE_PLACEMENT_IN_REGION_FEATURE_NAME =
+        "reppDisallowBookiePlacementInRegionFeatureName";
     public static final String REPP_DISABLE_DURABILITY_ENFORCEMENT_FEATURE = "reppDisableDurabilityEnforcementFeature";
     public static final String REPP_ENABLE_VALIDATION = "reppEnableValidation";
     public static final String REGION_AWARE_ANOMALOUS_ENSEMBLE = "region_aware_anomalous_ensemble";
@@ -112,7 +113,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
     public void handleBookiesThatLeft(Set<BookieSocketAddress> leftBookies) {
         super.handleBookiesThatLeft(leftBookies);
 
-        for(TopologyAwareEnsemblePlacementPolicy policy: perRegionPlacement.values()) {
+        for (TopologyAwareEnsemblePlacementPolicy policy: perRegionPlacement.values()) {
             policy.handleBookiesThatLeft(leftBookies);
         }
     }
@@ -129,7 +130,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             String region = getLocalRegion(node);
             if (null == perRegionPlacement.get(region)) {
                 perRegionPlacement.put(region, new RackawareEnsemblePlacementPolicy()
-                        .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds, 
+                        .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds,
                                 this.isWeighted, this.maxWeightMultiple, statsLogger)
                         .withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK));
             }
@@ -181,17 +182,20 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                                 this.isWeighted, this.maxWeightMultiple, statsLogger)
                         .withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK));
             }
-            minRegionsForDurability = conf.getInt(REPP_MINIMUM_REGIONS_FOR_DURABILITY, MINIMUM_REGIONS_FOR_DURABILITY_DEFAULT);
+            minRegionsForDurability = conf.getInt(REPP_MINIMUM_REGIONS_FOR_DURABILITY,
+                    MINIMUM_REGIONS_FOR_DURABILITY_DEFAULT);
             if (minRegionsForDurability > 0) {
                 enforceDurability = true;
                 enforceDurabilityInReplace = conf.getBoolean(REPP_ENABLE_DURABILITY_ENFORCEMENT_IN_REPLACE, true);
             }
             if (regions.length < minRegionsForDurability) {
-                throw new IllegalArgumentException("Regions provided are insufficient to meet the durability constraints");
+                throw new IllegalArgumentException(
+                        "Regions provided are insufficient to meet the durability constraints");
             }
         }
         this.featureProvider = featureProvider;
-        this.disallowBookiePlacementInRegionFeatureName = conf.getString(REPP_DISALLOW_BOOKIE_PLACEMENT_IN_REGION_FEATURE_NAME);
+        this.disallowBookiePlacementInRegionFeatureName =
+            conf.getString(REPP_DISALLOW_BOOKIE_PLACEMENT_IN_REGION_FEATURE_NAME);
         this.disableDurabilityFeature = conf.getFeature(REPP_DISABLE_DURABILITY_ENFORCEMENT_FEATURE, null);
         if (null == disableDurabilityFeature) {
             this.disableDurabilityFeature =
@@ -209,7 +213,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                                             Ensemble<BookieNode> ensemble)
         throws BKException.BKNotEnoughBookiesException {
         List<BookieNode> availableBookies = new ArrayList<BookieNode>();
-        for(BookieNode bookieNode: knownBookies.values()) {
+        for (BookieNode bookieNode: knownBookies.values()) {
             if (availableRegions.contains(getLocalRegion(bookieNode))) {
                 availableBookies.add(bookieNode);
             }
@@ -220,17 +224,22 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
 
 
     @Override
-    public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize, int writeQuorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Set<BookieSocketAddress> excludeBookies) throws BKException.BKNotEnoughBookiesException {
+    public ArrayList<BookieSocketAddress> newEnsemble(int ensembleSize, int writeQuorumSize, int ackQuorumSize,
+            Map<String, byte[]> customMetadata, Set<BookieSocketAddress> excludeBookies)
+            throws BKException.BKNotEnoughBookiesException {
 
         int effectiveMinRegionsForDurability = disableDurabilityFeature.isAvailable() ? 1 : minRegionsForDurability;
 
         // All of these conditions indicate bad configuration
         if (ackQuorumSize < effectiveMinRegionsForDurability) {
-            throw new IllegalArgumentException("Ack Quorum size provided are insufficient to meet the durability constraints");
+            throw new IllegalArgumentException(
+                    "Ack Quorum size provided are insufficient to meet the durability constraints");
         } else if (ensembleSize < writeQuorumSize) {
-            throw new IllegalArgumentException("write quorum (" + writeQuorumSize + ") cannot exceed ensemble size (" + ensembleSize + ")");
+            throw new IllegalArgumentException(
+                    "write quorum (" + writeQuorumSize + ") cannot exceed ensemble size (" + ensembleSize + ")");
         } else if (writeQuorumSize < ackQuorumSize) {
-            throw new IllegalArgumentException("ack quorum (" + ackQuorumSize + ") cannot exceed write quorum size (" + writeQuorumSize + ")");
+            throw new IllegalArgumentException(
+                    "ack quorum (" + ackQuorumSize + ") cannot exceed write quorum size (" + writeQuorumSize + ")");
         } else if (effectiveMinRegionsForDurability > 0) {
             // We must survive the failure of numRegions - effectiveMinRegionsForDurability. When these
             // regions have failed we would spread the replicas over the remaining
@@ -238,8 +247,8 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             // enough such that there is a configuration for spreading the replicas across
             // effectiveMinRegionsForDurability - 1 regions
             if (ackQuorumSize <= (writeQuorumSize - (writeQuorumSize / effectiveMinRegionsForDurability))) {
-                throw new IllegalArgumentException("ack quorum (" + ackQuorumSize + ") " +
-                    "violates the requirement to satisfy durability constraints when running in degraded mode");
+                throw new IllegalArgumentException("ack quorum (" + ackQuorumSize + ") "
+                    + "violates the requirement to satisfy durability constraints when running in degraded mode");
             }
         }
 
@@ -248,8 +257,9 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             Set<Node> excludeNodes = convertBookiesToNodes(excludeBookies);
             Set<String> availableRegions = new HashSet<String>();
             for (String region: perRegionPlacement.keySet()) {
-                if ((null == disallowBookiePlacementInRegionFeatureName) ||
-                    !featureProvider.scope(region).getFeature(disallowBookiePlacementInRegionFeatureName).isAvailable()) {
+                if ((null == disallowBookiePlacementInRegionFeatureName)
+                        || !featureProvider.scope(region).getFeature(disallowBookiePlacementInRegionFeatureName)
+                            .isAvailable()) {
                     availableRegions.add(region);
                 }
             }
@@ -262,8 +272,8 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                 if (perRegionPlacement.keySet().size() >= 1) {
                     LOG.error("No regions available, invalid configuration");
                 }
-                List<BookieNode> bns = selectRandom(ensembleSize, excludeNodes, TruePredicate.instance,
-                    EnsembleForReplacementWithNoConstraints.instance);
+                List<BookieNode> bns = selectRandom(ensembleSize, excludeNodes, TruePredicate.INSTANCE,
+                    EnsembleForReplacementWithNoConstraints.INSTANCE);
                 ArrayList<BookieSocketAddress> addrs = new ArrayList<BookieSocketAddress>(ensembleSize);
                 for (BookieNode bn : bns) {
                     addrs.add(bn.getAddr());
@@ -274,13 +284,13 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             // Single region, fall back to RackAwareEnsemblePlacement
             if (numRegionsAvailable < 2) {
                 RRTopologyAwareCoverageEnsemble ensemble = new RRTopologyAwareCoverageEnsemble(ensembleSize,
-                                                                    writeQuorumSize,
-                                                                    ackQuorumSize,
-                                                                    REGIONID_DISTANCE_FROM_LEAVES,
-                                                                    effectiveMinRegionsForDurability > 0 ? new HashSet<String>(perRegionPlacement.keySet()) : null,
-                                                                    effectiveMinRegionsForDurability);
-                TopologyAwareEnsemblePlacementPolicy nextPolicy = perRegionPlacement.get(availableRegions.iterator().next());
-                return nextPolicy.newEnsemble(ensembleSize, writeQuorumSize, writeQuorumSize, excludeBookies, ensemble, ensemble);
+                        writeQuorumSize, ackQuorumSize, REGIONID_DISTANCE_FROM_LEAVES,
+                        effectiveMinRegionsForDurability > 0 ? new HashSet<>(perRegionPlacement.keySet()) : null,
+                        effectiveMinRegionsForDurability);
+                TopologyAwareEnsemblePlacementPolicy nextPolicy = perRegionPlacement.get(
+                        availableRegions.iterator().next());
+                return nextPolicy.newEnsemble(ensembleSize, writeQuorumSize, writeQuorumSize, excludeBookies, ensemble,
+                        ensemble);
             }
 
             int remainingEnsemble = ensembleSize;
@@ -291,9 +301,9 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             // Try and place as many nodes in a region as possible, the ones that cannot be
             // accommodated are placed on other regions
             // Within each region try and follow rack aware placement
-            Map<String, Pair<Integer,Integer>> regionsWiseAllocation = new HashMap<String, Pair<Integer,Integer>>();
+            Map<String, Pair<Integer, Integer>> regionsWiseAllocation = new HashMap<>();
             for (String region: availableRegions) {
-                regionsWiseAllocation.put(region, Pair.of(0,0));
+                regionsWiseAllocation.put(region, Pair.of(0, 0));
             }
             int remainingEnsembleBeforeIteration;
             int numRemainingRegions;
@@ -301,15 +311,13 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             RRTopologyAwareCoverageEnsemble ensemble;
             do {
                 numRemainingRegions = numRegionsAvailable - regionsReachedMaxAllocation.size();
-                ensemble = new RRTopologyAwareCoverageEnsemble(ensembleSize,
-                                    writeQuorumSize,
-                                    ackQuorumSize,
-                                    REGIONID_DISTANCE_FROM_LEAVES,
-                                    // We pass all regions we know off to the coverage ensemble as
-                                    // regardless of regions that are available; constraints are
-                                    // always applied based on all possible regions
-                                    effectiveMinRegionsForDurability > 0 ? new HashSet<String>(perRegionPlacement.keySet()) : null,
-                                    effectiveMinRegionsForDurability);
+                ensemble = new RRTopologyAwareCoverageEnsemble(ensembleSize, writeQuorumSize, ackQuorumSize,
+                        REGIONID_DISTANCE_FROM_LEAVES,
+                        // We pass all regions we know off to the coverage ensemble as
+                        // regardless of regions that are available; constraints are
+                        // always applied based on all possible regions
+                        effectiveMinRegionsForDurability > 0 ? new HashSet<>(perRegionPlacement.keySet()) : null,
+                        effectiveMinRegionsForDurability);
                 remainingEnsembleBeforeIteration = remainingEnsemble;
                 int regionsToAllocate = numRemainingRegions;
                 for (Map.Entry<String, Pair<Integer, Integer>> regionEntry: regionsWiseAllocation.entrySet()) {
@@ -322,25 +330,31 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                             throw new BKException.BKNotEnoughBookiesException();
                         }
                         // try to place the bookies as balance as possible across all the regions
-                        int addToEnsembleSize = Math.min(remainingEnsemble, remainingEnsemble / regionsToAllocate + (remainingEnsemble % regionsToAllocate == 0 ? 0 : 1));
+                        int addToEnsembleSize = Math.min(remainingEnsemble, remainingEnsemble / regionsToAllocate
+                                + (remainingEnsemble % regionsToAllocate == 0 ? 0 : 1));
                         boolean success = false;
                         while (addToEnsembleSize > 0) {
-                            int addToWriteQuorum = Math.max(1, Math.min(remainingWriteQuorum, Math.round(1.0f * writeQuorumSize * addToEnsembleSize / ensembleSize)));
-                            // Temp ensemble will be merged back into the ensemble only if we are able to successfully allocate
-                            // the target number of bookies in this region; if we fail because we dont have enough bookies; then we
-                            // retry the process with a smaller target
-                            RRTopologyAwareCoverageEnsemble tempEnsemble = new RRTopologyAwareCoverageEnsemble(ensemble);
+                            int addToWriteQuorum = Math.max(1, Math.min(remainingWriteQuorum,
+                                        Math.round(1.0f * writeQuorumSize * addToEnsembleSize / ensembleSize)));
+                            // Temp ensemble will be merged back into the ensemble only if we are able to successfully
+                            // allocate the target number of bookies in this region; if we fail because we dont have
+                            // enough bookies; then we retry the process with a smaller target
+                            RRTopologyAwareCoverageEnsemble tempEnsemble =
+                                new RRTopologyAwareCoverageEnsemble(ensemble);
                             int newEnsembleSize = currentAllocation.getLeft() + addToEnsembleSize;
                             int newWriteQuorumSize = currentAllocation.getRight() + addToWriteQuorum;
                             try {
-                                List<BookieSocketAddress> allocated = policyWithinRegion.newEnsemble(newEnsembleSize, newWriteQuorumSize, newWriteQuorumSize, excludeBookies, tempEnsemble, tempEnsemble);
+                                List<BookieSocketAddress> allocated = policyWithinRegion.newEnsemble(newEnsembleSize,
+                                        newWriteQuorumSize, newWriteQuorumSize, excludeBookies, tempEnsemble,
+                                        tempEnsemble);
                                 ensemble = tempEnsemble;
                                 remainingEnsemble -= addToEnsembleSize;
                                 remainingWriteQuorum -= addToWriteQuorum;
                                 regionsWiseAllocation.put(region, Pair.of(newEnsembleSize, newWriteQuorumSize));
                                 success = true;
                                 regionsToAllocate--;
-                                LOG.info("Region {} allocating bookies with ensemble size {} and write quorum size {} : {}",
+                                LOG.info("Region {} allocating bookies with ensemble size {} "
+                                        + "and write quorum size {} : {}",
                                     new Object[]{region, newEnsembleSize, newWriteQuorumSize, allocated});
                                 break;
                             } catch (BKException.BKNotEnoughBookiesException exc) {
@@ -386,7 +400,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                 throw new BKException.BKNotEnoughBookiesException();
             }
 
-            if(enableValidation && !ensemble.validate()) {
+            if (enableValidation && !ensemble.validate()) {
                 LOG.error("Not enough {} bookies are available to form a valid ensemble : {}.",
                     ensembleSize, bookieList);
                 throw new BKException.BKNotEnoughBookiesException();
@@ -399,7 +413,10 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
     }
 
     @Override
-    public BookieSocketAddress replaceBookie(int ensembleSize, int writeQuorumSize, int ackQuorumSize, java.util.Map<String, byte[]> customMetadata, Collection<BookieSocketAddress> currentEnsemble, BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies) throws BKException.BKNotEnoughBookiesException {
+    public BookieSocketAddress replaceBookie(int ensembleSize, int writeQuorumSize, int ackQuorumSize,
+            Map<String, byte[]> customMetadata, Collection<BookieSocketAddress> currentEnsemble,
+            BookieSocketAddress bookieToReplace, Set<BookieSocketAddress> excludeBookies)
+            throws BKException.BKNotEnoughBookiesException {
         rwLock.readLock().lock();
         try {
             boolean enforceDurability = enforceDurabilityInReplace && !disableDurabilityFeature.isAvailable();
@@ -418,7 +435,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             }
             excludeNodes.add(bookieNodeToReplace);
 
-            for(BookieSocketAddress bookieAddress: currentEnsemble) {
+            for (BookieSocketAddress bookieAddress: currentEnsemble) {
                 if (bookieAddress.equals(bookieToReplace)) {
                     continue;
                 }
@@ -465,8 +482,9 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
         throws BKException.BKNotEnoughBookiesException {
         Set<String> availableRegions = new HashSet<String>();
         for (String region: perRegionPlacement.keySet()) {
-            if ((null == disallowBookiePlacementInRegionFeatureName) ||
-                !featureProvider.scope(region).getFeature(disallowBookiePlacementInRegionFeatureName).isAvailable()) {
+            if ((null == disallowBookiePlacementInRegionFeatureName)
+                    || !featureProvider.scope(region).getFeature(disallowBookiePlacementInRegionFeatureName)
+                        .isAvailable()) {
                 availableRegions.add(region);
             }
         }
@@ -482,8 +500,8 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                     return regionPolicy.selectFromNetworkLocation(
                         bookieNodeToReplace.getNetworkLocation(),
                         excludeBookies,
-                        TruePredicate.instance,
-                        EnsembleForReplacementWithNoConstraints.instance);
+                        TruePredicate.INSTANCE,
+                        EnsembleForReplacementWithNoConstraints.INSTANCE);
                 } catch (BKException.BKNotEnoughBookiesException e) {
                     LOG.warn("Failed to choose a bookie from {} : "
                             + "excluded {}, fallback to choose bookie randomly from the cluster.",
@@ -496,8 +514,8 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
         // enforcing durability.
         return selectRandomFromRegions(availableRegions, 1,
             excludeBookies,
-            enforceDurability ? predicate : TruePredicate.instance,
-            enforceDurability ? ensemble : EnsembleForReplacementWithNoConstraints.instance).get(0);
+            enforceDurability ? predicate : TruePredicate.INSTANCE,
+            enforceDurability ? ensemble : EnsembleForReplacementWithNoConstraints.INSTANCE).get(0);
     }
 
     @Override
@@ -532,19 +550,16 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                             || (lastFailedEntryOnBookie < 0)) {
                         writeSet.set(i, idx | LOCAL_MASK);
                     } else {
-                        long failIdx
-                            = lastFailedEntryOnBookie * ensembleSize + idx;
-                        writeSet.set(i, (int)(failIdx & ~MASK_BITS)
-                                     | LOCAL_FAIL_MASK);
+                        long failIdx = lastFailedEntryOnBookie * ensembleSize + idx;
+                        writeSet.set(i, (int) (failIdx & ~MASK_BITS) | LOCAL_FAIL_MASK);
                     }
                 } else {
                     if ((lastFailedEntryOnBookie == null)
                             || (lastFailedEntryOnBookie < 0)) {
                         writeSet.set(i, idx | REMOTE_MASK);
                     } else {
-                        long failIdx
-                            = lastFailedEntryOnBookie * ensembleSize + idx;
-                        writeSet.set(i, (int)(failIdx & ~MASK_BITS)
+                        long failIdx = lastFailedEntryOnBookie * ensembleSize + idx;
+                        writeSet.set(i, (int) (failIdx & ~MASK_BITS)
                                      | REMOTE_FAIL_MASK);
                     }
                 }
@@ -595,8 +610,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             }
             if (firstRemote != -1) {
                 int i = 0;
-                for (;i < REMOTE_NODE_IN_REORDER_SEQUENCE
-                         && i < writeSet.size(); i++) {
+                for (; i < REMOTE_NODE_IN_REORDER_SEQUENCE && i < writeSet.size(); i++) {
                     if ((writeSet.get(i) & MASK_BITS) != LOCAL_MASK) {
                         break;
                     }
@@ -622,8 +636,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             return super.reorderReadLACSequence(ensemble, bookieFailureHistory,
                                                 writeSet);
         }
-        DistributionSchedule.WriteSet finalList
-            = reorderReadSequence(ensemble, bookieFailureHistory, writeSet);
+        DistributionSchedule.WriteSet finalList = reorderReadSequence(ensemble, bookieFailureHistory, writeSet);
         finalList.addMissingIndices(ensemble.size());
         return finalList;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
@@ -17,20 +17,18 @@
  */
 package org.apache.bookkeeper.client;
 
-import com.google.common.collect.ImmutableMap;
-import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.commons.lang3.ArrayUtils;
-
-import java.util.BitSet;
-import java.util.Map;
-import java.util.Arrays;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Map;
+
+import org.apache.bookkeeper.net.BookieSocketAddress;
 
 /**
  * A specific {@link DistributionSchedule} that places entries in round-robin
@@ -70,8 +68,7 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
         int size;
 
         private final Handle<WriteSetImpl> recyclerHandle;
-        private static final Recycler<WriteSetImpl> RECYCLER
-            = new Recycler<WriteSetImpl>() {
+        private static final Recycler<WriteSetImpl> RECYCLER = new Recycler<WriteSetImpl>() {
                     protected WriteSetImpl newObject(
                             Recycler.Handle<WriteSetImpl> handle) {
                         return new WriteSetImpl(handle);
@@ -94,7 +91,7 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
                            long entryId) {
             setSize(writeQuorumSize);
             for (int w = 0; w < writeQuorumSize; w++) {
-                set(w, (int)((entryId + w) % ensembleSize));
+                set(w, (int) ((entryId + w) % ensembleSize));
             }
         }
 
@@ -111,7 +108,9 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
         }
 
         @Override
-        public int size() { return size; }
+        public int size() {
+            return size;
+        }
 
         @Override
         public boolean contains(int i) {
@@ -153,7 +152,7 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
                 int oldSize = size;
                 setSize(maxIndex);
                 for (int i = 0, j = oldSize;
-                     i < maxIndex && j < maxIndex; i++) {
+                    i < maxIndex && j < maxIndex; i++) {
                     if (!contains(i)) {
                         set(j, i);
                         j++;
@@ -169,13 +168,13 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
             if (from > to) {
                 int tmp = array[from];
                 for (int i = from; i > to; i--) {
-                    array[i] = array[i-1];
+                    array[i] = array[i - 1];
                 }
                 array[to] = tmp;
             } else if (from < to) {
                 int tmp = array[from];
                 for (int i = from; i < to; i++) {
-                    array[i] = array[i+1];
+                    array[i] = array[i + 1];
                 }
                 array[to] = tmp;
             }
@@ -208,7 +207,7 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
         @Override
         public boolean equals(Object other) {
             if (other instanceof WriteSetImpl) {
-                WriteSetImpl o = (WriteSetImpl)other;
+                WriteSetImpl o = (WriteSetImpl) other;
                 if (o.size() != size()) {
                     return false;
                 }
@@ -301,8 +300,7 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
 
         @Override
         public Map<Integer, BookieSocketAddress> getFailedBookies() {
-            ImmutableMap.Builder<Integer, BookieSocketAddress> builder
-                = new ImmutableMap.Builder<>();
+            ImmutableMap.Builder<Integer, BookieSocketAddress> builder = new ImmutableMap.Builder<>();
             for (int i = 0; i < failureMap.length; i++) {
                 if (failureMap[i] != null) {
                     builder.put(i, failureMap[i]);
@@ -367,8 +365,8 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
                     int nodeIndex = (i + j) % ensembleSize;
                     if (covered[nodeIndex] == BKException.Code.OK) {
                         nodesOkay++;
-                    } else if (covered[nodeIndex] != BKException.Code.NoSuchEntryException &&
-                            covered[nodeIndex] != BKException.Code.NoSuchLedgerExistsException) {
+                    } else if (covered[nodeIndex] != BKException.Code.NoSuchEntryException
+                            && covered[nodeIndex] != BKException.Code.NoSuchLedgerExistsException) {
                         nodesNotCovered++;
                     } else if (covered[nodeIndex] == BKException.Code.UNINITIALIZED) {
                         nodesUninitialized++;
@@ -376,8 +374,7 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
                 }
                 // if we haven't seen any OK responses and there are still nodes not heard from,
                 // let's wait until
-                if (nodesNotCovered >= ackQuorumSize ||
-                        (nodesOkay == 0 && nodesUninitialized > 0)) {
+                if (nodesNotCovered >= ackQuorumSize || (nodesOkay == 0 && nodesUninitialized > 0)) {
                     return false;
                 }
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutionPolicy.java
@@ -23,7 +23,7 @@ package org.apache.bookkeeper.client;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * Define a policy for speculative request execution. 
+ * Define a policy for speculative request execution.
  *
  * <p>The implementation can define its execution policy. For example, when to issue speculative requests
  * and how many speculative requests to issue.
@@ -33,7 +33,7 @@ import java.util.concurrent.ScheduledExecutorService;
 public interface SpeculativeRequestExecutionPolicy {
 
     /**
-     * Initialize the speculative request execution policy and initiate requests
+     * Initialize the speculative request execution policy and initiate requests.
      *
      * @param scheduler The scheduler service to issue the speculative request
      * @param requestExectuor The executor is used to issue the actual speculative requests

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutor.java
@@ -34,7 +34,7 @@ public interface SpeculativeRequestExecutor {
 
     /**
      * Issues a speculative request and indicates if more speculative
-     * requests should be issued
+     * requests should be issued.
      *
      * @return whether more speculative requests should be issued
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCallbackUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCallbackUtils.java
@@ -25,7 +25,7 @@ import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
 import org.apache.bookkeeper.client.impl.LastConfirmedAndEntryImpl;
 
 /**
- * Utility for callbacks
+ * Utility for callbacks.
  *
  */
 @Slf4j
@@ -47,8 +47,8 @@ class SyncCallbackUtils {
             if (err.getCause() instanceof BKException) {
                 throw (BKException) err.getCause();
             } else {
-                BKException unexpectedConditionException
-                    = BKException.create(BKException.Code.UnexpectedConditionException);
+                BKException unexpectedConditionException =
+                    BKException.create(BKException.Code.UnexpectedConditionException);
                 unexpectedConditionException.initCause(err.getCause());
                 throw unexpectedConditionException;
             }
@@ -57,7 +57,7 @@ class SyncCallbackUtils {
     }
 
     /**
-     * Handle the Response Code and transform it to a BKException
+     * Handle the Response Code and transform it to a BKException.
      *
      * @param <T>
      * @param rc
@@ -129,7 +129,7 @@ class SyncCallbackUtils {
         }
 
         /**
-         * Callback method for synchronous open operation
+         * Callback method for synchronous open operation.
          *
          * @param rc
          *          return code
@@ -256,7 +256,7 @@ class SyncCallbackUtils {
         public void readLastConfirmedComplete(int rc, long lastConfirmed, Object ctx) {
             LedgerHandle.LastConfirmedCtx lcCtx = (LedgerHandle.LastConfirmedCtx) ctx;
 
-            synchronized(lcCtx) {
+            synchronized (lcCtx) {
                 lcCtx.setRC(rc);
                 lcCtx.setLastConfirmed(lastConfirmed);
                 lcCtx.notify();
@@ -273,7 +273,7 @@ class SyncCallbackUtils {
         }
 
         /**
-         * Close callback method
+         * Close callback method.
          *
          * @param rc
          * @param lh

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCounter.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCounter.java
@@ -24,7 +24,7 @@ package org.apache.bookkeeper.client;
 import java.util.Enumeration;
 
 /**
- * Implements objects to help with the synchronization of asynchronous calls
+ * Implements objects to help with the synchronization of asynchronous calls.
  *
  */
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -17,28 +17,29 @@
  */
 package org.apache.bookkeeper.client;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.net.NetworkTopology;
 import org.apache.bookkeeper.net.NodeBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEnsemblePlacementPolicy<TopologyAwareEnsemblePlacementPolicy.BookieNode> {
+abstract class TopologyAwareEnsemblePlacementPolicy implements
+        ITopologyAwareEnsemblePlacementPolicy<TopologyAwareEnsemblePlacementPolicy.BookieNode> {
     static final Logger LOG = LoggerFactory.getLogger(TopologyAwareEnsemblePlacementPolicy.class);
 
     protected static class TruePredicate implements Predicate<BookieNode> {
 
-        public static final TruePredicate instance = new TruePredicate();
+        public static final TruePredicate INSTANCE = new TruePredicate();
 
         @Override
         public boolean apply(BookieNode candidate, Ensemble chosenNodes) {
@@ -49,7 +50,8 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
 
     protected static class EnsembleForReplacementWithNoConstraints implements Ensemble<BookieNode> {
 
-        public static final EnsembleForReplacementWithNoConstraints instance = new EnsembleForReplacementWithNoConstraints();
+        public static final EnsembleForReplacementWithNoConstraints INSTANCE =
+            new EnsembleForReplacementWithNoConstraints();
         static final ArrayList<BookieSocketAddress> EMPTY_LIST = new ArrayList<BookieSocketAddress>(0);
 
         @Override
@@ -64,7 +66,7 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
         }
 
         /**
-         * Validates if an ensemble is valid
+         * Validates if an ensemble is valid.
          *
          * @return true if the ensemble is valid; false otherwise
          */
@@ -118,7 +120,7 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
         protected interface CoverageSet {
             boolean apply(BookieNode candidate);
             void addBookie(BookieNode candidate);
-            public CoverageSet duplicate();
+            CoverageSet duplicate();
         }
 
         protected class RackQuorumCoverageSet implements CoverageSet {
@@ -134,7 +136,8 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
                 }
 
                 if (seenBookies + 1 == writeQuorumSize) {
-                    return racksOrRegionsInQuorum.size() > (racksOrRegionsInQuorum.contains(candidate.getNetworkLocation(distanceFromLeaves)) ? 1 : 0);
+                    return racksOrRegionsInQuorum.size()
+                        > (racksOrRegionsInQuorum.contains(candidate.getNetworkLocation(distanceFromLeaves)) ? 1 : 0);
                 }
                 return true;
             }
@@ -178,14 +181,15 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
                     if (maxAllowedSum < 0) {
                         if (LOG.isTraceEnabled()) {
                             LOG.trace(
-                                    "CHECK FAILED: RacksOrRegions Included {} Remaining {}, subsetSize {}, maxAllowedSum {}",
+                                    "CHECK FAILED: RacksOrRegions Included {} Remaining {}, subsetSize {}, "
+                                    + "maxAllowedSum {}",
                                     includedRacksOrRegions, remainingRacksOrRegions, subsetSize, maxAllowedSum);
                         }
                     }
                     return (maxAllowedSum >= 0);
                 }
 
-                for(String rackOrRegion: remainingRacksOrRegions) {
+                for (String rackOrRegion: remainingRacksOrRegions) {
                     Integer currentAllocation = allocationToRacksOrRegions.get(rackOrRegion);
                     if (currentAllocation == null) {
                         allocationToRacksOrRegions.put(rackOrRegion, 0);
@@ -195,7 +199,8 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
                     if (currentAllocation > maxAllowedSum) {
                         if (LOG.isTraceEnabled()) {
                             LOG.trace(
-                                    "CHECK FAILED: RacksOrRegions Included {} Candidate {}, subsetSize {}, maxAllowedSum {}",
+                                    "CHECK FAILED: RacksOrRegions Included {} Candidate {}, subsetSize {}, "
+                                    + "maxAllowedSum {}",
                                     includedRacksOrRegions, rackOrRegion, subsetSize, maxAllowedSum);
                         }
                         return false;
@@ -223,7 +228,8 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
                 }
 
                 String candidateRackOrRegion = candidate.getNetworkLocation(distanceFromLeaves);
-                candidateRackOrRegion = candidateRackOrRegion.startsWith(NodeBase.PATH_SEPARATOR_STR) ? candidateRackOrRegion.substring(1) : candidateRackOrRegion;
+                candidateRackOrRegion = candidateRackOrRegion.startsWith(NodeBase.PATH_SEPARATOR_STR)
+                    ? candidateRackOrRegion.substring(1) : candidateRackOrRegion;
                 final Set<String> remainingRacksOrRegions = new HashSet<String>(racksOrRegions);
                 remainingRacksOrRegions.remove(candidateRackOrRegion);
                 final Set<String> includedRacksOrRegions = new HashSet<String>();
@@ -253,7 +259,8 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
             @Override
             public void addBookie(BookieNode candidate) {
                 String candidateRackOrRegion = candidate.getNetworkLocation(distanceFromLeaves);
-                candidateRackOrRegion = candidateRackOrRegion.startsWith(NodeBase.PATH_SEPARATOR_STR) ? candidateRackOrRegion.substring(1) : candidateRackOrRegion;
+                candidateRackOrRegion = candidateRackOrRegion.startsWith(NodeBase.PATH_SEPARATOR_STR)
+                    ? candidateRackOrRegion.substring(1) : candidateRackOrRegion;
                 int oldCount = 0;
                 if (null != allocationToRacksOrRegions.get(candidateRackOrRegion)) {
                     oldCount = allocationToRacksOrRegions.get(candidateRackOrRegion);
@@ -425,7 +432,7 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
         }
 
         /**
-         * Validates if an ensemble is valid
+         * Validates if an ensemble is valid.
          *
          * @return true if the ensemble is valid; false otherwise
          */
@@ -441,8 +448,8 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements ITopologyAwareEns
                 racksOrRegions.add(bn.getNetworkLocation(distanceFromLeaves));
             }
 
-            return ((minRacksOrRegionsForDurability == 0) ||
-                    (racksOrRegions.size() >= minRacksOrRegionsForDurability));
+            return ((minRacksOrRegionsForDurability == 0)
+                    || (racksOrRegions.size() >= minRacksOrRegionsForDurability));
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryReadLastConfirmedOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryReadLastConfirmedOp.java
@@ -17,14 +17,14 @@
  */
 package org.apache.bookkeeper.client;
 
+import io.netty.buffer.ByteBuf;
+
 import org.apache.bookkeeper.client.DigestManager.RecoveryData;
 import org.apache.bookkeeper.client.ReadLastConfirmedOp.LastConfirmedDataCallback;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.netty.buffer.ByteBuf;
 
 /**
  * This op is try to read last confirmed without involving quorum coverage checking.
@@ -88,8 +88,7 @@ class TryReadLastConfirmedOp implements ReadEntryCallback {
         } else if (BKException.Code.UnauthorizedAccessException == rc && !completed) {
             cb.readLastConfirmedDataComplete(rc, maxRecoveredData);
             completed = true;
-        } else if (BKException.Code.NoSuchLedgerExistsException == rc ||
-                   BKException.Code.NoSuchEntryException == rc) {
+        } else if (BKException.Code.NoSuchLedgerExistsException == rc || BKException.Code.NoSuchEntryException == rc) {
             hasValidResponse = true;
         }
         if (numResponsesPending == 0 && !completed) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/UpdateLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/UpdateLedgerOp.java
@@ -18,6 +18,13 @@
 
 package org.apache.bookkeeper.client;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,19 +45,12 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.RateLimiter;
-import com.google.common.util.concurrent.SettableFuture;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 /**
- * Encapsulates updating the ledger metadata operation
+ * Encapsulates updating the ledger metadata operation.
  */
 public class UpdateLedgerOp {
 
-    private final static Logger LOG = LoggerFactory.getLogger(UpdateLedgerOp.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateLedgerOp.class);
     private final BookKeeper bkc;
     private final BookKeeperAdmin admin;
 
@@ -80,7 +80,7 @@ public class UpdateLedgerOp {
      *             interrupted exception when update ledger meta
      */
     public void updateBookieIdInLedgers(final BookieSocketAddress oldBookieId, final BookieSocketAddress newBookieId,
-            final int rate, final int limit, final UpdateLedgerNotifier progressable) throws BKException, IOException {
+            final int rate, final int limit, final UpdateLedgerNotifier progressable) throws IOException {
 
         final ThreadFactoryBuilder tfb = new ThreadFactoryBuilder().setNameFormat("UpdateLedgerThread").setDaemon(true);
         final ExecutorService executor = Executors.newSingleThreadExecutor(tfb.build());
@@ -108,7 +108,8 @@ public class UpdateLedgerOp {
                         throttler.acquire();
 
                         final Long lId = ledgerItr.next();
-                        final ReadLedgerMetadataCb readCb = new ReadLedgerMetadataCb(bkc, lId, oldBookieId, newBookieId);
+                        final ReadLedgerMetadataCb readCb = new ReadLedgerMetadataCb(bkc, lId, oldBookieId,
+                                newBookieId);
                         outstandings.add(lId);
 
                         FutureCallback<Void> updateLedgerCb = new UpdateLedgerCb(lId, stop, issuedLedgerCnt,
@@ -146,7 +147,7 @@ public class UpdateLedgerOp {
         }
     }
 
-    private final static class UpdateLedgerCb implements FutureCallback<Void> {
+    private static final class UpdateLedgerCb implements FutureCallback<Void> {
         final long ledgerId;
         final AtomicBoolean stop;
         final AtomicInteger issuedLedgerCnt;
@@ -191,7 +192,7 @@ public class UpdateLedgerOp {
         }
     }
 
-    private final static class ReadLedgerMetadataCb implements GenericCallback<LedgerMetadata> {
+    private static final class ReadLedgerMetadataCb implements GenericCallback<LedgerMetadata> {
         final BookKeeper bkc;
         final Long ledgerId;
         final BookieSocketAddress curBookieAddr;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/WeightedRandomSelection.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/WeightedRandomSelection.java
@@ -58,7 +58,7 @@ class WeightedRandomSelection<T> {
     void updateMap(Map<T, WeightedObject> map) {
         // get the sum total of all the values; this will be used to
         // calculate the weighted probability later on
-        Long totalWeight = 0L, min= Long.MAX_VALUE;
+        Long totalWeight = 0L, min = Long.MAX_VALUE;
         List<WeightedObject> values = new ArrayList<WeightedObject>(map.values());
         Collections.sort(values, new Comparator<WeightedObject>() {
             public int compare(WeightedObject o1, WeightedObject o2) {
@@ -72,7 +72,7 @@ class WeightedRandomSelection<T> {
                 }
             }
         });
-        for (int i=0; i < values.size(); i++) {
+        for (int i = 0; i < values.size(); i++) {
             totalWeight += values.get(i).getWeight();
             if (values.get(i).getWeight() != 0 && min > values.get(i).getWeight()) {
                 min = values.get(i).getWeight();
@@ -85,38 +85,38 @@ class WeightedRandomSelection<T> {
             // to the size of the values
             min = 1L;
             median = 1;
-            totalWeight = (long)values.size();
+            totalWeight = (long) values.size();
         } else {
-            int mid = values.size()/2;
+            int mid = values.size() / 2;
             if ((values.size() % 2) == 1) {
                 median = values.get(mid).getWeight();
             } else {
-                median = (double)(values.get(mid-1).getWeight() + values.get(mid).getWeight())/2;
+                median = (double) (values.get(mid - 1).getWeight() + values.get(mid).getWeight()) / 2;
             }
         }
 
         double medianWeight, minWeight;
-        medianWeight = median/(double)totalWeight;
-        minWeight = (double)min/totalWeight;
+        medianWeight = median / (double) totalWeight;
+        minWeight = (double) min / totalWeight;
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Updating weights map. MediaWeight: " + medianWeight + " MinWeight: " + minWeight);
+            LOG.debug("Updating weights map. MediaWeight: {} MinWeight: {}", medianWeight, minWeight);
         }
 
-        double maxWeight = maxProbabilityMultiplier*medianWeight;
+        double maxWeight = maxProbabilityMultiplier * medianWeight;
         Map<T, Double> weightMap = new HashMap<T, Double>();
         for (Map.Entry<T, WeightedObject> e : map.entrySet()) {
             double weightedProbability;
             if (e.getValue().getWeight() > 0) {
-                weightedProbability = (double)e.getValue().getWeight()/(double)totalWeight;
+                weightedProbability = (double) e.getValue().getWeight() / (double) totalWeight;
             } else {
                 weightedProbability = minWeight;
             }
             if (maxWeight > 0 && weightedProbability > maxWeight) {
-                weightedProbability=maxWeight;
+                weightedProbability = maxWeight;
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Capping the probability to " + weightedProbability + " for " + e.getKey() + " Value: "
-                            + e.getValue());
+                    LOG.debug("Capping the probability to {} for {} Value: {}",
+                            weightedProbability, e.getKey(), e.getValue());
                 }
             }
             weightMap.put(e.getKey(), weightedProbability);
@@ -126,12 +126,12 @@ class WeightedRandomSelection<T> {
         // but we change that priority by looking at the weight that each bookie
         // carries.
         TreeMap<Double, T> tmpCummulativeMap = new TreeMap<Double, T>();
-        Double key=0.0;
+        Double key = 0.0;
         for (Map.Entry<T, Double> e : weightMap.entrySet()) {
             tmpCummulativeMap.put(key, e.getKey());
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Key: " + e.getKey() + " Value: " + e.getValue() + " AssignedKey: " + key
-                        + " AssignedWeight: " + e.getValue());
+                LOG.debug("Key: {} Value: {} AssignedKey: {} AssignedWeight: {}",
+                        e.getKey(), e.getValue(), key, e.getValue());
             }
             key += e.getValue();
         }
@@ -150,10 +150,11 @@ class WeightedRandomSelection<T> {
         rwLock.readLock().lock();
         try {
             // pick a random number between 0 and randMax
-            Double randomNum = randomMax*Math.random();
+            Double randomNum = randomMax * Math.random();
             // find the nearest key in the map corresponding to the randomNum
             Double key = cummulativeMap.floorKey(randomNum);
-            //LOG.info("Random max: " + randomMax + " CummulativeMap size: " + cummulativeMap.size() + " selected key: " + key);
+            //LOG.info("Random max: {} CummulativeMap size: {} selected key: {}", randomMax, cummulativeMap.size(),
+            //    key);
             return cummulativeMap.get(key);
         } finally {
             rwLock.readLock().unlock();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntries.java
@@ -39,7 +39,7 @@ public interface LedgerEntries
      * Get an iterator over all the ledger entries contained in the
      * LedgerEntries object.
      *
-     * Calling this method does not modify the reference count of the ByteBuf in the returned LedgerEntry objects.
+     * <p>Calling this method does not modify the reference count of the ByteBuf in the returned LedgerEntry objects.
      * The caller who calls {@link #iterator()} should make sure that they do not call ByteBuf.release() on the
      * LedgerEntry objects to avoid a double free.
      * All reference counts will be decremented when the containing LedgerEntries object is closed via {@link #close()}.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
@@ -98,7 +98,7 @@ public interface ReadHandle extends Handle {
     /**
      * Get the last confirmed entry id on this ledger. It reads the local state of the ledger handle,
      * which is different from the {@link #readLastAddConfirmed()} call.
-
+     *
      * <p>In the case the ledger is not closed and the client is a reader, it is necessary to
      * call {@link #readLastAddConfirmed()} to obtain a fresh value of last add confirmed entry id.
      *

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LedgerEntriesImpl.java
@@ -20,14 +20,16 @@
  */
 package org.apache.bookkeeper.client.impl;
 
-import io.netty.util.Recycler;
-import java.util.Iterator;
-import java.util.List;
-import org.apache.bookkeeper.client.api.LedgerEntries;
-import org.apache.bookkeeper.client.api.LedgerEntry;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.netty.util.Recycler;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.bookkeeper.client.api.LedgerEntries;
+import org.apache.bookkeeper.client.api.LedgerEntry;
 
 /**
  * Ledger entries implementation. It is a simple wrap of a list of ledger entries.
@@ -82,8 +84,8 @@ public class LedgerEntriesImpl implements LedgerEntries {
         long firstId = entries.get(0).getEntryId();
         long lastId = entries.get(entries.size() - 1).getEntryId();
         if (entryId < firstId || entryId > lastId) {
-            throw new IndexOutOfBoundsException("required index: " + entryId +
-                " is out of bounds: [ " + firstId + ", " + lastId + " ].");
+            throw new IndexOutOfBoundsException("required index: " + entryId
+                + " is out of bounds: [ " + firstId + ", " + lastId + " ].");
         }
         return entries.get((int) (entryId - firstId));
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/package-info.java
@@ -19,7 +19,7 @@
  *
  */
 /**
- * BookKeeper Client implementation package
+ * BookKeeper Client implementation package.
  *
  * @since 4.6
  */

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -21,8 +21,6 @@
     <suppress checks="JavadocPackage" files=".*[\\/]maven-archetypes[\\/].*"/>
     <suppress checks="JavadocPackage" files=".*[\\/]examples[\\/].*"/>
     <!-- suppress packages by packages -->
-    <suppress checks=".*" files=".*[\\/]bookie[\\/].*"/>
-    <suppress checks=".*" files=".*[\\/]client[\\/](?:[^\\/]+$|(?!api)|(?!impl)[^\\/]+[\\/])"/>
     <suppress checks=".*" files=".*[\\/]test[\\/].*"/>
     <suppress checks=".*" files=".*[\\/]util[\\/].*"/>
 


### PR DESCRIPTION
Part of #230, this adds checkstyle verification to the bookie and client packages in `bookkeeper-server`.

Descriptions of the changes in this PR:

The changes here are primarily cosmetic, but there are also two notable changes to point out:

1. In both `TopologyAwareEnsemblePlacementPolicy.TruePredicate` and `TopologyAwareEnsemblePlacementPolicy.EnsembleForReplacementWithNoConstraints` a `public static final` field was renamed from `instance` to `INSTANCE`. This is consistent with the use of an `INSTANCE` field in the `bookkeeper-stats` package. An alternative would be to introduce a public method `getInstance()`, but either way the checkstyle rules don't like a public constant field in lower case.

2. In `UpdateLedgerOp#updateBookieIdInLedgers()`, the `throws BKException` part of the signature is problematic and prevents the checkstyle validation from completing successfully. From what I can tell, that checked exception is never thrown; as such, I have removed that from the signature. I have also removed the corresponding guard from `bookie.BookieShell`.