### PR TITLE
ISSUE #230: Enable checkstyle on some test classes

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/auth/TestAuth.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/auth/TestAuth.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -47,7 +48,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+/**
+ * Test authentication.
+ */
 public class TestAuth extends BookKeeperClusterTestCase {
     static final Logger LOG = LoggerFactory.getLogger(TestAuth.class);
     public static final String TEST_AUTH_PROVIDER_PLUGIN_NAME = "TestAuthProviderPlugin";
@@ -88,7 +91,7 @@ public class TestAuth extends BookKeeperClusterTestCase {
         }
         clientConf.setClientAuthProviderFactoryClass(
                 SendUntilCompleteClientAuthProviderFactory.class.getName());
-        
+
         restartBookies();
 
         BookKeeper bkc = new BookKeeper(clientConf, zkc);
@@ -129,7 +132,7 @@ public class TestAuth extends BookKeeperClusterTestCase {
         assertFalse(ledgerId.get() == -1);
         assertEquals("Should have entry", 1, entryCount(ledgerId.get(), bookieConf, clientConf));
     }
-    
+
     @Test
     public void testCloseMethodCalledOnAuthProvider() throws Exception {
         ServerConfiguration bookieConf = newServerConfiguration();
@@ -170,18 +173,18 @@ public class TestAuth extends BookKeeperClusterTestCase {
 
     /**
      * Test that when the bookie provider sends a failure message
-     * the client will not be able to write
+     * the client will not be able to write.
      */
     @Test
     public void testSingleMessageAuthFailure() throws Exception {
         ServerConfiguration bookieConf = newServerConfiguration();
         bookieConf.setBookieAuthProviderFactoryClass(
                 AlwaysFailBookieAuthProviderFactory.class.getName());
-        
+
         ClientConfiguration clientConf = newClientConfiguration();
         clientConf.setClientAuthProviderFactoryClass(
                 SendUntilCompleteClientAuthProviderFactory.class.getName());
-        
+
         startAndStoreBookie(bookieConf);
 
         AtomicLong ledgerId = new AtomicLong(-1);
@@ -198,18 +201,18 @@ public class TestAuth extends BookKeeperClusterTestCase {
 
     /**
      * Test that authentication works when the providers
-     * exchange multiple messages
+     * exchange multiple messages.
      */
     @Test
     public void testMultiMessageAuth() throws Exception {
         ServerConfiguration bookieConf = newServerConfiguration();
         bookieConf.setBookieAuthProviderFactoryClass(
                 SucceedAfter3BookieAuthProviderFactory.class.getName());
-        
+
         ClientConfiguration clientConf = newClientConfiguration();
         clientConf.setClientAuthProviderFactoryClass(
                 SendUntilCompleteClientAuthProviderFactory.class.getName());
-        
+
         AtomicLong ledgerId = new AtomicLong(-1);
         startAndStoreBookie(bookieConf);
         connectAndWriteToBookie(clientConf, ledgerId); // should succeed
@@ -217,21 +220,21 @@ public class TestAuth extends BookKeeperClusterTestCase {
         assertFalse(ledgerId.get() == -1);
         assertEquals("Should have entry", 1, entryCount(ledgerId.get(), bookieConf, clientConf));
     }
-    
+
     /**
      * Test that when the bookie provider sends a failure message
-     * the client will not be able to write
+     * the client will not be able to write.
      */
     @Test
     public void testMultiMessageAuthFailure() throws Exception {
         ServerConfiguration bookieConf = newServerConfiguration();
         bookieConf.setBookieAuthProviderFactoryClass(
                 FailAfter3BookieAuthProviderFactory.class.getName());
-        
+
         ClientConfiguration clientConf = newClientConfiguration();
         clientConf.setClientAuthProviderFactoryClass(
                 SendUntilCompleteClientAuthProviderFactory.class.getName());
-        
+
         startAndStoreBookie(bookieConf);
 
         AtomicLong ledgerId = new AtomicLong(-1);
@@ -255,11 +258,11 @@ public class TestAuth extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = newServerConfiguration();
         bookieConf.setBookieAuthProviderFactoryClass(
                 DifferentPluginBookieAuthProviderFactory.class.getName());
-        
+
         ClientConfiguration clientConf = newClientConfiguration();
         clientConf.setClientAuthProviderFactoryClass(
                 SendUntilCompleteClientAuthProviderFactory.class.getName());
-        
+
         startAndStoreBookie(bookieConf);
         AtomicLong ledgerId = new AtomicLong(-1);
         try {
@@ -275,7 +278,7 @@ public class TestAuth extends BookKeeperClusterTestCase {
 
     /**
      * Test that when the plugin class does exist, but
-     * doesn't implement the interface, we fail predictably
+     * doesn't implement the interface, we fail predictably.
      */
     @Test
     public void testExistantButNotValidPlugin() throws Exception {
@@ -317,7 +320,7 @@ public class TestAuth extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = newServerConfiguration();
         bookieConf.setBookieAuthProviderFactoryClass(
                 "NonExistantClassNameForTestingAuthPlugins");
-        
+
         ClientConfiguration clientConf = newClientConfiguration();
         clientConf.setClientAuthProviderFactoryClass(
                 "NonExistantClassNameForTestingAuthPlugins");
@@ -349,7 +352,7 @@ public class TestAuth extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = newServerConfiguration();
         bookieConf.setBookieAuthProviderFactoryClass(
                 CrashAfter3BookieAuthProviderFactory.class.getName());
-        
+
         ClientConfiguration clientConf = newClientConfiguration();
         clientConf.setClientAuthProviderFactoryClass(
                 SendUntilCompleteClientAuthProviderFactory.class.getName());
@@ -377,7 +380,7 @@ public class TestAuth extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = newServerConfiguration();
         bookieConf.setBookieAuthProviderFactoryClass(
                 CrashType2After3BookieAuthProviderFactory.class.getName());
-        
+
         ClientConfiguration clientConf = newClientConfiguration();
         clientConf.setClientAuthProviderFactoryClass(
                 SendUntilCompleteClientAuthProviderFactory.class.getName());
@@ -396,7 +399,7 @@ public class TestAuth extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Client will try to perform authentication but bookies are not configured
+     * Client will try to perform authentication but bookies are not configured.
      */
     @Test
     public void testClientWithAuthAndBookieWithDisabledAuth() throws Exception {
@@ -417,7 +420,7 @@ public class TestAuth extends BookKeeperClusterTestCase {
     }
 
     /**
-     * The plugin will drop the connection from the bookie side
+     * The plugin will drop the connection from the bookie side.
      */
     @Test
     public void testDropConnectionFromBookieAuthPlugin() throws Exception {
@@ -446,6 +449,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
         return s;
     }
 
+    /**
+     * Factory for a bookie that always succeeds.
+     */
     public static class AlwaysSucceedBookieAuthProviderFactory
         implements BookieAuthProvider.Factory {
         @Override
@@ -488,7 +494,8 @@ public class TestAuth extends BookKeeperClusterTestCase {
         }
 
         @Override
-        public BookieAuthProvider newProvider(BookieConnectionPeer connection, AuthCallbacks.GenericCallback<Void> completeCb) {
+        public BookieAuthProvider newProvider(BookieConnectionPeer connection,
+                AuthCallbacks.GenericCallback<Void> completeCb) {
             return new BookieAuthProvider() {
                 {
                     completeCb.operationComplete(BKException.Code.OK, null);
@@ -513,6 +520,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
 
     }
 
+    /**
+     * Factory for a bookie that drops connections.
+     */
     public static class DropConnectionBookieAuthProviderFactory
         implements BookieAuthProvider.Factory {
         @Override
@@ -535,6 +545,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
         }
     }
 
+    /**
+     * Factory for a bookie that always fails.
+     */
     public static class AlwaysFailBookieAuthProviderFactory
         implements BookieAuthProvider.Factory {
         @Override
@@ -573,7 +586,8 @@ public class TestAuth extends BookKeeperClusterTestCase {
         }
 
         @Override
-        public ClientAuthProvider newProvider(ClientConnectionPeer connection, AuthCallbacks.GenericCallback<Void> completeCb) {
+        public ClientAuthProvider newProvider(ClientConnectionPeer connection,
+                AuthCallbacks.GenericCallback<Void> completeCb) {
             return new ClientAuthProvider() {
 
                 @Override
@@ -605,6 +619,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
 
     }
 
+    /**
+     * Factory for bookie that will send until complete.
+     */
     private static class SendUntilCompleteClientAuthProviderFactory
         implements ClientAuthProvider.Factory {
 
@@ -626,10 +643,10 @@ public class TestAuth extends BookKeeperClusterTestCase {
                 }
                 public void process(AuthToken m, AuthCallbacks.GenericCallback<AuthToken> cb) {
                     byte[] type = m.getData();
-                    if (Arrays.equals(type,SUCCESS_RESPONSE)) {
+                    if (Arrays.equals(type, SUCCESS_RESPONSE)) {
                         addr.setAuthorizedId(new BookKeeperPrincipal("test-client-principal"));
                         completeCb.operationComplete(BKException.Code.OK, null);
-                    } else if (Arrays.equals(type,FAILURE_RESPONSE)) {
+                    } else if (Arrays.equals(type, FAILURE_RESPONSE)) {
                         completeCb.operationComplete(BKException.Code.UnauthorizedAccessException, null);
                     } else {
                         cb.operationComplete(BKException.Code.OK, AuthToken.wrap(PAYLOAD_MESSAGE));
@@ -639,6 +656,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
         }
     }
 
+    /**
+     * Factory for bookie that succeeds after three messages.
+     */
     public static class SucceedAfter3BookieAuthProviderFactory
         implements BookieAuthProvider.Factory {
         AtomicInteger numMessages = new AtomicInteger(0);
@@ -669,6 +689,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
         }
     }
 
+    /**
+     * Factory for bookie that fails after three messages.
+     */
     public static class FailAfter3BookieAuthProviderFactory
         implements BookieAuthProvider.Factory {
         AtomicInteger numMessages = new AtomicInteger(0);
@@ -700,6 +723,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
         }
     }
 
+    /**
+     * Factory for crashing the bookie after 3 messages with an auth provider.
+     */
     public static class CrashAfter3BookieAuthProviderFactory
         implements BookieAuthProvider.Factory {
         AtomicInteger numMessages = new AtomicInteger(0);
@@ -730,6 +756,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
     }
 
     private static BookieServer crashType2bookieInstance = null;
+    /**
+     * Factory for a bookie with CrashType2 after three messages.
+     */
     public static class CrashType2After3BookieAuthProviderFactory
         implements BookieAuthProvider.Factory {
         AtomicInteger numMessages = new AtomicInteger(0);
@@ -758,6 +787,9 @@ public class TestAuth extends BookKeeperClusterTestCase {
         }
     }
 
+    /**
+     * Factory for a DifferentAuthProviderPlugin.
+     */
     public static class DifferentPluginBookieAuthProviderFactory
         implements BookieAuthProvider.Factory {
         @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadEntryListener.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadEntryListener.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestReadEntryListener extends BookKeeperClusterTestCase {
 
-    static Logger LOG = LoggerFactory.getLogger(TestReadEntryListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestReadEntryListener.class);
 
     final DigestType digestType;
     final byte[] passwd = "read-entry-listener".getBytes();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedAndEntry.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedAndEntry.java
@@ -20,7 +20,19 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import io.netty.buffer.ByteBuf;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -31,17 +43,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static com.google.common.base.Charsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
+/**
+ * Test reading the last confirmed and entry.
+ */
 public class TestReadLastConfirmedAndEntry extends BookKeeperClusterTestCase {
 
     private static final Logger logger = LoggerFactory.getLogger(TestReadLastConfirmedAndEntry.class);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedLongPoll.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedLongPoll.java
@@ -20,15 +20,18 @@ package org.apache.bookkeeper.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
+/**
+ * Test read last confirmed long by polling.
+ */
 public class TestReadLastConfirmedLongPoll extends BookKeeperClusterTestCase {
     final DigestType digestType;
 
@@ -70,9 +73,10 @@ public class TestReadLastConfirmedLongPoll extends BookKeeperClusterTestCase {
         // try read last confirmed again
         success.set(false);
         numCallbacks.set(0);
-        long entryId = readLh.getLastAddConfirmed()+1;
+        long entryId = readLh.getLastAddConfirmed() + 1;
         final CountDownLatch secondReadComplete = new CountDownLatch(1);
-        readLh.asyncReadLastConfirmedAndEntry(entryId++, 1000, true, new AsyncCallback.ReadLastConfirmedAndEntryCallback() {
+        readLh.asyncReadLastConfirmedAndEntry(entryId++, 1000, true,
+                new AsyncCallback.ReadLastConfirmedAndEntryCallback() {
             @Override
             public void readLastConfirmedAndEntryComplete(int rc, long lastConfirmed, LedgerEntry entry, Object ctx) {
                 numCallbacks.incrementAndGet();
@@ -93,7 +97,8 @@ public class TestReadLastConfirmedLongPoll extends BookKeeperClusterTestCase {
         success.set(false);
         numCallbacks.set(0);
         final CountDownLatch thirdReadComplete = new CountDownLatch(1);
-        readLh.asyncReadLastConfirmedAndEntry(entryId++, 1000, false, new AsyncCallback.ReadLastConfirmedAndEntryCallback() {
+        readLh.asyncReadLastConfirmedAndEntry(entryId++, 1000, false,
+                new AsyncCallback.ReadLastConfirmedAndEntryCallback() {
             @Override
             public void readLastConfirmedAndEntryComplete(int rc, long lastConfirmed, LedgerEntry entry, Object ctx) {
                 numCallbacks.incrementAndGet();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadTimeout.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadTimeout.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.client;
-
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,11 +18,13 @@ package org.apache.bookkeeper.client;
  * under the License.
  *
  */
+package org.apache.bookkeeper.client;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -35,11 +35,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This unit test tests ledger fencing;
+ * This unit test tests ledger fencing.
  *
  */
 public class TestReadTimeout extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(TestReadTimeout.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestReadTimeout.class);
 
     DigestType digestType;
 
@@ -64,8 +64,7 @@ public class TestReadTimeout extends BookKeeperClusterTestCase {
         Set<BookieSocketAddress> beforeSet = new HashSet<BookieSocketAddress>();
         beforeSet.addAll(writelh.getLedgerMetadata().getEnsemble(numEntries));
 
-        final BookieSocketAddress bookieToSleep
-            = writelh.getLedgerMetadata().getEnsemble(numEntries).get(0);
+        final BookieSocketAddress bookieToSleep = writelh.getLedgerMetadata().getEnsemble(numEntries).get(0);
         int sleeptime = baseClientConf.getReadTimeout() * 3;
         CountDownLatch latch = sleepBookie(bookieToSleep, sleeptime);
         latch.await();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -17,20 +17,24 @@
  */
 package org.apache.bookkeeper.client;
 
-import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.*;
+import static org.apache.bookkeeper.client.RoundRobinDistributionSchedule.writeSetFromValues;
+import static org.apache.bookkeeper.feature.SettableFeatureProvider.DISABLE_ALL;
 
-import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.netty.util.HashedWheelTimer;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import junit.framework.TestCase;
 
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -47,13 +51,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import junit.framework.TestCase;
-
-
-import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.*;
-import static org.apache.bookkeeper.client.RoundRobinDistributionSchedule.writeSetFromValues;
-import static org.apache.bookkeeper.feature.SettableFeatureProvider.DISABLE_ALL;
-
+/**
+ * Test a region-aware ensemble placement policy.
+ */
 public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
     static final Logger LOG = LoggerFactory.getLogger(TestRegionAwareEnsemblePlacementPolicy.class);
@@ -94,7 +94,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         ensemble.add(addr3);
         ensemble.add(addr4);
 
-        writeSet = writeSetFromValues(0,1,2,3);
+        writeSet = writeSetFromValues(0, 1, 2, 3);
 
         timer = new HashedWheelTimer(
                 new ThreadFactoryBuilder().setNameFormat("TestTimer-%d").build(),
@@ -190,8 +190,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         DistributionSchedule.WriteSet origWriteSet = writeSet.copy();
         DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
                 ensemble, new HashMap<BookieSocketAddress, Long>(), writeSet);
-        DistributionSchedule.WriteSet expectedSet
-            = writeSetFromValues(3, 1, 2, 0);
+        DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 1, 2, 0);
         LOG.info("reorder set : {}", reorderSet);
         assertFalse(reorderSet.equals(origWriteSet));
         assertEquals(expectedSet, reorderSet);
@@ -220,8 +219,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         DistributionSchedule.WriteSet origWriteSet = writeSet.copy();
         DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
                 ensemble, new HashMap<BookieSocketAddress, Long>(), writeSet);
-        DistributionSchedule.WriteSet expectedSet
-            = writeSetFromValues(3, 1, 2, 0);
+        DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 1, 2, 0);
         LOG.info("reorder set : {}", reorderSet);
         assertFalse(reorderSet.equals(origWriteSet));
         assertEquals(expectedSet, reorderSet);
@@ -249,8 +247,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         DistributionSchedule.WriteSet origWriteSet = writeSet.copy();
         DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
                 ensemble, new HashMap<BookieSocketAddress, Long>(), writeSet);
-        DistributionSchedule.WriteSet expectedSet
-            = writeSetFromValues(3, 2, 0, 1);
+        DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 2, 0, 1);
         LOG.info("reorder set : {}", reorderSet);
         assertFalse(reorderSet.equals(origWriteSet));
         assertEquals(expectedSet, reorderSet);
@@ -275,7 +272,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         addrs.add(addr4);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         // replace node under r2
-        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<BookieSocketAddress>(), addr2, new HashSet<BookieSocketAddress>());
+        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<BookieSocketAddress>(),
+                addr2, new HashSet<BookieSocketAddress>());
         assertEquals(addr3, replacedBookie);
     }
 
@@ -300,7 +298,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         // replace node under r2
         Set<BookieSocketAddress> excludedAddrs = new HashSet<BookieSocketAddress>();
         excludedAddrs.add(addr1);
-        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<BookieSocketAddress>(), addr2, excludedAddrs);
+        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null,
+                new HashSet<BookieSocketAddress>(), addr2, excludedAddrs);
 
         assertFalse(addr1.equals(replacedBookie));
         assertTrue(addr3.equals(replacedBookie) || addr4.equals(replacedBookie));
@@ -386,9 +385,11 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         addrs.add(addr4);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null,
+                    new HashSet<BookieSocketAddress>());
             assertEquals(0, getNumCoveredRegionsInWriteQuorum(ensemble, 2));
-            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null,
+                    new HashSet<BookieSocketAddress>());
             assertEquals(0, getNumCoveredRegionsInWriteQuorum(ensemble2, 2));
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
@@ -417,7 +418,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         addrs.add(addr4);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null,
+                    new HashSet<BookieSocketAddress>());
             int numCovered = getNumCoveredRegionsInWriteQuorum(ensemble, 2);
             assertTrue(numCovered >= 1);
             assertTrue(numCovered < 3);
@@ -425,7 +427,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             fail("Should not get not enough bookies exception even there is only one rack.");
         }
         try {
-            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null,
+                    new HashSet<BookieSocketAddress>());
             int numCovered = getNumCoveredRegionsInWriteQuorum(ensemble2, 2);
             assertTrue(numCovered >= 1 && numCovered < 3);
         } catch (BKNotEnoughBookiesException bnebe) {
@@ -464,9 +467,11 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         addrs.add(addr8);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble1 = repp.newEnsemble(3, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble1 = repp.newEnsemble(3, 2, 2, null,
+                    new HashSet<BookieSocketAddress>());
             assertEquals(3, getNumCoveredRegionsInWriteQuorum(ensemble1, 2));
-            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null,
+                    new HashSet<BookieSocketAddress>());
             assertEquals(4, getNumCoveredRegionsInWriteQuorum(ensemble2, 2));
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
@@ -513,7 +518,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         addrs.add(addr10);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(6, 6, 4, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(6, 6, 4, null,
+                    new HashSet<BookieSocketAddress>());
             assert(ensemble.contains(addr4));
             assert(ensemble.contains(addr8));
             assert(ensemble.size() == 6);
@@ -581,7 +587,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
             ((SettableFeature) featureProvider.scope("region1").getFeature("disallowBookies")).set(true);
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(6, 6, 4, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(6, 6, 4, null,
+                    new HashSet<BookieSocketAddress>());
             assertEquals(2, getNumRegionsInEnsemble(ensemble));
             assert(ensemble.contains(addr1));
             assert(ensemble.contains(addr3));
@@ -595,14 +602,16 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         }
         try {
             ((SettableFeature) featureProvider.scope("region2").getFeature("disallowBookies")).set(true);
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(6, 6, 4, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(6, 6, 4, null,
+                    new HashSet<BookieSocketAddress>());
             fail("Should get not enough bookies exception even there is only one region with insufficient bookies.");
         } catch (BKNotEnoughBookiesException bnebe) {
             // Expected
         }
         try {
             ((SettableFeature) featureProvider.scope("region2").getFeature("disallowBookies")).set(false);
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(6, 6, 4, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(6, 6, 4, null,
+                    new HashSet<BookieSocketAddress>());
             assert(ensemble.contains(addr1));
             assert(ensemble.contains(addr3));
             assert(ensemble.contains(addr4));
@@ -675,7 +684,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
 
         try {
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(10, 10, 10, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(10, 10, 10, null,
+                    new HashSet<BookieSocketAddress>());
             assert(ensemble.size() == 10);
             assertEquals(5, getNumRegionsInEnsemble(ensemble));
         } catch (BKNotEnoughBookiesException bnebe) {
@@ -683,7 +693,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             fail("Should not get not enough bookies exception even there is only one rack.");
         }
 
-        try{
+        try {
             Set<BookieSocketAddress> excludedAddrs = new HashSet<BookieSocketAddress>();
             excludedAddrs.add(addr10);
             ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(10, 10, 10, null, excludedAddrs);
@@ -715,7 +725,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         testEnsembleWithThreeRegionsReplaceInternal(1, true, false);
     }
 
-    public void testEnsembleWithThreeRegionsReplaceInternal(int minDurability, boolean disableDurability, boolean disableOneRegion) throws Exception {
+    public void testEnsembleWithThreeRegionsReplaceInternal(int minDurability, boolean disableDurability,
+            boolean disableOneRegion) throws Exception {
         repp.uninitalize();
         repp = new RegionAwareEnsemblePlacementPolicy();
         conf.setProperty(REPP_REGIONS_TO_WRITE, "region1;region2;region3");
@@ -796,9 +807,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             region1And3Bookies.removeAll(region2Bookies);
 
             Set<BookieSocketAddress> excludedAddrs = new HashSet<BookieSocketAddress>();
-            for(BookieSocketAddress addr: region2Bookies) {
+            for (BookieSocketAddress addr: region2Bookies) {
                 if (ensemble.contains(addr)) {
-                    BookieSocketAddress replacedBookie = repp.replaceBookie(6, 6, ackQuorum, null, ensemble, addr, excludedAddrs);
+                    BookieSocketAddress replacedBookie = repp.replaceBookie(6, 6, ackQuorum, null, ensemble,
+                            addr, excludedAddrs);
                     ensemble.remove(addr);
                     ensemble.add(replacedBookie);
                 }
@@ -822,7 +834,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             Set<BookieSocketAddress> excludedAddrs = new HashSet<BookieSocketAddress>();
 
             try {
-                BookieSocketAddress replacedBookie = repp.replaceBookie(6, 6, ackQuorum, null, ensemble, bookieToReplace, excludedAddrs);
+                BookieSocketAddress replacedBookie = repp.replaceBookie(6, 6, ackQuorum, null, ensemble,
+                        bookieToReplace, excludedAddrs);
                 assert (replacedBookie.equals(replacedBookieExpected));
                 assertEquals(3, getNumRegionsInEnsemble(ensemble));
             } catch (BKNotEnoughBookiesException bnebe) {
@@ -831,7 +844,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
             excludedAddrs.add(replacedBookieExpected);
             try {
-                BookieSocketAddress replacedBookie = repp.replaceBookie(6, 6, ackQuorum, null, ensemble, bookieToReplace, excludedAddrs);
+                BookieSocketAddress replacedBookie = repp.replaceBookie(6, 6, ackQuorum, null, ensemble,
+                        bookieToReplace, excludedAddrs);
                 if (minDurability > 1 && !disableDurabilityFeature.isAvailable()) {
                     fail("Should throw BKNotEnoughBookiesException when there is not enough bookies");
                 }
@@ -900,7 +914,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
 
         if (disableDurability) {
-            ((SettableFeature) featureProvider.getFeature(BookKeeperConstants.FEATURE_REPP_DISABLE_DURABILITY_ENFORCEMENT))
+            ((SettableFeature) featureProvider.getFeature(
+                BookKeeperConstants.FEATURE_REPP_DISABLE_DURABILITY_ENFORCEMENT))
                     .set(true);
         }
 
@@ -916,7 +931,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
         Set<BookieSocketAddress> excludedAddrs = new HashSet<BookieSocketAddress>();
 
-        try{
+        try {
             repp.replaceBookie(6, 6, 4, null, ensemble, addr4, excludedAddrs);
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
@@ -1203,7 +1218,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
     private int getNumRegionsInEnsemble(ArrayList<BookieSocketAddress> ensemble) {
         Set<String> regions = new HashSet<String>();
-        for(BookieSocketAddress addr: ensemble) {
+        for (BookieSocketAddress addr: ensemble) {
             regions.add(StaticDNSResolver.getRegion(addr.getHostName()));
         }
         return regions.size();
@@ -1249,8 +1264,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         ensemble.add(addr7);
         ensemble.add(addr8);
 
-        DistributionSchedule.WriteSet writeSet2
-            = writeSetFromValues(0,1,2,3,4,5,6,7);
+        DistributionSchedule.WriteSet writeSet2 = writeSetFromValues(0, 1, 2, 3, 4, 5, 6, 7);
 
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSequenceRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSequenceRead.java
@@ -23,8 +23,11 @@ package org.apache.bookkeeper.client;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.CountDownLatch;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
@@ -33,15 +36,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-
 /**
  * Test reading an entry from replicas in sequence way.
  */
 public class TestSequenceRead extends BookKeeperClusterTestCase {
 
-    static final Logger logger = LoggerFactory.getLogger(TestSequenceRead.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestSequenceRead.class);
 
     final DigestType digestType;
     final byte[] passwd = "sequence-read".getBytes();
@@ -67,13 +67,15 @@ public class TestSequenceRead extends BookKeeperClusterTestCase {
         lh.getLedgerMetadata().setEnsembles(newEnsembles);
         // update the ledger metadata with duplicated bookies
         final CountDownLatch latch = new CountDownLatch(1);
-        bkc.getLedgerManager().writeLedgerMetadata(lh.getId(), lh.getLedgerMetadata(), new BookkeeperInternalCallbacks.GenericCallback<Void>() {
+        bkc.getLedgerManager().writeLedgerMetadata(lh.getId(), lh.getLedgerMetadata(),
+                new BookkeeperInternalCallbacks.GenericCallback<Void>() {
             @Override
             public void operationComplete(int rc, Void result) {
                 if (BKException.Code.OK == rc) {
                     latch.countDown();
                 } else {
-                    logger.error("Error on writing ledger metadata for ledger {} : ", lh.getId(), BKException.getMessage(rc));
+                    logger.error("Error on writing ledger metadata for ledger {} : ", lh.getId(),
+                            BKException.getMessage(rc));
                 }
             }
         });

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
@@ -29,9 +29,10 @@ import java.util.BitSet;
 import java.util.Enumeration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.apache.bookkeeper.conf.ClientConfiguration;
+
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
@@ -39,11 +40,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This unit test tests ledger fencing;
+ * This unit test tests ledger fencing.
  *
  */
 public class TestSpeculativeRead extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(TestSpeculativeRead.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestSpeculativeRead.class);
 
     private final DigestType digestType;
     byte[] passwd = "specPW".getBytes();
@@ -120,7 +121,7 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
      */
     @Test
     public void testSpeculativeRead() throws Exception {
-        long id = getLedgerToRead(3,2);
+        long id = getLedgerToRead(3, 2);
         BookKeeper bknospec = createClient(0); // disabled
         BookKeeper bkspec = createClient(2000);
 
@@ -164,7 +165,7 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
      */
     @Test
     public void testSpeculativeReadMultipleReplicasDown() throws Exception {
-        long id = getLedgerToRead(5,5);
+        long id = getLedgerToRead(5, 5);
         int timeout = 5000;
         BookKeeper bkspec = createClient(timeout);
 
@@ -181,46 +182,46 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
             // as bookie 0 has the entry
             LatchCallback latch0 = new LatchCallback();
             l.asyncReadEntries(0, 0, latch0, null);
-            latch0.expectSuccess(timeout/2);
+            latch0.expectSuccess(timeout / 2);
 
             // second should have to hit two timeouts (bookie 1 & 2)
             // bookie 3 has the entry
             LatchCallback latch1 = new LatchCallback();
             l.asyncReadEntries(1, 1, latch1, null);
             latch1.expectTimeout(timeout);
-            latch1.expectSuccess(timeout*2);
+            latch1.expectSuccess(timeout * 2);
             LOG.info("Timeout {} latch1 duration {}", timeout, latch1.getDuration());
             assertTrue("should have taken longer than two timeouts, but less than 3",
-                       latch1.getDuration() >= timeout*2
-                       && latch1.getDuration() < timeout*3);
+                       latch1.getDuration() >= timeout * 2
+                       && latch1.getDuration() < timeout * 3);
 
             // third should have to hit one timeouts (bookie 2)
             // bookie 3 has the entry
             LatchCallback latch2 = new LatchCallback();
             l.asyncReadEntries(2, 2, latch2, null);
-            latch2.expectTimeout(timeout/2);
+            latch2.expectTimeout(timeout / 2);
             latch2.expectSuccess(timeout);
             LOG.info("Timeout {} latch2 duration {}", timeout, latch2.getDuration());
             assertTrue("should have taken longer than one timeout, but less than 2",
                        latch2.getDuration() >= timeout
-                       && latch2.getDuration() < timeout*2);
+                       && latch2.getDuration() < timeout * 2);
 
             // fourth should have no timeout
             // bookie 3 has the entry
             LatchCallback latch3 = new LatchCallback();
             l.asyncReadEntries(3, 3, latch3, null);
-            latch3.expectSuccess(timeout/2);
+            latch3.expectSuccess(timeout / 2);
 
             // fifth should hit one timeout, (bookie 4)
             // bookie 0 has the entry
             LatchCallback latch4 = new LatchCallback();
             l.asyncReadEntries(4, 4, latch4, null);
-            latch4.expectTimeout(timeout/2);
+            latch4.expectTimeout(timeout / 2);
             latch4.expectSuccess(timeout);
             LOG.info("Timeout {} latch4 duration {}", timeout, latch4.getDuration());
             assertTrue("should have taken longer than one timeout, but less than 2",
                        latch4.getDuration() >= timeout
-                       && latch4.getDuration() < timeout*2);
+                       && latch4.getDuration() < timeout * 2);
 
         } finally {
             sleepLatch.countDown();
@@ -235,7 +236,7 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
      */
     @Test
     public void testSpeculativeReadFirstReadCompleteIsOk() throws Exception {
-        long id = getLedgerToRead(2,2);
+        long id = getLedgerToRead(2, 2);
         int timeout = 1000;
         BookKeeper bkspec = createClient(timeout);
 
@@ -256,14 +257,14 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
 
             // wake up first bookie
             sleepLatch0.countDown();
-            latch0.expectSuccess(timeout/2);
+            latch0.expectSuccess(timeout / 2);
 
             sleepLatch1.countDown();
 
             // check we can read next entry without issue
             LatchCallback latch1 = new LatchCallback();
             l.asyncReadEntries(1, 1, latch1, null);
-            latch1.expectSuccess(timeout/2);
+            latch1.expectSuccess(timeout / 2);
 
         } finally {
             sleepLatch0.countDown();
@@ -274,11 +275,11 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Unit test for the speculative read scheduling method
+     * Unit test for the speculative read scheduling method.
      */
     @Test
     public void testSpeculativeReadScheduling() throws Exception {
-        long id = getLedgerToRead(3,2);
+        long id = getLedgerToRead(3, 2);
         int timeout = 1000;
         BookKeeper bkspec = createClient(timeout);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestTryReadLastConfirmed.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestTryReadLastConfirmed.java
@@ -17,6 +17,15 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
@@ -24,16 +33,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.junit.Assert.*;
-
+/**
+ * Test try read last confirmed.
+ */
 public class TestTryReadLastConfirmed extends BookKeeperClusterTestCase {
 
-    static final Logger logger = LoggerFactory.getLogger(TestTryReadLastConfirmed.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestTryReadLastConfirmed.class);
 
     final DigestType digestType;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWatchEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWatchEnsembleChange.java
@@ -20,6 +20,16 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.meta.FlatLedgerManagerFactory;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
@@ -39,23 +49,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.*;
-
+/**
+ * Test an EnsembleChange watcher.
+ */
 @RunWith(Parameterized.class)
 public class TestWatchEnsembleChange extends BookKeeperClusterTestCase {
 
-    static Logger LOG = LoggerFactory.getLogger(TestWatchEnsembleChange.class);
+    static final Logger LOG = LoggerFactory.getLogger(TestWatchEnsembleChange.class);
 
     final DigestType digestType;
     final Class<? extends LedgerManagerFactory> lmFactoryCls;
@@ -82,7 +85,7 @@ public class TestWatchEnsembleChange extends BookKeeperClusterTestCase {
     public void testWatchEnsembleChange() throws Exception {
         int numEntries = 10;
         LedgerHandle lh = bkc.createLedger(3, 3, 3, digestType, "".getBytes());
-        for (int i=0; i<numEntries; i++) {
+        for (int i = 0; i < numEntries; i++) {
             lh.addEntry(("data" + i).getBytes());
             LOG.info("Added entry {}.", i);
         }
@@ -95,7 +98,7 @@ public class TestWatchEnsembleChange extends BookKeeperClusterTestCase {
             killBookie(addr);
         }
         // write another batch of entries, which will trigger ensemble change
-        for (int i=0; i<numEntries; i++) {
+        for (int i = 0; i < numEntries; i++) {
             lh.addEntry(("data" + (numEntries + i)).getBytes());
             LOG.info("Added entry {}.", (numEntries + i));
         }
@@ -137,18 +140,18 @@ public class TestWatchEnsembleChange extends BookKeeperClusterTestCase {
         assertTrue(createLatch.await(2000, TimeUnit.MILLISECONDS));
         final long createdLid = bbLedgerId.getLong();
 
-        manager.registerLedgerMetadataListener( createdLid,
+        manager.registerLedgerMetadataListener(createdLid,
                 new LedgerMetadataListener() {
 
             @Override
-            public void onChanged( long ledgerId, LedgerMetadata metadata ) {
+            public void onChanged(long ledgerId, LedgerMetadata metadata) {
                 assertEquals(ledgerId, createdLid);
                 assertEquals(metadata, null);
                 removeLatch.countDown();
             }
         });
 
-        manager.removeLedgerMetadata( createdLid, Version.ANY,
+        manager.removeLedgerMetadata(createdLid, Version.ANY,
                 new BookkeeperInternalCallbacks.GenericCallback<Void>() {
 
             @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWeightedRandomSelection.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWeightedRandomSelection.java
@@ -18,7 +18,7 @@
 
 package org.apache.bookkeeper.client;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,6 +35,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test weighted random selection methods.
+ */
 public class TestWeightedRandomSelection {
 
     static final Logger LOG = LoggerFactory.getLogger(TestWeightedRandomSelection.class);
@@ -67,10 +70,10 @@ public class TestWeightedRandomSelection {
     public void testSelectionWithEqualWeights() throws Exception {
         Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
 
-        Long val=100L;
-        int numKeys = 50,  totalTries = 1000000;
+        Long val = 100L;
+        int numKeys = 50, totalTries = 1000000;
         Map<String, Integer> randomSelection = new HashMap<String, Integer>();
-        for (Integer i=0; i < numKeys; i++) {
+        for (Integer i = 0; i < numKeys; i++) {
             map.put(i.toString(), new TestObj(val));
             randomSelection.put(i.toString(), 0);
         }
@@ -78,15 +81,16 @@ public class TestWeightedRandomSelection {
         wRS.updateMap(map);
         for (int i = 0; i < totalTries; i++) {
             String key = wRS.getNextRandom();
-            randomSelection.put(key, randomSelection.get(key)+1);
+            randomSelection.put(key, randomSelection.get(key) + 1);
         }
 
         // there should be uniform distribution
-        double expectedPct = ((double)1/(double)numKeys)*100;
+        double expectedPct = ((double) 1 / (double) numKeys) * 100;
         for (Map.Entry<String, Integer> e : randomSelection.entrySet()) {
-            double actualPct = ((double)e.getValue()/(double)totalTries)*100;
-            double delta = (Math.abs(expectedPct-actualPct)/expectedPct)*100;
-            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue() + " Expected: " + expectedPct + " Actual: " + actualPct);
+            double actualPct = ((double) e.getValue() / (double) totalTries) * 100;
+            double delta = (Math.abs(expectedPct - actualPct) / expectedPct) * 100;
+            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue() + " Expected: " + expectedPct
+                    + " Actual: " + actualPct);
             // should be within 5% of expected
             assertTrue("Not doing uniform selection when weights are equal", delta < 5);
         }
@@ -96,9 +100,9 @@ public class TestWeightedRandomSelection {
     public void testSelectionWithAllZeroWeights() throws Exception {
         Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
 
-        int numKeys = 50,  totalTries = 1000000;
+        int numKeys = 50, totalTries = 1000000;
         Map<String, Integer> randomSelection = new HashMap<String, Integer>();
-        for (Integer i=0; i < numKeys; i++) {
+        for (Integer i = 0; i < numKeys; i++) {
             map.put(i.toString(), new TestObj(0L));
             randomSelection.put(i.toString(), 0);
         }
@@ -106,15 +110,16 @@ public class TestWeightedRandomSelection {
         wRS.updateMap(map);
         for (int i = 0; i < totalTries; i++) {
             String key = wRS.getNextRandom();
-            randomSelection.put(key, randomSelection.get(key)+1);
+            randomSelection.put(key, randomSelection.get(key) + 1);
         }
 
         // when all the values are zeros, there should be uniform distribution
-        double expectedPct = ((double)1/(double)numKeys)*100;
+        double expectedPct = ((double) 1 / (double) numKeys) * 100;
         for (Map.Entry<String, Integer> e : randomSelection.entrySet()) {
-            double actualPct = ((double)e.getValue()/(double)totalTries)*100;
-            double delta = (Math.abs(expectedPct-actualPct)/expectedPct)*100;
-            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue() + " Expected: " + expectedPct + " Actual: " + actualPct);
+            double actualPct = ((double) e.getValue() / (double) totalTries) * 100;
+            double delta = (Math.abs(expectedPct - actualPct) / expectedPct) * 100;
+            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue() + " Expected: " + expectedPct
+                    + " Actual: " + actualPct);
             // should be within 5% of expected
             assertTrue("Not doing uniform selection when weights are equal", delta < 5);
         }
@@ -125,36 +130,36 @@ public class TestWeightedRandomSelection {
         List<Integer> values = new ArrayList<Integer>(randomSelection.values());
         Collections.sort(values);
         double medianObserved, medianObservedWeight, medianExpectedWeight;
-        int mid = values.size()/2;
+        int mid = values.size() / 2;
         if ((values.size() % 2) == 1) {
             medianObserved = values.get(mid);
         } else {
-            medianObserved = (double)(values.get(mid-1) + values.get(mid))/2;
+            medianObserved = (double) (values.get(mid - 1) + values.get(mid)) / 2;
         }
 
-        medianObservedWeight = (double)medianObserved/(double)totalTries;
-        medianExpectedWeight = (double)medianWeight/totalWeight;
+        medianObservedWeight = (double) medianObserved / (double) totalTries;
+        medianExpectedWeight = (double) medianWeight / totalWeight;
 
         for (Map.Entry<String, Integer> e : randomSelection.entrySet()) {
-            double observed = (((double)e.getValue()/(double)totalTries));
+            double observed = (((double) e.getValue() / (double) totalTries));
 
             double expected;
             if (map.get(e.getKey()).getWeight() == 0) {
                 // if the value is 0 for any key, we make it equal to the first non zero value
-                expected = (double)minWeight/(double)totalWeight;
+                expected = (double) minWeight / (double) totalWeight;
             } else {
-                expected = (double)map.get(e.getKey()).getWeight()/(double)totalWeight;
+                expected = (double) map.get(e.getKey()).getWeight() / (double) totalWeight;
             }
-            if (multiplier > 0 && expected > multiplier*medianExpectedWeight) {
-                expected = multiplier*medianExpectedWeight;
+            if (multiplier > 0 && expected > multiplier * medianExpectedWeight) {
+                expected = multiplier * medianExpectedWeight;
             }
             // We can't compare these weights because they are derived from different
             // values. But if we express them as a multiple of the min in each, then
             // they should be comparable
-            double expectedMultiple = expected/medianExpectedWeight;
-            double observedMultiple = observed/medianObservedWeight;
-            double delta = (Math.abs(expectedMultiple-observedMultiple)/expectedMultiple)*100;
-            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue() 
+            double expectedMultiple = expected / medianExpectedWeight;
+            double observedMultiple = observed / medianObservedWeight;
+            double delta = (Math.abs(expectedMultiple - observedMultiple) / expectedMultiple) * 100;
+            System.out.println("Key:" + e.getKey() + " Value:" + e.getValue()
                     + " Expected " + expectedMultiple + " actual " + observedMultiple + " delta " + delta + "%");
 
             // the observed should be within 5% of expected
@@ -167,16 +172,16 @@ public class TestWeightedRandomSelection {
         Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
         Map<String, Integer> randomSelection = new HashMap<String, Integer>();
         int numKeys = 50;
-        multiplier=3;
-        long val=0L, total=0L, minWeight = 100L, medianWeight=minWeight;
+        multiplier = 3;
+        long val = 0L, total = 0L, minWeight = 100L, medianWeight = minWeight;
         wRS.setMaxProbabilityMultiplier(multiplier);
-        for (Integer i=0; i < numKeys; i++) {
-            if (i < numKeys/3) {
+        for (Integer i = 0; i < numKeys; i++) {
+            if (i < numKeys / 3) {
                 val = 0L;
-            } else if (i < 2*(numKeys/3)){
+            } else if (i < 2 * (numKeys / 3)){
                 val = minWeight;
             } else {
-                val = 2*minWeight;
+                val = 2 * minWeight;
             }
             total += val;
             map.put(i.toString(), new TestObj(val));
@@ -187,7 +192,7 @@ public class TestWeightedRandomSelection {
         int totalTries = 10000000;
         for (int i = 0; i < totalTries; i++) {
             String key = wRS.getNextRandom();
-            randomSelection.put(key, randomSelection.get(key)+1);
+            randomSelection.put(key, randomSelection.get(key) + 1);
         }
         verifyResult(map, randomSelection, multiplier, minWeight, medianWeight, total, totalTries);
     }
@@ -197,16 +202,16 @@ public class TestWeightedRandomSelection {
         Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
         Map<String, Integer> randomSelection = new HashMap<String, Integer>();
         int numKeys = 50;
-        multiplier=4;
-        long val=0L, total=0L, minWeight=100L, medianWeight=2*minWeight;
+        multiplier = 4;
+        long val = 0L, total = 0L, minWeight = 100L, medianWeight = 2 * minWeight;
         wRS.setMaxProbabilityMultiplier(multiplier);
-        for (Integer i=0; i < numKeys; i++) {
-            if (i < numKeys/3) {
+        for (Integer i = 0; i < numKeys; i++) {
+            if (i < numKeys / 3) {
                 val = minWeight;
-            } else if (i < 2*(numKeys/3)){
-                val = 2*minWeight;
+            } else if (i < 2 * (numKeys / 3)){
+                val = 2 * minWeight;
             } else {
-                val = 10*minWeight;
+                val = 10 * minWeight;
             }
             total += val;
             map.put(i.toString(), new TestObj(val));
@@ -217,7 +222,7 @@ public class TestWeightedRandomSelection {
         int totalTries = 10000000;
         for (int i = 0; i < totalTries; i++) {
             String key = wRS.getNextRandom();
-            randomSelection.put(key, randomSelection.get(key)+1);
+            randomSelection.put(key, randomSelection.get(key) + 1);
         }
         verifyResult(map, randomSelection, multiplier, minWeight, medianWeight, total, totalTries);
     }
@@ -227,14 +232,14 @@ public class TestWeightedRandomSelection {
         Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
         Map<String, Integer> randomSelection = new HashMap<String, Integer>();
 
-        multiplier=3; // no max
+        multiplier = 3; // no max
         int numKeys = 50;
-        long total=0L, minWeight = 100L, val = minWeight, medianWeight=minWeight;
+        long total = 0L, minWeight = 100L, val = minWeight, medianWeight = minWeight;
         wRS.setMaxProbabilityMultiplier(multiplier);
-        for (Integer i=0; i < numKeys; i++) {
-            if (i == numKeys-1) {
+        for (Integer i = 0; i < numKeys; i++) {
+            if (i == numKeys - 1) {
                 // last one has 10X more weight than the rest put together
-                val=10*(numKeys-1)*100L;
+                val = 10 * (numKeys - 1) * 100L;
             }
             total += val;
             map.put(i.toString(), new TestObj(val));
@@ -245,7 +250,7 @@ public class TestWeightedRandomSelection {
         int totalTries = 10000000;
         for (int i = 0; i < totalTries; i++) {
             String key = wRS.getNextRandom();
-            randomSelection.put(key, randomSelection.get(key)+1);
+            randomSelection.put(key, randomSelection.get(key) + 1);
         }
         verifyResult(map, randomSelection, multiplier, minWeight, medianWeight, total, totalTries);
     }
@@ -255,14 +260,14 @@ public class TestWeightedRandomSelection {
         Map<String, WeightedObject> map = new HashMap<String, WeightedObject>();
         Map<String, Integer> randomSelection = new HashMap<String, Integer>();
 
-        multiplier=3; // limit the max load on hot node to be 3X
+        multiplier = 3; // limit the max load on hot node to be 3X
         int numKeys = 50;
-        long total=0L, minWeight = 100L, val = minWeight, medianWeight=minWeight;
+        long total = 0L, minWeight = 100L, val = minWeight, medianWeight = minWeight;
         wRS.setMaxProbabilityMultiplier(multiplier);
-        for (Integer i=0; i < numKeys; i++) {
-            if (i == numKeys-1) {
+        for (Integer i = 0; i < numKeys; i++) {
+            if (i == numKeys - 1) {
                 // last one has 10X more weight than the rest put together
-                val=10*(numKeys-1)*100L;
+                val = 10 * (numKeys - 1) * 100L;
             }
             total += val;
             map.put(i.toString(), new TestObj(val));
@@ -273,7 +278,7 @@ public class TestWeightedRandomSelection {
         int totalTries = 10000000;
         for (int i = 0; i < totalTries; i++) {
             String key = wRS.getNextRandom();
-            randomSelection.put(key, randomSelection.get(key)+1);
+            randomSelection.put(key, randomSelection.get(key) + 1);
         }
         verifyResult(map, randomSelection, multiplier, minWeight, medianWeight, total, totalTries);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerCmdTest.java
@@ -20,6 +20,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -27,8 +29,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Assert;
 
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieShell;
@@ -42,9 +42,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test an update command on a ledger.
+ */
 public class UpdateLedgerCmdTest extends BookKeeperClusterTestCase {
 
-    private final static Logger LOG = LoggerFactory.getLogger(UpdateLedgerCmdTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateLedgerCmdTest.class);
     private DigestType digestType = DigestType.CRC32;
     private static final String PASSWORD = "testPasswd";
 
@@ -55,7 +58,7 @@ public class UpdateLedgerCmdTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * updateledgers to hostname
+     * updateledgers to hostname.
      */
     @Test
     public void testUpdateLedgersToHostname() throws Exception {
@@ -78,7 +81,7 @@ public class UpdateLedgerCmdTest extends BookKeeperClusterTestCase {
         updateLedgerCmd(argv, 0, conf);
 
         int updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
-        Assert.assertEquals("Failed to update the ledger metadata to use bookie host name", 40, updatedLedgersCount);
+        assertEquals("Failed to update the ledger metadata to use bookie host name", 40, updatedLedgersCount);
     }
 
     private void updateLedgerCmd(String[] argv, int exitCode, ServerConfiguration conf) throws KeeperException,
@@ -87,7 +90,7 @@ public class UpdateLedgerCmdTest extends BookKeeperClusterTestCase {
         BookieShell bkShell = new BookieShell();
         bkShell.setConf(conf);
 
-        Assert.assertEquals("Failed to return exit code!", exitCode, bkShell.run(argv));
+        assertEquals("Failed to return exit code!", exitCode, bkShell.run(argv));
     }
 
     private int getUpdatedLedgersCount(BookKeeper bk, List<LedgerHandle> ledgers, BookieSocketAddress toBookieAddr)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
@@ -20,6 +20,11 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -35,11 +40,13 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.MathUtils;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test update operations on a ledger.
+ */
 public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
     private static final Logger LOG = LoggerFactory.getLogger(UpdateLedgerOpTest.class);
     private DigestType digestType = DigestType.CRC32;
@@ -97,9 +104,9 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
             lh.close();
             LedgerHandle openLedger = bk.openLedger(lh.getId(), digestType, PASSWORD.getBytes());
             ensemble = openLedger.getLedgerMetadata().getEnsemble(0);
-            Assert.assertTrue("Failed to update the ledger metadata to use bookie host name",
+            assertTrue("Failed to update the ledger metadata to use bookie host name",
                     ensemble.contains(toBookieAddr));
-            Assert.assertFalse("Failed to update the ledger metadata to use bookie host name",
+            assertFalse("Failed to update the ledger metadata to use bookie host name",
                     ensemble.contains(curBookieAddr));
         }
     }
@@ -130,27 +137,27 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
         UpdateLedgerOp updateLedgerOp = new UpdateLedgerOp(bk, bkadmin);
         updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 7, 4, progressable);
         int updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
-        Assert.assertEquals("Failed to update the ledger metadata to use bookie host name", 4, updatedLedgersCount);
+        assertEquals("Failed to update the ledger metadata to use bookie host name", 4, updatedLedgersCount);
 
         // next execution
         updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 2, 10, progressable);
         updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
-        Assert.assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
+        assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
 
         // no ledgers
         updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 3, 20, progressable);
         updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
-        Assert.assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
+        assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
 
         // no ledgers
         updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 3, Integer.MIN_VALUE, progressable);
         updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
-        Assert.assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
+        assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
     }
 
     /**
      * Tests verifies the ensemble reformation after updating the bookie id in
-     * the existing ensemble
+     * the existing ensemble.
      */
     @Test
     public void testChangeEnsembleAfterRenaming() throws Exception {
@@ -169,7 +176,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
                 curBookieAddr = bookieSocketAddress;
             }
         }
-        Assert.assertNotNull("Couldn't find the bookie in ledger metadata!", curBookieAddr);
+        assertNotNull("Couldn't find the bookie in ledger metadata!", curBookieAddr);
         baseConf.setUseHostNameAsBookieID(true);
         BookieSocketAddress toBookieId = Bookie.getBookieAddress(baseConf);
         BookieSocketAddress toBookieAddr = new BookieSocketAddress(toBookieId.getHostName() + ":"
@@ -204,15 +211,15 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
         lh.close();
         LedgerHandle openLedger = bk.openLedger(lh.getId(), digestType, PASSWORD.getBytes());
         final LedgerMetadata ledgerMetadata = openLedger.getLedgerMetadata();
-        Assert.assertEquals("Failed to reform ensemble!", 2, ledgerMetadata.getEnsembles().size());
+        assertEquals("Failed to reform ensemble!", 2, ledgerMetadata.getEnsembles().size());
         ensemble = ledgerMetadata.getEnsemble(0);
-        Assert.assertTrue("Failed to update the ledger metadata to use bookie host name",
+        assertTrue("Failed to update the ledger metadata to use bookie host name",
                 ensemble.contains(toBookieAddr));
     }
 
     /**
      * Tests verifies simultaneous flow between adding entries and rename of
-     * bookie id
+     * bookie id.
      */
     @Test
     public void testRenameWhenAddEntryInProgress() throws Exception {
@@ -258,7 +265,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
         lh.close();
         LedgerHandle openLedger = bk.openLedger(lh.getId(), digestType, PASSWORD.getBytes());
         ensemble = openLedger.getLedgerMetadata().getEnsemble(0);
-        Assert.assertTrue("Failed to update the ledger metadata to use bookie host name",
+        assertTrue("Failed to update the ledger metadata to use bookie host name",
                 ensemble.contains(toBookieAddr));
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
@@ -17,18 +17,18 @@
  */
 package org.apache.bookkeeper.conf;
 
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
+
 /**
- * Test Configuration API
+ * Test Configuration API.
  *
- * @author enrico.olivelli
  * @see SystemPropertiesConfigurationTest
  */
 public class NoSystemPropertiesConfigurationTest {
 
-    static {  
+    static {
         // this property is read when AbstractConfiguration class is loaded.
         // this test will work as expected only using a new JVM (or classloader) for the test
         System.setProperty(ClientConfiguration.THROTTLE, "10");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/SystemPropertiesConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/SystemPropertiesConfigurationTest.java
@@ -17,14 +17,14 @@
  */
 package org.apache.bookkeeper.conf;
 
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
+
 /**
- * Test Configuration API
+ * Test Configuration API.
  *
- * @author enrico.olivelli
- * @see  NoSystemPropertiesConfigurationTest
+ * @see NoSystemPropertiesConfigurationTest
  */
 public class SystemPropertiesConfigurationTest {
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
@@ -21,6 +21,9 @@
 
 package org.apache.bookkeeper.conf;
 
+/**
+ * Test the BK configuration object.
+ */
 public class TestBKConfiguration {
 
     public static ServerConfiguration newServerConfiguration() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -71,7 +71,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test garbage collection ledgers in ledger manager
+ * Test garbage collection ledgers in ledger manager.
  */
 public class GcLedgersTest extends LedgerManagerTestCase {
     static final Logger LOG = LoggerFactory.getLogger(GcLedgersTest.class);
@@ -81,11 +81,11 @@ public class GcLedgersTest extends LedgerManagerTestCase {
     }
 
     /**
-     * Create ledgers
+     * Create ledgers.
      */
     private void createLedgers(int numLedgers, final Set<Long> createdLedgers) throws IOException {
         final AtomicInteger expected = new AtomicInteger(numLedgers);
-        for (int i=0; i<numLedgers; i++) {
+        for (int i = 0; i < numLedgers; i++) {
             getLedgerIdGenerator().generateLedgerId(new GenericCallback<Long>() {
                 @Override
                 public void operationComplete(int rc, final Long ledgerId) {
@@ -159,7 +159,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         tmpList.addAll(createdLedgers);
         Collections.shuffle(tmpList, r);
         // random remove several ledgers
-        for (int i=0; i<numRemovedLedgers; i++) {
+        for (int i = 0; i < numRemovedLedgers; i++) {
             long ledgerId = tmpList.get(i);
             synchronized (removedLedgers) {
                 getLedgerManager().removeLedgerMetadata(ledgerId, Version.ANY,
@@ -268,13 +268,13 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         removeLedger(last);
         garbageCollector.gc(cleaner);
         assertNotNull("Should have cleaned something", cleaned.peek());
-        assertEquals("Should have cleaned last ledger" + last, (long)last, (long)cleaned.poll());
+        assertEquals("Should have cleaned last ledger" + last, (long) last, (long) cleaned.poll());
 
         long first = createdLedgers.first();
         removeLedger(first);
         garbageCollector.gc(cleaner);
         assertNotNull("Should have cleaned something", cleaned.peek());
-        assertEquals("Should have cleaned first ledger" + first, (long)first, (long)cleaned.poll());
+        assertEquals("Should have cleaned first ledger" + first, (long) first, (long) cleaned.poll());
     }
 
     @Test
@@ -425,7 +425,8 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         }
 
         @Override
-        public Observable waitForLastAddConfirmedUpdate(long ledgerId, long previoisLAC, Observer observer) throws IOException {
+        public Observable waitForLastAddConfirmedUpdate(long ledgerId, long previoisLAC, Observer observer)
+                throws IOException {
             return null;
         }
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerLayoutTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerLayoutTest.java
@@ -21,19 +21,25 @@
 
 package org.apache.bookkeeper.meta;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 
 import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.BookKeeperConstants;
+import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooDefs.Ids;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
+/**
+ * Test the ledger layout.
+ */
 public class LedgerLayoutTest extends BookKeeperClusterTestCase {
 
     public LedgerLayoutTest() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerIteratorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerIteratorTest.java
@@ -21,11 +21,15 @@
 
 package org.apache.bookkeeper.meta;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
+/**
+ * Test the ledger manager iterator.
+ */
 public class LedgerManagerIteratorTest extends LedgerManagerTestCase {
     public LedgerManagerIteratorTest(Class<? extends LedgerManagerFactory> lmFactoryCls) {
         super(lmFactoryCls);
@@ -36,8 +40,9 @@ public class LedgerManagerIteratorTest extends LedgerManagerTestCase {
         LedgerManager lm = getLedgerManager();
         LedgerRangeIterator lri = lm.getLedgerRanges();
         assertNotNull(lri);
-        if (lri.hasNext())
+        if (lri.hasNext()) {
             lri.next();
+        }
 
         assertEquals(false, lri.hasNext());
         assertEquals(false, lri.hasNext());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -48,7 +48,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Test case to run over serveral ledger managers
+ * Test case to run over serveral ledger managers.
  */
 @RunWith(Parameterized.class)
 public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
@@ -110,6 +110,9 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         super.tearDown();
     }
 
+    /**
+     * Mocked ledger storage.
+     */
     public class MockLedgerStorage implements CompactableLedgerStorage {
 
         @Override
@@ -210,7 +213,8 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         }
 
         @Override
-        public Observable waitForLastAddConfirmedUpdate(long ledgerId, long previoisLAC, Observer observer) throws IOException {
+        public Observable waitForLastAddConfirmedUpdate(long ledgerId, long previoisLAC, Observer observer)
+                throws IOException {
             return null;
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerMetadataCreationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerMetadataCreationTest.java
@@ -40,6 +40,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test the creation of ledger metadata.
+ */
 public class LedgerMetadataCreationTest extends LedgerManagerTestCase {
     static final Logger LOG = LoggerFactory.getLogger(LedgerMetadataCreationTest.class);
 
@@ -57,7 +60,7 @@ public class LedgerMetadataCreationTest extends LedgerManagerTestCase {
     public void testLedgerCreationAndDeletion() throws Exception{
         testExecution(false);
     }
-    
+
     public void testExecution(boolean randomLedgerId) throws Exception {
         Set<Long> createRequestsLedgerIds = ConcurrentHashMap.newKeySet();
         ConcurrentLinkedDeque<Long> existingLedgerIds = new ConcurrentLinkedDeque<Long>();
@@ -128,7 +131,7 @@ public class LedgerMetadataCreationTest extends LedgerManagerTestCase {
                 failedDeletes.isEmpty());
         bookKeeper.close();
     }
-    
+
     @Test
     public void testParentNodeDeletion() throws Exception {
         /*

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerManager.java
@@ -20,26 +20,31 @@
  */
 package org.apache.bookkeeper.meta;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
-import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.ZooDefs.Ids;
-import java.util.concurrent.CyclicBarrier;
-import java.util.List;
-import java.util.ArrayList;
-import java.lang.reflect.Field;
 import org.apache.zookeeper.ZooDefs;
-
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
+/**
+ * Test the ledger manager.
+ */
 public class TestLedgerManager extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(TestLedgerManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestLedgerManager.class);
 
     public TestLedgerManager() {
         super(0);
@@ -59,7 +64,7 @@ public class TestLedgerManager extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test bad client configuration
+     * Test bad client configuration.
      */
     @Test
     public void testBadConf() throws Exception {
@@ -105,7 +110,7 @@ public class TestLedgerManager extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test bad client configuration
+     * Test bad client configuration.
      */
     @SuppressWarnings("deprecation")
     @Test
@@ -147,7 +152,7 @@ public class TestLedgerManager extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test bad zk configuration
+     * Test bad zk configuration.
      */
     @Test
     public void testBadZkContents() throws Exception {
@@ -243,7 +248,7 @@ public class TestLedgerManager extends BookKeeperClusterTestCase {
         zkc.create(root0, new byte[0],
                    Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
-        CyclicBarrier barrier = new CyclicBarrier(numThreads+1);
+        CyclicBarrier barrier = new CyclicBarrier(numThreads + 1);
         List<CreateLMThread> threads = new ArrayList<CreateLMThread>(numThreads);
         for (int i = 0; i < numThreads; i++) {
             CreateLMThread t = new CreateLMThread(zkUtil.getZooKeeperConnectString(),
@@ -273,7 +278,7 @@ public class TestLedgerManager extends BookKeeperClusterTestCase {
         zkc.create(root0, new byte[0],
                    Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
-        CyclicBarrier barrier = new CyclicBarrier(numThreadsEach*2+1);
+        CyclicBarrier barrier = new CyclicBarrier(numThreadsEach * 2 + 1);
         List<CreateLMThread> threadsA = new ArrayList<CreateLMThread>(numThreadsEach);
         for (int i = 0; i < numThreadsEach; i++) {
             CreateLMThread t = new CreateLMThread(zkUtil.getZooKeeperConnectString(),

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLongZkLedgerIdGenerator.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLongZkLedgerIdGenerator.java
@@ -24,22 +24,25 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import junit.framework.TestCase;
+
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.test.ZooKeeperUtil;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.KeeperException.Code;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import junit.framework.TestCase;
-
+/**
+ * Test ZK ledger id generator of long values.
+ */
 public class TestLongZkLedgerIdGenerator extends TestCase {
     private static final Logger LOG = LoggerFactory.getLogger(TestZkLedgerIdGenerator.class);
 
@@ -60,7 +63,7 @@ public class TestLongZkLedgerIdGenerator extends TestCase {
 
         ZkLedgerIdGenerator shortLedgerIdGenerator = new ZkLedgerIdGenerator(zk,
                 "/test-zk-ledger-id-generator", "idgen", ZooDefs.Ids.OPEN_ACL_UNSAFE);
-        ledgerIdGenerator = new LongZkLedgerIdGenerator(zk, 
+        ledgerIdGenerator = new LongZkLedgerIdGenerator(zk,
                 "/test-zk-ledger-id-generator", "idgen-long", shortLedgerIdGenerator, ZooDefs.Ids.OPEN_ACL_UNSAFE);
     }
 
@@ -82,7 +85,7 @@ public class TestLongZkLedgerIdGenerator extends TestCase {
         final int nThread = 2;
         final int nLedgers = 2000;
         // Multiply by two. We're going to do half in the old legacy space and half in the new.
-        final CountDownLatch countDownLatch = new CountDownLatch(nThread*nLedgers*2); 
+        final CountDownLatch countDownLatch = new CountDownLatch(nThread * nLedgers * 2);
 
         final AtomicInteger errCount = new AtomicInteger(0);
         final ConcurrentLinkedQueue<Long> ledgerIds = new ConcurrentLinkedQueue<Long>();
@@ -110,12 +113,13 @@ public class TestLongZkLedgerIdGenerator extends TestCase {
                 }
             }.start();
         }
-        
+
         // Go and create the long-id directory in zookeeper. This should cause the id generator to generate ids with the
         // new algo once we clear it's stored status.
-        ZkUtils.createFullPathOptimistic(zk, "/test-zk-ledger-id-generator/idgen-long", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        ZkUtils.createFullPathOptimistic(zk, "/test-zk-ledger-id-generator/idgen-long", new byte[0],
+                Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         ledgerIdGenerator.invalidateLedgerIdGenPathStatus();
-        
+
         for (int i = 0; i < nThread; i++) {
             new Thread() {
                 @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestZkLedgerIdGenerator.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestZkLedgerIdGenerator.java
@@ -37,6 +37,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test the ZK ledger id generator.
+ */
 public class TestZkLedgerIdGenerator extends TestCase {
     private static final Logger LOG = LoggerFactory.getLogger(TestZkLedgerIdGenerator.class);
 
@@ -76,7 +79,7 @@ public class TestZkLedgerIdGenerator extends TestCase {
         // and then check there is no identical ledger id.
         final int nThread = 2;
         final int nLedgers = 2000;
-        final CountDownLatch countDownLatch = new CountDownLatch(nThread*nLedgers);
+        final CountDownLatch countDownLatch = new CountDownLatch(nThread * nLedgers);
 
         final AtomicInteger errCount = new AtomicInteger(0);
         final ConcurrentLinkedQueue<Long> ledgerIds = new ConcurrentLinkedQueue<Long>();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/MetastoreScannableTableAsyncToSyncConverter.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/MetastoreScannableTableAsyncToSyncConverter.java
@@ -21,6 +21,9 @@ import java.util.Set;
 
 import org.apache.bookkeeper.metastore.MetastoreScannableTable.Order;
 
+/**
+ * Async to sync converter for a metastore scannable table.
+ */
 public class MetastoreScannableTableAsyncToSyncConverter extends
              MetastoreTableAsyncToSyncConverter {
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/MetastoreTableAsyncToSyncConverter.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/MetastoreTableAsyncToSyncConverter.java
@@ -21,17 +21,15 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.bookkeeper.metastore.MetastoreCallback;
-import org.apache.bookkeeper.metastore.MetastoreTable;
-import org.apache.bookkeeper.metastore.MSException;
 import org.apache.bookkeeper.metastore.MSException.Code;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
 
-// Converts async calls to sync calls for MetastoreTable. Currently not
-// intended to be used other than for simple functional tests, however,
-// could be developed into a sync API.
-
+/**
+ * Converts async calls to sync calls for MetastoreTable. Currently not
+ * intended to be used other than for simple functional tests, however,
+ * could be developed into a sync API.
+ */
 public class MetastoreTableAsyncToSyncConverter {
 
     static class HeldValue<T> implements MetastoreCallback<T> {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/TestMetaStore.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/TestMetaStore.java
@@ -21,6 +21,16 @@ import static org.apache.bookkeeper.metastore.MetastoreScannableTable.EMPTY_END_
 import static org.apache.bookkeeper.metastore.MetastoreScannableTable.EMPTY_START_KEY;
 import static org.apache.bookkeeper.metastore.MetastoreTable.ALL_FIELDS;
 import static org.apache.bookkeeper.metastore.MetastoreTable.NON_FIELDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -42,19 +52,16 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.MapDifference;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
-import static org.junit.Assert.*;
-
+/**
+ * Test the metastore.
+ */
 public class TestMetaStore {
-    private final static Logger logger = LoggerFactory.getLogger(TestMetaStore.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestMetaStore.class);
 
-    protected final static String TABLE = "myTable";
-    protected final static String RECORDID = "test";
-    protected final static String FIELD_NAME = "name";
-    protected final static String FIELD_COUNTER = "counter";
+    protected static final String TABLE = "myTable";
+    protected static final String RECORDID = "test";
+    protected static final String FIELD_NAME = "name";
+    protected static final String FIELD_COUNTER = "counter";
 
     protected String getFieldFromValue(Value value, String field) {
         byte[] v = value.getField(field);
@@ -75,6 +82,9 @@ public class TestMetaStore {
         return data;
     }
 
+    /**
+     * A metastore record.
+     */
     protected class Record {
         String name;
         Integer counter;
@@ -219,7 +229,7 @@ public class TestMetaStore {
     }
 
     protected Integer getRandom() {
-        return (int)(Math.random()*65536);
+        return (int) (Math.random() * 65536);
     }
 
     protected Versioned<Value> getRecord(String recordId) throws Exception {
@@ -240,7 +250,7 @@ public class TestMetaStore {
     }
 
     /**
-     * put and check fields
+     * put and check fields.
      */
     protected void putAndCheck(String recordId, String name,
                                       Integer counter, Version version,
@@ -548,8 +558,8 @@ public class TestMetaStore {
 
         Set<String> counterFields = Sets.newHashSet(FIELD_COUNTER);
 
-        for (int i=5; i<24; i++) {
-            char c = (char)('a' + i);
+        for (int i = 5; i < 24; i++) {
+            char c = (char) ('a' + i);
             String key = String.valueOf(c);
             Value v = makeValue("value" + i, i);
             Value cv = v.project(counterFields);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/NetworkLessBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/NetworkLessBookieTest.java
@@ -21,21 +21,23 @@
 
 package org.apache.bookkeeper.proto;
 
+import static org.junit.Assert.fail;
+
 import io.netty.channel.Channel;
 import io.netty.channel.local.LocalChannel;
+
 import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests of the main BookKeeper client using networkless comunication
+ * Tests of the main BookKeeper client using networkless comunication.
  */
 public class NetworkLessBookieTest extends BookKeeperClusterTestCase {
-    
+
     public NetworkLessBookieTest() {
         super(1);
         baseConf.setDisableServerSocketBind(true);
@@ -49,7 +51,7 @@ public class NetworkLessBookieTest extends BookKeeperClusterTestCase {
                 .setZkTimeout(20000);
 
         try (BookKeeper bkc = new BookKeeper(conf)) {
-            try (LedgerHandle h = bkc.createLedger(1,1, DigestType.CRC32, "testPasswd".getBytes())) {
+            try (LedgerHandle h = bkc.createLedger(1, 1, DigestType.CRC32, "testPasswd".getBytes())) {
                 h.addEntry("test".getBytes());
             }
         }
@@ -57,7 +59,7 @@ public class NetworkLessBookieTest extends BookKeeperClusterTestCase {
         for (BookieServer bk : bs) {
             for (Channel channel : bk.nettyServer.allChannels) {
                 if (!(channel instanceof LocalChannel)) {
-                    Assert.fail();
+                    fail();
                 }
             }
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestBKStats.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestBKStats.java
@@ -25,7 +25,9 @@ import static org.junit.Assert.assertEquals;
 import org.apache.bookkeeper.proto.BKStats.OpStats;
 import org.junit.Test;
 
-/** Tests that Statistics updation in Bookie Server */
+/**
+ * Tests that Statistics updation in Bookie Server.
+ */
 public class TestBKStats {
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestBackwardCompatCMS42.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestBackwardCompatCMS42.java
@@ -20,13 +20,11 @@
  */
 package org.apache.bookkeeper.proto;
 
-import com.google.protobuf.ByteString;
-import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
 
 import io.netty.channel.Channel;
@@ -34,21 +32,30 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 
-import org.apache.bookkeeper.auth.ClientAuthProvider;
-import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.util.OrderedSafeExecutor;
-import org.apache.bookkeeper.auth.TestAuth;
-import org.apache.bookkeeper.auth.AuthProviderFactoryFactory;
-
-import org.apache.bookkeeper.proto.BookieProtocol.*;
-import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
-
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.*;
+import org.apache.bookkeeper.auth.AuthProviderFactoryFactory;
+import org.apache.bookkeeper.auth.ClientAuthProvider;
+import org.apache.bookkeeper.auth.TestAuth;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieProtocol.AuthRequest;
+import org.apache.bookkeeper.proto.BookieProtocol.AuthResponse;
+import org.apache.bookkeeper.proto.BookieProtocol.ReadRequest;
+import org.apache.bookkeeper.proto.BookieProtocol.Request;
+import org.apache.bookkeeper.proto.BookieProtocol.Response;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.util.OrderedSafeExecutor;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Test backward compatibility.
+ */
 public class TestBackwardCompatCMS42 extends BookKeeperClusterTestCase {
     static final Logger LOG = LoggerFactory.getLogger(TestBackwardCompatCMS42.class);
 
@@ -106,11 +113,11 @@ public class TestBackwardCompatCMS42 extends BookKeeperClusterTestCase {
         CompatClient42 client = newCompatClient(bookie1.getLocalAddress());
 
         Request request = new AuthRequest(BookieProtocol.CURRENT_PROTOCOL_VERSION, authMessage);
-        for (int i = 0; i < 3 ; i++) {
+        for (int i = 0; i < 3; i++) {
             client.sendRequest(request);
             Response response = client.takeResponse();
             assertTrue("Should be auth response", response instanceof AuthResponse);
-            AuthResponse authResponse = (AuthResponse)response;
+            AuthResponse authResponse = (AuthResponse) response;
             assertEquals("Should have succeeded",
                          response.getErrorCode(), BookieProtocol.EOK);
             byte[] type = authResponse.getAuthMessage()
@@ -139,11 +146,11 @@ public class TestBackwardCompatCMS42 extends BookKeeperClusterTestCase {
         CompatClient42 client = newCompatClient(bookie1.getLocalAddress());
 
         Request request = new AuthRequest(BookieProtocol.CURRENT_PROTOCOL_VERSION, authMessage);
-        for (int i = 0; i < 3 ; i++) {
+        for (int i = 0; i < 3; i++) {
             client.sendRequest(request);
             Response response = client.takeResponse();
             assertTrue("Should be auth response", response instanceof AuthResponse);
-            AuthResponse authResponse = (AuthResponse)response;
+            AuthResponse authResponse = (AuthResponse) response;
             assertEquals("Should have succeeded",
                          response.getErrorCode(), BookieProtocol.EOK);
             byte[] type = authResponse.getAuthMessage()
@@ -159,7 +166,7 @@ public class TestBackwardCompatCMS42 extends BookKeeperClusterTestCase {
         }
 
         client.sendRequest(new ReadRequest(BookieProtocol.CURRENT_PROTOCOL_VERSION,
-                                           1L, 1L, (short)0));
+                                           1L, 1L, (short) 0));
         Response response = client.takeResponse();
         assertEquals("Should have failed",
                      response.getErrorCode(), BookieProtocol.EUA);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -20,22 +20,8 @@
  */
 package org.apache.bookkeeper.proto;
 
-import org.apache.bookkeeper.auth.ClientAuthProvider;
-import org.apache.bookkeeper.auth.AuthProviderFactoryFactory;
-import org.apache.bookkeeper.bookie.Bookie;
-import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
-import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
-import org.apache.bookkeeper.proto.PerChannelBookieClient.ConnectionState;
-import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.bookkeeper.util.OrderedSafeExecutor;
-import org.apache.bookkeeper.util.SafeRunnable;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.ExtensionRegistry;
 
@@ -49,14 +35,29 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import org.apache.bookkeeper.auth.AuthProviderFactoryFactory;
+import org.apache.bookkeeper.auth.ClientAuthProvider;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
+import org.apache.bookkeeper.proto.PerChannelBookieClient.ConnectionState;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.util.OrderedSafeExecutor;
+import org.apache.bookkeeper.util.SafeRunnable;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests for PerChannelBookieClient. Historically, this class has
  * had a few race conditions, so this is what these tests focus on.
  */
 public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(TestPerChannelBookieClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestPerChannelBookieClient.class);
 
     ExtensionRegistry extRegistry = ExtensionRegistry.newInstance();
     ClientAuthProvider.Factory authProvider;
@@ -151,7 +152,7 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
                 // we just want to trigger it connecting.
             }
         };
-        final int ITERATIONS = 100000;
+        final int iterations = 100000;
         EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
         OrderedSafeExecutor executor = getOrderedSafeExecutor();
         BookieSocketAddress addr = getBookie(0);
@@ -173,7 +174,7 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
                         Thread.currentThread().interrupt();
                         running.set(false);
                     }
-                    for (int i = 0; i < ITERATIONS && running.get(); i++) {
+                    for (int i = 0; i < iterations && running.get(); i++) {
                         client.connectIfNeededAndDoOp(nullop);
                     }
                     running.set(false);
@@ -226,7 +227,7 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
 
     /**
      * Test that requests are completed even if the channel is disconnected
-     * {@link https://issues.apache.org/jira/browse/BOOKKEEPER-668}
+     * {@link https://issues.apache.org/jira/browse/BOOKKEEPER-668}.
      */
     @Test
     public void testRequestCompletesAfterDisconnectRace() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorBookieTest.java
@@ -20,11 +20,16 @@
  */
 package org.apache.bookkeeper.replication;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.junit.Assert;
 
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
@@ -35,17 +40,15 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
  * This test verifies the auditor bookie scenarios which will be monitoring the
- * bookie failures
+ * bookie failures.
  */
 public class AuditorBookieTest extends BookKeeperClusterTestCase {
     // Depending on the taste, select the amount of logging
     // by decommenting one of the two lines below
-    // private final static Logger LOG = Logger.getRootLogger();
-    private final static Logger LOG = LoggerFactory
+    // private static final Logger LOG = Logger.getRootLogger();
+    private static final Logger LOG = LoggerFactory
             .getLogger(AuditorBookieTest.class);
     private String electionPath;
     private HashMap<String, AuditorElector> auditorElectors = new HashMap<String, AuditorElector>();
@@ -96,14 +99,14 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
         startNewBookie();
         // grace period for the auditor re-election if any
         BookieServer newAuditor = waitForNewAuditor(auditor);
-        Assert.assertSame(
+        assertSame(
                 "Auditor re-election is not happened for auditor failure!",
                 auditor, newAuditor);
     }
 
     /**
      * Test Auditor crashes should trigger re-election and another bookie should
-     * take over the auditor ship
+     * take over the auditor ship.
      */
     @Test
     public void testSuccessiveAuditorCrashes() throws Exception {
@@ -115,7 +118,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
 
         shutdownBookie(newAuditor1);
         BookieServer newAuditor2 = waitForNewAuditor(newAuditor1);
-        Assert.assertNotSame(
+        assertNotSame(
                 "Auditor re-election is not happened for auditor failure!",
                 auditor, newAuditor2);
         bs.remove(newAuditor1);
@@ -123,7 +126,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
 
     /**
      * Test restarting the entire bookie cluster. It shouldn't create multiple
-     * bookie auditors
+     * bookie auditors.
      */
     @Test
     public void testBookieClusterRestart() throws Exception {
@@ -138,7 +141,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
         startBKCluster();
         startAuditorElectors();
         BookieServer newAuditor = waitForNewAuditor(auditor);
-        Assert.assertNotSame(
+        assertNotSame(
                 "Auditor re-election is not happened for auditor failure!",
                 auditor, newAuditor);
     }
@@ -153,7 +156,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
 
         // waiting for new auditor
         BookieServer newAuditor = waitForNewAuditor(auditor);
-        Assert.assertNotSame(
+        assertNotSame(
                 "Auditor re-election is not happened for auditor failure!",
                 auditor, newAuditor);
         int indexOfDownBookie = bs.indexOf(auditor);
@@ -164,7 +167,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
             byte[] data = zkc.getData(electionPath + '/' + child, false, null);
             String bookieIP = new String(data);
             String addr = auditor.getLocalAddress().toString();
-            Assert.assertFalse("AuditorElection cleanup fails", bookieIP
+            assertFalse("AuditorElection cleanup fails", bookieIP
                     .contains(addr));
         }
     }
@@ -195,10 +198,10 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
 
         // waiting for new auditor to come
         BookieServer newAuditor = waitForNewAuditor(auditor);
-        Assert.assertNotSame(
+        assertNotSame(
                 "Auditor re-election is not happened for auditor failure!",
                 auditor, newAuditor);
-        Assert.assertFalse("No relection after old auditor rejoins", auditor
+        assertFalse("No relection after old auditor rejoins", auditor
                 .getLocalAddress().getPort() == newAuditor.getLocalAddress()
                 .getPort());
     }
@@ -233,7 +236,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
 
     private BookieServer verifyAuditor() throws Exception {
         List<BookieServer> auditors = getAuditorBookie();
-        Assert.assertEquals("Multiple Bookies acting as Auditor!", 1, auditors
+        assertEquals("Multiple Bookies acting as Auditor!", 1, auditors
                 .size());
         LOG.debug("Bookie running as Auditor:" + auditors.get(0));
         return auditors.get(0);
@@ -242,7 +245,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
     private List<BookieServer> getAuditorBookie() throws Exception {
         List<BookieServer> auditors = new LinkedList<BookieServer>();
         byte[] data = zkc.getData(electionPath, false, null);
-        Assert.assertNotNull("Auditor election failed", data);
+        assertNotNull("Auditor election failed", data);
         for (BookieServer bks : bs) {
             if (new String(data).contains(bks.getLocalAddress().getPort() + "")) {
                 auditors.add(bks);
@@ -276,7 +279,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
             Thread.sleep(500);
             retryCount--;
         }
-        Assert.assertNotNull(
+        assertNotNull(
                 "New Auditor is not reelected after auditor crashes",
                 newAuditor);
         verifyAuditor();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.replication;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -70,14 +71,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Tests publishing of under replicated ledgers by the Auditor bookie node when
- * corresponding bookies identifes as not running
+ * corresponding bookies identifes as not running.
  */
 public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
 
     // Depending on the taste, select the amount of logging
     // by decommenting one of the two lines below
-    // private final static Logger LOG = Logger.getRootLogger();
-    private final static Logger LOG = LoggerFactory
+    // private static final Logger LOG = Logger.getRootLogger();
+    private static final Logger LOG = LoggerFactory
             .getLogger(AuditorLedgerCheckerTest.class);
 
     private static final byte[] ledgerPassword = "aaa".getBytes();
@@ -85,7 +86,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
 
     private DigestType digestType;
 
-    private final String UNDERREPLICATED_PATH = baseClientConf
+    private final String underreplicatedPath = baseClientConf
             .getZkLedgersRootPath()
             + "/underreplication/ledgers";
     private Map<String, AuditorElector> auditorElectors = new ConcurrentHashMap<>();
@@ -151,7 +152,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test publishing of under replicated ledgers by the auditor bookie
+     * Test publishing of under replicated ledgers by the auditor bookie.
      */
     @Test
     public void testSimpleLedger() throws Exception {
@@ -190,7 +191,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
 
     /**
      * Test once published under replicated ledger should exists even after
-     * restarting respective bookie
+     * restarting respective bookie.
      */
     @Test
     public void testRestartBookie() throws Exception {
@@ -347,7 +348,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
                 data.contains(shutdownBookie));
     }
 
-    public void _testDelayedAuditOfLostBookies() throws Exception {
+    public void testInnerDelayedAuditOfLostBookies() throws Exception {
         LedgerHandle lh1 = createAndAddEntriesToLedger();
         Long ledgerId = lh1.getId();
         LOG.debug("Created ledger : " + ledgerId);
@@ -382,14 +383,14 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
 
     /**
      * Test publishing of under replicated ledgers by the auditor
-     * bookie is delayed if LostBookieRecoveryDelay option is set
+     * bookie is delayed if LostBookieRecoveryDelay option is set.
      */
     @Test
     public void testDelayedAuditOfLostBookies() throws Exception {
         // wait for a second so that the initial periodic check finishes
         Thread.sleep(1000);
 
-        _testDelayedAuditOfLostBookies();
+        testInnerDelayedAuditOfLostBookies();
     }
 
     /**
@@ -413,14 +414,14 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
 
         // the delaying of audit should just work despite the fact
         // we have enabled periodic bookie check
-        _testDelayedAuditOfLostBookies();
+        testInnerDelayedAuditOfLostBookies();
     }
 
     @Test
     public void testRescheduleOfDelayedAuditOfLostBookiesToStartImmediately() throws Exception {
      // wait for a second so that the initial periodic check finishes
         Thread.sleep(1000);
-        
+
         LedgerHandle lh1 = createAndAddEntriesToLedger();
         Long ledgerId = lh1.getId();
         LOG.debug("Created ledger : " + ledgerId);
@@ -443,7 +444,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
 
         // set lostBookieRecoveryDelay to 0, so that it triggers AuditTask immediately
         urLedgerMgr.setLostBookieRecoveryDelay(0);
-        
+
         // wait for 1 second for the ledger to get reported as under replicated
         assertTrue("audit of lost bookie isn't delayed", underReplicaLatch.await(1, TimeUnit.SECONDS));
 
@@ -455,12 +456,12 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
                 + "is not listed in the ledger as missing replica :" + data,
                 data.contains(shutdownBookie));
     }
-    
+
     @Test
     public void testRescheduleOfDelayedAuditOfLostBookiesToStartLater() throws Exception {
      // wait for a second so that the initial periodic check finishes
         Thread.sleep(1000);
-        
+
         LedgerHandle lh1 = createAndAddEntriesToLedger();
         Long ledgerId = lh1.getId();
         LOG.debug("Created ledger : " + ledgerId);
@@ -480,16 +481,16 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         assertFalse("audit of lost bookie isn't delayed", underReplicaLatch.await(2, TimeUnit.SECONDS));
         assertEquals("under replicated ledgers identified when it was not expected", 0,
                 urLedgerList.size());
-        
+
         // set lostBookieRecoveryDelay to 4, so the pending AuditTask is resheduled
         urLedgerMgr.setLostBookieRecoveryDelay(4);
-        
+
         // since we changed the BookieRecoveryDelay period to 4, the audittask shouldn't have been executed
         LOG.debug("Waiting for ledgers to be marked as under replicated");
         assertFalse("audit of lost bookie isn't delayed", underReplicaLatch.await(2, TimeUnit.SECONDS));
         assertEquals("under replicated ledgers identified when it was not expected", 0,
-                urLedgerList.size());        
-        
+                urLedgerList.size());
+
         // wait for 3 seconds (since we already waited for 2 secs) for the ledger to get reported as under replicated
         assertTrue("audit of lost bookie isn't delayed", underReplicaLatch.await(3, TimeUnit.SECONDS));
         assertTrue("Ledger is not marked as underreplicated:" + ledgerId,
@@ -500,7 +501,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
                 + "is not listed in the ledger as missing replica :" + data,
                 data.contains(shutdownBookie));
     }
-    
+
     @Test
     public void testTriggerAuditorWithNoPendingAuditTask() throws Exception {
         // wait for a second so that the initial periodic check finishes
@@ -513,14 +514,14 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         Assert.assertEquals(
                 "lostBookieRecoveryDelayBeforeChange of Auditor should be equal to BaseConf's lostBookieRecoveryDelay",
                 lostBookieRecoveryDelayConfValue, lostBookieRecoveryDelayBeforeChange);
-        
-        // there is no easy way to validate if the Auditor has executed Audit process (Auditor.startAudit), 
+
+        // there is no easy way to validate if the Auditor has executed Audit process (Auditor.startAudit),
         // without shuttingdown Bookie. To test if by resetting LostBookieRecoveryDelay it does Auditing
         // even when there is no pending AuditTask, following approach is needed.
-        
+
         // Here we are creating few ledgers ledgermetadata with non-existing bookies as its ensemble.
-        // When Auditor does audit it recognizes these ledgers as underreplicated and mark them as 
-        // under-replicated, since these bookies are not available. 
+        // When Auditor does audit it recognizes these ledgers as underreplicated and mark them as
+        // under-replicated, since these bookies are not available.
         int numofledgers = 5;
         Random rand = new Random();
         for (int i = 0; i < numofledgers; i++) {
@@ -549,25 +550,25 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
                     ledgerCreateRC.getValue());
             ledgerList.add(ledgerId);
         }
-        
+
         final CountDownLatch underReplicaLatch = registerUrLedgerWatcher(ledgerList.size());
         urLedgerMgr.setLostBookieRecoveryDelay(lostBookieRecoveryDelayBeforeChange);
         assertTrue("Audit should be triggered and created ledgers should be marked as underreplicated",
                 underReplicaLatch.await(2, TimeUnit.SECONDS));
         assertEquals("All the ledgers should be marked as underreplicated", ledgerList.size(), urLedgerList.size());
-        
+
         auditTask = auditorBookiesAuditor.getAuditTask();
         Assert.assertEquals("auditTask is supposed to be null", null, auditTask);
         Assert.assertEquals(
                 "lostBookieRecoveryDelayBeforeChange of Auditor should be equal to BaseConf's lostBookieRecoveryDelay",
                 lostBookieRecoveryDelayBeforeChange, auditorBookiesAuditor.getLostBookieRecoveryDelayBeforeChange());
     }
-    
+
     @Test
     public void testTriggerAuditorWithPendingAuditTask() throws Exception {
      // wait for a second so that the initial periodic check finishes
         Thread.sleep(1000);
-        
+
         Auditor auditorBookiesAuditor = getAuditorBookiesAuditor();
         LedgerHandle lh1 = createAndAddEntriesToLedger();
         Long ledgerId = lh1.getId();
@@ -589,19 +590,19 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         assertFalse("audit of lost bookie isn't delayed", underReplicaLatch.await(2, TimeUnit.SECONDS));
         assertEquals("under replicated ledgers identified when it was not expected", 0,
                 urLedgerList.size());
-        
+
         Future<?> auditTask = auditorBookiesAuditor.getAuditTask();
         Assert.assertNotEquals("auditTask is not supposed to be null", null, auditTask);
         Assert.assertEquals(
                 "lostBookieRecoveryDelayBeforeChange of Auditor should be equal to what we set",
                 lostBookieRecoveryDelay, auditorBookiesAuditor.getLostBookieRecoveryDelayBeforeChange());
-        
-        // set lostBookieRecoveryDelay to 5 (previous value), so that Auditor is triggered immediately 
+
+        // set lostBookieRecoveryDelay to 5 (previous value), so that Auditor is triggered immediately
         urLedgerMgr.setLostBookieRecoveryDelay(lostBookieRecoveryDelay);
         assertTrue("audit of lost bookie shouldn't be delayed", underReplicaLatch.await(2, TimeUnit.SECONDS));
         assertEquals("all under replicated ledgers should be identified", ledgerList.size(),
-                urLedgerList.size());        
-        
+                urLedgerList.size());
+
         Thread.sleep(100);
         auditTask = auditorBookiesAuditor.getAuditTask();
         Assert.assertEquals("auditTask is supposed to be null", null, auditTask);
@@ -609,12 +610,12 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
                 "lostBookieRecoveryDelayBeforeChange of Auditor should be equal to previously set value",
                 lostBookieRecoveryDelay, auditorBookiesAuditor.getLostBookieRecoveryDelayBeforeChange());
     }
-    
+
     @Test
     public void testTriggerAuditorBySettingDelayToZeroWithPendingAuditTask() throws Exception {
      // wait for a second so that the initial periodic check finishes
         Thread.sleep(1000);
-        
+
         Auditor auditorBookiesAuditor = getAuditorBookiesAuditor();
         LedgerHandle lh1 = createAndAddEntriesToLedger();
         Long ledgerId = lh1.getId();
@@ -636,27 +637,27 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         assertFalse("audit of lost bookie isn't delayed", underReplicaLatch.await(2, TimeUnit.SECONDS));
         assertEquals("under replicated ledgers identified when it was not expected", 0,
                 urLedgerList.size());
-        
+
         Future<?> auditTask = auditorBookiesAuditor.getAuditTask();
         Assert.assertNotEquals("auditTask is not supposed to be null", null, auditTask);
         Assert.assertEquals(
                 "lostBookieRecoveryDelayBeforeChange of Auditor should be equal to what we set",
                 lostBookieRecoveryDelay, auditorBookiesAuditor.getLostBookieRecoveryDelayBeforeChange());
-        
-        // set lostBookieRecoveryDelay to 0, so that Auditor is triggered immediately 
+
+        // set lostBookieRecoveryDelay to 0, so that Auditor is triggered immediately
         urLedgerMgr.setLostBookieRecoveryDelay(0);
         assertTrue("audit of lost bookie shouldn't be delayed", underReplicaLatch.await(1, TimeUnit.SECONDS));
         assertEquals("all under replicated ledgers should be identified", ledgerList.size(),
-                urLedgerList.size());        
-        
+                urLedgerList.size());
+
         Thread.sleep(100);
         auditTask = auditorBookiesAuditor.getAuditTask();
-        Assert.assertEquals("auditTask is supposed to be null", null, auditTask);
-        Assert.assertEquals(
+        assertEquals("auditTask is supposed to be null", null, auditTask);
+        assertEquals(
                 "lostBookieRecoveryDelayBeforeChange of Auditor should be equal to previously set value",
                 0, auditorBookiesAuditor.getLostBookieRecoveryDelayBeforeChange());
     }
-    
+
     /**
      * Test audit of bookies is delayed when one bookie is down. But when
      * another one goes down, the audit is started immediately.
@@ -788,7 +789,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Wait for ledger to be underreplicated, and to be missing all replicas specified
+     * Wait for ledger to be underreplicated, and to be missing all replicas specified.
      */
     private boolean waitForLedgerMissingReplicas(Long ledgerId, long secondsToWait, String... replicas)
             throws Exception {
@@ -815,7 +816,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         final CountDownLatch underReplicaLatch = new CountDownLatch(count);
         for (Long ledgerId : ledgerList) {
             Watcher urLedgerWatcher = new ChildWatcher(underReplicaLatch);
-            String znode = ZkLedgerUnderreplicationManager.getUrLedgerZnode(UNDERREPLICATED_PATH,
+            String znode = ZkLedgerUnderreplicationManager.getUrLedgerZnode(underreplicatedPath,
                                                                             ledgerId);
             zkc.exists(znode, urLedgerWatcher);
         }
@@ -879,7 +880,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
             throws KeeperException, InterruptedException {
         Map<Long, String> urLedgerData = new HashMap<Long, String>();
         for (Long ledgerId : urLedgerList) {
-            String znode = ZkLedgerUnderreplicationManager.getUrLedgerZnode(UNDERREPLICATED_PATH,
+            String znode = ZkLedgerUnderreplicationManager.getUrLedgerZnode(underreplicatedPath,
                                                                             ledgerId);
             byte[] data = zkc.getData(znode, false, null);
             urLedgerData.put(ledgerId, new String(data));
@@ -912,13 +913,13 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
     private BookieServer getAuditorBookie() throws Exception {
         List<BookieServer> auditors = new LinkedList<BookieServer>();
         byte[] data = zkc.getData(electionPath, false, null);
-        Assert.assertNotNull("Auditor election failed", data);
+        assertNotNull("Auditor election failed", data);
         for (BookieServer bks : bs) {
             if (new String(data).contains(bks.getLocalAddress().getPort() + "")) {
                 auditors.add(bks);
             }
         }
-        Assert.assertEquals("Multiple Bookies acting as Auditor!", 1, auditors
+        assertEquals("Multiple Bookies acting as Auditor!", 1, auditors
                 .size());
         return auditors.get(0);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
@@ -20,12 +20,10 @@
  */
 package org.apache.bookkeeper.replication;
 
-import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.bookkeeper.test.TestCallbacks;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
-import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.LedgerHandleAdapter;
@@ -35,27 +33,29 @@ import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.test.TestCallbacks;
+import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.zookeeper.ZooKeeper;
-import org.junit.Before;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * This test verifies that the period check on the auditor
- * will pick up on missing data in the client
+ * will pick up on missing data in the client.
  */
 public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory
+    private static final Logger LOG = LoggerFactory
             .getLogger(AuditorPeriodicBookieCheckTest.class);
 
     private AuditorElector auditorElector = null;
     private ZooKeeper auditorZookeeper = null;
 
-    private final static int CHECK_INTERVAL = 1; // run every second
+    private static final int CHECK_INTERVAL = 1; // run every second
 
     public AuditorPeriodicBookieCheckTest() {
         super(3);
@@ -91,7 +91,7 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test that the periodic bookie checker works
+     * Test that the periodic bookie checker works.
      */
     @Test
     public void testPeriodicBookieCheckInterval() throws Exception {
@@ -115,7 +115,7 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
             if (underReplicatedLedger != -1) {
                 break;
             }
-            Thread.sleep(CHECK_INTERVAL*1000);
+            Thread.sleep(CHECK_INTERVAL * 1000);
         }
         assertEquals("Ledger should be under replicated", lh.getId(), underReplicatedLedger);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
@@ -20,6 +20,25 @@
  */
 package org.apache.bookkeeper.replication;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.netty.buffer.ByteBuf;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieAccessor;
 import org.apache.bookkeeper.bookie.IndexPersistenceMgr;
@@ -40,35 +59,18 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.buffer.ByteBuf;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.junit.Assert.*;
-
 /**
  * This test verifies that the period check on the auditor
- * will pick up on missing data in the client
+ * will pick up on missing data in the client.
  */
 public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory
+    private static final Logger LOG = LoggerFactory
             .getLogger(AuditorPeriodicCheckTest.class);
 
     private HashMap<String, AuditorElector> auditorElectors = new HashMap<String, AuditorElector>();
     private List<ZooKeeper> zkClients = new LinkedList<ZooKeeper>();
 
-    private final static int CHECK_INTERVAL = 1; // run every second
+    private static final int CHECK_INTERVAL = 1; // run every second
 
     public AuditorPeriodicCheckTest() {
         super(3);
@@ -115,7 +117,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
 
     /**
      * test that the periodic checking will detect corruptions in
-     * the bookie entry log
+     * the bookie entry log.
      */
     @Test
     public void testEntryLogCorruption() throws Exception {
@@ -141,7 +143,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
                     return name.endsWith(".log");
                 }
             });
-        ByteBuffer junk = ByteBuffer.allocate(1024*1024);
+        ByteBuffer junk = ByteBuffer.allocate(1024 * 1024);
         for (File f : entryLogs) {
             FileOutputStream out = new FileOutputStream(f);
             out.getChannel().write(junk);
@@ -164,7 +166,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
 
     /**
      * test that the period checker will detect corruptions in
-     * the bookie index files
+     * the bookie index files.
      */
     @Test
     public void testIndexCorruption() throws Exception {
@@ -193,7 +195,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
         // corrupt of entryLogs
         File index = new File(ledgerDir, IndexPersistenceMgr.getLedgerName(ledgerToCorrupt));
         LOG.info("file to corrupt{}" , index);
-        ByteBuffer junk = ByteBuffer.allocate(1024*1024);
+        ByteBuffer junk = ByteBuffer.allocate(1024 * 1024);
         FileOutputStream out = new FileOutputStream(index);
         out.getChannel().write(junk);
         out.close();
@@ -211,7 +213,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test that the period checker will not run when auto replication has been disabled
+     * Test that the period checker will not run when auto replication has been disabled.
      */
     @Test
     public void testPeriodicCheckWhenDisabled() throws Exception {
@@ -219,7 +221,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
         final LedgerUnderreplicationManager underReplicationManager = mFactory.newLedgerUnderreplicationManager();
         final int numLedgers = 10;
         final int numMsgs = 2;
-        final CountDownLatch completeLatch = new CountDownLatch(numMsgs*numLedgers);
+        final CountDownLatch completeLatch = new CountDownLatch(numMsgs * numLedgers);
         final AtomicInteger rc = new AtomicInteger(BKException.Code.OK);
 
         List<LedgerHandle> lhs = new ArrayList<LedgerHandle>();
@@ -296,7 +298,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test that the period check will succeed if a ledger is deleted midway
+     * Test that the period check will succeed if a ledger is deleted midway.
      */
     @Test
     public void testPeriodicCheckWhenLedgerDeleted() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorRollingRestartTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorRollingRestartTest.java
@@ -20,22 +20,20 @@
  */
 package org.apache.bookkeeper.replication;
 
-import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.bookkeeper.test.TestCallbacks;
+import static org.junit.Assert.assertEquals;
 
-import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
-
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.test.TestCallbacks;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 /**
- * Test auditor behaviours during a rolling restart
+ * Test auditor behaviours during a rolling restart.
  */
 public class AuditorRollingRestartTest extends BookKeeperClusterTestCase {
 
@@ -46,7 +44,7 @@ public class AuditorRollingRestartTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test no auditing during restart if disabled
+     * Test no auditing during restart if disabled.
      */
     @Test
     public void testAuditingDuringRollingRestart() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuthAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuthAutoRecoveryTest.java
@@ -20,28 +20,27 @@
  */
 package org.apache.bookkeeper.replication;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.bookkeeper.auth.AuthCallbacks;
 import org.apache.bookkeeper.auth.AuthToken;
 import org.apache.bookkeeper.auth.ClientAuthProvider;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.conf.ClientConfiguration;
-
-
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.proto.ClientConnectionPeer;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-import org.apache.bookkeeper.proto.ClientConnectionPeer;
-
 /**
- * This test verifies the auditor bookie scenarios from the auth point-of-view
+ * This test verifies the auditor bookie scenarios from the auth point-of-view.
  */
 public class AuthAutoRecoveryTest extends BookKeeperClusterTestCase {
 
-    private final static Logger LOG = LoggerFactory
+    private static final Logger LOG = LoggerFactory
         .getLogger(AuthAutoRecoveryTest.class);
 
     public static final String TEST_AUTH_PROVIDER_PLUGIN_NAME = "TestAuthProviderPlugin";
@@ -68,7 +67,7 @@ public class AuthAutoRecoveryTest extends BookKeeperClusterTestCase {
                 public void init(AuthCallbacks.GenericCallback<AuthToken> cb) {
                     completeCb.operationComplete(BKException.Code.OK, null);
                 }
-                
+
                 public void process(AuthToken m, AuthCallbacks.GenericCallback<AuthToken> cb) {
                 }
             };

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AutoRecoveryMainTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AutoRecoveryMainTest.java
@@ -20,14 +20,15 @@
  */
 package org.apache.bookkeeper.replication;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
-/*
- * Test the AuditorPeer
+/**
+ * Test the AuditorPeer.
  */
 public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
 
@@ -35,8 +36,8 @@ public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
         super(3);
     }
 
-    /*
-     * test the startup of the auditorElector and RW.
+    /**
+     * Test the startup of the auditorElector and RW.
      */
     @Test
     public void testStartup() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -19,6 +19,11 @@
  */
 package org.apache.bookkeeper.replication;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,8 +55,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
  * Integration tests verifies the complete functionality of the
  * Auditor-rereplication process: Auditor will publish the bookie failures,
@@ -69,7 +72,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
     private LedgerUnderreplicationManager underReplicationManager;
     private LedgerManager ledgerManager;
 
-    private final String UNDERREPLICATED_PATH = baseClientConf
+    private final String underreplicatedPath = baseClientConf
             .getZkLedgersRootPath() + "/underreplication/ledgers";
 
     public BookieAutoRecoveryTest() throws IOException, KeeperException,
@@ -118,7 +121,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
 
     /**
      * Test verifies publish urLedger by Auditor and replication worker is
-     * picking up the entries and finishing the rereplication of open ledger
+     * picking up the entries and finishing the rereplication of open ledger.
      */
     @Test
     public void testOpenLedgers() throws Exception {
@@ -165,7 +168,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
 
     /**
      * Test verifies publish urLedger by Auditor and replication worker is
-     * picking up the entries and finishing the rereplication of closed ledgers
+     * picking up the entries and finishing the rereplication of closed ledgers.
      */
     @Test
     public void testClosedLedgers() throws Exception {
@@ -305,7 +308,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
     /**
      * Verify the published urledgers of deleted ledgers(those ledgers where
      * deleted after publishing as urledgers by Auditor) should be cleared off
-     * by the newly selected replica bookie
+     * by the newly selected replica bookie.
      */
     @Test
     public void testNoSuchLedgerExists() throws Exception {
@@ -394,7 +397,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
 
     /**
      * Test verifies bookie recovery, the host (recorded via ipaddress in
-     * ledgermetadata)
+     * ledgermetadata).
      */
     @Test
     public void testLedgerMetadataContainsIpAddressAsBookieID()
@@ -423,7 +426,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         final ArrayList<BookieSocketAddress> bkAddresses = ensembles.get(0L);
         BookieSocketAddress replicaToKillAddr = bkAddresses.get(0);
         for (BookieSocketAddress bookieSocketAddress : bkAddresses) {
-            if(!isCreatedFromIp(bookieSocketAddress)){
+            if (!isCreatedFromIp(bookieSocketAddress)){
                 replicaToKillAddr = bookieSocketAddress;
                 LOG.info("Kill bookie which has registered using hostname");
                 break;
@@ -472,7 +475,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
 
     /**
      * Test verifies bookie recovery, the host (recorded via useHostName in
-     * ledgermetadata)
+     * ledgermetadata).
      */
     @Test
     public void testLedgerMetadataContainsHostNameAsBookieID()
@@ -602,7 +605,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
 
     private String getUrLedgerZNode(LedgerHandle lh) {
         return ZkLedgerUnderreplicationManager.getUrLedgerZnode(
-                UNDERREPLICATED_PATH, lh.getId());
+                underreplicatedPath, lh.getId());
     }
 
     private Stat watchUrLedgerNode(final String znode,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
@@ -17,6 +17,10 @@
  */
 package org.apache.bookkeeper.replication;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -26,9 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+
 import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.MSLedgerManagerFactory;
@@ -42,10 +47,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
- * Tests verifies bookie vs ledger mapping generating by the BookieLedgerIndexer
+ * Tests verifies bookie vs ledger mapping generating by the BookieLedgerIndexer.
  */
 public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
 
@@ -106,7 +109,7 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
 
     /**
      * Verify the bookie-ledger mapping with minimum number of bookies and few
-     * ledgers
+     * ledgers.
      */
     @Test
     public void testSimpleBookieLedgerMapping() throws Exception {
@@ -135,7 +138,7 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify ledger index with failed bookies and throws exception
+     * Verify ledger index with failed bookies and throws exception.
      */
     @Test
     public void testWithoutZookeeper() throws Exception {
@@ -162,7 +165,7 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify indexing with multiple ensemble reformation
+     * Verify indexing with multiple ensemble reformation.
      */
     @Test
     public void testEnsembleReformation() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/ReplicationTestUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/ReplicationTestUtil.java
@@ -24,10 +24,14 @@ import java.util.List;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 
-/** Utility class for replication tests */
+/**
+ * Utility class for replication tests.
+ */
 public class ReplicationTestUtil {
 
-    /** Checks whether ledger is in under-replication */
+    /**
+     * Checks whether ledger is in under-replication.
+     */
     static boolean isLedgerInUnderReplication(ZooKeeper zkc, long id,
             String basePath) throws KeeperException, InterruptedException {
         List<String> children;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
@@ -37,6 +37,9 @@ import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.junit.Test;
 
+/**
+ * Test auto recovery.
+ */
 public class TestAutoRecoveryAlongWithBookieServers extends
         BookKeeperClusterTestCase {
 
@@ -50,7 +53,9 @@ public class TestAutoRecoveryAlongWithBookieServers extends
                 + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH;
     }
 
-    /** Tests that the auto recovery service along with Bookie servers itself */
+    /**
+     * Tests that the auto recovery service along with Bookie servers itself.
+     */
     @Test
     public void testAutoRecoveryAlongWithBookieServers() throws Exception {
         LedgerHandle lh = bkc.createLedger(3, 3, BookKeeper.DigestType.CRC32,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestLedgerUnderreplicationManager.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.protobuf.TextFormat;
+
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -66,10 +68,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.protobuf.TextFormat;
-
 /**
- * Test the zookeeper implementation of the ledger replication manager
+ * Test the zookeeper implementation of the ledger replication manager.
  */
 public class TestLedgerUnderreplicationManager {
     static final Logger LOG = LoggerFactory.getLogger(TestLedgerUnderreplicationManager.class);
@@ -399,7 +399,7 @@ public class TestLedgerUnderreplicationManager {
 
     /**
      * Test that multiple LedgerUnderreplicationManagers should be able to take
-     * lock and release for same ledger
+     * lock and release for same ledger.
      */
     @Test
     public void testMultipleManagersShouldBeAbleToTakeAndReleaseLock()
@@ -448,11 +448,11 @@ public class TestLedgerUnderreplicationManager {
     /**
      * Test verifies failures of bookies which are resembling each other.
      *
-     * BK servers named like*********************************************
+     * <p>BK servers named like*********************************************
      * 1.cluster.com, 2.cluster.com, 11.cluster.com, 12.cluster.com
      * *******************************************************************
      *
-     * BKserver IP:HOST like*********************************************
+     * <p>BKserver IP:HOST like*********************************************
      * localhost:3181, localhost:318, localhost:31812
      * *******************************************************************
      */
@@ -555,7 +555,7 @@ public class TestLedgerUnderreplicationManager {
                     LOG.debug("Recieved node creation event for the zNodePath:"
                             + event.getPath());
                 }
-                
+
             }});
         // getLedgerToRereplicate is waiting until enable rereplication
         Thread thread1 = new Thread() {
@@ -596,7 +596,7 @@ public class TestLedgerUnderreplicationManager {
 
     /**
      * Test that the hierarchy gets cleaned up as ledgers
-     * are marked as fully replicated
+     * are marked as fully replicated.
      */
     @Test
     public void testHierarchyCleanup() throws Exception {
@@ -638,7 +638,7 @@ public class TestLedgerUnderreplicationManager {
 
     /**
      * Test that as the hierarchy gets cleaned up, it doesn't interfere
-     * with the marking of other ledgers as underreplicated
+     * with the marking of other ledgers as underreplicated.
      */
     @Test
     public void testHierarchyCleanupInterference() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -93,11 +93,11 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        if(null != mFactory){
+        if (null != mFactory){
             mFactory.uninitialize();
             mFactory = null;
         }
-        if(null != underReplicationManager){
+        if (null != underReplicationManager){
             underReplicationManager.close();
             underReplicationManager = null;
         }
@@ -154,7 +154,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
 
     /**
      * Tests that replication worker should retry for replication until enough
-     * bookies available for replication
+     * bookies available for replication.
      */
     @Test
     public void testRWShouldRetryUntilThereAreEnoughBksAvailableForReplication()
@@ -272,7 +272,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
 
     /**
      * Tests that Replication worker should clean the leadger under replication
-     * node of the ledger already deleted
+     * node of the ledger already deleted.
      */
     @Test
     public void testRWShouldCleanTheLedgerFromUnderReplicationIfLedgerAlreadyDeleted()
@@ -506,7 +506,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test that the replication worker will not shutdown on a simple ZK disconnection
+     * Test that the replication worker will not shutdown on a simple ZK disconnection.
      */
     @Test
     public void testRWZKConnectionLost() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/sasl/GSSAPIBookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/sasl/GSSAPIBookKeeperTest.java
@@ -1,14 +1,3 @@
-package org.apache.bookkeeper.sasl;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.Arrays;
-import org.apache.bookkeeper.client.*;
-import java.util.Enumeration;
-import java.util.Properties;
-
 /*
 *
 * Licensed to the Apache Software Foundation (ASF) under one
@@ -28,13 +17,31 @@ import java.util.Properties;
 * specific language governing permissions and limitations
 * under the License.
 *
- */
+*/
+package org.apache.bookkeeper.sasl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.security.auth.login.Configuration;
-import org.apache.bookkeeper.client.BKException.BKUnauthorizedAccessException;
 
-import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BKException.BKUnauthorizedAccessException;
+import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
@@ -42,16 +49,16 @@ import org.apache.hadoop.minikdc.MiniKdc;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.AfterClass;
-
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-
+/**
+ * GSSAPI tests.
+ */
 public class GSSAPIBookKeeperTest extends BookKeeperClusterTestCase {
 
     static final Logger LOG = LoggerFactory.getLogger(GSSAPIBookKeeperTest.class);
@@ -90,8 +97,8 @@ public class GSSAPIBookKeeperTest extends BookKeeperClusterTestCase {
         File keytabServer = new File(kerberosWorkDir.getRoot(), "bookkeeperserver.keytab");
         kdc.createPrincipal(keytabServer, principalServerNoRealm);
 
-        File jaas_file = new File(kerberosWorkDir.getRoot(), "jaas.conf");
-        try (FileWriter writer = new FileWriter(jaas_file)) {
+        File jaasFile = new File(kerberosWorkDir.getRoot(), "jaas.conf");
+        try (FileWriter writer = new FileWriter(jaasFile)) {
             writer.write("\n"
                 + "Bookie {\n"
                 + "  com.sun.security.auth.module.Krb5LoginModule required debug=true\n"
@@ -130,7 +137,7 @@ public class GSSAPIBookKeeperTest extends BookKeeperClusterTestCase {
 
         }
 
-        System.setProperty("java.security.auth.login.config", jaas_file.getAbsolutePath());
+        System.setProperty("java.security.auth.login.config", jaasFile.getAbsolutePath());
         System.setProperty("java.security.krb5.conf", krb5file.getAbsolutePath());
         javax.security.auth.login.Configuration.getConfiguration().refresh();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/sasl/MD5DigestBookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/sasl/MD5DigestBookKeeperTest.java
@@ -1,10 +1,3 @@
-package org.apache.bookkeeper.sasl;
-
-import java.io.File;
-import java.util.Arrays;
-import org.apache.bookkeeper.client.*;
-import java.util.Enumeration;
-
 /*
 *
 * Licensed to the Apache Software Foundation (ASF) under one
@@ -24,24 +17,36 @@ import java.util.Enumeration;
 * specific language governing permissions and limitations
 * under the License.
 *
- */
+*/
+package org.apache.bookkeeper.sasl;
+
+import static org.apache.bookkeeper.sasl.SaslConstants.JAAS_CLIENT_ALLOWED_IDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.security.auth.login.Configuration;
 
-import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
-import static org.apache.bookkeeper.sasl.SaslConstants.JAAS_CLIENT_ALLOWED_IDS;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.AfterClass;
-
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
+/**
+ * MD5 digest test.
+ */
 public class MD5DigestBookKeeperTest extends BookKeeperClusterTestCase {
 
     static final Logger LOG = LoggerFactory.getLogger(MD5DigestBookKeeperTest.class);
@@ -50,7 +55,8 @@ public class MD5DigestBookKeeperTest extends BookKeeperClusterTestCase {
     private static final byte[] ENTRY = "TestEntry".getBytes();
 
     static {
-        System.setProperty("java.security.auth.login.config", new File("src/test/resources/jaas_md5.conf").getAbsolutePath());
+        System.setProperty("java.security.auth.login.config",
+                new File("src/test/resources/jaas_md5.conf").getAbsolutePath());
     }
 
     public MD5DigestBookKeeperTest() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/TestMain.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/TestMain.java
@@ -23,13 +23,12 @@ import static org.apache.bookkeeper.server.Main.buildBookieServer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import java.io.IOException;
+
 import org.apache.bookkeeper.common.component.LifecycleComponentStack;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/component/TestServerLifecycleComponent.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/component/TestServerLifecycleComponent.java
@@ -26,12 +26,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
+
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.junit.Test;
 
+/**
+ * Manage the test server lifecycle.
+ */
 public class TestServerLifecycleComponent {
 
     static class TestComponent extends ServerLifecycleComponent {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -23,11 +23,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Maps;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.LedgerHandleAdapter;
@@ -53,6 +55,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test the HTTP service.
+ */
 public class TestHttpService extends BookKeeperClusterTestCase {
 
     static final Logger LOG = LoggerFactory.getLogger(TestHttpService.class);
@@ -219,7 +224,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
     }
 
     /**
-     * create ledgers, then test ListLedgerService
+     * Create ledgers, then test ListLedgerService.
      */
     @Test
     public void testListLedgerService() throws Exception {
@@ -283,7 +288,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
     }
 
     /**
-     * create ledgers, then test Delete Ledger service
+     * Create ledgers, then test Delete Ledger service.
      */
     @Test
     public void testDeleteLedgerService() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/AsyncLedgerOpsTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/AsyncLedgerOpsTest.java
@@ -20,27 +20,29 @@
  */
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Random;
 import java.util.Set;
+
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
-import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CreateCallback;
 import org.apache.bookkeeper.client.AsyncCallback.OpenCallback;
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.BKException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This test tests read and write, synchronous and asynchronous, strings and
@@ -51,7 +53,7 @@ import static org.junit.Assert.*;
 public class AsyncLedgerOpsTest extends BookKeeperClusterTestCase
     implements AddCallback, ReadCallback, CreateCallback,
     CloseCallback, OpenCallback {
-    private final static Logger LOG = LoggerFactory.getLogger(AsyncLedgerOpsTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncLedgerOpsTest.class);
 
     private final DigestType digestType;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -24,7 +24,6 @@ package org.apache.bookkeeper.test;
 import com.google.common.base.Stopwatch;
 import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -45,8 +44,8 @@ import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.metastore.InMemoryMetaStore;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
-import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.replication.Auditor;
+import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.util.IOUtils;
@@ -142,7 +141,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     /**
-     * Start zookeeper cluster
+     * Start zookeeper cluster.
      *
      * @throws Exception
      */
@@ -152,7 +151,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     /**
-     * Stop zookeeper cluster
+     * Stop zookeeper cluster.
      *
      * @throws Exception
      */
@@ -224,14 +223,15 @@ public abstract class BookKeeperClusterTestCase {
         return new ClientConfiguration(baseConf);
     }
 
-    protected ServerConfiguration newServerConfiguration(int port, String zkServers, File journalDir, File[] ledgerDirs) {
+    protected ServerConfiguration newServerConfiguration(int port, String zkServers, File journalDir,
+            File[] ledgerDirs) {
         ServerConfiguration conf = new ServerConfiguration(baseConf);
         conf.setBookiePort(port);
         conf.setZkServers(zkServers);
         conf.setAllowLoopback(true);
         conf.setJournalDirName(journalDir.getPath());
         String[] ledgerDirNames = new String[ledgerDirs.length];
-        for (int i=0; i<ledgerDirs.length; i++) {
+        for (int i = 0; i < ledgerDirs.length; i++) {
             ledgerDirNames[i] = ledgerDirs[i].getPath();
         }
         conf.setLedgerDirNames(ledgerDirNames);
@@ -257,7 +257,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     /**
-     * Get bookie address for bookie at index
+     * Get bookie address for bookie at index.
      */
     public BookieSocketAddress getBookie(int index) throws Exception {
         if (bs.size() <= index || index < 0) {
@@ -268,7 +268,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     /**
-     * Get bookie configuration for bookie
+     * Get bookie configuration for bookie.
      */
     public ServerConfiguration getBkConf(BookieSocketAddress addr) throws Exception {
         int bkIndex = 0;
@@ -313,11 +313,10 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     /**
-     * Set the bookie identified by its socket address to readonly
+     * Set the bookie identified by its socket address to readonly.
      *
      * @param addr
      *          Socket Address
-     * @return the configuration of killed bookie
      * @throws InterruptedException
      */
     public void setBookieToReadOnly(BookieSocketAddress addr) throws InterruptedException, UnknownHostException {
@@ -351,7 +350,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     /**
-     * Kill bookie by index and verify that it's stopped
+     * Kill bookie by index and verify that it's stopped.
      *
      * @param index index of bookie to kill
      *
@@ -371,7 +370,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     /**
-     * Sleep a bookie
+     * Sleep a bookie.
      *
      * @param addr
      *          Socket Address
@@ -393,7 +392,7 @@ public abstract class BookKeeperClusterTestCase {
                                 bookie.suspendProcessing();
                                 LOG.info("bookie {} is asleep", bookie.getLocalAddress());
                                 l.countDown();
-                                Thread.sleep(seconds*1000);
+                                Thread.sleep(seconds * 1000);
                                 bookie.resumeProcessing();
                                 LOG.info("bookie {} is awake", bookie.getLocalAddress());
                             } catch (Exception e) {
@@ -409,7 +408,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     /**
-     * Sleep a bookie until I count down the latch
+     * Sleep a bookie until I count down the latch.
      *
      * @param addr
      *          Socket Address
@@ -469,7 +468,7 @@ public abstract class BookKeeperClusterTestCase {
     /**
      * Restart a bookie. Also restart the respective auto recovery process,
      * if isAutoRecoveryEnabled is true.
-     * 
+     *
      * @param addr
      * @throws InterruptedException
      * @throws IOException
@@ -685,7 +684,7 @@ public abstract class BookKeeperClusterTestCase {
      * isAutoRecoveryEnabled is true.
      */
     public void stopReplicationService() throws Exception{
-        if(!isAutoRecoveryEnabled()){
+        if (!isAutoRecoveryEnabled()){
             return;
         }
         for (Entry<BookieServer, AutoRecoveryMain> autoRecoveryProcess : autoRecoveryProcesses

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.test;
-
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,6 +18,10 @@ package org.apache.bookkeeper.test;
  * under the License.
  *
  */
+package org.apache.bookkeeper.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -37,23 +39,24 @@ import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GetBookieInfoCallback;
-import org.apache.bookkeeper.proto.BookkeeperProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
-import org.apache.bookkeeper.util.OrderedSafeExecutor;
+import org.apache.bookkeeper.proto.BookkeeperProtocol;
 import org.apache.bookkeeper.util.IOUtils;
+import org.apache.bookkeeper.util.OrderedSafeExecutor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
+/**
+ * Test the bookie client.
+ */
 public class BookieClientTest {
     BookieServer bs;
     File tmpDir;
@@ -255,8 +258,8 @@ public class BookieClientTest {
     public void testGetBookieInfo() throws IOException, InterruptedException {
         BookieSocketAddress addr = new BookieSocketAddress("127.0.0.1", port);
         BookieClient bc = new BookieClient(new ClientConfiguration(), new NioEventLoopGroup(), executor);
-        long flags = BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE |
-                BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE;
+        long flags = BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE
+                | BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE;
 
         class CallbackObj {
             int rc;
@@ -274,13 +277,14 @@ public class BookieClientTest {
         bc.getBookieInfo(addr, flags, new GetBookieInfoCallback() {
             @Override
             public void getBookieInfoComplete(int rc, BookieInfo bInfo, Object ctx) {
-                CallbackObj obj = (CallbackObj)ctx;
-                obj.rc=rc;
+                CallbackObj obj = (CallbackObj) ctx;
+                obj.rc = rc;
                 if (rc == Code.OK) {
                     if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE) != 0) {
                         obj.freeDiskSpace = bInfo.getFreeDiskSpace();
                     }
-                    if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE) != 0) {
+                    if ((obj.requested
+                                & BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE) != 0) {
                         obj.totalDiskCapacity = bInfo.getTotalDiskSpace();
                     }
                 }
@@ -289,7 +293,8 @@ public class BookieClientTest {
 
         }, obj);
         obj.latch.await();
-        System.out.println("Return code: " + obj.rc + "FreeDiskSpace: " + obj.freeDiskSpace + " TotalCapacity: " + obj.totalDiskCapacity);
+        System.out.println("Return code: " + obj.rc + "FreeDiskSpace: " + obj.freeDiskSpace + " TotalCapacity: "
+                + obj.totalDiskCapacity);
         assertTrue("GetBookieInfo failed with error " + obj.rc, obj.rc == Code.OK);
         assertTrue("GetBookieInfo failed with error " + obj.rc, obj.freeDiskSpace <= obj.totalDiskCapacity);
         assertTrue("GetBookieInfo failed with error " + obj.rc, obj.totalDiskCapacity > 0);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieFailureTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieFailureTest.java
@@ -20,25 +20,28 @@
  */
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Random;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
+import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.BookKeeperTestClient;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.proto.BookieServer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This test tests read and write, synchronous and asynchronous, strings and
@@ -52,8 +55,8 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
 
     // Depending on the taste, select the amount of logging
     // by decommenting one of the two lines below
-    // private final static Logger LOG = Logger.getRootLogger();
-    private final static Logger LOG = LoggerFactory.getLogger(BookieFailureTest.class);
+    // private static final Logger LOG = Logger.getRootLogger();
+    private static final Logger LOG = LoggerFactory.getLogger(BookieFailureTest.class);
 
     byte[] ledgerPassword = "aaa".getBytes();
     LedgerHandle lh, lh2;
@@ -93,7 +96,7 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
     /**
      * Tests writes and reads when a bookie fails.
      *
-     * @throws {@link IOException}
+     * @throws IOException
      */
     @Test
     public void testAsyncBK1() throws IOException {
@@ -127,11 +130,11 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
         bs.get(2).shutdown();
 
         byte[] passwd = "blah".getBytes();
-        LedgerHandle lh = bkc.createLedger(1, 1,digestType, passwd);
+        LedgerHandle lh = bkc.createLedger(1, 1, digestType, passwd);
 
         int numEntries = 100;
-        for (int i=0; i< numEntries; i++) {
-            byte[] data = (""+i).getBytes();
+        for (int i = 0; i < numEntries; i++) {
+            byte[] data = ("" + i).getBytes();
             lh.addEntry(data);
         }
 
@@ -145,7 +148,7 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
 
         int numScanned = 0;
         while (entries.hasMoreElements()) {
-            assertEquals((""+numScanned), new String(entries.nextElement().getEntry()));
+            assertEquals(("" + numScanned), new String(entries.nextElement().getEntry()));
             numScanned++;
         }
         assertEquals(numEntries, numScanned);
@@ -286,7 +289,7 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
 
         int numEntries = 10;
         String tmp = "BookKeeper is cool!";
-        for (int i=0; i<numEntries; i++) {
+        for (int i = 0; i < numEntries; i++) {
             beforelh.addEntry(tmp.getBytes());
         }
 
@@ -301,7 +304,7 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
         startNewBookie();
         LedgerHandle beforelh2 = bkc.createLedger(numBookies, 1, digestType, "".getBytes());
 
-        for (int i=0; i<numEntries; i++) {
+        for (int i = 0; i < numEntries; i++) {
             beforelh2.addEntry(tmp.getBytes());
         }
 
@@ -324,7 +327,7 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
 
         int numEntries = 10;
         String tmp = "BookKeeper is cool!";
-        for (int i=0; i<numEntries; i++) {
+        for (int i = 0; i < numEntries; i++) {
             beforelh.addEntry(tmp.getBytes());
         }
 
@@ -339,7 +342,7 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
 
         LedgerHandle beforelh2 = bkc.createLedger(numBookies, 1, digestType, "".getBytes());
 
-        for (int i=0; i<numEntries; i++) {
+        for (int i = 0; i < numEntries; i++) {
             beforelh2.addEntry(tmp.getBytes());
         }
 
@@ -363,7 +366,7 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
      * establishment. Now the future.addlistener() will notify back in the same
      * thread and simultaneously invoke the pendingOp.operationComplete() event.
      *
-     * BOOKKEEPER-326
+     * <p>BOOKKEEPER-326
      */
     @Test
     public void testReadLastConfirmedOp() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieJournalRollingTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieJournalRollingTest.java
@@ -20,6 +20,10 @@
  */
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.Enumeration;
 import java.util.concurrent.CountDownLatch;
@@ -33,19 +37,16 @@ import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
- * This class tests that bookie rolling journals
+ * This class tests that bookie rolling journals.
  */
 public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(BookieJournalRollingTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BookieJournalRollingTest.class);
 
     private final DigestType digestType;
 
@@ -94,7 +95,7 @@ public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
         }
         String msg = msgSB.toString();
 
-        final CountDownLatch completeLatch = new CountDownLatch(numMsgs*lhs.length);
+        final CountDownLatch completeLatch = new CountDownLatch(numMsgs * lhs.length);
         final AtomicInteger rc = new AtomicInteger(BKException.Code.OK);
 
         // Write all of the entries for all of the ledgers
@@ -150,7 +151,7 @@ public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
                     StringBuilder sb = new StringBuilder();
                     sb.append(ledgerIds[j]).append('-').append(entryId).append('-')
                       .append(msg);
-                    Assert.assertArrayEquals(sb.toString().getBytes(), e.getEntry());
+                    assertArrayEquals(sb.toString().getBytes(), e.getEntry());
                     entryId++;
                 }
                 assertEquals(entryId - 1, end);
@@ -162,9 +163,9 @@ public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * This test writes enough ledger entries to roll over the journals
+     * This test writes enough ledger entries to roll over the journals.
      *
-     * It will then keep only 1 journal file before last marked journal
+     * <p>It will then keep only 1 journal file before last marked journal
      *
      * @throws Exception
      */
@@ -176,7 +177,7 @@ public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
         // Write enough ledger entries so that we roll over journals
         LedgerHandle[] lhs = writeLedgerEntries(4, 1024, 1024);
         long[] ledgerIds = new long[lhs.length];
-        for (int i=0; i<lhs.length; i++) {
+        for (int i = 0; i < lhs.length; i++) {
             ledgerIds[i] = lhs[i].getId();
             lhs[i].close();
         }
@@ -205,7 +206,7 @@ public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
 
     /**
      * This test writes enough ledger entries to roll over the journals
-     * without sync up
+     * without sync up.
      *
      * @throws Exception
      */
@@ -225,7 +226,7 @@ public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
         // Write enough ledger entries so that we roll over journals
         LedgerHandle[] lhs = writeLedgerEntries(4, 1024, 1024);
         long[] ledgerIds = new long[lhs.length];
-        for (int i=0; i<lhs.length; i++) {
+        for (int i = 0; i < lhs.length; i++) {
             ledgerIds[i] = lhs[i].getId();
             lhs[i].close();
         }
@@ -239,7 +240,7 @@ public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
 
     /**
      * This test writes enough ledger entries to roll over the journals
-     * without sync up
+     * without sync up.
      *
      * @throws Exception
      */

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieReadWriteTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieReadWriteTest.java
@@ -20,34 +20,38 @@
  */
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Random;
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadLastConfirmedCallback;
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.streaming.LedgerInputStream;
 import org.apache.bookkeeper.streaming.LedgerOutputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This test tests read and write, synchronous and asynchronous, strings and
@@ -60,8 +64,8 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
 
     // Depending on the taste, select the amount of logging
     // by decommenting one of the two lines below
-    // private final static Logger LOG = Logger.getRootLogger();
-    private final static Logger LOG = LoggerFactory.getLogger(BookieReadWriteTest.class);
+    // private static final Logger LOG = Logger.getRootLogger();
+    private static final Logger LOG = LoggerFactory.getLogger(BookieReadWriteTest.class);
 
     byte[] ledgerPassword = "aaa".getBytes();
     LedgerHandle lh, lh2;
@@ -126,9 +130,9 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
     }
 
     /**
-     * test the streaming api for reading and writing
+     * test the streaming api for reading and writing.
      *
-     * @throws {@link IOException}
+     * @throws IOException
      */
     @Test
     public void testStreamingClients() throws IOException, BKException, InterruptedException {
@@ -277,12 +281,12 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
             // bkc.initMessageDigest("SHA1");
             ledgerId = lh.getId();
             LOG.info("Ledger ID: " + lh.getId());
-            byte bytes[] = {'a','b','c','d','e','f','g','h','i'};
+            byte bytes[] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'};
 
             lh.asyncAddEntry(bytes, 0, bytes.length, this, sync);
             lh.asyncAddEntry(bytes, 0, 4, this, sync); // abcd
             lh.asyncAddEntry(bytes, 3, 4, this, sync); // defg
-            lh.asyncAddEntry(bytes, 3, (bytes.length-3), this, sync); // defghi
+            lh.asyncAddEntry(bytes, 3, (bytes.length - 3), this, sync); // defghi
             int numEntries = 4;
 
             // wait for all entries to be acknowledged
@@ -301,13 +305,13 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
                 // expected
             }
             try {
-                lh.asyncAddEntry(bytes, 0, bytes.length+1, this, sync);
+                lh.asyncAddEntry(bytes, 0, bytes.length + 1, this, sync);
                 fail("Shouldn't be able to use that much length");
             } catch (ArrayIndexOutOfBoundsException aiob) {
                 // expected
             }
             try {
-                lh.asyncAddEntry(bytes, -1, bytes.length+2, this, sync);
+                lh.asyncAddEntry(bytes, -1, bytes.length + 2, this, sync);
                 fail("Shouldn't be able to use negative offset "
                      + "with that much length");
             } catch (ArrayIndexOutOfBoundsException aiob) {
@@ -367,10 +371,10 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
                     expected = Arrays.copyOfRange(bytes, 0, 4);
                     break;
                 case 2:
-                    expected = Arrays.copyOfRange(bytes, 3, 3+4);
+                    expected = Arrays.copyOfRange(bytes, 3, 3 + 4);
                     break;
                 case 3:
-                    expected = Arrays.copyOfRange(bytes, 3, 3+(bytes.length-3));
+                    expected = Arrays.copyOfRange(bytes, 3, 3 + (bytes.length - 3));
                     break;
                 }
                 assertNotNull("There are more checks than writes", expected);
@@ -403,10 +407,10 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
 
         @Override
         public void readComplete(int rc, LedgerHandle lh, Enumeration<LedgerEntry> seq, Object ctx) {
-            SyncObj sync = (SyncObj)ctx;
+            SyncObj sync = (SyncObj) ctx;
             sync.setLedgerEntries(seq);
             sync.setReturnCode(rc);
-            synchronized(sync) {
+            synchronized (sync) {
                 sync.counter += throttle;
                 sync.notify();
             }
@@ -598,7 +602,7 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
             long ledgerId = lh.getId();
             long ledgerId2 = lh2.getId();
 
-            final CountDownLatch completeLatch = new CountDownLatch(numEntriesToWrite*2);
+            final CountDownLatch completeLatch = new CountDownLatch(numEntriesToWrite * 2);
             final AtomicInteger rc = new AtomicInteger(BKException.Code.OK);
 
             // bkc.initMessageDigest("SHA1");
@@ -766,7 +770,7 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
             assertTrue("Enumeration of ledger entries has no element", readEntry.hasMoreElements());
             LedgerEntry e = readEntry.nextElement();
             assertEquals(toRead, e.getEntryId());
-            Assert.assertArrayEquals(entries.get((int)toRead), e.getEntry());
+            assertArrayEquals(entries.get((int) toRead), e.getEntry());
             // should not written to a read only ledger
             try {
                 ByteBuffer entry = ByteBuffer.allocate(4);
@@ -835,7 +839,7 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
             ledgerId = lh.getId();
             LOG.info("Ledger ID: " + lh.getId());
             LedgerHandle lhOpen = bkc.openLedgerNoRecovery(ledgerId, digestType, ledgerPassword);
-            writeNEntriesLastWriteSync(lh, numEntriesToWrite/2);
+            writeNEntriesLastWriteSync(lh, numEntriesToWrite / 2);
 
             ByteBuffer entry = ByteBuffer.allocate(4);
             entry.putInt(rng.nextInt(maxInt));
@@ -844,7 +848,7 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
             // no recovery opened ledger 's last confirmed entry id is
             // less than written
             // and it just can read until (i-1)
-            int toRead = numEntriesToWrite/2 - 2;
+            int toRead = numEntriesToWrite / 2 - 2;
 
             long readLastConfirmed = lhOpen.readLastConfirmed();
             assertTrue(readLastConfirmed != 0);
@@ -852,7 +856,7 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
             assertTrue("Enumeration of ledger entries has no element", readEntry.hasMoreElements());
             LedgerEntry e = readEntry.nextElement();
             assertEquals(toRead, e.getEntryId());
-            Assert.assertArrayEquals(entries.get(toRead), e.getEntry());
+            assertArrayEquals(entries.get(toRead), e.getEntry());
             // should not written to a read only ledger
             try {
                 lhOpen.addEntry(entry.array());
@@ -863,7 +867,7 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
                 LOG.error("Unexpected exception", ex);
                 fail("Unexpected exception");
             }
-            writeNEntriesLastWriteSync(lh, numEntriesToWrite/2);
+            writeNEntriesLastWriteSync(lh, numEntriesToWrite / 2);
 
             long last = lh.readLastConfirmed();
             assertTrue("Last confirmed add: " + last, last == (numEntriesToWrite - 2));
@@ -1027,7 +1031,7 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
     public void readLastConfirmedComplete(int rc, long lastConfirmed, Object ctx) {
         SyncObj sync = (SyncObj) ctx;
         sync.setReturnCode(rc);
-        synchronized(sync) {
+        synchronized (sync) {
             sync.lastConfirmed = lastConfirmed;
             sync.notify();
         }
@@ -1050,16 +1054,19 @@ public class BookieReadWriteTest extends BookKeeperClusterTestCase
             String[] children = dir.list();
             for (String string : children) {
                 boolean success = cleanUpDir(new File(dir, string));
-                if (!success)
+                if (!success) {
                     return false;
+                }
             }
         }
         // The directory is now empty so delete it
         return dir.delete();
     }
 
-    /* User for testing purposes, void */
-    class emptyWatcher implements Watcher {
+    /**
+     * Used for testing purposes, void.
+     */
+    class EmptyWatcher implements Watcher {
         @Override
         public void process(WatchedEvent event) {
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
@@ -21,15 +21,20 @@
 
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import java.util.HashSet;
 
 import org.apache.bookkeeper.conf.ServerConfiguration;
-
-import java.util.HashSet;
 import org.apache.bookkeeper.proto.BookieServer;
+import org.junit.Test;
 
+/**
+ * Test bookie expiration.
+ */
 public class BookieZKExpireTest extends BookKeeperClusterTestCase {
 
     public BookieZKExpireTest() {
@@ -48,9 +53,9 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
 
             HashSet<Thread> threadset = new HashSet<Thread>();
             int threadCount = Thread.activeCount();
-            Thread threads[] = new Thread[threadCount*2];
+            Thread threads[] = new Thread[threadCount * 2];
             threadCount = Thread.enumerate(threads);
-            for(int i = 0; i < threadCount; i++) {
+            for (int i = 0; i < threadCount; i++) {
                 if (threads[i].getName().indexOf("SendThread") != -1) {
                     threadset.add(threads[i]);
                 }
@@ -70,9 +75,9 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             }
             Thread sendthread = null;
             threadCount = Thread.activeCount();
-            threads = new Thread[threadCount*2];
+            threads = new Thread[threadCount * 2];
             threadCount = Thread.enumerate(threads);
-            for(int i = 0; i < threadCount; i++) {
+            for (int i = 0; i < threadCount; i++) {
                 if (threads[i].getName().indexOf("SendThread") != -1
                         && !threadset.contains(threads[i])) {
                     sendthread = threads[i];
@@ -82,7 +87,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             assertNotNull("Send thread not found", sendthread);
 
             sendthread.suspend();
-            Thread.sleep(2*conf.getZkTimeout());
+            Thread.sleep(2 * conf.getZkTimeout());
             sendthread.resume();
 
             // allow watcher thread to run

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/CloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/CloseTest.java
@@ -20,9 +20,9 @@
  */
 package org.apache.bookkeeper.test;
 
-import org.junit.*;
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.junit.Test;
 
 /**
  * This unit test tests closing ledgers sequentially. It creates 4 ledgers, then

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
@@ -21,22 +21,24 @@
 
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertEquals;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
 import org.junit.After;
 import org.junit.Before;
@@ -44,13 +46,11 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
- * Tests writing to concurrent ledgers
+ * Tests writing to concurrent ledgers.
  */
 public class ConcurrentLedgerTest {
-    private final static Logger LOG = LoggerFactory.getLogger(ConcurrentLedgerTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConcurrentLedgerTest.class);
 
     Bookie bookie;
     File txnDir, ledgerDir;
@@ -77,10 +77,10 @@ public class ConcurrentLedgerTest {
             ledgerDir = new File(ledgerDirName);
         }
         File tmpFile = createTempDir("book", ".txn", txnDir);
-        txnDir = new File(tmpFile.getParent(), tmpFile.getName()+".dir");
+        txnDir = new File(tmpFile.getParent(), tmpFile.getName() + ".dir");
         txnDir.mkdirs();
         tmpFile = createTempDir("book", ".ledger", ledgerDir);
-        ledgerDir = new File(tmpFile.getParent(), tmpFile.getName()+".dir");
+        ledgerDir = new File(tmpFile.getParent(), tmpFile.getName() + ".dir");
         ledgerDir.mkdirs();
 
         conf.setBookiePort(5000);
@@ -95,7 +95,7 @@ public class ConcurrentLedgerTest {
         if (f.isFile()) {
             f.delete();
         } else {
-            for(File i: f.listFiles()) {
+            for (File i: f.listFiles()) {
                 recursiveDelete(i);
             }
             f.delete();
@@ -135,12 +135,12 @@ public class ConcurrentLedgerTest {
         LOG.info("Running up to " + iterations + " iterations");
         LOG.info("Total writes = " + totalwrites);
         int ledgers;
-        for(ledgers = 1; ledgers <= iterations; ledgers += iterationStep) {
+        for (ledgers = 1; ledgers <= iterations; ledgers += iterationStep) {
             long duration = doWrites(ledgers, size, totalwrites);
             LOG.info(totalwrites + " on " + ledgers + " took " + duration + " ms");
         }
         LOG.info("ledgers " + ledgers);
-        for(ledgers = 1; ledgers <= iterations; ledgers += iterationStep) {
+        for (ledgers = 1; ledgers <= iterations; ledgers += iterationStep) {
             long duration = doReads(ledgers, size, totalwrites);
             LOG.info(ledgers + " read " + duration + " ms");
         }
@@ -149,14 +149,14 @@ public class ConcurrentLedgerTest {
     private long doReads(int ledgers, int size, int totalwrites)
             throws IOException, InterruptedException, BookieException {
         long start = System.currentTimeMillis();
-        for(int i = 1; i <= totalwrites/ledgers; i++) {
-            for(int j = 1; j <= ledgers; j++) {
+        for (int i = 1; i <= totalwrites / ledgers; i++) {
+            for (int j = 1; j <= ledgers; j++) {
                 ByteBuf entry = bookie.readEntry(j, i);
                 // skip the ledger id and the entry id
                 entry.readLong();
                 entry.readLong();
-                assertEquals(j + "@" + i, j+2, entry.readLong());
-                assertEquals(j + "@" + i, i+3, entry.readLong());
+                assertEquals(j + "@" + i, j + 2, entry.readLong());
+                assertEquals(j + "@" + i, i + 3, entry.readLong());
             }
         }
         long finish = System.currentTimeMillis();
@@ -169,20 +169,20 @@ public class ConcurrentLedgerTest {
             @Override
             public void writeComplete(int rc, long ledgerId, long entryId,
                     BookieSocketAddress addr, Object ctx) {
-                AtomicInteger counter = (AtomicInteger)ctx;
+                AtomicInteger counter = (AtomicInteger) ctx;
                 counter.getAndIncrement();
                 throttle.release();
             }
         };
         AtomicInteger counter = new AtomicInteger();
         long start = System.currentTimeMillis();
-        for(int i = 1; i <= totalwrites/ledgers; i++) {
-            for(int j = 1; j <= ledgers; j++) {
+        for (int i = 1; i <= totalwrites / ledgers; i++) {
+            for (int j = 1; j <= ledgers; j++) {
                 ByteBuffer bytes = ByteBuffer.allocate(size);
                 bytes.putLong(j);
                 bytes.putLong(i);
-                bytes.putLong(j+2);
-                bytes.putLong(i+3);
+                bytes.putLong(j + 2);
+                bytes.putLong(i + 3);
                 bytes.put(("This is ledger " + j + " entry " + i).getBytes());
                 bytes.position(0);
                 bytes.limit(bytes.capacity());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConditionalSetTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConditionalSetTest.java
@@ -20,25 +20,26 @@
  */
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
-import org.apache.bookkeeper.client.BookKeeperTestClient;
+
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.BookKeeperTestClient;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
  * Tests conditional set of the ledger metadata znode.
  */
 public class ConditionalSetTest extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(ConditionalSetTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConditionalSetTest.class);
 
     byte[] entry;
     private final DigestType digestType;
@@ -93,7 +94,7 @@ public class ConditionalSetTest extends BookKeeperClusterTestCase {
         /*
          * Writer tries to close the ledger, and if should fail.
          */
-        try{
+        try {
             lhWrite.close();
             fail("Should have received an exception when trying to close the ledger.");
         } catch (BKException e) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConfigurationTest.java
@@ -20,14 +20,17 @@
  */
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.bookkeeper.conf.AbstractConfiguration;
-import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
+/**
+ * Test the configuration class.
+ */
 public class ConfigurationTest {
 
     static {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ForceReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ForceReadOnlyBookieTest.java
@@ -20,6 +20,9 @@
  */
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.Enumeration;
 
@@ -33,14 +36,13 @@ import org.junit.Test;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.junit.Assert.*;
 
 /**
- * Test to verify force start readonly bookie
+ * Test to verify force start readonly bookie.
  */
 public class ForceReadOnlyBookieTest extends BookKeeperClusterTestCase {
 
-    private final static Logger LOG = LoggerFactory.getLogger(ForceReadOnlyBookieTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ForceReadOnlyBookieTest.class);
     public ForceReadOnlyBookieTest() {
         super(2);
         baseConf.setLedgerStorageClass(InterleavedLedgerStorage.class.getName());
@@ -48,7 +50,7 @@ public class ForceReadOnlyBookieTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Check force start readonly bookie
+     * Check force start readonly bookie.
      */
     @Test
     public void testBookieForceStartAsReadOnly() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerCreateDeleteTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerCreateDeleteTest.java
@@ -25,15 +25,15 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerHandle;
 
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test Create/Delete ledgers
+ * Test Create/Delete ledgers.
  */
 public class LedgerCreateDeleteTest extends BookKeeperClusterTestCase {
 
@@ -44,7 +44,7 @@ public class LedgerCreateDeleteTest extends BookKeeperClusterTestCase {
     @Override
     @Before
     public void setUp() throws Exception {
-        baseConf.setOpenFileLimit(1); 
+        baseConf.setOpenFileLimit(1);
         super.setUp();
     }
 
@@ -52,9 +52,9 @@ public class LedgerCreateDeleteTest extends BookKeeperClusterTestCase {
     public void testCreateDeleteLedgers() throws Exception {
         int numLedgers = 3;
         ArrayList<Long> ledgers = new ArrayList<Long>();
-        for (int i=0; i<numLedgers; i++) {
+        for (int i = 0; i < numLedgers; i++) {
             LedgerHandle lh = bkc.createLedger(1, 1, DigestType.CRC32, "bk is cool".getBytes());
-            for (int j=0; j<5; j++) {
+            for (int j = 0; j < 5; j++) {
                 lh.addEntry("just test".getBytes());
             }
             ledgers.add(lh.getId());
@@ -65,9 +65,9 @@ public class LedgerCreateDeleteTest extends BookKeeperClusterTestCase {
         }
         ledgers.clear();
         Thread.sleep(baseConf.getGcWaitTime() * 2);
-        for (int i=0; i<numLedgers; i++) {
+        for (int i = 0; i < numLedgers; i++) {
             LedgerHandle lh = bkc.createLedger(1, 1, DigestType.CRC32, "bk is cool".getBytes());
-            for (int j=0; j<5; j++) {
+            for (int j = 0; j < 5; j++) {
                 lh.addEntry("just test".getBytes());
             }
             ledgers.add(lh.getId());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerDeleteTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerDeleteTest.java
@@ -20,28 +20,29 @@
  */
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertFalse;
+
 import java.io.File;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
-import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
+import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.util.TestUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class tests the ledger delete functionality both from the BookKeeper
  * client and the server side.
  */
 public class LedgerDeleteTest extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(LedgerDeleteTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LedgerDeleteTest.class);
     DigestType digestType;
 
     public LedgerDeleteTest() {
@@ -84,7 +85,7 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
             msgSB.append("a");
         }
         String msg = msgSB.toString();
-        final CountDownLatch completeLatch = new CountDownLatch(numMsgs*numLedgers);
+        final CountDownLatch completeLatch = new CountDownLatch(numMsgs * numLedgers);
         final AtomicInteger rc = new AtomicInteger(BKException.Code.OK);
         // Write all of the entries for all of the ledgers
         for (int i = 0; i < numMsgs; i++) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LocalBookiesRegistryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LocalBookiesRegistryTest.java
@@ -29,10 +29,10 @@ import org.apache.bookkeeper.proto.LocalBookiesRegistry;
 import org.junit.Test;
 
 /**
- * Test the correctness and the availability outside of its package of LocalBookiesRegistryTest
+ * Test the correctness and the availability outside of its package of LocalBookiesRegistryTest.
  */
 public class LocalBookiesRegistryTest extends BookKeeperClusterTestCase {
-    
+
     public LocalBookiesRegistryTest() {
         super(3);
         baseConf.setDisableServerSocketBind(true);
@@ -41,7 +41,7 @@ public class LocalBookiesRegistryTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testAccessibleLocalBookiesRegistry() throws Exception {
-        assertEquals(3,bs.size());
+        assertEquals(3, bs.size());
         for (BookieServer bk : bs) {
             assertTrue(LocalBookiesRegistry.isLocalBookie(bk.getLocalAddress()));
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LoopbackClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LoopbackClient.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.test;
-
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,6 +18,7 @@ package org.apache.bookkeeper.test;
  * under the License.
  *
  */
+package org.apache.bookkeeper.test;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.EventLoopGroup;
@@ -60,12 +59,14 @@ class LoopbackClient implements WriteCallback {
         }
 
         synchronized void increment() {
-            if (++c == limit)
+            if (++c == limit) {
                 this.notify();
+            }
         }
     }
 
-    LoopbackClient(EventLoopGroup eventLoopGroup, OrderedSafeExecutor executor, long begin, int limit) throws IOException {
+    LoopbackClient(EventLoopGroup eventLoopGroup, OrderedSafeExecutor executor, long begin, int limit)
+            throws IOException {
         this.client = new BookieClient(new ClientConfiguration(), eventLoopGroup, executor);
         this.begin = begin;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/MultipleThreadReadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/MultipleThreadReadTest.java
@@ -20,6 +20,10 @@
  */
 package org.apache.bookkeeper.test;
 
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +31,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -37,11 +42,11 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-import static com.google.common.base.Charsets.UTF_8;
-
+/**
+ * Multi-thread read test.
+ */
 public class MultipleThreadReadTest extends BookKeeperClusterTestCase {
-    static Logger LOG = LoggerFactory.getLogger(MultipleThreadReadTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MultipleThreadReadTest.class);
 
     BookKeeper.DigestType digestType;
     byte [] ledgerPassword = "aaa".getBytes();
@@ -81,7 +86,7 @@ public class MultipleThreadReadTest extends BookKeeperClusterTestCase {
                     lh.asyncAddEntry(entry, new AsyncCallback.AddCallback() {
                         @Override
                         public void addComplete(int rc, LedgerHandle ledgerHandle, long eid, Object o) {
-                            SyncObj syncObj = (SyncObj)o;
+                            SyncObj syncObj = (SyncObj) o;
                             synchronized (syncObj) {
                                 if (rc != BKException.Code.OK) {
                                     LOG.error("Add entry {} failed : rc = {}", new String(entry, UTF_8), rc);
@@ -132,7 +137,8 @@ public class MultipleThreadReadTest extends BookKeeperClusterTestCase {
         Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
-                //LedgerHandle lh = clientList.get(0).openLedger(ledgerIds.get(tNo % numLedgers), digestType, ledgerPassword);
+                //LedgerHandle lh = clientList.get(0).openLedger(ledgerIds.get(tNo % numLedgers),
+                //    digestType, ledgerPassword);
                 long startEntryId = 0;
                 long endEntryId;
                 long eid = 0;
@@ -160,7 +166,7 @@ public class MultipleThreadReadTest extends BookKeeperClusterTestCase {
                             byte[] data = e.getEntry();
                             if (!Arrays.equals(("Entry-" + ledgerNumber + "-" + e.getEntryId()).getBytes(), data)) {
                                 LOG.error("Expected entry data 'Entry-{}-{}' but {} found for ledger {}.",
-                                          new Object[] { ledgerNumber, e.getEntryId(), new String(data, UTF_8), lh.getId() });
+                                          ledgerNumber, e.getEntryId(), new String(data, UTF_8), lh.getId());
                                 success = false;
                                 break;
                             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/PortManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/PortManager.java
@@ -20,8 +20,9 @@
  */
 package org.apache.bookkeeper.test;
 
-import java.net.ServerSocket;
 import java.io.IOException;
+import java.net.ServerSocket;
+
 /**
  * Port manager allows a base port to be specified on the commandline.
  * Tests will then use ports, counting up from this base port.
@@ -30,7 +31,7 @@ import java.io.IOException;
 public class PortManager {
     private static int nextPort = getBasePort();
 
-    public synchronized static int nextFreePort() {
+    public static synchronized int nextFreePort() {
         while (true) {
             ServerSocket ss = null;
             try {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -37,11 +37,10 @@ import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.junit.Test;
 
 /**
- * Test to verify the readonly feature of bookies
+ * Test to verify the readonly feature of bookies.
  */
 public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
 
@@ -52,7 +51,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Check readonly bookie
+     * Check readonly bookie.
      */
     @Test
     public void testBookieShouldServeAsReadOnly() throws Exception {
@@ -165,7 +164,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * check readOnlyModeEnabled=false
+     * check readOnlyModeEnabled=false.
      */
     @Test
     public void testBookieShutdownIfReadOnlyModeNotEnabled() throws Exception {
@@ -204,7 +203,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Check multiple ledger dirs
+     * Check multiple ledger dirs.
      */
     @Test
     public void testBookieContinueWritingIfMultipleLedgersPresent()
@@ -254,7 +253,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test ledger creation with readonly bookies
+     * Test ledger creation with readonly bookies.
      */
     @Test
     public void testLedgerCreationShouldFailWithReadonlyBookie() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestCallbacks.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestCallbacks.java
@@ -20,21 +20,25 @@
  */
 package org.apache.bookkeeper.test;
 
+import com.google.common.util.concurrent.AbstractFuture;
+
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
-import com.google.common.util.concurrent.AbstractFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Callbacks implemented with SettableFuture, to be used in tests
+ * Callbacks implemented with SettableFuture, to be used in tests.
  */
 public class TestCallbacks {
 
     private static final Logger logger = LoggerFactory.getLogger(TestCallbacks.class);
 
+    /**
+     * Generic callback future.
+     */
     public static class GenericCallbackFuture<T>
         extends AbstractFuture<T> implements GenericCallback<T> {
         @Override
@@ -47,6 +51,9 @@ public class TestCallbacks {
         }
     }
 
+    /**
+     * Add callback future implementation.
+     */
     public static class AddCallbackFuture
         extends AbstractFuture<Long> implements AddCallback {
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
@@ -21,12 +21,15 @@
 
 package org.apache.bookkeeper.test;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase;
@@ -41,8 +44,10 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.test.ClientBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.junit.Assert.*;
 
+/**
+ * Test the zookeeper utilities.
+ */
 public class ZooKeeperUtil {
 
     static {
@@ -59,7 +64,7 @@ public class ZooKeeperUtil {
     protected ZooKeeperServer zks;
     protected ZooKeeper zkc; // zookeeper client
     protected NIOServerCnxnFactory serverFactory;
-    protected File ZkTmpDir;
+    protected File zkTmpDir;
     private String connectString;
 
     public ZooKeeperUtil() {
@@ -81,7 +86,7 @@ public class ZooKeeperUtil {
         LOG.debug("Running ZK server");
         // ServerStats.registerAsConcrete();
         ClientBase.setupTestEnv();
-        ZkTmpDir = IOUtils.createTempDir("zookeeper", "test");
+        zkTmpDir = IOUtils.createTempDir("zookeeper", "test");
 
         // start the server and client.
         restartServer();
@@ -98,7 +103,7 @@ public class ZooKeeperUtil {
     }
 
     public void restartServer() throws Exception {
-        zks = new ZooKeeperServer(ZkTmpDir, ZkTmpDir,
+        zks = new ZooKeeperServer(zkTmpDir, zkTmpDir,
                 ZooKeeperServer.DEFAULT_TICK_TIME);
         serverFactory = new NIOServerCnxnFactory();
         serverFactory.configure(zkaddr, 100);
@@ -180,6 +185,6 @@ public class ZooKeeperUtil {
     public void killServer() throws Exception {
         stopServer();
         // ServerStats.unregister();
-        FileUtils.deleteDirectory(ZkTmpDir);
+        FileUtils.deleteDirectory(zkTmpDir);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -17,48 +17,44 @@
  */
 package org.apache.bookkeeper.tls;
 
-import org.junit.*;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.Enumeration;
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.bookkeeper.tls.SecurityException;
-import org.apache.bookkeeper.tls.TLSContextFactory;
-import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.client.LedgerEntry;
-import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
-
-import java.io.IOException;
-import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.apache.bookkeeper.auth.AuthCallbacks;
-import org.apache.bookkeeper.auth.AuthToken;
-import org.apache.bookkeeper.auth.BookieAuthProvider;
-import org.apache.bookkeeper.auth.ClientAuthProvider;
-import org.apache.bookkeeper.client.BookKeeperAdmin;
-import org.apache.bookkeeper.client.LedgerMetadata;
-import org.apache.bookkeeper.proto.BookieConnectionPeer;
-import org.apache.bookkeeper.proto.ClientConnectionPeer;
-import org.apache.bookkeeper.proto.TestPerChannelBookieClient;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.bookkeeper.auth.AuthCallbacks;
+import org.apache.bookkeeper.auth.AuthToken;
+import org.apache.bookkeeper.auth.BookieAuthProvider;
+import org.apache.bookkeeper.auth.ClientAuthProvider;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.LedgerMetadata;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieConnectionPeer;
+import org.apache.bookkeeper.proto.ClientConnectionPeer;
+import org.apache.bookkeeper.proto.TestPerChannelBookieClient;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestTLS extends BookKeeperClusterTestCase {
 
-    static Logger LOG = LoggerFactory.getLogger(TestPerChannelBookieClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestPerChannelBookieClient.class);
 
     private static boolean secureClientSideChannel = false;
     private static Collection<Object> secureClientSideChannelPrincipals = null;
@@ -117,7 +113,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify that a server will not start if tls is enabled but no cert is specified
+     * Verify that a server will not start if tls is enabled but no cert is specified.
      */
     @Test
     public void testStartTLSServerNoKeyStore() throws Exception {
@@ -132,7 +128,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify that a server will not start if tls is enabled but the cert password is incorrect
+     * Verify that a server will not start if tls is enabled but the cert password is incorrect.
      */
     @Test
     public void testStartTLSServerBadPassword() throws Exception {
@@ -170,7 +166,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify the basic use of TLS. TLS client, TLS servers
+     * Verify the basic use of TLS. TLS client, TLS servers.
      */
     @Test
     public void testConnectToTLSClusterTLSClient() throws Exception {
@@ -180,7 +176,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
 
 
     /**
-     * Multiple clients, some with TLS, and some without TLS
+     * Multiple clients, some with TLS, and some without TLS.
      */
     @Test
     public void testConnectToTLSClusterMixedClient() throws Exception {
@@ -219,7 +215,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify that a client without tls enabled can connect to a cluster with TLS
+     * Verify that a client without tls enabled can connect to a cluster with TLS.
      */
     @Test
     public void testConnectToTLSClusterNonTLSClient() throws Exception {
@@ -285,7 +281,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify that a client-side Auth plugin can access server certificates
+     * Verify that a client-side Auth plugin can access server certificates.
      */
     @Test
     public void testClientAuthPlugin() throws Exception {
@@ -305,7 +301,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify that a bookie-side Auth plugin can access server certificates
+     * Verify that a bookie-side Auth plugin can access server certificates.
      */
     @Test
     public void testBookieAuthPluginRequireClientTLSAuthentication() throws Exception {
@@ -327,7 +323,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify that a bookie-side Auth plugin can access server certificates
+     * Verify that a bookie-side Auth plugin can access server certificates.
      */
     @Test
     public void testBookieAuthPluginDenyAccesstoClientWithoutTLSAuthentication() throws Exception {
@@ -353,7 +349,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Verify that a bookie-side Auth plugin can access server certificates
+     * Verify that a bookie-side Auth plugin can access server certificates.
      */
     @Test
     public void testBookieAuthPluginDenyAccessToClientWithoutTLS() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/DoubleByteBufTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/DoubleByteBufTest.java
@@ -20,13 +20,16 @@ package org.apache.bookkeeper.util;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 import java.nio.ByteBuffer;
 
 import org.junit.Test;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
+/**
+ * Test the Double byte buffer.
+ */
 public class DoubleByteBufTest {
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/SubTreeCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/SubTreeCacheTest.java
@@ -21,14 +21,6 @@
 
 package org.apache.bookkeeper.util;
 
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.KeeperException.NoNodeException;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,6 +29,17 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test the subtree cache.
+ */
 public class SubTreeCacheTest {
     class TestTreeProvider implements SubTreeCache.TreeProvider {
         class Node {
@@ -50,8 +53,9 @@ public class SubTreeCacheTest {
             String[] pathSegments = path.split("/");
             Node cur = root;
             for (String segment : pathSegments) {
-                if (segment.length() == 0)
+                if (segment.length() == 0) {
                     continue; // ignore leading empty one for leading /
+                }
                 if (cur.children.containsKey(segment)) {
                     cur = cur.children.get(segment);
                 } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestDiskChecker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestDiskChecker.java
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test to verify {@link DiskChecker}
+ * Test to verify {@link DiskChecker}.
  *
  */
 public class TestDiskChecker {
@@ -71,7 +71,7 @@ public class TestDiskChecker {
     }
 
     /**
-     * Check the disk full
+     * Check the disk full.
      */
     @Test(expected = DiskOutOfSpaceException.class)
     public void testCheckDiskFull() throws IOException {
@@ -98,7 +98,7 @@ public class TestDiskChecker {
 
     /**
      * Check disk full on non exist file. in this case it should check for
-     * parent file
+     * parent file.
      */
     @Test(expected = DiskOutOfSpaceException.class)
     public void testCheckDiskFullOnNonExistFile() throws IOException {
@@ -112,7 +112,7 @@ public class TestDiskChecker {
     }
 
     /**
-     * Check disk error for file
+     * Check disk error for file.
      */
     @Test(expected = DiskErrorException.class)
     public void testCheckDiskErrorForFile() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestUtils.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestUtils.java
@@ -27,6 +27,9 @@ import java.util.Set;
 
 import org.apache.bookkeeper.bookie.Bookie;
 
+/**
+ * Test utilities.
+ */
 public class TestUtils {
     public static boolean hasLogFiles(File ledgerDirectory, boolean partial, Integer... logsId) {
         boolean result = partial ? false : true;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestZkUtils.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestZkUtils.java
@@ -22,6 +22,8 @@ package org.apache.bookkeeper.util;
 
 import java.io.IOException;
 
+import junit.framework.TestCase;
+
 import org.apache.bookkeeper.test.ZooKeeperUtil;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -33,11 +35,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import junit.framework.TestCase;
-
+/**
+ * Test ZooKeeper utilities.
+ */
 public class TestZkUtils extends TestCase {
 
-    static final Logger logger = LoggerFactory.getLogger(TestZkUtils.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestZkUtils.class);
 
     // ZooKeeper related variables
     protected ZooKeeperUtil zkUtil = new ZooKeeperUtil();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMapTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Lists;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,8 +43,9 @@ import java.util.function.LongFunction;
 
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-
+/**
+ * Test the ConcurrentLongHashMap class.
+ */
 public class ConcurrentLongHashMapTest {
 
     @Test
@@ -171,7 +174,7 @@ public class ConcurrentLongHashMapTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
         String value = "value";
 
         List<Future<?>> futures = new ArrayList<>();
@@ -181,7 +184,7 @@ public class ConcurrentLongHashMapTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = random.nextLong();
                     // Ensure keys are uniques
                     key -= key % (threadIdx + 1);
@@ -195,7 +198,7 @@ public class ConcurrentLongHashMapTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -206,7 +209,7 @@ public class ConcurrentLongHashMapTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
         String value = "value";
 
         List<Future<?>> futures = new ArrayList<>();
@@ -216,7 +219,7 @@ public class ConcurrentLongHashMapTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = random.nextLong();
                     // Ensure keys are uniques
                     key -= key % (threadIdx + 1);
@@ -230,7 +233,7 @@ public class ConcurrentLongHashMapTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -280,15 +283,15 @@ public class ConcurrentLongHashMapTest {
 
     @Test
     public void testHashConflictWithDeletion() {
-        final int Buckets = 16;
-        ConcurrentLongHashMap<String> map = new ConcurrentLongHashMap<>(Buckets, 1);
+        final int buckets = 16;
+        ConcurrentLongHashMap<String> map = new ConcurrentLongHashMap<>(buckets, 1);
 
         // Pick 2 keys that fall into the same bucket
         long key1 = 1;
         long key2 = 27;
 
-        int bucket1 = ConcurrentLongHashMap.signSafeMod(ConcurrentLongHashMap.hash(key1), Buckets);
-        int bucket2 = ConcurrentLongHashMap.signSafeMod(ConcurrentLongHashMap.hash(key2), Buckets);
+        int bucket1 = ConcurrentLongHashMap.signSafeMod(ConcurrentLongHashMap.hash(key1), buckets);
+        int bucket2 = ConcurrentLongHashMap.signSafeMod(ConcurrentLongHashMap.hash(key2), buckets);
         assertEquals(bucket1, bucket2);
 
         assertEquals(map.put(key1, "value-1"), null);
@@ -345,9 +348,9 @@ public class ConcurrentLongHashMapTest {
         assertEquals(map.get(2).intValue(), 2);
     }
 
-    final static int Iterations = 1;
-    final static int ReadIterations = 100;
-    final static int N = 1_000_000;
+    static final int Iterations = 1;
+    static final int ReadIterations = 100;
+    static final int N = 1_000_000;
 
     public void benchConcurrentLongHashMap() throws Exception {
         // public static void main(String args[]) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSetTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSetTest.java
@@ -25,6 +25,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,9 +38,9 @@ import java.util.concurrent.Future;
 
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
+/**
+ * Test the ConcurrentLongHashSet class.
+ */
 public class ConcurrentLongHashSetTest {
 
     @Test
@@ -150,7 +153,7 @@ public class ConcurrentLongHashSetTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
 
         List<Future<?>> futures = new ArrayList<>();
         for (int i = 0; i < nThreads; i++) {
@@ -159,7 +162,7 @@ public class ConcurrentLongHashSetTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = Math.abs(random.nextLong());
                     // Ensure keys are unique
                     key -= key % (threadIdx + 1);
@@ -173,7 +176,7 @@ public class ConcurrentLongHashSetTest {
             future.get();
         }
 
-        assertEquals(set.size(), N * nThreads);
+        assertEquals(set.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -184,7 +187,7 @@ public class ConcurrentLongHashSetTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
 
         List<Future<?>> futures = new ArrayList<>();
         for (int i = 0; i < nThreads; i++) {
@@ -193,7 +196,7 @@ public class ConcurrentLongHashSetTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = Math.abs(random.nextLong());
                     // Ensure keys are unique
                     key -= key % (threadIdx + 1);
@@ -207,7 +210,7 @@ public class ConcurrentLongHashSetTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -240,15 +243,15 @@ public class ConcurrentLongHashSetTest {
 
     @Test
     public void testHashConflictWithDeletion() {
-        final int Buckets = 16;
-        ConcurrentLongHashSet set = new ConcurrentLongHashSet(Buckets, 1);
+        final int buckets = 16;
+        ConcurrentLongHashSet set = new ConcurrentLongHashSet(buckets, 1);
 
         // Pick 2 keys that fall into the same bucket
         long key1 = 1;
         long key2 = 27;
 
-        int bucket1 = ConcurrentOpenHashSet.signSafeMod(ConcurrentOpenHashSet.hash(key1), Buckets);
-        int bucket2 = ConcurrentOpenHashSet.signSafeMod(ConcurrentOpenHashSet.hash(key2), Buckets);
+        int bucket1 = ConcurrentOpenHashSet.signSafeMod(ConcurrentOpenHashSet.hash(key1), buckets);
+        int bucket2 = ConcurrentOpenHashSet.signSafeMod(ConcurrentOpenHashSet.hash(key2), buckets);
         assertEquals(bucket1, bucket2);
 
         assertTrue(set.add(key1));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMapTest.java
@@ -25,6 +25,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,9 +41,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap.LongLongFunction;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
+/**
+ * Test the ConcurrentLongLongHashMap class.
+ */
 public class ConcurrentLongLongHashMapTest {
 
     @Test
@@ -169,7 +172,7 @@ public class ConcurrentLongLongHashMapTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
         long value = 55;
 
         List<Future<?>> futures = new ArrayList<>();
@@ -179,7 +182,7 @@ public class ConcurrentLongLongHashMapTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = Math.abs(random.nextLong());
                     // Ensure keys are uniques
                     key -= key % (threadIdx + 1);
@@ -193,7 +196,7 @@ public class ConcurrentLongLongHashMapTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -204,7 +207,7 @@ public class ConcurrentLongLongHashMapTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
         final long value = 55;
 
         List<Future<?>> futures = new ArrayList<>();
@@ -214,7 +217,7 @@ public class ConcurrentLongLongHashMapTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = Math.abs(random.nextLong());
                     // Ensure keys are uniques
                     key -= key % (threadIdx + 1);
@@ -228,7 +231,7 @@ public class ConcurrentLongLongHashMapTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -278,15 +281,15 @@ public class ConcurrentLongLongHashMapTest {
 
     @Test
     public void testHashConflictWithDeletion() {
-        final int Buckets = 16;
-        ConcurrentLongLongHashMap map = new ConcurrentLongLongHashMap(Buckets, 1);
+        final int buckets = 16;
+        ConcurrentLongLongHashMap map = new ConcurrentLongLongHashMap(buckets, 1);
 
         // Pick 2 keys that fall into the same bucket
         long key1 = 1;
         long key2 = 27;
 
-        int bucket1 = ConcurrentLongLongHashMap.signSafeMod(ConcurrentLongLongHashMap.hash(key1), Buckets);
-        int bucket2 = ConcurrentLongLongHashMap.signSafeMod(ConcurrentLongLongHashMap.hash(key2), Buckets);
+        int bucket1 = ConcurrentLongLongHashMap.signSafeMod(ConcurrentLongLongHashMap.hash(key1), buckets);
+        int bucket2 = ConcurrentLongLongHashMap.signSafeMod(ConcurrentLongLongHashMap.hash(key2), buckets);
         assertEquals(bucket1, bucket2);
 
         final long value1 = 1;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -25,6 +25,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,9 +40,9 @@ import java.util.concurrent.Future;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
+/**
+ * Test the concurrent long-long pair hashmap class.
+ */
 public class ConcurrentLongLongPairHashMapTest {
 
     @Test
@@ -168,7 +171,7 @@ public class ConcurrentLongLongPairHashMapTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
         long value = 55;
 
         List<Future<?>> futures = new ArrayList<>();
@@ -178,7 +181,7 @@ public class ConcurrentLongLongPairHashMapTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key1 = Math.abs(random.nextLong());
                     // Ensure keys are uniques
                     key1 -= key1 % (threadIdx + 1);
@@ -196,7 +199,7 @@ public class ConcurrentLongLongPairHashMapTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -207,7 +210,7 @@ public class ConcurrentLongLongPairHashMapTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
         final long value = 55;
 
         List<Future<?>> futures = new ArrayList<>();
@@ -217,7 +220,7 @@ public class ConcurrentLongLongPairHashMapTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key1 = Math.abs(random.nextLong());
                     // Ensure keys are uniques
                     key1 -= key1 % (threadIdx + 1);
@@ -235,7 +238,7 @@ public class ConcurrentLongLongPairHashMapTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMapTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Lists;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,8 +44,9 @@ import java.util.function.Function;
 
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-
+/**
+ * Test the concurrent open HashMap class.
+ */
 public class ConcurrentOpenHashMapTest {
 
     @Test
@@ -158,7 +161,7 @@ public class ConcurrentOpenHashMapTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
         String value = "value";
 
         List<Future<?>> futures = new ArrayList<>();
@@ -168,7 +171,7 @@ public class ConcurrentOpenHashMapTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = random.nextLong();
                     // Ensure keys are uniques
                     key -= key % (threadIdx + 1);
@@ -182,7 +185,7 @@ public class ConcurrentOpenHashMapTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -193,7 +196,7 @@ public class ConcurrentOpenHashMapTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
         String value = "value";
 
         List<Future<?>> futures = new ArrayList<>();
@@ -203,7 +206,7 @@ public class ConcurrentOpenHashMapTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = random.nextLong();
                     // Ensure keys are uniques
                     key -= key % (threadIdx + 1);
@@ -217,7 +220,7 @@ public class ConcurrentOpenHashMapTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -267,15 +270,15 @@ public class ConcurrentOpenHashMapTest {
 
     @Test
     public void testHashConflictWithDeletion() {
-        final int Buckets = 16;
-        ConcurrentOpenHashMap<Long, String> map = new ConcurrentOpenHashMap<>(Buckets, 1);
+        final int buckets = 16;
+        ConcurrentOpenHashMap<Long, String> map = new ConcurrentOpenHashMap<>(buckets, 1);
 
         // Pick 2 keys that fall into the same bucket
         long key1 = 1;
         long key2 = 27;
 
-        int bucket1 = ConcurrentOpenHashMap.signSafeMod(ConcurrentOpenHashMap.hash(key1), Buckets);
-        int bucket2 = ConcurrentOpenHashMap.signSafeMod(ConcurrentOpenHashMap.hash(key2), Buckets);
+        int bucket1 = ConcurrentOpenHashMap.signSafeMod(ConcurrentOpenHashMap.hash(key1), buckets);
+        int bucket2 = ConcurrentOpenHashMap.signSafeMod(ConcurrentOpenHashMap.hash(key2), buckets);
         assertEquals(bucket1, bucket2);
 
         assertEquals(map.put(key1, "value-1"), null);
@@ -381,26 +384,26 @@ public class ConcurrentOpenHashMapTest {
         ConcurrentOpenHashMap<T, String> map = new ConcurrentOpenHashMap<>();
 
         T t1 = new T(1);
-        T t1_b = new T(1);
+        T t1B = new T(1);
         T t2 = new T(2);
 
-        assertEquals(t1, t1_b);
+        assertEquals(t1, t1B);
         assertFalse(t1.equals(t2));
-        assertFalse(t1_b.equals(t2));
+        assertFalse(t1B.equals(t2));
 
         assertNull(map.put(t1, "t1"));
         assertEquals(map.get(t1), "t1");
-        assertEquals(map.get(t1_b), "t1");
+        assertEquals(map.get(t1B), "t1");
         assertNull(map.get(t2));
 
-        assertEquals(map.remove(t1_b), "t1");
+        assertEquals(map.remove(t1B), "t1");
         assertNull(map.get(t1));
-        assertNull(map.get(t1_b));
+        assertNull(map.get(t1B));
     }
 
-    final static int Iterations = 1;
-    final static int ReadIterations = 100;
-    final static int N = 1_000_000;
+    static final int Iterations = 1;
+    static final int ReadIterations = 100;
+    static final int N = 1_000_000;
 
     public void benchConcurrentOpenHashMap() throws Exception {
         // public static void main(String args[]) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSetTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSetTest.java
@@ -25,6 +25,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Lists;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,8 +37,9 @@ import java.util.concurrent.Future;
 
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-
+/**
+ * Test the concurrent open HashSet class.
+ */
 public class ConcurrentOpenHashSetTest {
 
     @Test
@@ -149,7 +152,7 @@ public class ConcurrentOpenHashSetTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
 
         List<Future<?>> futures = new ArrayList<>();
         for (int i = 0; i < nThreads; i++) {
@@ -158,7 +161,7 @@ public class ConcurrentOpenHashSetTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = random.nextLong();
                     // Ensure keys are unique
                     key -= key % (threadIdx + 1);
@@ -172,7 +175,7 @@ public class ConcurrentOpenHashSetTest {
             future.get();
         }
 
-        assertEquals(set.size(), N * nThreads);
+        assertEquals(set.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -183,7 +186,7 @@ public class ConcurrentOpenHashSetTest {
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
-        final int N = 100_000;
+        final int n = 100_000;
 
         List<Future<?>> futures = new ArrayList<>();
         for (int i = 0; i < nThreads; i++) {
@@ -192,7 +195,7 @@ public class ConcurrentOpenHashSetTest {
             futures.add(executor.submit(() -> {
                 Random random = new Random();
 
-                for (int j = 0; j < N; j++) {
+                for (int j = 0; j < n; j++) {
                     long key = random.nextLong();
                     // Ensure keys are unique
                     key -= key % (threadIdx + 1);
@@ -206,7 +209,7 @@ public class ConcurrentOpenHashSetTest {
             future.get();
         }
 
-        assertEquals(map.size(), N * nThreads);
+        assertEquals(map.size(), n * nThreads);
 
         executor.shutdown();
     }
@@ -239,15 +242,15 @@ public class ConcurrentOpenHashSetTest {
 
     @Test
     public void testHashConflictWithDeletion() {
-        final int Buckets = 16;
-        ConcurrentOpenHashSet<Long> set = new ConcurrentOpenHashSet<>(Buckets, 1);
+        final int buckets = 16;
+        ConcurrentOpenHashSet<Long> set = new ConcurrentOpenHashSet<>(buckets, 1);
 
         // Pick 2 keys that fall into the same bucket
         long key1 = 1;
         long key2 = 27;
 
-        int bucket1 = ConcurrentOpenHashSet.signSafeMod(ConcurrentOpenHashSet.hash(key1), Buckets);
-        int bucket2 = ConcurrentOpenHashSet.signSafeMod(ConcurrentOpenHashSet.hash(key2), Buckets);
+        int bucket1 = ConcurrentOpenHashSet.signSafeMod(ConcurrentOpenHashSet.hash(key1), buckets);
+        int bucket2 = ConcurrentOpenHashSet.signSafeMod(ConcurrentOpenHashSet.hash(key2), buckets);
         assertEquals(bucket1, bucket2);
 
         assertTrue(set.add(key1));
@@ -298,21 +301,21 @@ public class ConcurrentOpenHashSetTest {
         ConcurrentOpenHashSet<T> set = new ConcurrentOpenHashSet<>();
 
         T t1 = new T(1);
-        T t1_b = new T(1);
+        T t1B = new T(1);
         T t2 = new T(2);
 
-        assertEquals(t1, t1_b);
+        assertEquals(t1, t1B);
         assertFalse(t1.equals(t2));
-        assertFalse(t1_b.equals(t2));
+        assertFalse(t1B.equals(t2));
 
         set.add(t1);
         assertTrue(set.contains(t1));
-        assertTrue(set.contains(t1_b));
+        assertTrue(set.contains(t1B));
         assertFalse(set.contains(t2));
 
-        assertTrue(set.remove(t1_b));
+        assertTrue(set.remove(t1B));
         assertFalse(set.contains(t1));
-        assertFalse(set.contains(t1_b));
+        assertFalse(set.contains(t1B));
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/GrowableArrayBlockingQueueTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/GrowableArrayBlockingQueueTest.java
@@ -20,9 +20,11 @@
  */
 package org.apache.bookkeeper.util.collections;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,8 +35,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-
+/**
+ * Test the growable array blocking queue.
+ */
 public class GrowableArrayBlockingQueueTest {
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/versioning/TestLongVersion.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/versioning/TestLongVersion.java
@@ -18,9 +18,12 @@
 package org.apache.bookkeeper.versioning;
 
 import org.apache.bookkeeper.versioning.Version.Occurred;
-import org.junit.Test;
 import org.junit.Assert;
+import org.junit.Test;
 
+/**
+ * Test long version.
+ */
 public class TestLongVersion {
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestRetryPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestRetryPolicy.java
@@ -20,9 +20,13 @@
  */
 package org.apache.bookkeeper.zookeeper;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
+
+/**
+ * Test the retry policy.
+ */
 public class TestRetryPolicy {
 
     private static void assertTimeRange(long waitTime, long minTime, long maxTime) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestZooKeeperClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestZooKeeperClient.java
@@ -28,10 +28,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import junit.framework.TestCase;
+
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.ZooKeeperUtil;
-import org.apache.zookeeper.AsyncCallback.Create2Callback;
 import org.apache.zookeeper.AsyncCallback.Children2Callback;
+import org.apache.zookeeper.AsyncCallback.Create2Callback;
 import org.apache.zookeeper.AsyncCallback.DataCallback;
 import org.apache.zookeeper.AsyncCallback.StatCallback;
 import org.apache.zookeeper.AsyncCallback.StringCallback;
@@ -46,20 +48,18 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.junit.Assert;
-import junit.framework.TestCase;
 
 /**
  * Test the wrapper of {@link org.apache.zookeeper.ZooKeeper} client.
  */
 public class TestZooKeeperClient extends TestCase {
 
-    static final Logger logger = LoggerFactory.getLogger(TestZooKeeperClient.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestZooKeeperClient.class);
 
     // ZooKeeper related variables
     protected ZooKeeperUtil zkUtil = new ZooKeeperUtil();
@@ -86,8 +86,7 @@ public class TestZooKeeperClient extends TestCase {
 
             @Override
             public void process(WatchedEvent event) {
-                if (event.getType() == EventType.None &&
-                        event.getState() == KeeperState.SyncConnected) {
+                if (event.getType() == EventType.None && event.getState() == KeeperState.SyncConnected) {
                     latch.countDown();
                 }
             }
@@ -117,8 +116,7 @@ public class TestZooKeeperClient extends TestCase {
 
         @Override
         public void process(WatchedEvent event) {
-            if (event.getType() == EventType.None &&
-                    event.getState() == KeeperState.Expired) {
+            if (event.getType() == EventType.None && event.getState() == KeeperState.Expired) {
                 try {
                     zkUtil.stopServer();
                 } catch (Exception e) {
@@ -137,8 +135,7 @@ public class TestZooKeeperClient extends TestCase {
 
             @Override
             public void process(WatchedEvent event) {
-                if (event.getType() == EventType.None &&
-                        event.getState() == KeeperState.Expired) {
+                if (event.getType() == EventType.None && event.getState() == KeeperState.Expired) {
                     expireLatch.countDown();
                 }
             }
@@ -178,7 +175,7 @@ public class TestZooKeeperClient extends TestCase {
         zkUtil.restartServer();
 
         // wait for a reconnect cycle
-        Thread.sleep(2*timeout);
+        Thread.sleep(2 * timeout);
         Assert.assertTrue("Client failed to connect zookeeper even it was back.",
                 client.getState().isConnected());
         try {

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -21,7 +21,8 @@
     <suppress checks="JavadocPackage" files=".*[\\/]maven-archetypes[\\/].*"/>
     <suppress checks="JavadocPackage" files=".*[\\/]examples[\\/].*"/>
     <!-- suppress packages by packages -->
-    <suppress checks=".*" files=".*[\\/]test[\\/].*"/>
+    <suppress checks=".*" files=".*[\\/]test[\\/].*[\\/]client[\\/]"/>
+    <suppress checks=".*" files=".*[\\/]test[\\/].*[\\/]bookie[\\/]"/>
 
     <!-- suppress all checks in the generated directories -->
     <suppress checks=".*" files=".+[\\/]generated[\\/].+\.java" />


### PR DESCRIPTION
Part of #230, this enables checkstyle verification on some
of the test code. This does not do checkstyle validation on
the client or bookie package test code.

Enabling checkstyle on the entire test codebase would result in a _very_ large PR. This is an attempt to break it up into smaller pieces. The changes here are almost exclusively related to whitespace, javadocs and import order.

One public change of note is in `replication.AuditorLedgerCheckerTest`: the `_testDelayedAuditOfLostBookies` method is changed to `testInnerDelayedAuditOfLostBookies`.