### PR TITLE
Fix flake in TestPerChannelBookieClient

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -282,9 +282,10 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
         Thread.sleep(1000);
         client.disconnect();
         client.close();
-        eventLoopGroup.shutdownGracefully();
-        executor.shutdown();
 
         assertTrue("Request should have completed", completion.await(5, TimeUnit.SECONDS));
+
+        eventLoopGroup.shutdownGracefully();
+        executor.shutdown();
     }
 }


### PR DESCRIPTION
Flake is in testRequestCompletesAfterDisconnectRace. It tests a race
between disconnection and making a request. The flake occurred because
when the disconnection happened, the request would be errorred out,
and this would add a callback to the ordered executor. The test was
shutting down the executor before the callback was actually run (it
may not even have been added in some cases), and this was causing the
request to never complete, failing the test.

The fix is to move the shutdown of the executor to after the assertion
that the request has completed.
