### PR TITLE
ISSUE #230: Enable checkstyle on util package

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/BookKeeperConstants.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/BookKeeperConstants.java
@@ -18,7 +18,7 @@
 package org.apache.bookkeeper.util;
 
 /**
- * This class contains constants used in BookKeeper
+ * This class contains constants used in BookKeeper.
  */
 public class BookKeeperConstants {
 
@@ -29,10 +29,10 @@ public class BookKeeperConstants {
     public static final String COLON = ":";
     public static final String VERSION_FILENAME = "VERSION";
     public static final String BOOKIE_STATUS_FILENAME = "BOOKIE_STATUS";
-    public final static String PASSWD = "passwd";
+    public static final String PASSWD = "passwd";
     public static final String CURRENT_DIR = "current";
     public static final String READONLY = "readonly";
-    
+
     // //////////////////////////
     // ///// Znodes//////////////
     // //////////////////////////

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DaemonThreadFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DaemonThreadFactory.java
@@ -18,9 +18,12 @@
 
 package org.apache.bookkeeper.util;
 
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
+/**
+ * Daemon thread factory.
+ */
 public class DaemonThreadFactory implements ThreadFactory {
     private ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
     private int priority = Thread.NORM_PRIORITY;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DirectMemoryUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DirectMemoryUtils.java
@@ -28,18 +28,21 @@ import java.lang.reflect.Method;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * DirectMemory Utility.
+ */
 public class DirectMemoryUtils {
     /**
      * Returns the max configured size of direct memory for the JVM process.
      *
-     * Direct memory can be specified with the flag <code>-XX:MaxDirectMemorySize=8G</code> on the command line. If not
-     * specified, the default value will be set to the max size of the JVM heap.
+     * <p>Direct memory can be specified with the flag <code>-XX:MaxDirectMemorySize=8G</code> on the command line.
+     * If not specified, the default value will be set to the max size of the JVM heap.
      */
     public static long maxDirectMemory() {
         try {
 
-            Class<?> VM = Class.forName("sun.misc.VM");
-            Method maxDirectMemory = VM.getDeclaredMethod("maxDirectMemory");
+            Class<?> vm = Class.forName("sun.misc.VM");
+            Method maxDirectMemory = vm.getDeclaredMethod("maxDirectMemory");
             Object result = maxDirectMemory.invoke(null, (Object[]) null);
 
             checkNotNull(result);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
@@ -18,6 +18,8 @@
 
 package org.apache.bookkeeper.util;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileStore;
@@ -26,12 +28,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Class that provides utility functions for checking disk problems
+ * Class that provides utility functions for checking disk problems.
  */
 public class DiskChecker {
 
@@ -40,12 +41,18 @@ public class DiskChecker {
     private float diskUsageThreshold;
     private float diskUsageWarnThreshold;
 
+    /**
+     * A general marker for disk-related exceptions.
+     */
     public abstract static class DiskException extends IOException {
         public DiskException(String msg) {
             super(msg);
         }
     }
 
+    /**
+     * A disk error exception.
+     */
     public static class DiskErrorException extends DiskException {
         private static final long serialVersionUID = 9091606022449761729L;
 
@@ -54,6 +61,9 @@ public class DiskChecker {
         }
     }
 
+    /**
+     * An out-of-space disk exception.
+     */
     public static class DiskOutOfSpaceException extends DiskException {
         private static final long serialVersionUID = 160898797915906860L;
 
@@ -69,6 +79,9 @@ public class DiskChecker {
         }
     }
 
+    /**
+     * A disk warn threshold exception.
+     */
     public static class DiskWarnThresholdException extends DiskException {
         private static final long serialVersionUID = -1629284987500841657L;
 
@@ -150,7 +163,7 @@ public class DiskChecker {
                 LOG.warn("Space left on device {} : {}, Used space fraction: {} < WarnThreshold {}.",
                         new Object[] { dir, usableSpace, used, diskUsageThreshold });
                 throw new DiskWarnThresholdException("Space left on device:"
-                        + usableSpace + " Used space fraction:" + used +" < WarnThreshold:" + diskUsageWarnThreshold,
+                        + usableSpace + " Used space fraction:" + used + " < WarnThreshold:" + diskUsageWarnThreshold,
                         used);
             }
             return used;
@@ -165,7 +178,7 @@ public class DiskChecker {
      * in all of the ledger directories put together.
      *
      * @return totalDiskSpace in bytes
-     * @throws IOException 
+     * @throws IOException
      */
     public long getTotalFreeSpace(List<File> dirs) throws IOException {
         long totalFreeSpace = 0;
@@ -184,7 +197,7 @@ public class DiskChecker {
      * in all of the ledger directories put together.
      *
      * @return freeDiskSpace in bytes
-     * @throws IOException 
+     * @throws IOException
      */
     public long getTotalDiskSpace(List<File> dirs) throws IOException {
         long totalDiskSpace = 0;
@@ -197,14 +210,14 @@ public class DiskChecker {
         }
         return totalDiskSpace;
     }
-    
+
     /**
-     * calculates and returns the disk usage factor in the provided list of dirs
-     * 
+     * calculates and returns the disk usage factor in the provided list of dirs.
+     *
      * @param dirs
      *            list of directories
      * @return disk usage factor in the provided list of dirs
-     * @throws IOException 
+     * @throws IOException
      */
     public float getTotalDiskUsage(List<File> dirs) throws IOException {
         if (dirs == null || dirs.isEmpty()) {
@@ -217,7 +230,7 @@ public class DiskChecker {
     }
 
     /**
-     * Create the directory if it doesn't exist and
+     * Create the directory if it doesn't exist.
      *
      * @param dir
      *            Directory to check for the disk error/full.
@@ -231,25 +244,29 @@ public class DiskChecker {
     public float checkDir(File dir) throws DiskErrorException,
             DiskOutOfSpaceException, DiskWarnThresholdException {
         float usage = checkDiskFull(dir);
-        if (!mkdirsWithExistsCheck(dir))
+        if (!mkdirsWithExistsCheck(dir)) {
             throw new DiskErrorException("can not create directory: "
                     + dir.toString());
+        }
 
-        if (!dir.isDirectory())
+        if (!dir.isDirectory()) {
             throw new DiskErrorException("not a directory: " + dir.toString());
+        }
 
-        if (!dir.canRead())
+        if (!dir.canRead()) {
             throw new DiskErrorException("directory is not readable: "
                     + dir.toString());
+        }
 
-        if (!dir.canWrite())
+        if (!dir.canWrite()) {
             throw new DiskErrorException("directory is not writable: "
                     + dir.toString());
+        }
         return usage;
     }
 
     /**
-     * Set the disk space threshold
+     * Set the disk space threshold.
      *
      * @param diskSpaceThreshold
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
@@ -17,6 +17,17 @@
 */
 package org.apache.bookkeeper.util;
 
+import io.netty.buffer.AbstractReferenceCountedByteBuf;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetectorFactory;
+import io.netty.util.ResourceLeakTracker;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -29,17 +40,6 @@ import java.nio.channels.ScatteringByteChannel;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.netty.buffer.AbstractReferenceCountedByteBuf;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.buffer.Unpooled;
-import io.netty.util.Recycler;
-import io.netty.util.Recycler.Handle;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetectorFactory;
-import io.netty.util.ResourceLeakTracker;
 
 /**
  * ByteBuf that holds 2 buffers. Similar to {@see CompositeByteBuf} but doesn't allocate list to hold them.
@@ -418,23 +418,23 @@ public final class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
     private static final Constructor<ByteBuf> advancedLeakAwareByteBufConstructor;
 
     static {
-        Constructor<ByteBuf> _simpleLeakAwareByteBufConstructor = null;
-        Constructor<ByteBuf> _advancedLeakAwareByteBufConstructor = null;
+        Constructor<ByteBuf> tmpSimpleLeakAwareByteBufConstructor = null;
+        Constructor<ByteBuf> tmpAdvancedLeakAwareByteBufConstructor = null;
         try {
             Class<?> simpleLeakAwareByteBufClass = Class.forName("io.netty.buffer.SimpleLeakAwareByteBuf");
-            _simpleLeakAwareByteBufConstructor = (Constructor<ByteBuf>) simpleLeakAwareByteBufClass
+            tmpSimpleLeakAwareByteBufConstructor = (Constructor<ByteBuf>) simpleLeakAwareByteBufClass
                     .getDeclaredConstructor(ByteBuf.class, ResourceLeakTracker.class);
-            _simpleLeakAwareByteBufConstructor.setAccessible(true);
+            tmpSimpleLeakAwareByteBufConstructor.setAccessible(true);
 
             Class<?> advancedLeakAwareByteBufClass = Class.forName("io.netty.buffer.AdvancedLeakAwareByteBuf");
-            _advancedLeakAwareByteBufConstructor = (Constructor<ByteBuf>) advancedLeakAwareByteBufClass
+            tmpAdvancedLeakAwareByteBufConstructor = (Constructor<ByteBuf>) advancedLeakAwareByteBufClass
                     .getDeclaredConstructor(ByteBuf.class, ResourceLeakTracker.class);
-            _advancedLeakAwareByteBufConstructor.setAccessible(true);
+            tmpAdvancedLeakAwareByteBufConstructor.setAccessible(true);
         } catch (Throwable t) {
             log.error("Failed to use reflection to enable leak detection", t);
         } finally {
-            simpleLeakAwareByteBufConstructor = _simpleLeakAwareByteBufConstructor;
-            advancedLeakAwareByteBufConstructor = _advancedLeakAwareByteBufConstructor;
+            simpleLeakAwareByteBufConstructor = tmpSimpleLeakAwareByteBufConstructor;
+            advancedLeakAwareByteBufConstructor = tmpAdvancedLeakAwareByteBufConstructor;
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/EntryFormatter.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/EntryFormatter.java
@@ -27,11 +27,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Formatter to format an entry
+ * Formatter to format an entry.
  */
 public abstract class EntryFormatter {
 
-    private final static Logger LOG = LoggerFactory.getLogger(EntryFormatter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(EntryFormatter.class);
 
     protected Configuration conf;
 
@@ -40,7 +40,7 @@ public abstract class EntryFormatter {
     }
 
     /**
-     * Format an entry into a readable format
+     * Format an entry into a readable format.
      *
      * @param data
      *          Data Payload
@@ -48,14 +48,14 @@ public abstract class EntryFormatter {
     public abstract void formatEntry(byte[] data);
 
     /**
-     * Format an entry from a string into a readable format
+     * Format an entry from a string into a readable format.
      *
      * @param input
      *          Input Stream
      */
     public abstract void formatEntry(java.io.InputStream input);
 
-    public final static EntryFormatter STRING_FORMATTER = new StringEntryFormatter();
+    public static final EntryFormatter STRING_FORMATTER = new StringEntryFormatter();
 
     public static EntryFormatter newEntryFormatter(Configuration conf, String clsProperty) {
         String cls = conf.getString(clsProperty, StringEntryFormatter.class.getName());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/HardLink.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/HardLink.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.fs;
 */
 package org.apache.bookkeeper.util;
 
+import static com.google.common.base.Charsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -27,39 +29,40 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 
-import static com.google.common.base.Charsets.UTF_8;
-
 /**
  * Class for creating hardlinks.
  * Supports Unix/Linux, WinXP/2003/Vista via Cygwin, and Mac OS X.
- * 
- * The HardLink class was formerly a static inner class of FSUtil,
+ *
+ * <p>The HardLink class was formerly a static inner class of FSUtil,
  * and the methods provided were blatantly non-thread-safe.
- * To enable volume-parallel Update snapshots, we now provide static 
+ * To enable volume-parallel Update snapshots, we now provide static
  * threadsafe methods that allocate new buffer string arrays
  * upon each call.  We also provide an API to hardlink all files in a
- * directory with a single command, which is up to 128 times more 
+ * directory with a single command, which is up to 128 times more
  * efficient - and minimizes the impact of the extra buffer creations.
  */
-public class HardLink { 
+public class HardLink {
 
+  /**
+   * OS Types.
+   */
   public enum OSType {
     OS_TYPE_UNIX,
     OS_TYPE_WINXP,
     OS_TYPE_SOLARIS,
     OS_TYPE_MAC
   }
-  
-  public static final OSType osType;
+
+  public static final OSType OS_TYPE;
   private static HardLinkCommandGetter getHardLinkCommand;
-  
+
   public final LinkStats linkStats; //not static
-  
-  //initialize the command "getters" statically, so can use their 
+
+  //initialize the command "getters" statically, so can use their
   //methods without instantiating the HardLink object
-  static { 
-    osType = getOSType();
-    if (osType == OSType.OS_TYPE_WINXP) {
+  static {
+    OS_TYPE = getOSType();
+    if (OS_TYPE == OSType.OS_TYPE_WINXP) {
       // Windows
       getHardLinkCommand = new HardLinkCGWin();
     } else {
@@ -67,12 +70,12 @@ public class HardLink {
       getHardLinkCommand = new HardLinkCGUnix();
       //override getLinkCountCommand for the particular Unix variant
       //Linux is already set as the default - {"stat","-c%h", null}
-      if (osType == OSType.OS_TYPE_MAC) {
-        String[] linkCountCmdTemplate = {"stat","-f%l", null};
+      if (OS_TYPE == OSType.OS_TYPE_MAC) {
+        String[] linkCountCmdTemplate = {"stat", "-f%l", null};
         HardLinkCGUnix.setLinkCountCmdTemplate(linkCountCmdTemplate);
-      } else if (osType == OSType.OS_TYPE_SOLARIS) {
-        String[] linkCountCmdTemplate = {"ls","-l", null};
-        HardLinkCGUnix.setLinkCountCmdTemplate(linkCountCmdTemplate);        
+      } else if (OS_TYPE == OSType.OS_TYPE_SOLARIS) {
+        String[] linkCountCmdTemplate = {"ls", "-l", null};
+        HardLinkCGUnix.setLinkCountCmdTemplate(linkCountCmdTemplate);
       }
     }
   }
@@ -80,70 +83,66 @@ public class HardLink {
   public HardLink() {
     linkStats = new LinkStats();
   }
-  
-  static private OSType getOSType() {
+
+  private static OSType getOSType() {
     String osName = System.getProperty("os.name");
-    if (osName.contains("Windows") &&
-            (osName.contains("XP") 
-            || osName.contains("2003") 
+    if (osName.contains("Windows") && (osName.contains("XP")
+            || osName.contains("2003")
             || osName.contains("Vista")
             || osName.contains("Windows_7")
-            || osName.contains("Windows 7") 
+            || osName.contains("Windows 7")
             || osName.contains("Windows7"))) {
       return OSType.OS_TYPE_WINXP;
-    }
-    else if (osName.contains("SunOS") 
+    } else if (osName.contains("SunOS")
             || osName.contains("Solaris")) {
        return OSType.OS_TYPE_SOLARIS;
-    }
-    else if (osName.contains("Mac")) {
+    } else if (osName.contains("Mac")) {
        return OSType.OS_TYPE_MAC;
-    }
-    else {
+    } else {
       return OSType.OS_TYPE_UNIX;
     }
   }
-  
+
   /**
-   * This abstract class bridges the OS-dependent implementations of the 
+   * This abstract class bridges the OS-dependent implementations of the
    * needed functionality for creating hardlinks and querying link counts.
-   * The particular implementation class is chosen during 
+   * The particular implementation class is chosen during
    * static initialization phase of the HardLink class.
    * The "getter" methods construct shell command strings for various purposes.
    */
-  private static abstract class HardLinkCommandGetter {
+  private abstract static class HardLinkCommandGetter {
 
     /**
      * Get the command string needed to hardlink a bunch of files from
      * a single source directory into a target directory.  The source directory
      * is not specified here, but the command will be executed using the source
      * directory as the "current working directory" of the shell invocation.
-     * 
+     *
      * @param fileBaseNames - array of path-less file names, relative
      *            to the source directory
      * @param linkDir - target directory where the hardlinks will be put
      * @return - an array of Strings suitable for use as a single shell command
-     *            with {@link Runtime.exec()}
+     *            with {@code Runtime.exec()}
      * @throws IOException - if any of the file or path names misbehave
      */
-    abstract String[] linkMult(String[] fileBaseNames, File linkDir) 
+    abstract String[] linkMult(String[] fileBaseNames, File linkDir)
                           throws IOException;
-    
+
     /**
-     * Get the command string needed to hardlink a single file
+     * Get the command string needed to hardlink a single file.
      */
     abstract String[] linkOne(File file, File linkName) throws IOException;
-    
+
     /**
-     * Get the command string to query the hardlink count of a file
+     * Get the command string to query the hardlink count of a file.
      */
     abstract String[] linkCount(File file) throws IOException;
-    
+
     /**
      * Calculate the total string length of the shell command
      * resulting from execution of linkMult, plus the length of the
-     * source directory name (which will also be provided to the shell)
-     * 
+     * source directory name (which will also be provided to the shell).
+     *
      * @param fileDir - source directory, parent of fileBaseNames
      * @param fileBaseNames - array of path-less file names, relative
      *            to the source directory
@@ -152,61 +151,61 @@ public class HardLink {
      * @throws IOException
      */
     abstract int getLinkMultArgLength(
-                     File fileDir, String[] fileBaseNames, File linkDir) 
+                     File fileDir, String[] fileBaseNames, File linkDir)
                      throws IOException;
-    
+
     /**
      * Get the maximum allowed string length of a shell command on this OS,
      * which is just the documented minimum guaranteed supported command
      * length - aprx. 32KB for Unix, and 8KB for Windows.
      */
-    abstract int getMaxAllowedCmdArgLength(); 
+    abstract int getMaxAllowedCmdArgLength();
   }
-  
+
   /**
-   * Implementation of HardLinkCommandGetter class for Unix
+   * Implementation of HardLinkCommandGetter class for Unix.
    */
   static class HardLinkCGUnix extends HardLinkCommandGetter {
     private static String[] hardLinkCommand = {"ln", null, null};
     private static String[] hardLinkMultPrefix = {"ln"};
     private static String[] hardLinkMultSuffix = {null};
-    private static String[] getLinkCountCommand = {"stat","-c%h", null};
+    private static String[] getLinkCountCommand = {"stat", "-c%h", null};
     //Unix guarantees at least 32K bytes cmd length.
     //Subtract another 64b to allow for Java 'exec' overhead
-    private static final int maxAllowedCmdArgLength = 32*1024 - 65;
-    
-    private static synchronized 
+    private static final int maxAllowedCmdArgLength = 32 * 1024 - 65;
+
+    private static synchronized
     void setLinkCountCmdTemplate(String[] template) {
-      //May update this for specific unix variants, 
+      //May update this for specific unix variants,
       //after static initialization phase
       getLinkCountCommand = template;
     }
-    
+
     /*
      * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#linkOne(java.io.File, java.io.File)
      */
     @Override
-    String[] linkOne(File file, File linkName) 
+    String[] linkOne(File file, File linkName)
     throws IOException {
       String[] buf = new String[hardLinkCommand.length];
       System.arraycopy(hardLinkCommand, 0, buf, 0, hardLinkCommand.length);
       //unix wants argument order: "ln <existing> <new>"
-      buf[1] = makeShellPath(file); 
+      buf[1] = makeShellPath(file);
       buf[2] = makeShellPath(linkName);
       return buf;
     }
-    
+
     /*
      * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#linkMult(java.lang.String[], java.io.File)
      */
     @Override
-    String[] linkMult(String[] fileBaseNames, File linkDir) 
+    String[] linkMult(String[] fileBaseNames, File linkDir)
     throws IOException {
-      String[] buf = new String[fileBaseNames.length 
-                                + hardLinkMultPrefix.length 
+      String[] buf = new String[fileBaseNames.length
+                                + hardLinkMultPrefix.length
                                 + hardLinkMultSuffix.length];
-      int mark=0;
-      System.arraycopy(hardLinkMultPrefix, 0, buf, mark, 
+      int mark = 0;
+      System.arraycopy(hardLinkMultPrefix, 0, buf, mark,
                        hardLinkMultPrefix.length);
       mark += hardLinkMultPrefix.length;
       System.arraycopy(fileBaseNames, 0, buf, mark, fileBaseNames.length);
@@ -214,25 +213,25 @@ public class HardLink {
       buf[mark] = makeShellPath(linkDir);
       return buf;
     }
-    
+
     /*
      * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#linkCount(java.io.File)
      */
     @Override
-    String[] linkCount(File file) 
+    String[] linkCount(File file)
     throws IOException {
       String[] buf = new String[getLinkCountCommand.length];
-      System.arraycopy(getLinkCountCommand, 0, buf, 0, 
+      System.arraycopy(getLinkCountCommand, 0, buf, 0,
                        getLinkCountCommand.length);
       buf[getLinkCountCommand.length - 1] = makeShellPath(file);
       return buf;
     }
-    
+
     /*
-     * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#getLinkMultArgLength(java.io.File, java.lang.String[], java.io.File)
+     * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#getLinkMultArgLength(File, String[], File)
      */
     @Override
-    int getLinkMultArgLength(File fileDir, String[] fileBaseNames, File linkDir) 
+    int getLinkMultArgLength(File fileDir, String[] fileBaseNames, File linkDir)
     throws IOException{
       int sum = 0;
       for (String x : fileBaseNames) {
@@ -245,7 +244,7 @@ public class HardLink {
       sum += 3; //length("ln") + 1
       return sum;
     }
-    
+
     /*
      * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#getMaxAllowedCmdArgLength()
      */
@@ -254,79 +253,78 @@ public class HardLink {
       return maxAllowedCmdArgLength;
     }
   }
-  
-  
+
   /**
-   * Implementation of HardLinkCommandGetter class for Windows
-   * 
-   * Note that the linkCount shell command for Windows is actually
+   * Implementation of HardLinkCommandGetter class for Windows.
+   *
+   * <p>Note that the linkCount shell command for Windows is actually
    * a Cygwin shell command, and depends on ${cygwin}/bin
    * being in the Windows PATH environment variable, so
    * stat.exe can be found.
    */
   static class HardLinkCGWin extends HardLinkCommandGetter {
     //The Windows command getter impl class and its member fields are
-    //package-private ("default") access instead of "private" to assist 
+    //package-private ("default") access instead of "private" to assist
     //unit testing (sort of) on non-Win servers
 
     static String[] hardLinkCommand = {
-                        "fsutil","hardlink","create", null, null};
+                        "fsutil", "hardlink", "create", null, null};
     static String[] hardLinkMultPrefix = {
-                        "cmd","/q","/c","for", "%f", "in", "("};
+                        "cmd", "/q", "/c", "for", "%f", "in", "("};
     static String   hardLinkMultDir = "\\%f";
     static String[] hardLinkMultSuffix = {
-                        ")", "do", "fsutil", "hardlink", "create", null, 
+                        ")", "do", "fsutil", "hardlink", "create", null,
                         "%f", "1>NUL"};
-    static String[] getLinkCountCommand = {"stat","-c%h", null};
+    static String[] getLinkCountCommand = {"stat", "-c%h", null};
     //Windows guarantees only 8K - 1 bytes cmd length.
     //Subtract another 64b to allow for Java 'exec' overhead
-    static final int maxAllowedCmdArgLength = 8*1024 - 65;
+    private static final int maxAllowedCmdArgLength = 8 * 1024 - 65;
 
     /*
      * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#linkOne(java.io.File, java.io.File)
      */
     @Override
-    String[] linkOne(File file, File linkName) 
+    String[] linkOne(File file, File linkName)
     throws IOException {
       String[] buf = new String[hardLinkCommand.length];
       System.arraycopy(hardLinkCommand, 0, buf, 0, hardLinkCommand.length);
       //windows wants argument order: "create <new> <existing>"
-      buf[4] = file.getCanonicalPath(); 
+      buf[4] = file.getCanonicalPath();
       buf[3] = linkName.getCanonicalPath();
       return buf;
     }
-    
+
     /*
      * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#linkMult(java.lang.String[], java.io.File)
      */
     @Override
-    String[] linkMult(String[] fileBaseNames, File linkDir) 
+    String[] linkMult(String[] fileBaseNames, File linkDir)
     throws IOException {
-      String[] buf = new String[fileBaseNames.length 
-                                + hardLinkMultPrefix.length 
+      String[] buf = new String[fileBaseNames.length
+                                + hardLinkMultPrefix.length
                                 + hardLinkMultSuffix.length];
       String td = linkDir.getCanonicalPath() + hardLinkMultDir;
-      int mark=0;
-      System.arraycopy(hardLinkMultPrefix, 0, buf, mark, 
+      int mark = 0;
+      System.arraycopy(hardLinkMultPrefix, 0, buf, mark,
                        hardLinkMultPrefix.length);
       mark += hardLinkMultPrefix.length;
       System.arraycopy(fileBaseNames, 0, buf, mark, fileBaseNames.length);
       mark += fileBaseNames.length;
-      System.arraycopy(hardLinkMultSuffix, 0, buf, mark, 
+      System.arraycopy(hardLinkMultSuffix, 0, buf, mark,
                        hardLinkMultSuffix.length);
       mark += hardLinkMultSuffix.length;
       buf[mark - 3] = td;
       return buf;
     }
-    
+
     /*
      * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#linkCount(java.io.File)
      */
     @Override
-    String[] linkCount(File file) 
+    String[] linkCount(File file)
     throws IOException {
       String[] buf = new String[getLinkCountCommand.length];
-      System.arraycopy(getLinkCountCommand, 0, buf, 0, 
+      System.arraycopy(getLinkCountCommand, 0, buf, 0,
                        getLinkCountCommand.length);
       //The linkCount command is actually a Cygwin shell command,
       //not a Windows shell command, so we should use "makeShellPath()"
@@ -337,27 +335,26 @@ public class HardLink {
       buf[getLinkCountCommand.length - 1] = file.getCanonicalPath();
       return buf;
     }
-    
+
     /*
-     * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#getLinkMultArgLength(java.io.File, java.lang.String[], java.io.File)
+     * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#getLinkMultArgLength(File, String[], File)
      */
     @Override
-    int getLinkMultArgLength(File fileDir, String[] fileBaseNames, File linkDir) 
+    int getLinkMultArgLength(File fileDir, String[] fileBaseNames, File linkDir)
     throws IOException {
       int sum = 0;
       for (String x : fileBaseNames) {
         // add 1 to account for terminal null or delimiter space
         sum += 1 + ((x == null) ? 0 : x.length());
       }
-      sum += 2 + fileDir.getCanonicalPath().length() +
-               linkDir.getCanonicalPath().length();
-      //add the fixed overhead of the hardLinkMult command 
+      sum += 2 + fileDir.getCanonicalPath().length() + linkDir.getCanonicalPath().length();
+      //add the fixed overhead of the hardLinkMult command
       //(prefix, suffix, and Dir suffix)
       sum += ("cmd.exe /q /c for %f in ( ) do "
               + "fsutil hardlink create \\%f %f 1>NUL ").length();
       return sum;
     }
-    
+
     /*
      * @see org.apache.hadoop.fs.HardLink.HardLinkCommandGetter#getMaxAllowedCmdArgLength()
      */
@@ -366,16 +363,15 @@ public class HardLink {
       return maxAllowedCmdArgLength;
     }
   }
-  
-  
+
   /**
-   * Calculate the nominal length of all contributors to the total 
-   * commandstring length, including fixed overhead of the OS-dependent 
+   * Calculate the nominal length of all contributors to the total
+   * commandstring length, including fixed overhead of the OS-dependent
    * command.  It's protected rather than private, to assist unit testing,
-   * but real clients are not expected to need it -- see the way 
+   * but real clients are not expected to need it -- see the way
    * createHardLinkMult() uses it internally so the user doesn't need to worry
    * about it.
-   * 
+   *
    * @param fileDir - source directory, parent of fileBaseNames
    * @param fileBaseNames - array of path-less file names, relative
    *            to the source directory
@@ -384,12 +380,12 @@ public class HardLink {
    * @throws IOException
    */
   protected static int getLinkMultArgLength(
-          File fileDir, String[] fileBaseNames, File linkDir) 
+          File fileDir, String[] fileBaseNames, File linkDir)
   throws IOException {
-    return getHardLinkCommand.getLinkMultArgLength(fileDir, 
+    return getHardLinkCommand.getLinkMultArgLength(fileDir,
           fileBaseNames, linkDir);
   }
-  
+
   /**
    * Return this private value for use by unit tests.
    * Shell commands are not allowed to have a total string length
@@ -398,7 +394,7 @@ public class HardLink {
   protected static int getMaxAllowedCmdArgLength() {
     return getHardLinkCommand.getMaxAllowedCmdArgLength();
   }
-  
+
   /*
    * ****************************************************
    * Complexity is above.  User-visible functionality is below
@@ -406,11 +402,11 @@ public class HardLink {
    */
 
   /**
-   * Creates a hardlink 
+   * Creates a hardlink.
    * @param file - existing source file
    * @param linkName - desired target link file
    */
-  public static void createHardLink(File file, File linkName) 
+  public static void createHardLink(File file, File linkName)
   throws IOException {
     if (file == null) {
       throw new IOException(
@@ -420,17 +416,21 @@ public class HardLink {
       throw new IOException(
           "invalid arguments to createHardLink: link name is null");
     }
-	  // construct and execute shell command
+    // construct and execute shell command
     String[] hardLinkCommand = getHardLinkCommand.linkOne(file, linkName);
     Process process = Runtime.getRuntime().exec(hardLinkCommand);
     try {
       if (process.waitFor() != 0) {
         String errMsg = new BufferedReader(new InputStreamReader(
                                                    process.getInputStream(), UTF_8)).readLine();
-        if (errMsg == null)  errMsg = "";
+        if (errMsg == null) {
+            errMsg = "";
+        }
         String inpMsg = new BufferedReader(new InputStreamReader(
                                                    process.getErrorStream(), UTF_8)).readLine();
-        if (inpMsg == null)  inpMsg = "";
+        if (inpMsg == null) {
+            inpMsg = "";
+        }
         throw new IOException(errMsg + inpMsg);
       }
     } catch (InterruptedException e) {
@@ -444,19 +444,19 @@ public class HardLink {
    * Creates hardlinks from multiple existing files within one parent
    * directory, into one target directory.
    * @param parentDir - directory containing source files
-   * @param fileBaseNames - list of path-less file names, as returned by 
+   * @param fileBaseNames - list of path-less file names, as returned by
    *                        parentDir.list()
    * @param linkDir - where the hardlinks should be put.  It must already exist.
-   * 
+   *
    * If the list of files is too long (overflows maxAllowedCmdArgLength),
    * we will automatically split it into multiple invocations of the
    * underlying method.
    */
-  public static void createHardLinkMult(File parentDir, String[] fileBaseNames, 
+  public static void createHardLinkMult(File parentDir, String[] fileBaseNames,
       File linkDir) throws IOException {
     //This is the public method all non-test clients are expected to use.
     //Normal case - allow up to maxAllowedCmdArgLength characters in the cmd
-    createHardLinkMult(parentDir, fileBaseNames, linkDir, 
+    createHardLinkMult(parentDir, fileBaseNames, linkDir,
                        getHardLinkCommand.getMaxAllowedCmdArgLength());
   }
 
@@ -467,8 +467,8 @@ public class HardLink {
    * the file list had to be split into.
    * Non-test clients are expected to call the public method instead.
    */
-  protected static int createHardLinkMult(File parentDir, 
-      String[] fileBaseNames, File linkDir, int maxLength) 
+  protected static int createHardLinkMult(File parentDir,
+      String[] fileBaseNames, File linkDir, int maxLength)
   throws IOException {
     if (parentDir == null) {
       throw new IOException(
@@ -484,9 +484,9 @@ public class HardLink {
           + "filename list can be empty but not null");
     }
     if (fileBaseNames.length == 0) {
-      //the OS cmds can't handle empty list of filenames, 
+      //the OS cmds can't handle empty list of filenames,
       //but it's legal, so just return.
-      return 0; 
+      return 0;
     }
     if (!linkDir.exists()) {
       throw new FileNotFoundException(linkDir + " not found.");
@@ -496,29 +496,33 @@ public class HardLink {
     int callCount = 0;
     if (getLinkMultArgLength(parentDir, fileBaseNames, linkDir) > maxLength
           && fileBaseNames.length > 1) {
-      String[] list1 = Arrays.copyOf(fileBaseNames, fileBaseNames.length/2);
+      String[] list1 = Arrays.copyOf(fileBaseNames, fileBaseNames.length / 2);
       callCount += createHardLinkMult(parentDir, list1, linkDir, maxLength);
-      String[] list2 = Arrays.copyOfRange(fileBaseNames, fileBaseNames.length/2,
+      String[] list2 = Arrays.copyOfRange(fileBaseNames, fileBaseNames.length / 2,
           fileBaseNames.length);
-      callCount += createHardLinkMult(parentDir, list2, linkDir, maxLength);  
+      callCount += createHardLinkMult(parentDir, list2, linkDir, maxLength);
       return callCount;
     } else {
       callCount = 1;
     }
-    
+
     // construct and execute shell command
-    String[] hardLinkCommand = getHardLinkCommand.linkMult(fileBaseNames, 
+    String[] hardLinkCommand = getHardLinkCommand.linkMult(fileBaseNames,
         linkDir);
-    Process process = Runtime.getRuntime().exec(hardLinkCommand, null, 
+    Process process = Runtime.getRuntime().exec(hardLinkCommand, null,
         parentDir);
     try {
       if (process.waitFor() != 0) {
         String errMsg = new BufferedReader(new InputStreamReader(
                                                    process.getInputStream(), UTF_8)).readLine();
-        if (errMsg == null)  errMsg = "";
+        if (errMsg == null) {
+            errMsg = "";
+        }
         String inpMsg = new BufferedReader(new InputStreamReader(
                                                    process.getErrorStream(), UTF_8)).readLine();
-        if (inpMsg == null)  inpMsg = "";
+        if (inpMsg == null) {
+            inpMsg = "";
+        }
         throw new IOException(errMsg + inpMsg);
       }
     } catch (InterruptedException e) {
@@ -561,7 +565,7 @@ public class HardLink {
       if (inpMsg == null || exitValue != 0) {
         throw createIOException(fileName, inpMsg, errMsg, exitValue, null);
       }
-      if (osType == OSType.OS_TYPE_SOLARIS) {
+      if (OS_TYPE == OSType.OS_TYPE_SOLARIS) {
         String[] result = inpMsg.split("\\s+");
         return Integer.parseInt(result[1]);
       } else {
@@ -573,68 +577,71 @@ public class HardLink {
       throw createIOException(fileName, inpMsg, errMsg, exitValue, e);
     } finally {
       process.destroy();
-      if (in != null) in.close();
-      if (err != null) err.close();
+      if (in != null) {
+          in.close();
+      }
+      if (err != null) {
+          err.close();
+      }
     }
   }
-  
+
   /* Create an IOException for failing to get link count. */
   private static IOException createIOException(File f, String message,
       String error, int exitvalue, Exception cause) {
-    
+
     final String winErrMsg = "; Windows errors in getLinkCount are often due "
          + "to Cygwin misconfiguration";
 
     final String s = "Failed to get link count on file " + f
         + ": message=" + message
         + "; error=" + error
-        + ((osType == OSType.OS_TYPE_WINXP) ? winErrMsg : "")
+        + ((OS_TYPE == OSType.OS_TYPE_WINXP) ? winErrMsg : "")
         + "; exit value=" + exitvalue;
     return (cause == null) ? new IOException(s) : new IOException(s, cause);
   }
-  
-  
+
   /**
    * HardLink statistics counters and methods.
    * Not multi-thread safe, obviously.
    * Init is called during HardLink instantiation, above.
-   * 
-   * These are intended for use by knowledgeable clients, not internally, 
+   *
+   * <p>These are intended for use by knowledgeable clients, not internally,
    * because many of the internal methods are static and can't update these
    * per-instance counters.
    */
   public static class LinkStats {
-    public int countDirs = 0; 
-    public int countSingleLinks = 0; 
-    public int countMultLinks = 0; 
-    public int countFilesMultLinks = 0; 
-    public int countEmptyDirs = 0; 
+    public int countDirs = 0;
+    public int countSingleLinks = 0;
+    public int countMultLinks = 0;
+    public int countFilesMultLinks = 0;
+    public int countEmptyDirs = 0;
     public int countPhysicalFileCopies = 0;
-  
+
     public void clear() {
-      countDirs = 0; 
-      countSingleLinks = 0; 
-      countMultLinks = 0; 
-      countFilesMultLinks = 0; 
-      countEmptyDirs = 0; 
+      countDirs = 0;
+      countSingleLinks = 0;
+      countMultLinks = 0;
+      countFilesMultLinks = 0;
+      countEmptyDirs = 0;
       countPhysicalFileCopies = 0;
     }
-    
+
     public String report() {
-      return "HardLinkStats: " + countDirs + " Directories, including " 
-      + countEmptyDirs + " Empty Directories, " 
-      + countSingleLinks 
-      + " single Link operations, " + countMultLinks 
-      + " multi-Link operations, linking " + countFilesMultLinks 
-      + " files, total " + (countSingleLinks + countFilesMultLinks) 
-      + " linkable files.  Also physically copied " 
+      return "HardLinkStats: " + countDirs + " Directories, including "
+      + countEmptyDirs + " Empty Directories, "
+      + countSingleLinks
+      + " single Link operations, " + countMultLinks
+      + " multi-Link operations, linking " + countFilesMultLinks
+      + " files, total " + (countSingleLinks + countFilesMultLinks)
+      + " linkable files.  Also physically copied "
       + countPhysicalFileCopies + " other files.";
     }
   }
 
   /**
    * Convert a os-native filename to a path that works for the shell.
-   * @param filename The filename to convert
+   * @param file The file to convert
    * @return The unix pathname
    * @throws IOException on windows, there can be problems with the subprocess
    */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/HexDumpEntryFormatter.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/HexDumpEntryFormatter.java
@@ -25,6 +25,9 @@ import java.io.IOException;
 
 import org.apache.commons.io.HexDump;
 
+/**
+ * A hex dump entry formatter.
+ */
 public class HexDumpEntryFormatter extends EntryFormatter {
     @Override
     public void formatEntry(byte[] data) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/JsonUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/JsonUtil.java
@@ -45,6 +45,9 @@ public class JsonUtil {
         }
     }
 
+    /**
+     * A JSON parsing exception.
+     */
     public static class ParseJsonException extends Exception {
         public ParseJsonException(String message) {
             super(message);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.util;
 
+import static com.google.common.base.Charsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -27,27 +29,26 @@ import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.shims.zk.ZooKeeperServerShim;
-import org.apache.bookkeeper.shims.zk.ZooKeeperServerShimFactory;
-import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
-import org.apache.commons.io.FileUtils;
 import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
-import org.apache.bookkeeper.stats.StatsLogger;
-import org.apache.bookkeeper.stats.StatsProvider;
+import org.apache.bookkeeper.shims.zk.ZooKeeperServerShim;
+import org.apache.bookkeeper.shims.zk.ZooKeeperServerShimFactory;
 import org.apache.bookkeeper.tls.SecurityException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
+import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs.Ids;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static com.google.common.base.Charsets.UTF_8;
-
+/**
+ * Local Bookkeeper.
+ */
 public class LocalBookKeeper {
     protected static final Logger LOG = LoggerFactory.getLogger(LocalBookKeeper.class);
     public static final int CONNECTION_TIMEOUT = 30000;
@@ -68,10 +69,10 @@ public class LocalBookKeeper {
         LOG.info("Running {} bookie(s) on zkServer {}.", this.numberOfBookies);
     }
 
-    static String ZooKeeperDefaultHost = "127.0.0.1";
-    static int ZooKeeperDefaultPort = 2181;
-    static int zkSessionTimeOut = 5000;
-    static Integer BookieDefaultInitialPort = 5000;
+    private static String zooKeeperDefaultHost = "127.0.0.1";
+    private static int zooKeeperDefaultPort = 2181;
+    private static int zkSessionTimeOut = 5000;
+    private static Integer bookieDefaultInitialPort = 5000;
 
     //BookKeeper variables
     File journalDirs[];
@@ -170,7 +171,7 @@ public class LocalBookKeeper {
         bs = new BookieServer[numberOfBookies];
         bsConfs = new ServerConfiguration[numberOfBookies];
 
-        for(int i = 0; i < numberOfBookies; i++) {
+        for (int i = 0; i < numberOfBookies; i++) {
             if (null == baseConf.getJournalDirNameWithoutDefault()) {
                 journalDirs[i] = IOUtils.createTempDir("localbookkeeper" + Integer.toString(i), dirSuffix);
                 tempDirs.add(journalDirs[i]);
@@ -220,7 +221,7 @@ public class LocalBookKeeper {
 
             if (null == baseConf.getZkServers()) {
                 bsConfs[i].setZkServers(InetAddress.getLocalHost().getHostAddress() + ":"
-                                  + ZooKeeperDefaultPort);
+                                  + zooKeeperDefaultPort);
             }
 
 
@@ -316,7 +317,7 @@ public class LocalBookKeeper {
     }
 
     public static void main(String[] args) throws Exception, SecurityException {
-        if(args.length < 1) {
+        if (args.length < 1) {
             usage();
             System.exit(-1);
         }
@@ -336,8 +337,8 @@ public class LocalBookKeeper {
             }
         }
 
-        startLocalBookiesInternal(conf, ZooKeeperDefaultHost, ZooKeeperDefaultPort,
-                numBookies, true, BookieDefaultInitialPort, false, "test");
+        startLocalBookiesInternal(conf, zooKeeperDefaultHost, zooKeeperDefaultPort,
+                numBookies, true, bookieDefaultInitialPort, false, "test");
     }
 
     private static void usage() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/NativeIO.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/NativeIO.java
@@ -18,13 +18,18 @@
 
 package org.apache.bookkeeper.util;
 
-import java.lang.reflect.Field;
-import java.io.FileDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 
+import java.io.FileDescriptor;
+import java.lang.reflect.Field;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Native I/O operations.
+ */
 public final class NativeIO {
     private static final Logger LOG = LoggerFactory.getLogger(NativeIO.class);
 
@@ -84,15 +89,12 @@ public final class NativeIO {
 
     /**
      * Remove pages from the file system page cache when they wont
-     * be accessed again
+     * be accessed again.
      *
      * @param fd     The file descriptor of the source file.
      * @param offset The offset within the file.
      * @param len    The length to be flushed.
-     *
-     * @throws nothing => Best effort
      */
-
     public static void bestEffortRemoveFromPageCache(int fd, long offset, long len) {
         if (!initialized || !fadvisePossible || fd < 0) {
             return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/OrderedSafeExecutor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/OrderedSafeExecutor.java
@@ -32,18 +32,18 @@ import org.slf4j.LoggerFactory;
 /**
  * This class provides 2 things over the java {@link ScheduledExecutorService}.
  *
- * 1. It takes {@link SafeRunnable objects} instead of plain Runnable objects.
+ * <p>1. It takes {@link SafeRunnable objects} instead of plain Runnable objects.
  * This means that exceptions in scheduled tasks wont go unnoticed and will be
  * logged.
  *
- * 2. It supports submitting tasks with an ordering key, so that tasks submitted
+ * <p>2. It supports submitting tasks with an ordering key, so that tasks submitted
  * with the same key will always be executed in order, but tasks across
  * different keys can be unordered. This retains parallelism while retaining the
  * basic amount of ordering we want (e.g. , per ledger handle). Ordering is
  * achieved by hashing the key objects to threads by their {@link #hashCode()}
  * method.
  *
- * @Deprecated since 4.6.0, in favor of using {@link org.apache.bookkeeper.common.util.OrderedScheduler}.
+ * <p>Note: deprecated since 4.6.0, in favor of using {@link org.apache.bookkeeper.common.util.OrderedScheduler}.
  */
 public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.OrderedScheduler {
 
@@ -51,6 +51,9 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
         return new Builder();
     }
 
+    /**
+     * A builder class for an OrderedSafeExecutor.
+     */
     public static class Builder extends AbstractBuilder<OrderedSafeExecutor> {
 
         public OrderedSafeExecutor build() {
@@ -64,7 +67,7 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
     }
 
     /**
-     * Constructs Safe executor
+     * Constructs Safe executor.
      *
      * @param numThreads
      *            - number of threads
@@ -88,14 +91,14 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
     }
 
     /**
-     * schedules a one time action to execute
+     * Schedules a one time action to execute.
      */
     public void submit(SafeRunnable r) {
         super.submit(r);
     }
 
     /**
-     * schedules a one time action to execute with an ordering guarantee on the key
+     * Schedules a one time action to execute with an ordering guarantee on the key.
      * @param orderingKey
      * @param r
      */
@@ -104,7 +107,7 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
     }
 
     /**
-     * schedules a one time action to execute with an ordering guarantee on the key
+     * Schedules a one time action to execute with an ordering guarantee on the key.
      * @param orderingKey
      * @param r
      */
@@ -113,7 +116,7 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
     }
 
     /**
-     * schedules a one time action to execute with an ordering guarantee on the key
+     * Schedules a one time action to execute with an ordering guarantee on the key.
      * @param orderingKey
      * @param r
      */
@@ -127,7 +130,8 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
      * @param command - the SafeRunnable to execute
      * @param delay - the time from now to delay execution
      * @param unit - the time unit of the delay parameter
-     * @return a ScheduledFuture representing pending completion of the task and whose get() method will return null upon completion
+     * @return a ScheduledFuture representing pending completion of the task and whose get() method
+     *      will return null upon completion
      */
     public ScheduledFuture<?> schedule(SafeRunnable command, long delay, TimeUnit unit) {
         return super.schedule(command, delay, unit);
@@ -140,7 +144,8 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
      * @param command - the SafeRunnable to execute
      * @param delay - the time from now to delay execution
      * @param unit - the time unit of the delay parameter
-     * @return a ScheduledFuture representing pending completion of the task and whose get() method will return null upon completion
+     * @return a ScheduledFuture representing pending completion of the task and whose get() method
+     *      will return null upon completion
      */
     public ScheduledFuture<?> scheduleOrdered(Object orderingKey, SafeRunnable command, long delay, TimeUnit unit) {
         return super.scheduleOrdered(orderingKey, command, delay, unit);
@@ -148,16 +153,16 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
 
     /**
      * Creates and executes a periodic action that becomes enabled first after
-     * the given initial delay, and subsequently with the given period;
+     * the given initial delay, and subsequently with the given period.
      *
-     * For more details check scheduleAtFixedRate in interface ScheduledExecutorService
+     * <p>For more details check scheduleAtFixedRate in interface ScheduledExecutorService
      *
      * @param command - the SafeRunnable to execute
      * @param initialDelay - the time to delay first execution
      * @param period - the period between successive executions
      * @param unit - the time unit of the initialDelay and period parameters
      * @return a ScheduledFuture representing pending completion of the task, and whose get()
-     * method will throw an exception upon cancellation
+     *      method will throw an exception upon cancellation
      */
     public ScheduledFuture<?> scheduleAtFixedRate(SafeRunnable command, long initialDelay, long period, TimeUnit unit) {
         return super.scheduleAtFixedRate(command, initialDelay, period, unit);
@@ -165,9 +170,9 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
 
     /**
      * Creates and executes a periodic action that becomes enabled first after
-     * the given initial delay, and subsequently with the given period;
+     * the given initial delay, and subsequently with the given period.
      *
-     * For more details check scheduleAtFixedRate in interface ScheduledExecutorService
+     * <p>For more details check scheduleAtFixedRate in interface ScheduledExecutorService
      *
      * @param orderingKey - the key used for ordering
      * @param command - the SafeRunnable to execute
@@ -186,7 +191,7 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
      * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently
      * with the given delay between the termination of one execution and the commencement of the next.
      *
-     * For more details check scheduleWithFixedDelay in interface ScheduledExecutorService
+     * <p>For more details check scheduleWithFixedDelay in interface ScheduledExecutorService
      *
      * @param command - the SafeRunnable to execute
      * @param initialDelay - the time to delay first execution
@@ -204,7 +209,7 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
      * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently
      * with the given delay between the termination of one execution and the commencement of the next.
      *
-     * For more details check scheduleWithFixedDelay in interface ScheduledExecutorService
+     * <p>For more details check scheduleWithFixedDelay in interface ScheduledExecutorService
      *
      * @param orderingKey - the key used for ordering
      * @param command - the SafeRunnable to execute
@@ -221,9 +226,9 @@ public class OrderedSafeExecutor extends org.apache.bookkeeper.common.util.Order
 
     /**
      * Generic callback implementation which will run the
-     * callback in the thread which matches the ordering key
+     * callback in the thread which matches the ordering key.
      */
-    public static abstract class OrderedSafeGenericCallback<T>
+    public abstract static class OrderedSafeGenericCallback<T>
             implements GenericCallback<T> {
         private static final Logger LOG = LoggerFactory.getLogger(OrderedSafeGenericCallback.class);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ReflectionUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ReflectionUtils.java
@@ -27,7 +27,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 
 /**
- * General Class Reflection Utils
+ * General Class Reflection Utils.
  */
 public class ReflectionUtils {
 
@@ -42,8 +42,8 @@ public class ReflectionUtils {
      * @param xface class interface
      * @return the class object associated with the class or interface with the given string name.
      */
-    public static <U> Class<? extends U> forName(String className,
-                                                 Class<U> xface) {
+    public static <T> Class<? extends T> forName(String className,
+                                                 Class<T> xface) {
 
         // Construct the class
         Class<?> theCls;
@@ -91,9 +91,9 @@ public class ReflectionUtils {
      * Get the value of the <code>name</code> property as a <code>Class</code> implementing
      * the interface specified by <code>xface</code>.
      *
-     * If no such property is specified, then <code>defaultValue</code> is returned.
+     * <p>If no such property is specified, then <code>defaultValue</code> is returned.
      *
-     * An exception is thrown if the returned class does not implement the named interface.
+     * <p>An exception is thrown if the returned class does not implement the named interface.
      *
      * @param conf
      *          Configuration Object.
@@ -108,9 +108,9 @@ public class ReflectionUtils {
      * @return property value as a <code>Class</code>, or <code>defaultValue</code>.
      * @throws ConfigurationException
      */
-    public static <U> Class<? extends U> getClass(Configuration conf,
-                                                  String name, Class<? extends U> defaultValue,
-                                                  Class<U> xface, ClassLoader classLoader)
+    public static <T> Class<? extends T> getClass(Configuration conf,
+                                                  String name, Class<? extends T> defaultValue,
+                                                  Class<T> xface, ClassLoader classLoader)
         throws ConfigurationException {
         try {
             Class<?> theCls = getClass(conf, name, defaultValue, classLoader);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/SafeRunnable.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/SafeRunnable.java
@@ -19,12 +19,15 @@ package org.apache.bookkeeper.util;
 
 import java.util.function.Consumer;
 
+/**
+ * A SafeRunnable implementation.
+ */
 public abstract class SafeRunnable implements org.apache.bookkeeper.common.util.SafeRunnable {
 
     /**
-     * Utility method to use SafeRunnable from lambdas
-     * <p>
-     * Eg:
+     * Utility method to use SafeRunnable from lambdas.
+     *
+     * <p>Eg:
      * <pre>
      * <code>
      * executor.submit(SafeRunnable.safeRun(() -> {
@@ -44,9 +47,9 @@ public abstract class SafeRunnable implements org.apache.bookkeeper.common.util.
 
     /**
      * Utility method to use SafeRunnable from lambdas with
-     * a custom exception handler
-     * <p>
-     * Eg:
+     * a custom exception handler.
+     *
+     * <p>Eg:
      * <pre>
      * <code>
      * executor.submit(SafeRunnable.safeRun(() -> {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/Shell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/Shell.java
@@ -36,17 +36,19 @@ import org.apache.commons.logging.LogFactory;
  * <code>df</code>. It also offers facilities to gate commands by
  * time-intervals.
  */
-abstract public class Shell {
+public abstract class Shell {
 
     public static final Log LOG = LogFactory.getLog(Shell.class);
 
     protected long timeOutInterval = 0L;
-    /** If or not script timed out*/
+    /* If or not script timed out */
     private AtomicBoolean timedOut;
 
-    /** Set to true on Windows platforms */
-    public static final boolean WINDOWS /* borrowed from Path.WINDOWS */
-    = System.getProperty("os.name").startsWith("Windows");
+    /**
+     * Set to true on Windows platforms.
+     */
+    public static final boolean WINDOWS = /* borrowed from Path.WINDOWS */
+            System.getProperty("os.name").startsWith("Windows");
 
     private long interval; // refresh interval in msec
     private long lastTime; // last time the command was performed
@@ -55,7 +57,7 @@ abstract public class Shell {
     private Process process; // sub process used to execute the command
     private int exitCode;
 
-    /**If or not script finished executing*/
+    /* If or not script finished executing */
     private volatile AtomicBoolean completed;
 
     public Shell() {
@@ -71,29 +73,36 @@ abstract public class Shell {
         this.lastTime = (interval < 0) ? 0 : -interval;
     }
 
-    /** set the environment for the command
+    /**
+     * Set the environment for the command.
      * @param env Mapping of environment variables
      */
     protected void setEnvironment(Map<String, String> env) {
         this.environment = env;
     }
 
-    /** set the working directory
+    /**
+     * Set the working directory.
      * @param dir The directory where the command would be executed
      */
     protected void setWorkingDirectory(File dir) {
         this.dir = dir;
     }
 
-    /** check to see if a command needs to be executed and execute if needed */
+    /**
+     * Check to see if a command needs to be executed and execute if needed.
+     */
     protected void run() throws IOException {
-        if (lastTime + interval > MathUtils.now())
+        if (lastTime + interval > MathUtils.now()) {
             return;
+        }
         exitCode = 0; // reset for next run
         runCommand();
     }
 
-    /** Run a command */
+    /**
+     * Run a command.
+     */
     private void runCommand() throws IOException {
         ProcessBuilder builder = new ProcessBuilder(getExecString());
         Timer timeOutTimer = null;
@@ -192,20 +201,26 @@ abstract public class Shell {
         }
     }
 
-    /** return an array containing the command name & its parameters */
+    /**
+     * Return an array containing the command name &amp; its parameters.
+     */
     protected abstract String[] getExecString();
 
-    /** Parse the execution result */
+    /**
+     * Parse the execution result.
+     */
     protected abstract void parseExecResult(BufferedReader lines) throws IOException;
 
-    /** get the current sub-process executing the given command
+    /**
+     * Get the current sub-process executing the given command.
      * @return process executing the command
      */
     public Process getProcess() {
         return process;
     }
 
-    /** get the exit code
+    /**
+     * Get the exit code.
      * @return the exit code of the process
      */
     public int getExitCode() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/SnapshotMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/SnapshotMap.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.util;
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,12 +15,12 @@ package org.apache.bookkeeper.util;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ConcurrentHashMap;
+package org.apache.bookkeeper.util;
 
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/StringUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/StringUtils.java
@@ -28,10 +28,10 @@ import java.io.IOException;
 public class StringUtils {
 
     // Ledger Node Prefix
-    static public final String LEDGER_NODE_PREFIX = "L";
+    public static final String LEDGER_NODE_PREFIX = "L";
 
     /**
-     * Formats ledger ID according to ZooKeeper rules
+     * Formats ledger ID according to ZooKeeper rules.
      *
      * @param id
      *            znode id
@@ -41,7 +41,7 @@ public class StringUtils {
     }
 
     /**
-     * Formats ledger ID according to ZooKeeper rules
+     * Formats ledger ID according to ZooKeeper rules.
      *
      * @param id
      *            znode id
@@ -49,9 +49,9 @@ public class StringUtils {
     public static String getZKStringIdForLongHierarchical(long id) {
         return String.format("%019d", id);
     }
-    
+
     /**
-     * Get the hierarchical ledger path according to the ledger id
+     * Get the hierarchical ledger path according to the ledger id.
      *
      * @param ledgerId
      *          ledger id
@@ -70,7 +70,7 @@ public class StringUtils {
     }
 
     /**
-     * Get the long hierarchical ledger path according to the ledger id
+     * Get the long hierarchical ledger path according to the ledger id.
      *
      * @param ledgerId
      *          ledger id
@@ -89,16 +89,16 @@ public class StringUtils {
           .append(ledgerIdStr.substring(15, 19));
         return sb.toString();
     }
-    
+
     public static String getHybridHierarchicalLedgerPath(long ledgerId) {
-        if(ledgerId < Integer.MAX_VALUE) {
+        if (ledgerId < Integer.MAX_VALUE) {
             return getShortHierarchicalLedgerPath(ledgerId);
         }
         return getLongHierarchicalLedgerPath(ledgerId);
     }
-    
+
     /**
-     * Parse the hierarchical ledger path to its ledger id
+     * Parse the hierarchical ledger path to its ledger id.
      *
      * @param hierarchicalLedgerPath
      * @return the ledger id
@@ -116,7 +116,7 @@ public class StringUtils {
     }
 
     /**
-     * Parse the long hierarchical ledger path to its ledger id
+     * Parse the long hierarchical ledger path to its ledger id.
      *
      * @param longHierarchicalLedgerPaths
      * @return the ledger id
@@ -132,9 +132,9 @@ public class StringUtils {
                 longHierarchicalParts[4].substring(LEDGER_NODE_PREFIX.length());
         return stringToHierarchicalLedgerId(longHierarchicalParts);
     }
-    
+
     /**
-     * Get ledger id
+     * Get ledger id.
      *
      * @param levelNodes
      *          level of the ledger path

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/Tool.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/Tool.java
@@ -25,13 +25,13 @@ import org.apache.commons.configuration.CompositeConfiguration;
  */
 public interface Tool {
     /**
-     * Exectue the command with given arguments
+     * Exectue the command with given arguments.
      *
      * @param args command specific arguments
      * @return exit code.
      * @throws Exception
      */
-    public int run(String[] args) throws Exception;
+    int run(String[] args) throws Exception;
 
     /**
      * Passe a configuration object to the tool.
@@ -39,5 +39,5 @@ public interface Tool {
      * @param conf configuration object
      * @throws Exception
      */
-    public void setConf(CompositeConfiguration conf) throws Exception;
+    void setConf(CompositeConfiguration conf) throws Exception;
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZeroBuffer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZeroBuffer.java
@@ -29,10 +29,10 @@ import java.nio.ByteBuffer;
  */
 
 public class ZeroBuffer {
-    static final byte zeroBytes[] = new byte[64*1024];
+    private static final byte zeroBytes[] = new byte[64 * 1024];
 
     /**
-     * fill zeros into given buffer
+     * Fill zeros into given buffer.
      * @param dst
      */
     public static void put(ByteBuffer dst) {
@@ -40,7 +40,7 @@ public class ZeroBuffer {
     }
 
     /**
-     * fill zeros into given buffer up to given length
+     * Fill zeros into given buffer up to given length.
      * @param dst
      * @param length
      */
@@ -55,7 +55,7 @@ public class ZeroBuffer {
     }
 
     /**
-     * returns read-only zero-filled buffer,
+     * Returns read-only zero-filled buffer.
      * @param length
      * @return ByteBuffer
      */
@@ -63,8 +63,7 @@ public class ZeroBuffer {
         ByteBuffer buffer;
         if (length <= zeroBytes.length) {
             buffer = ByteBuffer.wrap(zeroBytes, 0, length);
-        }
-        else {
+        } else {
             buffer = ByteBuffer.allocate(length);
             put(buffer);
             buffer.rewind();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
@@ -26,8 +26,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.bookkeeper.conf.AbstractConfiguration;
 
+import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.AsyncCallback.StringCallback;
@@ -36,8 +36,8 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +50,7 @@ public class ZkUtils {
     /**
      * Asynchronously create zookeeper path recursively and optimistically.
      *
-     * @see #createFullPathOptimistic(ZooKeeper,String,byte[],List<ACL>,CreateMode)
+     * @see #createFullPathOptimistic(ZooKeeper, String, byte[], List, CreateMode)
      *
      * @param zk
      *          Zookeeper client
@@ -113,7 +113,7 @@ public class ZkUtils {
      * it fails to delete the leafnode then it will callback with the received
      * error code, but it fails to delete the parent node for whatsoever reason
      * it stops proceeding further and it will callback with ok error code.
-     * 
+     *
      * @param zk
      *            Zookeeper client
      * @param originalPath
@@ -145,7 +145,7 @@ public class ZkUtils {
             }
         }, leafNodePath);
     }
-    
+
     /**
      * Create zookeeper path recursively and optimistically. This method can throw
      * any of the KeeperExceptions which can be thrown by ZooKeeper#create.
@@ -204,7 +204,7 @@ public class ZkUtils {
             throw KeeperException.create(Code.get(rc.get()));
         }
     }
-    
+
     private static class GetChildrenCtx {
         int rc;
         boolean done = false;
@@ -212,7 +212,7 @@ public class ZkUtils {
     }
 
     /**
-     * Sync get all children under single zk node
+     * Sync get all children under single zk node.
      *
      * @param zk
      *          zookeeper client
@@ -252,7 +252,7 @@ public class ZkUtils {
     }
 
     /**
-     * Async get direct children under single node
+     * Async get direct children under single node.
      *
      * @param zk
      *          zookeeper client
@@ -291,12 +291,12 @@ public class ZkUtils {
     }
 
     /**
-     * Compute ZooKeeper ACLs using actual configuration
+     * Compute ZooKeeper ACLs using actual configuration.
      *
      * @param conf Bookie or BookKeeper configuration
      */
     public static List<ACL> getACLs(AbstractConfiguration conf) {
-        return conf.isZkEnableSecurity() ? ZooDefs.Ids.CREATOR_ALL_ACL: ZooDefs.Ids.OPEN_ACL_UNSAFE;
+        return conf.isZkEnableSecurity() ? ZooDefs.Ids.CREATOR_ALL_ACL : ZooDefs.Ids.OPEN_ACL_UNSAFE;
     }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -23,19 +23,19 @@ package org.apache.bookkeeper.util.collections;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.Lists;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.LongFunction;
 
-import com.google.common.collect.Lists;
-
 /**
  * Map from long to an Object.
- * 
- * Provides similar methods as a ConcurrentMap<long,Object> with 2 differences:
+ *
+ * <p>Provides similar methods as a {@code ConcurrentMap<long,Object>} with 2 differences:
  * <ol>
- * <li>No boxing/unboxing from long -> Long
+ * <li>No boxing/unboxing from long -&gt; Long
  * <li>Open hash map with linear probing, no node allocations to store the values
  * </ol>
  *
@@ -182,7 +182,10 @@ public class ConcurrentLongHashMap<V> {
         return values;
     }
 
-    public static interface EntryProcessor<V> {
+    /**
+     * An entry processor.
+     */
+    public interface EntryProcessor<V> {
         void accept(long key, V value);
     }
 
@@ -484,11 +487,11 @@ public class ConcurrentLongHashMap<V> {
         return hash;
     }
 
-    static final int signSafeMod(long n, int Max) {
-        return (int) n & (Max - 1);
+    static final int signSafeMod(long n, int max) {
+        return (int) n & (max - 1);
     }
 
-    private static final int alignToPowerOfTwo(int n) {
+    private static int alignToPowerOfTwo(int n) {
         return (int) Math.pow(2, 32 - Integer.numberOfLeadingZeros(n - 1));
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
@@ -28,12 +28,12 @@ import java.util.Set;
 import java.util.concurrent.locks.StampedLock;
 
 /**
- * Concurrent hash set for primitive longs
+ * Concurrent hash set for primitive longs.
  *
- * Provides similar methods as a ConcurrentSet&lt;Long&gt; but since it's an open hash map with linear probing, no node
- * allocations are required to store the values.
- * <p>
- * Items <strong>MUST</strong> be >= 0.
+ * <p>Provides similar methods as a ConcurrentSet&lt;Long&gt; but since it's an open hash map with linear probing,
+ * no node allocations are required to store the values.
+ *
+ * <p>Items <strong>MUST</strong> be &gt;= 0.
  */
 public class ConcurrentLongHashSet {
 
@@ -47,7 +47,10 @@ public class ConcurrentLongHashSet {
 
     private final Section[] sections;
 
-    public static interface ConsumerLong {
+    /**
+     * A consumer of long values.
+     */
+    public interface ConsumerLong {
         void accept(long item);
     }
 
@@ -121,7 +124,7 @@ public class ConcurrentLongHashSet {
     }
 
     /**
-     * Remove an existing entry if found
+     * Remove an existing entry if found.
      *
      * @param item
      * @return true if removed or false if item was not present
@@ -132,7 +135,7 @@ public class ConcurrentLongHashSet {
         return getSection(h).remove(item, (int) h);
     }
 
-    private final Section getSection(long hash) {
+    private Section getSection(long hash) {
         // Use 32 msb out of long to get the section
         final int sectionIdx = (int) (hash >>> 32) & (sections.length - 1);
         return sections[sectionIdx];
@@ -398,22 +401,22 @@ public class ConcurrentLongHashSet {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static long hash(long key) {
+    static final long hash(long key) {
         long hash = key * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;
         return hash;
     }
 
-    static final int signSafeMod(long n, int Max) {
-        return (int) (n & (Max - 1));
+    static final int signSafeMod(long n, int max) {
+        return (int) (n & (max - 1));
     }
 
-    private static final int alignToPowerOfTwo(int n) {
+    private static int alignToPowerOfTwo(int n) {
         return (int) Math.pow(2, 32 - Integer.numberOfLeadingZeros(n - 1));
     }
 
-    private static final void checkBiggerEqualZero(long n) {
+    private static void checkBiggerEqualZero(long n) {
         if (n < 0L) {
             throw new IllegalArgumentException("Keys and values must be >= 0");
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
@@ -23,22 +23,22 @@ package org.apache.bookkeeper.util.collections;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.LongPredicate;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 /**
- * Concurrent hash map from primitive long to long
+ * Concurrent hash map from primitive long to long.
  *
- * Provides similar methods as a ConcurrentMap<K,V> but since it's an open hash map with linear probing, no node
- * allocations are required to store the values.
- * <p>
- * Keys <strong>MUST</strong> be >= 0.
+ * <p>Provides similar methods as a {@code ConcurrentMap<K,V>} but since it's an open hash map with linear probing,
+ * no node allocations are required to store the values.
+ *
+ * <p>Keys <strong>MUST</strong> be >= 0.
  */
 public class ConcurrentLongLongHashMap {
 
@@ -54,15 +54,24 @@ public class ConcurrentLongLongHashMap {
 
     private final Section[] sections;
 
-    public static interface BiConsumerLong {
+    /**
+     * A Long-Long BiConsumer.
+     */
+    public interface BiConsumerLong {
         void accept(long key, long value);
     }
 
-    public static interface LongLongFunction {
+    /**
+     * A Long-Long function.
+     */
+    public interface LongLongFunction {
         long apply(long key);
     }
 
-    public static interface LongLongPredicate {
+    /**
+     * A Long-Long predicate.
+     */
+    public interface LongLongPredicate {
         boolean test(long key, long value);
     }
 
@@ -193,7 +202,7 @@ public class ConcurrentLongLongHashMap {
     }
 
     /**
-     * Remove an existing entry if found
+     * Remove an existing entry if found.
      *
      * @param key
      * @return the value associated with the key or -1 if key was not present
@@ -233,7 +242,7 @@ public class ConcurrentLongLongHashMap {
         return removedCount;
     }
 
-    private final Section getSection(long hash) {
+    private Section getSection(long hash) {
         // Use 32 msb out of long to get the section
         final int sectionIdx = (int) (hash >>> 32) & (sections.length - 1);
         return sections[sectionIdx];
@@ -700,22 +709,22 @@ public class ConcurrentLongLongHashMap {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static long hash(long key) {
+    static final long hash(long key) {
         long hash = key * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;
         return hash;
     }
 
-    static final int signSafeMod(long n, int Max) {
-        return (int) (n & (Max - 1)) << 1;
+    static final int signSafeMod(long n, int max) {
+        return (int) (n & (max - 1)) << 1;
     }
 
-    private static final int alignToPowerOfTwo(int n) {
+    private static int alignToPowerOfTwo(int n) {
         return (int) Math.pow(2, 32 - Integer.numberOfLeadingZeros(n - 1));
     }
 
-    private static final void checkBiggerEqualZero(long n) {
+    private static void checkBiggerEqualZero(long n) {
         if (n < 0L) {
             throw new IllegalArgumentException("Keys and values must be >= 0");
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -22,23 +22,23 @@ package org.apache.bookkeeper.util.collections;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.StampedLock;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 /**
  * Concurrent hash map where both keys and values are composed of pairs of longs.
- * <p>
- * (long,long) --&gt; (long,long)
- * <p>
- * Provides similar methods as a ConcurrentMap<K,V> but since it's an open hash map with linear probing, no node
- * allocations are required to store the keys and values, and no boxing is required.
- * <p>
- * Keys <strong>MUST</strong> be >= 0.
+ *
+ * <p>(long,long) --&gt; (long,long)
+ *
+ * <p>Provides similar methods as a {@code ConcurrentMap<K,V>} but since it's an open hash map with linear probing,
+ * no node allocations are required to store the keys and values, and no boxing is required.
+ *
+ * <p>Keys <strong>MUST</strong> be &gt;= 0.
  */
 public class ConcurrentLongLongPairHashMap {
 
@@ -54,15 +54,24 @@ public class ConcurrentLongLongPairHashMap {
 
     private final Section[] sections;
 
-    public static interface BiConsumerLongPair {
+    /**
+     * A BiConsumer Long pair.
+     */
+    public interface BiConsumerLongPair {
         void accept(long key1, long key2, long value1, long value2);
     }
 
-    public static interface LongLongPairFunction {
+    /**
+     * A Long pair function.
+     */
+    public interface LongLongPairFunction {
         long apply(long key1, long key2);
     }
 
-    public static interface LongLongPairPredicate {
+    /**
+     * A Long pair predicate.
+     */
+    public interface LongLongPairPredicate {
         boolean test(long key1, long key2, long value1, long value2);
     }
 
@@ -153,7 +162,7 @@ public class ConcurrentLongLongPairHashMap {
     }
 
     /**
-     * Remove an existing entry if found
+     * Remove an existing entry if found.
      *
      * @param key
      * @return the value associated with the key or -1 if key was not present
@@ -171,7 +180,7 @@ public class ConcurrentLongLongPairHashMap {
         return getSection(h).remove(key1, key2, value1, value2, (int) h);
     }
 
-    private final Section getSection(long hash) {
+    private Section getSection(long hash) {
         // Use 32 msb out of long to get the section
         final int sectionIdx = (int) (hash >>> 32) & (sections.length - 1);
         return sections[sectionIdx];
@@ -491,7 +500,7 @@ public class ConcurrentLongLongPairHashMap {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static long hash(long key1, long key2) {
+    static final long hash(long key1, long key2) {
         long hash = key1 * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;
@@ -501,20 +510,23 @@ public class ConcurrentLongLongPairHashMap {
         return hash;
     }
 
-    static final int signSafeMod(long n, int Max) {
-        return (int) (n & (Max - 1)) << 2;
+    static final int signSafeMod(long n, int max) {
+        return (int) (n & (max - 1)) << 2;
     }
 
-    private static final int alignToPowerOfTwo(int n) {
+    private static int alignToPowerOfTwo(int n) {
         return (int) Math.pow(2, 32 - Integer.numberOfLeadingZeros(n - 1));
     }
 
-    private static final void checkBiggerEqualZero(long n) {
+    private static void checkBiggerEqualZero(long n) {
         if (n < 0L) {
             throw new IllegalArgumentException("Keys and values must be >= 0");
         }
     }
 
+    /**
+     * A pair of long values.
+     */
     public static class LongPair implements Comparable<LongPair> {
         public final long first;
         public final long second;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
@@ -23,6 +23,8 @@ package org.apache.bookkeeper.util.collections;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.Lists;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.StampedLock;
@@ -30,13 +32,11 @@ import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
-import com.google.common.collect.Lists;
-
 /**
- * Concurrent hash map
+ * Concurrent hash map.
  *
- * Provides similar methods as a ConcurrentMap<K,V> but since it's an open hash map with linear probing, no node
- * allocations are required to store the values
+ * <p>Provides similar methods as a {@code ConcurrentMap<K,V>} but since it's an open hash map with linear probing,
+ * no node allocations are required to store the values
  *
  * @param <V>
  */
@@ -168,7 +168,7 @@ public class ConcurrentOpenHashMap<K, V> {
         checkNotNull(filter);
 
         int removedCount = 0;
-        for (Section<K,V> s : sections) {
+        for (Section<K, V> s : sections) {
             removedCount += s.removeIf(filter);
         }
 
@@ -423,7 +423,7 @@ public class ConcurrentOpenHashMap<K, V> {
             }
         }
 
-        private final void cleanBucket(int bucket) {
+        private void cleanBucket(int bucket) {
             int nextInArray = (bucket + 2) & (table.length - 1);
             if (table[nextInArray] == EmptyKey) {
                 table[bucket] = EmptyKey;
@@ -476,18 +476,18 @@ public class ConcurrentOpenHashMap<K, V> {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static <K> long hash(K key) {
+    static final <K> long hash(K key) {
         long hash = key.hashCode() * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;
         return hash;
     }
 
-    static final int signSafeMod(long n, int Max) {
-        return (int) (n & (Max - 1)) << 1;
+    static final int signSafeMod(long n, int max) {
+        return (int) (n & (max - 1)) << 1;
     }
 
-    private static final int alignToPowerOfTwo(int n) {
+    private static int alignToPowerOfTwo(int n) {
         return (int) Math.pow(2, 32 - Integer.numberOfLeadingZeros(n - 1));
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
@@ -23,18 +23,18 @@ package org.apache.bookkeeper.util.collections;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.Lists;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 
-import com.google.common.collect.Lists;
-
 /**
- * Concurrent hash set
- * 
- * Provides similar methods as a ConcurrentMap<K,V> but since it's an open hash map with linear probing, no node
- * allocations are required to store the values
+ * Concurrent hash set.
+ *
+ * <p>Provides similar methods as a {@code ConcurrentMap<K,V>} but since it's an open hash map with linear probing,
+ * no node allocations are required to store the values
  *
  * @param <V>
  */
@@ -399,18 +399,18 @@ public class ConcurrentOpenHashSet<V> {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static <K> long hash(K key) {
+    static final <K> long hash(K key) {
         long hash = key.hashCode() * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;
         return hash;
     }
 
-    static final int signSafeMod(long n, int Max) {
-        return (int) n & (Max - 1);
+    static final int signSafeMod(long n, int max) {
+        return (int) n & (max - 1);
     }
 
-    private static final int alignToPowerOfTwo(int n) {
+    private static int alignToPowerOfTwo(int n) {
         return (int) Math.pow(2, 32 - Integer.numberOfLeadingZeros(n - 1));
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/GrowableArrayBlockingQueue.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/GrowableArrayBlockingQueue.java
@@ -36,7 +36,7 @@ import org.apache.bookkeeper.util.MathUtils;
 /**
  * This implements a {@link BlockingQueue} backed by an array with no fixed capacity.
  *
- * When the capacity is reached, data will be moved to a bigger array.
+ * <p>When the capacity is reached, data will be moved to a bigger array.
  *
  */
 public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements BlockingQueue<T> {
@@ -345,7 +345,7 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
         }
     }
 
-    final static class PaddedInt {
+    static final class PaddedInt {
         private int value;
 
         // Padding to avoid false sharing

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/RecyclableArrayList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/RecyclableArrayList.java
@@ -27,6 +27,9 @@ public final class RecyclableArrayList<T> extends ArrayList<T> {
 
     private static final int DEFAULT_INITIAL_CAPACITY = 8;
 
+    /**
+     * An ArrayList recycler.
+     */
     public static class Recycler<X>
         extends io.netty.util.Recycler<RecyclableArrayList<X>> {
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/package-info.java
@@ -1,5 +1,4 @@
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,33 +15,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-
-package org.apache.bookkeeper.util;
-
-import com.google.protobuf.ByteString;
-
-import java.io.IOException;
 
 /**
- * A String-based entry formatter.
+ * Bookkeeper collection utilities.
  */
-public class StringEntryFormatter extends EntryFormatter {
-    @Override
-    public void formatEntry(byte[] data) {
-        System.out.println(ByteString.copyFrom(data).toStringUtf8());
-    }
-
-    @Override
-    public void formatEntry(java.io.InputStream input) {
-        try {
-            byte[] data = new byte[input.available()];
-            input.read(data, 0, data.length);
-            formatEntry(data);
-        } catch (IOException ie) {
-            System.out.println("Warn: Unreadable entry : " + ie.getMessage());
-        }
-    }
-
-}
+package org.apache.bookkeeper.util.collections;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/package-info.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/package-info.java
@@ -1,5 +1,4 @@
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,33 +15,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-
-package org.apache.bookkeeper.util;
-
-import com.google.protobuf.ByteString;
-
-import java.io.IOException;
 
 /**
- * A String-based entry formatter.
+ * Bookkeeper utilities.
  */
-public class StringEntryFormatter extends EntryFormatter {
-    @Override
-    public void formatEntry(byte[] data) {
-        System.out.println(ByteString.copyFrom(data).toStringUtf8());
-    }
-
-    @Override
-    public void formatEntry(java.io.InputStream input) {
-        try {
-            byte[] data = new byte[input.available()];
-            input.read(data, 0, data.length);
-            formatEntry(data);
-        } catch (IOException ie) {
-            System.out.println("Warn: Unreadable entry : " + ie.getMessage());
-        }
-    }
-
-}
+package org.apache.bookkeeper.util;

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -22,7 +22,6 @@
     <suppress checks="JavadocPackage" files=".*[\\/]examples[\\/].*"/>
     <!-- suppress packages by packages -->
     <suppress checks=".*" files=".*[\\/]test[\\/].*"/>
-    <suppress checks=".*" files=".*[\\/]util[\\/].*"/>
 
     <!-- suppress all checks in the generated directories -->
     <suppress checks=".*" files=".+[\\/]generated[\\/].+\.java" />


### PR DESCRIPTION
Part of #230, this adds checkstyle verification to the util package in
bookkeeper-server.

A few notable changes:
  - in `util.HardLink`, the field `osType` becomes `OS_TYPE`.
  - in `util.LocalBookkeeper`, a few package-protected fields are marked private and changed to camelCase.
