### PR TITLE
Issue 568: Refactor EntryLoggerAllocator to enable preallocation

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -128,6 +128,7 @@ public class EntryLogger {
     private List<BufferedLogChannel> logChannelsToFlush;
     private volatile BufferedLogChannel logChannel;
     private volatile BufferedLogChannel compactionLogChannel;
+
     private final EntryLoggerAllocator entryLoggerAllocator;
     private final boolean entryLogPreAllocationEnabled;
     private final CopyOnWriteArrayList<EntryLogListener> listeners = new CopyOnWriteArrayList<EntryLogListener>();
@@ -494,6 +495,12 @@ public class EntryLogger {
     }
 
     /**
+     * get EntryLoggerAllocator, Just for tests.
+     */
+    protected EntryLoggerAllocator getEntryLoggerAllocator() {
+        return entryLoggerAllocator;
+    }
+    /**
      * Append the ledger map at the end of the entry log.
      * Updates the entry log file header with the offset and size of the map.
      */
@@ -647,6 +654,13 @@ public class EntryLogger {
             // wait until the preallocation finished.
             allocatorExecutor.shutdown();
             LOG.info("Stopped entry logger preallocator.");
+        }
+
+        /**
+         * get the preallocation for tests.
+         */
+        protected Future<BufferedLogChannel> getPreallocation(){
+            return preallocation;
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -497,7 +497,7 @@ public class EntryLogger {
     /**
      * get EntryLoggerAllocator, Just for tests.
      */
-    protected EntryLoggerAllocator getEntryLoggerAllocator() {
+    EntryLoggerAllocator getEntryLoggerAllocator() {
         return entryLoggerAllocator;
     }
     /**
@@ -659,7 +659,7 @@ public class EntryLogger {
         /**
          * get the preallocation for tests.
          */
-        protected Future<BufferedLogChannel> getPreallocation(){
+        Future<BufferedLogChannel> getPreallocationFuture(){
             return preallocation;
         }
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Enable 'entryLogFilePreallocationEnabled' which is  never be used.
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
