### PR TITLE
Handle unexpected throwable in Bookie V2 request processors

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -130,8 +130,8 @@ class ReadEntryProcessor extends PacketProcessorBase {
             LOG.error("Unauthorized access to ledger " + read.getLedgerId(), e);
             errorCode = BookieProtocol.EUA;
         } catch (Throwable t) {
-            LOG.error("Unexpected exception reading at {}:{} : {}",
-                    new Object[] { read.getLedgerId(), read.getEntryId(), t.getMessage(), t });
+            LOG.error("Unexpected exception reading at {}:{} : {}", read.getLedgerId(), read.getEntryId(),
+                    t.getMessage(), t);
             errorCode = BookieProtocol.EBADREQ;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -129,6 +129,10 @@ class ReadEntryProcessor extends PacketProcessorBase {
         } catch (BookieException e) {
             LOG.error("Unauthorized access to ledger " + read.getLedgerId(), e);
             errorCode = BookieProtocol.EUA;
+        } catch (Throwable t) {
+            LOG.error("Unexpected exception reading at {}:{} : {}",
+                    new Object[] { read.getLedgerId(), read.getEntryId(), t.getMessage(), t });
+            errorCode = BookieProtocol.EBADREQ;
         }
 
         if (LOG.isTraceEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -87,6 +87,10 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
         } catch (BookieException e) {
             LOG.error("Unauthorized access to ledger " + add.getLedgerId(), e);
             rc = BookieProtocol.EUA;
+        } catch (Throwable t) {
+            LOG.error("Unexpected exception while writing {}@{} : {}", new Object[] { add.ledgerId, add.entryId, t.getMessage(), t });
+            // some bad request which cause unexpected exception
+            rc = BookieProtocol.EBADREQ;
         } finally {
             addData.release();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -88,7 +88,7 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
             LOG.error("Unauthorized access to ledger " + add.getLedgerId(), e);
             rc = BookieProtocol.EUA;
         } catch (Throwable t) {
-            LOG.error("Unexpected exception while writing {}@{} : {}", new Object[] { add.ledgerId, add.entryId, t.getMessage(), t });
+            LOG.error("Unexpected exception while writing {}@{} : {}", add.ledgerId, add.entryId, t.getMessage(), t);
             // some bad request which cause unexpected exception
             rc = BookieProtocol.EBADREQ;
         } finally {


### PR DESCRIPTION
Merging from https://github.com/yahoo/bookkeeper/commit/c54eafbe

When getting any exception, the request processor for V2 protocol must make sure to get some response back to client. In the specific case, it was some NPE that was thrown and not handled properly.