### PR TITLE
ISSUE #230: Enable checkstyle on client tests

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperAdminTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperAdminTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Iterator;
+
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.client.BKException.BKIllegalOpException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -33,11 +34,13 @@ import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.test.annotations.FlakyTest;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test the bookkeeper admin.
+ */
 public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(BookKeeperAdminTest.class);
@@ -75,7 +78,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
         urLedgerMgr.disableLedgerReplication();
         try {
             bkAdmin.triggerAudit();
-            Assert.fail("Trigger Audit should have failed because LedgerReplication is disabled");
+            fail("Trigger Audit should have failed because LedgerReplication is disabled");
         } catch (UnavailableException une) {
             // expected
         }
@@ -124,7 +127,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
             LedgerHandle emptylh = bkc.createLedger(3, 2, digestType, PASSWORD.getBytes());
             emptylh.close();
         }
-        
+
         try {
             /*
              * if we try to call decommissionBookie for a bookie which is not
@@ -135,7 +138,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
         } catch (BKIllegalOpException bkioexc) {
             // expected IllegalException
         }
-        
+
         ServerConfiguration killedBookieConf = killBookie(1);
         /*
          * this decommisionBookie should make sure that there are no
@@ -152,7 +155,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
             }
             fail("There are not supposed to be any underreplicatedledgers");
         }
-        
+
         killedBookieConf = killBookie(0);
         bkAdmin.decommissionBookie(Bookie.getBookieAddress(killedBookieConf));
         bkAdmin.triggerAudit();
@@ -199,14 +202,14 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
             lh1.addEntry(j, "data".getBytes());
             lh2.addEntry(j, "data".getBytes());
         }
-        
+
         /*
          * Here lh1 and lh2 have multiple fragments and are writeclosed. But lh3 and lh4 are
          * not writeclosed and contains only one fragment.
          */
         lh1.close();
         lh2.close();
-        
+
         /*
          * If the last fragment of the ledger is underreplicated and if the
          * ledger is not closed then it will remain underreplicated for

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperClientZKSessionExpiry.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperClientZKSessionExpiry.java
@@ -21,15 +21,18 @@
 package org.apache.bookkeeper.client;
 
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.test.TestCallbacks.AddCallbackFuture;
 import org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.bookkeeper.test.TestCallbacks.AddCallbackFuture;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test the bookkeeper client while losing a ZK session.
+ */
 public class BookKeeperClientZKSessionExpiry extends BookKeeperClusterTestCase {
-    static Logger LOG = LoggerFactory.getLogger(BookKeeperClientZKSessionExpiry.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BookKeeperClientZKSessionExpiry.class);
 
     public BookKeeperClientZKSessionExpiry() {
         super(4);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
@@ -20,14 +20,21 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.google.common.util.concurrent.SettableFuture;
+
 import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
@@ -45,11 +52,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
  * This unit test verifies the behavior of bookkeeper apis, where the operations
- * are being executed through a closed bookkeeper client
+ * are being executed through a closed bookkeeper client.
  */
 public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
@@ -116,7 +121,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
     /**
      * Test that createledger using bookkeeper client which is closed should
-     * throw ClientClosedException
+     * throw ClientClosedException.
      */
     @Test
     public void testCreateLedger() throws Exception {
@@ -153,7 +158,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
     /**
      * Test that opening a ledger using bookkeeper client which is closed should
-     * throw ClientClosedException
+     * throw ClientClosedException.
      */
     @Test
     public void testFenceLedger() throws Exception {
@@ -200,7 +205,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
     /**
      * Test that deleting a ledger using bookkeeper client which is closed
-     * should throw ClientClosedException
+     * should throw ClientClosedException.
      */
     @Test
     public void testDeleteLedger() throws Exception {
@@ -236,7 +241,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
     /**
      * Test that adding entry to a ledger using bookkeeper client which is
-     * closed should throw ClientClosedException
+     * closed should throw ClientClosedException.
      */
     @Test
     public void testAddLedgerEntry() throws Exception {
@@ -276,7 +281,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
     /**
      * Test that closing a ledger using bookkeeper client which is closed should
-     * throw ClientClosedException
+     * throw ClientClosedException.
      */
     @Test
     public void testCloseLedger() throws Exception {
@@ -314,7 +319,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
     /**
      * Test that reading entry from a ledger using bookkeeper client which is
-     * closed should throw ClientClosedException
+     * closed should throw ClientClosedException.
      */
     @Test
     public void testReadLedgerEntry() throws Exception {
@@ -357,7 +362,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
     /**
      * Test that readlastconfirmed entry from a ledger using bookkeeper client
-     * which is closed should throw ClientClosedException
+     * which is closed should throw ClientClosedException.
      */
     @Test
     public void testReadLastConfirmed() throws Exception {
@@ -403,7 +408,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
 
     /**
      * Test that checking a ledger using a closed BK client will
-     * throw a ClientClosedException
+     * throw a ClientClosedException.
      */
     @Test
     public void testLedgerCheck() throws Exception {
@@ -460,7 +465,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
     }
     /**
      * Test that BookKeeperAdmin operationg using a closed BK client will
-     * throw a ClientClosedException
+     * throw a ClientClosedException.
      */
     @Test
     public void testBookKeeperAdmin() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
@@ -1,4 +1,3 @@
-package org.apache.bookkeeper.client;
 /*
 *
 * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,6 +18,10 @@ package org.apache.bookkeeper.client;
 * under the License.
 *
 */
+package org.apache.bookkeeper.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -28,9 +31,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
@@ -38,14 +41,12 @@ import org.apache.bookkeeper.test.annotations.FlakyTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
- * Tests of the main BookKeeper client
+ * Tests of the main BookKeeper client.
  */
 public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(BookKeeperDiskSpaceWeightedLedgerPlacementTest.class);
-    private final static long MS_WEIGHT_UPDATE_TIMEOUT = 30000;
+    private static final Logger LOG = LoggerFactory.getLogger(BookKeeperDiskSpaceWeightedLedgerPlacementTest.class);
+    private static final long MS_WEIGHT_UPDATE_TIMEOUT = 30000;
 
     public BookKeeperDiskSpaceWeightedLedgerPlacementTest() {
         super(10);
@@ -112,7 +113,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
             BookKeeperCheckInfoReader client,
             BookieServer bookie, final long freeDiskSpace)
             throws Exception {
-        for (int i=0; i < bs.size(); i++) {
+        for (int i = 0; i < bs.size(); i++) {
             if (bs.get(i).getLocalAddress().equals(bookie.getLocalAddress())) {
                 return replaceBookieWithCustomFreeDiskSpaceBookie(client, i, freeDiskSpace);
             }
@@ -132,12 +133,12 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
     }
 
     /**
-     * Test to show that weight based selection honors the disk weight of bookies
+     * Test to show that weight based selection honors the disk weight of bookies.
      */
     @FlakyTest("https://github.com/apache/bookkeeper/issues/503")
     public void testDiskSpaceWeightedBookieSelection() throws Exception {
-        long freeDiskSpace=1000000L;
-        int multiple=3;
+        long freeDiskSpace = 1000000L;
+        int multiple = 3;
 
         ClientConfiguration conf = new ClientConfiguration()
                 .setZkServers(zkUtil.getZooKeeperConnectString())
@@ -146,12 +147,12 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                 .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple);
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
-        for (int i=0; i < numBookies; i++) {
+        for (int i = 0; i < numBookies; i++) {
             // the first 8 bookies have freeDiskSpace of 1MB; While the remaining 2 have 3MB
-            if (i < numBookies-2) {
+            if (i < numBookies - 2) {
                 replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, freeDiskSpace);
             } else {
-                replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, multiple*freeDiskSpace);
+                replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, multiple * freeDiskSpace);
             }
         }
         Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
@@ -162,17 +163,21 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
         client.close();
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
-        for (int i=0; i < numBookies-2; i++) {
-            double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
-            double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        for (int i = 0; i < numBookies - 2; i++) {
+            double ratio1 = (double) m.get(bs.get(numBookies - 2).getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
+                    Math.abs(ratio1 - multiple) < 1);
+            double ratio2 = (double) m.get(bs.get(numBookies - 1).getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
+                    Math.abs(ratio2 - multiple) < 1);
         }
     }
 
@@ -182,8 +187,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
      */
     @FlakyTest("https://github.com/apache/bookkeeper/issues/503")
     public void testDiskSpaceWeightedBookieSelectionWithChangingWeights() throws Exception {
-        long freeDiskSpace=1000000L;
-        int multiple=3;
+        long freeDiskSpace = 1000000L;
+        int multiple = 3;
 
         ClientConfiguration conf = new ClientConfiguration()
                 .setZkServers(zkUtil.getZooKeeperConnectString())
@@ -192,12 +197,12 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                 .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple);
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
-        for (int i=0; i < numBookies; i++) {
+        for (int i = 0; i < numBookies; i++) {
             // the first 8 bookies have freeDiskSpace of 1MB; While the remaining 2 have 3MB
-            if (i < numBookies-2) {
-                replaceBookieWithCustomFreeDiskSpaceBookie(client,0, freeDiskSpace);
+            if (i < numBookies - 2) {
+                replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, freeDiskSpace);
             } else {
-                replaceBookieWithCustomFreeDiskSpaceBookie(client,0, multiple*freeDiskSpace);
+                replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, multiple * freeDiskSpace);
             }
         }
         Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
@@ -208,28 +213,32 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
 
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
-        for (int i=0; i < numBookies-2; i++) {
-            double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
-            double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        for (int i = 0; i < numBookies - 2; i++) {
+            double ratio1 = (double) m.get(bs.get(numBookies - 2).getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
+                    Math.abs(ratio1 - multiple) < 1);
+            double ratio2 = (double) m.get(bs.get(numBookies - 1).getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
+                    Math.abs(ratio2 - multiple) < 1);
         }
 
         // Restart the bookies in such a way that the first 2 bookies go from 1MB to 3MB free space and the last
         // 2 bookies go from 3MB to 1MB
         BookieServer server1 = bs.get(0);
         BookieServer server2 = bs.get(1);
-        BookieServer server3 = bs.get(numBookies-2);
-        BookieServer server4 = bs.get(numBookies-1);
+        BookieServer server3 = bs.get(numBookies - 2);
+        BookieServer server4 = bs.get(numBookies - 1);
 
-        server1 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server1, multiple*freeDiskSpace);
-        server2 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server2, multiple*freeDiskSpace);
+        server1 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server1, multiple * freeDiskSpace);
+        server2 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server2, multiple * freeDiskSpace);
         server3 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server3, freeDiskSpace);
         server4 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server4, freeDiskSpace);
 
@@ -239,21 +248,25 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
 
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
-        for (int i=0; i < numBookies; i++) {
-            if (server1.getLocalAddress().equals(bs.get(i).getLocalAddress()) ||
-                server2.getLocalAddress().equals(bs.get(i).getLocalAddress())) {
+        for (int i = 0; i < numBookies; i++) {
+            if (server1.getLocalAddress().equals(bs.get(i).getLocalAddress())
+                    || server2.getLocalAddress().equals(bs.get(i).getLocalAddress())) {
                 continue;
             }
-            double ratio1 = (double)m.get(server1.getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
-            double ratio2 = (double)m.get(server2.getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+            double ratio1 = (double) m.get(server1.getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
+                    Math.abs(ratio1 - multiple) < 1);
+            double ratio2 = (double) m.get(server2.getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
+                    Math.abs(ratio2 - multiple) < 1);
         }
         client.close();
     }
@@ -264,8 +277,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
      */
     @FlakyTest("https://github.com/apache/bookkeeper/issues/503")
     public void testDiskSpaceWeightedBookieSelectionWithBookiesDying() throws Exception {
-        long freeDiskSpace=1000000L;
-        int multiple=3;
+        long freeDiskSpace = 1000000L;
+        int multiple = 3;
 
         ClientConfiguration conf = new ClientConfiguration()
                 .setZkServers(zkUtil.getZooKeeperConnectString())
@@ -274,12 +287,12 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                 .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple);
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
-        for (int i=0; i < numBookies; i++) {
+        for (int i = 0; i < numBookies; i++) {
             // the first 8 bookies have freeDiskSpace of 1MB; While the remaining 2 have 1GB
-            if (i < numBookies-2) {
+            if (i < numBookies - 2) {
                 replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, freeDiskSpace);
             } else {
-                replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, multiple*freeDiskSpace);
+                replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, multiple * freeDiskSpace);
             }
         }
         Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
@@ -290,39 +303,45 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
 
         // make sure that bookies with higher weight are chosen 3X as often as the median;
-        // since the number of ledgers is small (2000), there may be variation 
-        double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(0).getLocalAddress());
-        assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
-        double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(1).getLocalAddress());
-        assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        // since the number of ledgers is small (2000), there may be variation
+        double ratio1 = (double) m.get(bs.get(numBookies - 2).getLocalAddress())
+            / (double) m.get(bs.get(0).getLocalAddress());
+        assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
+                Math.abs(ratio1 - multiple) < 1);
+        double ratio2 = (double) m.get(bs.get(numBookies - 1).getLocalAddress())
+            / (double) m.get(bs.get(1).getLocalAddress());
+        assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
+                Math.abs(ratio2 - multiple) < 1);
 
         // Bring down the 2 bookies that had higher weight; after this the allocation to all
         // the remaining bookies should be uniform
         for (BookieServer b : bs) {
             m.put(b.getLocalAddress(), 0);
         }
-        BookieServer server1 = bs.get(numBookies-2);
-        BookieServer server2 = bs.get(numBookies-1);
-        killBookieAndWaitForZK(numBookies-1);
-        killBookieAndWaitForZK(numBookies-2);
+        BookieServer server1 = bs.get(numBookies - 2);
+        BookieServer server2 = bs.get(numBookies - 1);
+        killBookieAndWaitForZK(numBookies - 1);
+        killBookieAndWaitForZK(numBookies - 2);
 
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
 
         // make sure that bookies with higher weight are chosen 3X as often as the median;
-        for (int i=0; i < numBookies-3; i++) {
-            double delta = Math.abs((double)m.get(bs.get(i).getLocalAddress())-(double)m.get(bs.get(i+1).getLocalAddress()));
-            delta = (delta*100)/(double)m.get(bs.get(i+1).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + delta, delta <= 30); // the deviation should be less than 30%
+        for (int i = 0; i < numBookies - 3; i++) {
+            double delta = Math.abs((double) m.get(bs.get(i).getLocalAddress())
+                    - (double) m.get(bs.get(i + 1).getLocalAddress()));
+            delta = (delta * 100) / (double) m.get(bs.get(i + 1).getLocalAddress());
+            // the deviation should be less than 30%
+            assertTrue("Weigheted placement is not honored: " + delta, delta <= 30);
         }
         // since the following 2 bookies were down, they shouldn't ever be selected
         assertTrue("Weigheted placement is not honored" + m.get(server1.getLocalAddress()),
@@ -339,8 +358,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
      */
     @FlakyTest("https://github.com/apache/bookkeeper/issues/503")
     public void testDiskSpaceWeightedBookieSelectionWithBookiesBeingAdded() throws Exception {
-        long freeDiskSpace=1000000L;
-        int multiple=3;
+        long freeDiskSpace = 1000000L;
+        int multiple = 3;
 
         ClientConfiguration conf = new ClientConfiguration()
                 .setZkServers(zkUtil.getZooKeeperConnectString())
@@ -349,13 +368,13 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                 .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple);
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
-        for (int i=0; i < numBookies; i++) {
+        for (int i = 0; i < numBookies; i++) {
             // all the bookies have freeDiskSpace of 1MB
             replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, freeDiskSpace);
         }
         // let the last two bookies be down initially
-        ServerConfiguration conf1 = killBookieAndWaitForZK(numBookies-1);
-        ServerConfiguration conf2 = killBookieAndWaitForZK(numBookies-2);
+        ServerConfiguration conf1 = killBookieAndWaitForZK(numBookies - 1);
+        ServerConfiguration conf2 = killBookieAndWaitForZK(numBookies - 2);
         Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
         for (BookieServer b : bs) {
             m.put(b.getLocalAddress(), 0);
@@ -364,21 +383,23 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
 
         // make sure that bookies with higher weight are chosen 3X as often as the median;
         // since the number of ledgers is small (2000), there may be variation
-        for (int i=0; i < numBookies-3; i++) {
-            double delta = Math.abs((double)m.get(bs.get(i).getLocalAddress())-(double)m.get(bs.get(i+1).getLocalAddress()));
-            delta = (delta*100)/(double)m.get(bs.get(i+1).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + delta, delta <= 30); // the deviation should be less than 30%
+        for (int i = 0; i < numBookies - 3; i++) {
+            double delta = Math.abs((double) m.get(bs.get(i).getLocalAddress())
+                    - (double) m.get(bs.get(i + 1).getLocalAddress()));
+            delta = (delta * 100) / (double) m.get(bs.get(i + 1).getLocalAddress());
+            // the deviation should be less than 30%
+            assertTrue("Weigheted placement is not honored: " + delta, delta <= 30);
         }
 
         // bring up the two dead bookies; they'll also have 3X more free space than the rest of the bookies
-        restartBookie(client, conf1, multiple*freeDiskSpace, multiple*freeDiskSpace, null);
-        restartBookie(client, conf2, multiple*freeDiskSpace, multiple*freeDiskSpace, null);
+        restartBookie(client, conf1, multiple * freeDiskSpace, multiple * freeDiskSpace, null);
+        restartBookie(client, conf2, multiple * freeDiskSpace, multiple * freeDiskSpace, null);
 
         for (BookieServer b : bs) {
             m.put(b.getLocalAddress(), 0);
@@ -386,17 +407,21 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
 
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
-        for (int i=0; i < numBookies-2; i++) {
-            double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
-            double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        for (int i = 0; i < numBookies - 2; i++) {
+            double ratio1 = (double) m.get(bs.get(numBookies - 2).getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
+                    Math.abs(ratio1 - multiple) < 1);
+            double ratio2 = (double) m.get(bs.get(numBookies - 1).getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
+                    Math.abs(ratio2 - multiple) < 1);
         }
         client.close();
     }
@@ -407,8 +432,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
      */
     @FlakyTest("https://github.com/apache/bookkeeper/issues/503")
     public void testDiskSpaceWeightedBookieSelectionWithPeriodicBookieInfoUpdate() throws Exception {
-        long freeDiskSpace=1000000L;
-        int multiple=3;
+        long freeDiskSpace = 1000000L;
+        int multiple = 3;
 
         int updateIntervalSecs = 6;
          ClientConfiguration conf = new ClientConfiguration()
@@ -420,14 +445,14 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
         AtomicBoolean useHigherValue = new AtomicBoolean(false);
-        for (int i=0; i < numBookies; i++) {
+        for (int i = 0; i < numBookies; i++) {
             // the first 8 bookies have freeDiskSpace of 1MB; the remaining 2 will advertise 1MB for
             // the start of the test, and 3MB once useHigherValue is set
-            if (i < numBookies-2) {
+            if (i < numBookies - 2) {
                 replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, freeDiskSpace);
             } else {
                 replaceBookieWithCustomFreeDiskSpaceBookie(
-                        client, 0, freeDiskSpace, multiple*freeDiskSpace, useHigherValue);
+                        client, 0, freeDiskSpace, multiple * freeDiskSpace, useHigherValue);
             }
         }
         Map<BookieSocketAddress, Integer> m = new HashMap<BookieSocketAddress, Integer>();
@@ -438,13 +463,14 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
 
-        for (int i=0; i < numBookies - 1; i++) {
-            double delta = Math.abs((double)m.get(bs.get(i).getLocalAddress())-(double)m.get(bs.get(i+1).getLocalAddress()));
-            delta = (delta*100)/(double)m.get(bs.get(i+1).getLocalAddress());
+        for (int i = 0; i < numBookies - 1; i++) {
+            double delta = Math.abs((double) m.get(bs.get(i).getLocalAddress())
+                    - (double) m.get(bs.get(i + 1).getLocalAddress()));
+            delta = (delta * 100) / (double) m.get(bs.get(i + 1).getLocalAddress());
             assertTrue("Weigheted placement is not honored: " + delta, delta <= 30); // the deviation should be <30%
         }
 
@@ -452,8 +478,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         // Sleep for double the time required to update the bookie infos, and then check each one
         useHigherValue.set(true);
         Thread.sleep(updateIntervalSecs * 1000);
-        for (int i=0; i < numBookies; i++) {
-            if (i < numBookies-2) {
+        for (int i = 0; i < numBookies; i++) {
+            if (i < numBookies - 2) {
                 client.blockUntilBookieWeightIs(bs.get(i).getLocalAddress(), Optional.of(freeDiskSpace));
             } else {
                 client.blockUntilBookieWeightIs(bs.get(i).getLocalAddress(), Optional.of(freeDiskSpace * multiple));
@@ -466,17 +492,21 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsemble(0)) {
-                m.put(b, m.get(b)+1);
+                m.put(b, m.get(b) + 1);
             }
         }
 
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
-        for (int i=0; i < numBookies-2; i++) {
-            double ratio1 = (double)m.get(bs.get(numBookies-2).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1-multiple), Math.abs(ratio1-multiple) < 1);
-            double ratio2 = (double)m.get(bs.get(numBookies-1).getLocalAddress())/(double)m.get(bs.get(i).getLocalAddress());
-            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2-multiple), Math.abs(ratio2-multiple) < 1);
+        for (int i = 0; i < numBookies - 2; i++) {
+            double ratio1 = (double) m.get(bs.get(numBookies - 2).getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
+                    Math.abs(ratio1 - multiple) < 1);
+            double ratio2 = (double) m.get(bs.get(numBookies - 1).getLocalAddress())
+                / (double) m.get(bs.get(i).getLocalAddress());
+            assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
+                    Math.abs(ratio2 - multiple) < 1);
         }
 
         client.close();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.client;
-
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,17 +18,18 @@ package org.apache.bookkeeper.client;
  * under the License.
  *
  */
+package org.apache.bookkeeper.client;
 
 import java.io.IOException;
-import java.util.Set;
-import java.util.concurrent.Future;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.discover.RegistrationClient.RegistrationListener;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
-import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 
 /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
@@ -20,19 +20,10 @@
  */
 package org.apache.bookkeeper.client;
 
-import org.apache.bookkeeper.client.AsyncCallback.RecoverCallback;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
-import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
-import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
-import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.netty.buffer.ByteBuf;
 
@@ -50,14 +41,26 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.*;
+import org.apache.bookkeeper.client.AsyncCallback.RecoverCallback;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class tests the bookie recovery admin functionality.
  */
 public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
-    private final static Logger LOG = LoggerFactory.getLogger(BookieRecoveryTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BookieRecoveryTest.class);
 
     // Object used for synchronizing async method calls
     class SyncObject {
@@ -123,27 +126,26 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
     @Override
     public void tearDown() throws Exception {
         // Release any resources used by the BookieRecoveryTest instance.
-        if(bkAdmin != null){
+        if (bkAdmin != null){
             bkAdmin.close();
         }
         super.tearDown();
     }
 
     /**
-     * Helper method to create a number of ledgers
+     * Helper method to create a number of ledgers.
      *
      * @param numLedgers
      *            Number of ledgers to create
      * @return List of LedgerHandles for each of the ledgers created
      */
     private List<LedgerHandle> createLedgers(int numLedgers)
-      throws BKException, IOException, InterruptedException
-    {
+      throws BKException, IOException, InterruptedException {
         return createLedgers(numLedgers, 3, 2);
     }
 
     /**
-     * Helper method to create a number of ledgers
+     * Helper method to create a number of ledgers.
      *
      * @param numLedgers
      *            Number of ledgers to create
@@ -211,8 +213,8 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
      * @throws BKException
      * @throws InterruptedException
      */
-    private void verifyRecoveredLedgers(List<LedgerHandle> oldLhs, long startEntryId, long endEntryId) throws BKException,
-      InterruptedException {
+    private void verifyRecoveredLedgers(List<LedgerHandle> oldLhs, long startEntryId, long endEntryId)
+            throws BKException, InterruptedException {
         // Get a set of LedgerHandles for all of the ledgers to verify
         List<LedgerHandle> lhs = new ArrayList<LedgerHandle>();
         for (int i = 0; i < oldLhs.size(); i++) {
@@ -525,16 +527,16 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
           Collections.enumeration(ensembles.keySet()));
         Collections.sort(keyList);
         for (int i = 0; i < keyList.size() - 1; i++) {
-            ranges.put(keyList.get(i), keyList.get(i+1));
+            ranges.put(keyList.get(i), keyList.get(i + 1));
         }
-        ranges.put(keyList.get(keyList.size()-1), untilEntry);
+        ranges.put(keyList.get(keyList.size() - 1), untilEntry);
 
         for (Map.Entry<Long, ArrayList<BookieSocketAddress>> e : ensembles.entrySet()) {
             int quorum = md.getAckQuorumSize();
             long startEntryId = e.getKey();
             long endEntryId = ranges.get(startEntryId);
-            long expectedSuccess = quorum*(endEntryId-startEntryId);
-            int numRequests = e.getValue().size()*((int)(endEntryId-startEntryId));
+            long expectedSuccess = quorum * (endEntryId - startEntryId);
+            int numRequests = e.getValue().size() * ((int) (endEntryId - startEntryId));
 
             ReplicationVerificationCallback cb = new ReplicationVerificationCallback(numRequests);
             for (long i = startEntryId; i < endEntryId; i++) {
@@ -615,7 +617,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test recoverying the closed ledgers when the failed bookie server is in the last ensemble
+     * Test recoverying the closed ledgers when the failed bookie server is in the last ensemble.
      */
     @Test
     public void testBookieRecoveryOnClosedLedgers() throws Exception {
@@ -813,10 +815,10 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         assertFalse("Dupes exist in ensembles", findDupesInEnsembles(lhs));
 
         // Write some more entries to ensure fencing hasn't broken stuff
-        writeEntriestoLedgers(numMsgs, numMsgs*2, lhs);
+        writeEntriestoLedgers(numMsgs, numMsgs * 2, lhs);
 
         for (LedgerHandle lh : lhs) {
-            assertTrue("Not fully replicated", verifyFullyReplicated(lh, numMsgs*3));
+            assertTrue("Not fully replicated", verifyFullyReplicated(lh, numMsgs * 3));
             lh.close();
         }
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -25,16 +25,18 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import io.netty.buffer.Unpooled;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.List;
-import java.util.Random;
-import java.util.Map;
-import java.util.UUID;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.meta.LongHierarchicalLedgerManagerFactory;
@@ -46,12 +48,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Testing ledger write entry cases
+ * Testing ledger write entry cases.
  */
 public class BookieWriteLedgerTest extends
     BookKeeperClusterTestCase implements AddCallback {
 
-    private final static Logger LOG = LoggerFactory
+    private static final Logger LOG = LoggerFactory
             .getLogger(BookieWriteLedgerTest.class);
 
     byte[] ledgerPassword = "aaa".getBytes();
@@ -97,7 +99,7 @@ public class BookieWriteLedgerTest extends
 
     /**
      * Verify write when few bookie failures in last ensemble and forcing
-     * ensemble reformation
+     * ensemble reformation.
      */
     @Test
     public void testWithMultipleBookieFailuresInLastEnsemble() throws Exception {
@@ -182,7 +184,7 @@ public class BookieWriteLedgerTest extends
     }
 
     /**
-     * Verify that LedgerHandleAdv cannnot handle addEntry without the entryId
+     * Verify that LedgerHandleAdv cannnot handle addEntry without the entryId.
      *
      * @throws Exception
      */
@@ -238,7 +240,7 @@ public class BookieWriteLedgerTest extends
 
         try {
             CompletableFuture<Object> done = new CompletableFuture<>();
-            lh.asyncAddEntry(entry.array(),0, 4,
+            lh.asyncAddEntry(entry.array(), 0, 4,
                 (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
                 SyncCallbackUtils.finish(rc, null, done);
             }, null);
@@ -317,7 +319,7 @@ public class BookieWriteLedgerTest extends
                 inputCustomMetadataMap.put("key" + j, UUID.randomUUID().toString().getBytes());
             }
 
-            if (i < maxLedgers/2) {
+            if (i < maxLedgers / 2) {
                 // 0 to 4 test with createLedger interface
                 lh = bkc.createLedger(5, 3, 2, digestType, ledgerPassword, inputCustomMetadataMap);
                 ledgerId = lh.getId();
@@ -464,7 +466,7 @@ public class BookieWriteLedgerTest extends
     }
 
     /**
-     * Verify Advanced asynchronous writing with entryIds in reverse order
+     * Verify Advanced asynchronous writing with entryIds in reverse order.
      */
     @Test
     public void testLedgerCreateAdvWithAsyncWritesWithBookieFailures() throws Exception {
@@ -518,7 +520,7 @@ public class BookieWriteLedgerTest extends
     }
 
     /**
-     * Verify Advanced asynchronous writing with entryIds in pseudo random order with bookie failures between writes
+     * Verify Advanced asynchronous writing with entryIds in pseudo random order with bookie failures between writes.
      */
     @Test
     public void testLedgerCreateAdvWithRandomAsyncWritesWithBookieFailuresBetweenWrites() throws Exception {
@@ -553,7 +555,7 @@ public class BookieWriteLedgerTest extends
                 byte[] entry2 = entries2.get(j);
                 lh.asyncAddEntry(j, entry1, 0, entry1.length, this, syncObj1);
                 lh2.asyncAddEntry(j, entry2, 0, entry2.length, this, syncObj2);
-                if (j == numEntriesToWrite/2) {
+                if (j == numEntriesToWrite / 2) {
                     // Start One more bookie and shutdown one from last ensemble at half-way
                     startNewBookie();
                     ArrayList<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsembles().entrySet()
@@ -586,7 +588,7 @@ public class BookieWriteLedgerTest extends
     }
 
     /**
-     * Verify Advanced asynchronous writing with entryIds in pseudo random order
+     * Verify Advanced asynchronous writing with entryIds in pseudo random order.
      */
     @Test
     public void testLedgerCreateAdvWithRandomAsyncWritesWithBookieFailures() throws Exception {
@@ -699,7 +701,7 @@ public class BookieWriteLedgerTest extends
     }
 
     /**
-     * Verify the functionality LedgerHandleAdv addEntry with duplicate entryIds
+     * Verify the functionality LedgerHandleAdv addEntry with duplicate entryIds.
      *
      * @throws Exception
      */
@@ -736,7 +738,7 @@ public class BookieWriteLedgerTest extends
 
     /**
      * Verify the functionality LedgerHandleAdv asyncAddEntry with duplicate
-     * entryIds
+     * entryIds.
      *
      * @throws Exception
      */

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ClientUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ClientUtil.java
@@ -20,6 +20,9 @@ package org.apache.bookkeeper.client;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
+/**
+ * Client utilities.
+ */
 public class ClientUtil {
     public static ByteBuf generatePacket(long ledgerId, long entryId, long lastAddConfirmed,
                                                long length, byte[] data) {
@@ -33,7 +36,9 @@ public class ClientUtil {
                                                     Unpooled.wrappedBuffer(data, offset, len));
     }
 
-    /** Returns that whether ledger is in open state */
+    /**
+     * Returns that whether ledger is in open state.
+     */
     public static boolean isLedgerOpen(LedgerHandle handle) {
         return !handle.metadata.isClosed();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/GenericEnsemblePlacementPolicyTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/GenericEnsemblePlacementPolicyTest.java
@@ -17,6 +17,11 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,15 +29,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * Testing a generic ensemble placement policy.
+ */
 public class GenericEnsemblePlacementPolicyTest extends BookKeeperClusterTestCase {
 
     private BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
@@ -47,6 +52,9 @@ public class GenericEnsemblePlacementPolicyTest extends BookKeeperClusterTestCas
         baseClientConf.setEnsemblePlacementPolicy(CustomEnsemblePlacementPolicy.class);
     }
 
+    /**
+     * A custom ensemble placement policy.
+     */
     public static final class CustomEnsemblePlacementPolicy extends DefaultEnsemblePlacementPolicy {
 
         @Override
@@ -69,7 +77,6 @@ public class GenericEnsemblePlacementPolicyTest extends BookKeeperClusterTestCas
             customMetadataOnNewEnsembleStack.add(customMetadata);
             return super.newEnsemble(ensembleSize, quorumSize, ackQuorumSize, customMetadata, excludeBookies);
         }
-        
     }
 
     @Before

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
@@ -17,6 +17,10 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
@@ -44,16 +48,13 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-import static com.google.common.base.Charsets.UTF_8;
-
 /**
  * This class tests the ledger close logic.
  */
 @SuppressWarnings("deprecation")
 public class LedgerCloseTest extends BookKeeperClusterTestCase {
 
-    private final static Logger LOG = LoggerFactory.getLogger(LedgerCloseTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LedgerCloseTest.class);
 
     static final int READ_TIMEOUT = 1;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerHandleAdapter.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerHandleAdapter.java
@@ -1,31 +1,33 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one 
- * or more contributor license agreements.  See the NOTICE file 
- * distributed with this work for additional information 
- * regarding copyright ownership.  The ASF licenses this file 
- * to you under the Apache License, Version 2.0 (the 
- * "License"); you may not use this file except in compliance 
- * with the License.  You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- * 
- * Unless required by applicable law or agreed to in writing, 
- * software distributed under the License is distributed on an 
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
- * KIND, either express or implied.  See the License for the 
- * specific language governing permissions and limitations 
- * under the License. 
- * 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.apache.bookkeeper.client;
 
 /**
  * Adapter for tests to get the public access from LedgerHandle for its default
- * scope
+ * scope.
  */
 public class LedgerHandleAdapter {
 
-    /** get the ledger handle */
+    /**
+     * Get the ledger handle.
+     */
     public static LedgerMetadata getLedgerMetadata(LedgerHandle lh) {
         return lh.getLedgerMetadata();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerMetadataTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerMetadataTest.java
@@ -32,7 +32,7 @@ import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat;
 import org.junit.Test;
 
 /**
- * Unit test for ledger metadata
+ * Unit test for ledger metadata.
  */
 public class LedgerMetadataTest {
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
@@ -20,13 +20,20 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
@@ -42,13 +49,11 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
  * This unit test tests ledger recovery.
  */
 public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(LedgerRecoveryTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LedgerRecoveryTest.class);
 
     private final DigestType digestType;
 
@@ -239,7 +244,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
     @Test
     public void testLedgerRecoveryWithRollingRestart() throws Exception {
         LedgerHandle lhbefore = bkc.createLedger(numBookies, 2, digestType, "".getBytes());
-        for (int i = 0; i < (numBookies*3)+1; i++) {
+        for (int i = 0; i < (numBookies * 3) + 1; i++) {
             lhbefore.addEntry("data".getBytes());
         }
 
@@ -320,7 +325,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
     @Test
     public void testBookieFailureDuringRecovery() throws Exception {
         LedgerHandle lhbefore = bkc.createLedger(numBookies, 2, digestType, "".getBytes());
-        for (int i = 0; i < (numBookies*3)+1; i++) {
+        for (int i = 0; i < (numBookies * 3) + 1; i++) {
             lhbefore.addEntry("data".getBytes());
         }
 
@@ -475,7 +480,8 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
 
         final CountDownLatch recoverLatch = new CountDownLatch(1);
         final AtomicBoolean success = new AtomicBoolean(false);
-        LedgerRecoveryOp recoveryOp = new LedgerRecoveryOp(recoverLh, new BookkeeperInternalCallbacks.GenericCallback<Void>() {
+        LedgerRecoveryOp recoveryOp = new LedgerRecoveryOp(recoverLh,
+                new BookkeeperInternalCallbacks.GenericCallback<Void>() {
             @Override
             public void operationComplete(int rc, Void result) {
                 success.set(BKException.Code.OK == rc);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ListLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ListLedgersTest.java
@@ -16,13 +16,20 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.Iterator;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Test ListLedgers.
+ */
 public class ListLedgersTest extends BookKeeperClusterTestCase {
 
     private final DigestType digestType;
@@ -41,7 +48,7 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
         .setZkServers(zkUtil.getZooKeeperConnectString());
 
         BookKeeper bkc = new BookKeeper(conf);
-        for (int i = 0; i < numOfLedgers ; i++) {
+        for (int i = 0; i < numOfLedgers; i++) {
             bkc.createLedger(digestType, "testPasswd".
                     getBytes()).close();
         }
@@ -55,7 +62,7 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
             counter++;
         }
 
-        Assert.assertTrue("Wrong number of ledgers: " + numOfLedgers,
+        assertTrue("Wrong number of ledgers: " + numOfLedgers,
                 counter == numOfLedgers);
     }
 
@@ -69,7 +76,7 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
                 getZooKeeperConnectString());
         Iterable<Long> iterable = admin.listLedgers();
 
-        Assert.assertFalse("There should be no ledger", iterable.iterator().hasNext());
+        assertFalse("There should be no ledger", iterable.iterator().hasNext());
     }
 
     @Test
@@ -81,7 +88,7 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
         .setZkServers(zkUtil.getZooKeeperConnectString());
 
         BookKeeper bkc = new BookKeeper(conf);
-        for (int i = 0; i < numOfLedgers ; i++) {
+        for (int i = 0; i < numOfLedgers; i++) {
             bkc.createLedger(digestType, "testPasswd".
                     getBytes()).close();
         }
@@ -90,17 +97,15 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
                 getZooKeeperConnectString());
         Iterator<Long> iterator = admin.listLedgers().iterator();
         iterator.next();
-        try{
+        try {
             iterator.remove();
         } catch (UnsupportedOperationException e) {
             // This exception is expected
             return;
         }
 
-        Assert.fail("Remove is not supported, we shouln't have reached this point");
+        fail("Remove is not supported, we shouln't have reached this point");
 
     }
-    
 
-    
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -59,11 +59,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Base class for Mock-based Client testcases
+ * Base class for Mock-based Client testcases.
  */
 public abstract class MockBookKeeperTestCase {
 
-    private final static Logger LOG = LoggerFactory.getLogger(MockBookKeeperTestCase.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MockBookKeeperTestCase.class);
 
     protected ScheduledExecutorService scheduler;
     protected OrderedSafeExecutor executor;
@@ -84,7 +84,7 @@ public abstract class MockBookKeeperTestCase {
     }
 
     private Map<Long, MockEntry> getMockLedgerContentsInBookie(long ledgerId, BookieSocketAddress bookieSocketAddress) {
-        return getMockLedgerContents(ledgerId).computeIfAbsent(bookieSocketAddress, (addr) -> new ConcurrentHashMap<>());
+        return getMockLedgerContents(ledgerId).computeIfAbsent(bookieSocketAddress, addr -> new ConcurrentHashMap<>());
     }
 
     private MockEntry getMockLedgerEntry(long ledgerId, BookieSocketAddress bookieSocketAddress, long entryId) {
@@ -220,7 +220,8 @@ public abstract class MockBookKeeperTestCase {
 
     protected void registerMockEntryForRead(long ledgerId, long entryId, BookieSocketAddress bookieSocketAddress,
         byte[] entryData, long lastAddConfirmed) {
-        getMockLedgerContentsInBookie(ledgerId, bookieSocketAddress).put(entryId, new MockEntry(entryData, lastAddConfirmed));
+        getMockLedgerContentsInBookie(ledgerId, bookieSocketAddress).put(entryId, new MockEntry(entryData,
+                    lastAddConfirmed));
     }
 
     protected void registerMockLedgerMetadata(long ledgerId, LedgerMetadata ledgerMetadata) {
@@ -325,7 +326,8 @@ public abstract class MockBookKeeperTestCase {
     protected void setupBookieClientReadEntry() {
         doAnswer(invokation -> {
             Object[] args = invokation.getArguments();
-            BookkeeperInternalCallbacks.ReadEntryCallback callback = (BookkeeperInternalCallbacks.ReadEntryCallback) args[4];
+            BookkeeperInternalCallbacks.ReadEntryCallback callback =
+                (BookkeeperInternalCallbacks.ReadEntryCallback) args[4];
             BookieSocketAddress bookieSocketAddress = (BookieSocketAddress) args[0];
             long ledgerId = (Long) args[1];
             long entryId = (Long) args[3];
@@ -335,13 +337,16 @@ public abstract class MockBookKeeperTestCase {
                 fencedLedgers.add(ledgerId);
                 MockEntry mockEntry = getMockLedgerEntry(ledgerId, bookieSocketAddress, entryId);
                 if (mockEntry != null) {
-                    LOG.info("readEntryAndFenceLedger - found mock entry {}@{} at {}", entryId, ledgerId, bookieSocketAddress);
+                    LOG.info("readEntryAndFenceLedger - found mock entry {}@{} at {}", entryId, ledgerId,
+                            bookieSocketAddress);
                     ByteBuf entry = macManager.computeDigestAndPackageForSending(entryId, mockEntry.lastAddConfirmed,
                         mockEntry.payload.length, Unpooled.wrappedBuffer(mockEntry.payload));
-                    callback.readEntryComplete(BKException.Code.OK, ledgerId, entryId, Unpooled.copiedBuffer(entry), args[5]);
+                    callback.readEntryComplete(BKException.Code.OK, ledgerId, entryId, Unpooled.copiedBuffer(entry),
+                            args[5]);
                     entry.release();
                 } else {
-                    LOG.info("readEntryAndFenceLedger - no such mock entry {}@{} at {}", entryId, ledgerId, bookieSocketAddress);
+                    LOG.info("readEntryAndFenceLedger - no such mock entry {}@{} at {}", entryId, ledgerId,
+                            bookieSocketAddress);
                     callback.readEntryComplete(BKException.Code.NoSuchEntryException, ledgerId, entryId, null, args[5]);
                 }
             });
@@ -354,7 +359,8 @@ public abstract class MockBookKeeperTestCase {
             BookieSocketAddress bookieSocketAddress = (BookieSocketAddress) args[0];
             long ledgerId = (Long) args[1];
             long entryId = (Long) args[2];
-            BookkeeperInternalCallbacks.ReadEntryCallback callback = (BookkeeperInternalCallbacks.ReadEntryCallback) args[3];
+            BookkeeperInternalCallbacks.ReadEntryCallback callback =
+                (BookkeeperInternalCallbacks.ReadEntryCallback) args[3];
 
             executor.submitOrdered(ledgerId, () -> {
                 DigestManager macManager = new CRC32DigestManager(ledgerId);
@@ -362,8 +368,10 @@ public abstract class MockBookKeeperTestCase {
                 if (mockEntry != null) {
                     LOG.info("readEntry - found mock entry {}@{} at {}", entryId, ledgerId, bookieSocketAddress);
                     ByteBuf entry = macManager.computeDigestAndPackageForSending(entryId,
-                        mockEntry.lastAddConfirmed, mockEntry.payload.length, Unpooled.wrappedBuffer(mockEntry.payload));
-                    callback.readEntryComplete(BKException.Code.OK, ledgerId, entryId, Unpooled.copiedBuffer(entry), args[4]);
+                        mockEntry.lastAddConfirmed, mockEntry.payload.length,
+                        Unpooled.wrappedBuffer(mockEntry.payload));
+                    callback.readEntryComplete(BKException.Code.OK, ledgerId, entryId, Unpooled.copiedBuffer(entry),
+                            args[4]);
                     entry.release();
                 } else {
                     LOG.info("readEntry - no such mock entry {}@{} at {}", entryId, ledgerId, bookieSocketAddress);
@@ -375,7 +383,8 @@ public abstract class MockBookKeeperTestCase {
             any(BookkeeperInternalCallbacks.ReadEntryCallback.class), any());
     }
 
-    private static byte[] extractEntryPayload(long ledgerId, long entryId, ByteBuf toSend) throws BKException.BKDigestMatchException {
+    private static byte[] extractEntryPayload(long ledgerId, long entryId, ByteBuf toSend)
+            throws BKException.BKDigestMatchException {
         ByteBuf toSendCopy = Unpooled.copiedBuffer(toSend);
         toSendCopy.resetReaderIndex();
         DigestManager macManager = new CRC32DigestManager(ledgerId);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
@@ -26,22 +26,32 @@ import static org.junit.Assert.assertTrue;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
+import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.LedgerMetadataListener;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.Processor;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
-import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
-import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.zookeeper.AsyncCallback.VoidCallback;
@@ -50,15 +60,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
+/**
+ * Test parallel ledger recovery.
+ */
 public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
 
     static final Logger LOG = LoggerFactory.getLogger(ParallelLedgerRecoveryTest.class);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
@@ -21,20 +21,25 @@
 
 package org.apache.bookkeeper.client;
 
-import java.util.Set;
-import java.util.HashSet;
+import static org.apache.bookkeeper.client.RoundRobinDistributionSchedule.writeSetFromValues;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Sets;
 
-import org.junit.Test;
-import static org.apache.bookkeeper.client.RoundRobinDistributionSchedule.writeSetFromValues;
-import static org.junit.Assert.*;
+import java.util.HashSet;
+import java.util.Set;
 
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test a round-robin distribution schedule.
+ */
 public class RoundRobinDistributionScheduleTest {
-    private final static Logger LOG = LoggerFactory.getLogger(RoundRobinDistributionScheduleTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RoundRobinDistributionScheduleTest.class);
 
     @Test
     public void testDistributionSchedule() throws Exception {
@@ -88,13 +93,13 @@ public class RoundRobinDistributionScheduleTest {
 
     /**
      * Check whether it is possible for a write to reach
-     * a quorum with a given set of nodes available
+     * a quorum with a given set of nodes available.
      */
     boolean canGetAckQuorum(int ensemble, int writeQuorum, int ackQuorum, boolean[] available) {
         for (int i = 0; i < ensemble; i++) {
             int count = 0;
             for (int j = 0; j < writeQuorum; j++) {
-                if (available[(i+j)%ensemble]) {
+                if (available[(i + j) % ensemble]) {
                     count++;
                 }
             }
@@ -136,24 +141,24 @@ public class RoundRobinDistributionScheduleTest {
 
     @Test
     public void testMoveAndShift() {
-        DistributionSchedule.WriteSet w = writeSetFromValues(1,2,3,4,5);
+        DistributionSchedule.WriteSet w = writeSetFromValues(1, 2, 3, 4, 5);
         w.moveAndShift(3, 1);
-        assertEquals(w, writeSetFromValues(1,4,2,3,5));
+        assertEquals(w, writeSetFromValues(1, 4, 2, 3, 5));
 
-        w = writeSetFromValues(1,2,3,4,5);
+        w = writeSetFromValues(1, 2, 3, 4, 5);
         w.moveAndShift(1, 3);
-        assertEquals(w, writeSetFromValues(1,3,4,2,5));
+        assertEquals(w, writeSetFromValues(1, 3, 4, 2, 5));
 
-        w = writeSetFromValues(1,2,3,4,5);
+        w = writeSetFromValues(1, 2, 3, 4, 5);
         w.moveAndShift(0, 4);
-        assertEquals(w, writeSetFromValues(2,3,4,5,1));
+        assertEquals(w, writeSetFromValues(2, 3, 4, 5, 1));
 
-        w = writeSetFromValues(1,2,3,4,5);
+        w = writeSetFromValues(1, 2, 3, 4, 5);
         w.moveAndShift(0, 0);
-        assertEquals(w, writeSetFromValues(1,2,3,4,5));
+        assertEquals(w, writeSetFromValues(1, 2, 3, 4, 5));
 
-        w = writeSetFromValues(1,2,3,4,5);
+        w = writeSetFromValues(1, 2, 3, 4, 5);
         w.moveAndShift(4, 4);
-        assertEquals(w, writeSetFromValues(1,2,3,4,5));
+        assertEquals(w, writeSetFromValues(1, 2, 3, 4, 5));
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
@@ -21,12 +21,15 @@
 
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -36,11 +39,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
+/**
+ * Test a slow bookie.
+ */
 @SuppressWarnings("deprecation")
 public class SlowBookieTest extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(SlowBookieTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SlowBookieTest.class);
 
     public SlowBookieTest() {
         super(4);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestAddEntryQuorumTimeout.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestAddEntryQuorumTimeout.java
@@ -20,22 +20,27 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-
+/**
+ * Test a quorum timeout for add entry operations.
+ */
 public class TestAddEntryQuorumTimeout extends BookKeeperClusterTestCase implements AddCallback {
 
-    final static Logger logger = LoggerFactory.getLogger(TestAddEntryQuorumTimeout.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestAddEntryQuorumTimeout.class);
 
     final DigestType digestType;
     final byte[] testPasswd = "".getBytes();
@@ -82,7 +87,7 @@ public class TestAddEntryQuorumTimeout extends BookKeeperClusterTestCase impleme
         sleepBookie(curEns.get(0), 5).await();
         try {
             lh.addEntry(data);
-            Assert.fail("should have thrown");
+            fail("should have thrown");
         } catch (BKException.BKAddEntryQuorumTimeoutException ex) {
         }
     }
@@ -114,11 +119,11 @@ public class TestAddEntryQuorumTimeout extends BookKeeperClusterTestCase impleme
         lh.asyncAddEntry(data, this, syncObj3);
 
         waitForSyncObj(syncObj1);
-        Assert.assertEquals(BKException.Code.AddEntryQuorumTimeoutException, syncObj1.rc);
+        assertEquals(BKException.Code.AddEntryQuorumTimeoutException, syncObj1.rc);
         waitForSyncObj(syncObj2);
-        Assert.assertEquals(BKException.Code.AddEntryQuorumTimeoutException, syncObj2.rc);
+        assertEquals(BKException.Code.AddEntryQuorumTimeoutException, syncObj2.rc);
         waitForSyncObj(syncObj3);
-        Assert.assertEquals(BKException.Code.AddEntryQuorumTimeoutException, syncObj3.rc);
+        assertEquals(BKException.Code.AddEntryQuorumTimeoutException, syncObj3.rc);
     }
 
     @Test
@@ -130,13 +135,13 @@ public class TestAddEntryQuorumTimeout extends BookKeeperClusterTestCase impleme
         CountDownLatch b0latch = sleepBookie(curEns.get(0), 5);
         try {
             lh.addEntry(data);
-            Assert.fail("should have thrown");
+            fail("should have thrown");
         } catch (BKException.BKAddEntryQuorumTimeoutException ex) {
         }
         b0latch.await();
         try {
             lh.addEntry(data);
-            Assert.fail("should have thrown");
+            fail("should have thrown");
         } catch (BKException.BKLedgerClosedException ex) {
         }
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestBookieHealthCheck.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestBookieHealthCheck.java
@@ -30,8 +30,11 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test the BookieHealthCheck.
+ */
 public class TestBookieHealthCheck extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(TestBookieHealthCheck.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestBookieHealthCheck.class);
 
     public TestBookieHealthCheck() {
         super(4);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestBookieWatcher.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestBookieWatcher.java
@@ -20,6 +20,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -34,8 +36,10 @@ import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
+/**
+ * Test a bookie watcher.
+ */
 public class TestBookieWatcher extends BookKeeperClusterTestCase {
 
     public TestBookieWatcher() {
@@ -50,8 +54,7 @@ public class TestBookieWatcher extends BookKeeperClusterTestCase {
 
             @Override
             public void process(WatchedEvent event) {
-                if (event.getType() == EventType.None &&
-                        event.getState() == KeeperState.SyncConnected) {
+                if (event.getType() == EventType.None && event.getState() == KeeperState.SyncConnected) {
                     latch.countDown();
                 }
             }
@@ -84,8 +87,8 @@ public class TestBookieWatcher extends BookKeeperClusterTestCase {
         ZooKeeper zk = new ZooKeeper(zkUtil.getZooKeeperConnectString(), timeout, new Watcher() {
             @Override
             public void process(WatchedEvent watchedEvent) {
-                if (EventType.None == watchedEvent.getType() &&
-                        KeeperState.SyncConnected == watchedEvent.getState()) {
+                if (EventType.None == watchedEvent.getType()
+                        && KeeperState.SyncConnected == watchedEvent.getState()) {
                     connectLatch.countDown();
                 }
             }
@@ -116,7 +119,7 @@ public class TestBookieWatcher extends BookKeeperClusterTestCase {
         TimeUnit.MILLISECONDS.sleep(3 * timeout);
 
         // start four new bookies
-        for (int i=0; i<2; i++) {
+        for (int i = 0; i < 2; i++) {
             startNewBookie();
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
@@ -25,6 +25,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.netty.buffer.ByteBuf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -35,14 +41,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicLong;
-
+/**
+ * Test a delayed ensemble change.
+ */
 public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
-    final static Logger logger = LoggerFactory.getLogger(TestDelayEnsembleChange.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestDelayEnsembleChange.class);
 
     final DigestType digestType;
     final byte[] testPasswd = "".getBytes();
@@ -76,7 +80,8 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
         public void readEntryComplete(int rc, long ledgerId, long entryId, ByteBuf buffer, Object ctx) {
             if (rc == BKException.Code.OK) {
                 numSuccess.incrementAndGet();
-            } else if (rc == BKException.Code.NoSuchEntryException || rc == BKException.Code.NoSuchLedgerExistsException) {
+            } else if (rc == BKException.Code.NoSuchEntryException
+                    || rc == BKException.Code.NoSuchLedgerExistsException) {
                 logger.error("Missed entry({}, {}) from host {}.", new Object[] { ledgerId, entryId, ctx });
                 numMissing.incrementAndGet();
             } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
@@ -20,7 +20,22 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Charsets.UTF_8;
+import static org.apache.bookkeeper.util.BookKeeperConstants.FEATURE_DISABLE_ENSEMBLE_CHANGE;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.util.concurrent.RateLimiter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.feature.SettableFeature;
@@ -31,23 +46,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.google.common.base.Charsets.UTF_8;
-import static org.apache.bookkeeper.util.BookKeeperConstants.*;
-import static org.junit.Assert.*;
-
 /**
- * Test Case on Disabling Ensemble Change Feature
+ * Test Case on Disabling Ensemble Change Feature.
  */
 public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
 
-    static final Logger logger = LoggerFactory.getLogger(TestDisableEnsembleChange.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestDisableEnsembleChange.class);
 
     public TestDisableEnsembleChange() {
         super(4);
@@ -85,7 +89,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
 
         assertEquals(1, lh.getLedgerMetadata().getEnsembles().size());
         ArrayList<BookieSocketAddress> ensembleBeforeFailure =
-                new ArrayList<BookieSocketAddress>(lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue());
+                new ArrayList<>(lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue());
 
         final RateLimiter rateLimiter = RateLimiter.create(10);
 
@@ -117,7 +121,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
         assertEquals("No new ensemble should be added when disable ensemble change.",
                 1, lh.getLedgerMetadata().getEnsembles().size());
         ArrayList<BookieSocketAddress> ensembleAfterFailure =
-                new ArrayList<BookieSocketAddress>(lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue());
+                new ArrayList<>(lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue());
         assertArrayEquals(ensembleBeforeFailure.toArray(new BookieSocketAddress[ensembleBeforeFailure.size()]),
                 ensembleAfterFailure.toArray(new BookieSocketAddress[ensembleAfterFailure.size()]));
 
@@ -182,7 +186,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
 
         LedgerHandle lh = bkc.createLedger(4, 4, 4, BookKeeper.DigestType.CRC32, new byte[] {});
         byte[] entry = "testRetryFailureBookie".getBytes();
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             lh.addEntry(entry);
         }
         // kill a bookie
@@ -232,7 +236,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
 
         LedgerHandle lh = bkc.createLedger(4, 4, 4, BookKeeper.DigestType.CRC32, new byte[] {});
         byte[] entry = "testRetryFailureBookie".getBytes();
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             lh.addEntry(entry);
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestFencing.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestFencing.java
@@ -1,5 +1,3 @@
-package org.apache.bookkeeper.client;
-
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,6 +18,11 @@ package org.apache.bookkeeper.client;
  * under the License.
  *
  */
+package org.apache.bookkeeper.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -32,14 +35,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
- * This unit test tests ledger fencing;
+ * This unit test tests ledger fencing.
  *
  */
 public class TestFencing extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(TestFencing.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestFencing.class);
 
     private final DigestType digestType;
 
@@ -114,7 +115,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
             BookKeeper bk = null;
             try {
                 barrier.await();
-                while(true) {
+                while (true) {
                     try {
                         bk = new BookKeeper(new ClientConfiguration(baseClientConf), bkc.getZkHandle());
 
@@ -180,7 +181,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
         writethread.start();
 
 
-        CyclicBarrier barrier = new CyclicBarrier(numRecovery+1);
+        CyclicBarrier barrier = new CyclicBarrier(numRecovery + 1);
         LedgerOpenThread threads[] = new LedgerOpenThread[numRecovery];
         for (int i = 0; i < numRecovery; i++) {
             threads[i] = new LedgerOpenThread(i, digestType, writelh.getId(), barrier);
@@ -201,7 +202,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
 
     /**
      * Test that opening a ledger in norecovery mode
-     * doesn't fence off a ledger
+     * doesn't fence off a ledger.
      */
     @Test
     public void testNoRecoveryOpen() throws Exception {
@@ -229,7 +230,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
         // should not have triggered recovery and fencing
         writelh.addEntry(tmp.getBytes());
         try {
-            readlh.readEntries(numReadable+1, numReadable+1);
+            readlh.readEntries(numReadable + 1, numReadable + 1);
             fail("Shouldn't have been able to read this far");
         } catch (BKException.BKReadException e) {
             // all is good
@@ -265,8 +266,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
             writelh.addEntry(tmp.getBytes());
         }
 
-        BookieSocketAddress bookieToKill
-            = writelh.getLedgerMetadata().getEnsemble(numEntries).get(0);
+        BookieSocketAddress bookieToKill = writelh.getLedgerMetadata().getEnsemble(numEntries).get(0);
         killBookie(bookieToKill);
 
         // write entries to change ensemble
@@ -318,8 +318,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
         LedgerHandle readlh = bkc.openLedger(writelh.getId(),
                                              digestType, "testPasswd".getBytes());
         // should be fenced by now
-        BookieSocketAddress bookieToKill
-            = writelh.getLedgerMetadata().getEnsemble(numEntries).get(0);
+        BookieSocketAddress bookieToKill = writelh.getLedgerMetadata().getEnsemble(numEntries).get(0);
         killBookie(bookieToKill);
         admin.recoverBookieData(bookieToKill);
 
@@ -336,7 +335,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test that fencing doesn't work with a bad password
+     * Test that fencing doesn't work with a bad password.
      */
     @Test
     public void testFencingBadPassword() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestGetBookieInfoTimeout.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestGetBookieInfoTimeout.java
@@ -23,6 +23,9 @@ package org.apache.bookkeeper.client;
 
 import static org.junit.Assert.assertTrue;
 
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.bookkeeper.client.BKException.Code;
@@ -41,15 +44,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-
 /**
- * This unit test tests timeout of GetBookieInfo request;
+ * This unit test tests timeout of GetBookieInfo request.
  *
  */
 public class TestGetBookieInfoTimeout extends BookKeeperClusterTestCase {
-    private final static Logger LOG = LoggerFactory.getLogger(TestGetBookieInfoTimeout.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestGetBookieInfoTimeout.class);
     DigestType digestType;
     public EventLoopGroup eventLoopGroup;
     public OrderedSafeExecutor executor;
@@ -80,7 +80,7 @@ public class TestGetBookieInfoTimeout extends BookKeeperClusterTestCase {
     public void testGetBookieInfoTimeout() throws Exception {
 
         // connect to the bookies and create a ledger
-        LedgerHandle writelh = bkc.createLedger(3,3,digestType, "testPasswd".getBytes());
+        LedgerHandle writelh = bkc.createLedger(3, 3, digestType, "testPasswd".getBytes());
         String tmp = "Foobar";
         final int numEntries = 10;
         for (int i = 0; i < numEntries; i++) {
@@ -92,7 +92,7 @@ public class TestGetBookieInfoTimeout extends BookKeeperClusterTestCase {
         cConf.setGetBookieInfoTimeout(2);
 
         final BookieSocketAddress bookieToSleep = writelh.getLedgerMetadata().getEnsemble(0).get(0);
-        int sleeptime = cConf.getBookieInfoTimeout()*3;
+        int sleeptime = cConf.getBookieInfoTimeout() * 3;
         CountDownLatch latch = sleepBookie(bookieToSleep, sleeptime);
         latch.await();
 
@@ -100,8 +100,8 @@ public class TestGetBookieInfoTimeout extends BookKeeperClusterTestCase {
         BookieSocketAddress addr = new BookieSocketAddress(bookieToSleep.getSocketAddress().getHostString(),
                 bookieToSleep.getPort());
         BookieClient bc = new BookieClient(cConf, eventLoopGroup, executor);
-        long flags = BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE |
-                BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE;
+        long flags = BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE
+                | BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE;
 
         class CallbackObj {
             int rc;
@@ -120,13 +120,14 @@ public class TestGetBookieInfoTimeout extends BookKeeperClusterTestCase {
         bc.getBookieInfo(addr, flags, new GetBookieInfoCallback() {
             @Override
             public void getBookieInfoComplete(int rc, BookieInfo bInfo, Object ctx) {
-                CallbackObj obj = (CallbackObj)ctx;
-                obj.rc=rc;
+                CallbackObj obj = (CallbackObj) ctx;
+                obj.rc = rc;
                 if (rc == Code.OK) {
                     if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.FREE_DISK_SPACE_VALUE) != 0) {
                         obj.freeDiskSpace = bInfo.getFreeDiskSpace();
                     }
-                    if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE) != 0) {
+                    if ((obj.requested & BookkeeperProtocol.GetBookieInfoRequest.Flags.TOTAL_DISK_CAPACITY_VALUE)
+                            != 0) {
                         obj.totalDiskCapacity = bInfo.getTotalDiskSpace();
                     }
                 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerChecker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerChecker.java
@@ -20,6 +20,9 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -31,8 +34,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
-
 /**
  * Tests the functionality of LedgerChecker. This Ledger checker should be able
  * to detect the correct underReplicated fragment
@@ -41,7 +42,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
     private static final byte[] TEST_LEDGER_ENTRY_DATA = "TestCheckerData"
             .getBytes();
     private static final byte[] TEST_LEDGER_PASSWORD = "testpasswd".getBytes();
-    private final static Logger LOG = LoggerFactory.getLogger(TestLedgerChecker.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestLedgerChecker.class);
 
     public TestLedgerChecker() {
         super(3);
@@ -64,7 +65,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
 
     /**
      * Tests that the LedgerChecker should detect the underReplicated fragments
-     * on multiple Bookie crashes
+     * on multiple Bookie crashes.
      */
     @Test
     public void testChecker() throws Exception {
@@ -176,7 +177,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
 
     /**
      * Tests that LedgerChecker should give two fragments when 2 bookies failed
-     * in same ensemble when ensemble = 3, quorum = 2
+     * in same ensemble when ensemble = 3, quorum = 2.
      */
     @Test
     public void testShouldGetTwoFrgamentsIfTwoBookiesFailedInSameEnsemble()
@@ -251,7 +252,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
 
     /**
      * Tests that LedgerChecker should get failed ensemble number of fragments
-     * if ensemble bookie failures on next entry
+     * if ensemble bookie failures on next entry.
      */
     @Test
     public void testShouldGetFailedEnsembleNumberOfFgmntsIfEnsembleBookiesFailedOnNextWrite()
@@ -287,7 +288,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
 
     /**
      * Tests that LedgerChecker should not get any fragments as underReplicated
-     * if Ledger itself is empty
+     * if Ledger itself is empty.
      */
     @Test
     public void testShouldNotGetAnyFragmentWithEmptyLedger() throws Exception {
@@ -339,7 +340,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         startNewBookie();
 
         //Open ledger separately for Ledger checker.
-        LedgerHandle lh1 =bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
+        LedgerHandle lh1 = bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
 
         Set<LedgerFragment> result = getUnderReplicatedFragments(lh1);
@@ -365,10 +366,8 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         }
         ArrayList<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
                 .getEnsembles().get(0L);
-        DistributionSchedule.WriteSet writeSet
-            = lh.getDistributionSchedule().getWriteSet(lh.getLastAddPushed());
-        BookieSocketAddress lastBookieFromEnsemble
-            = firstEnsemble.get(writeSet.get(0));
+        DistributionSchedule.WriteSet writeSet = lh.getDistributionSchedule().getWriteSet(lh.getLastAddPushed());
+        BookieSocketAddress lastBookieFromEnsemble = firstEnsemble.get(writeSet.get(0));
         LOG.info("Killing " + lastBookieFromEnsemble + " from ensemble="
                 + firstEnsemble);
         killBookie(lastBookieFromEnsemble);
@@ -384,7 +383,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         killBookie(lastBookieFromEnsemble);
 
         //Open ledger separately for Ledger checker.
-        LedgerHandle lh1 =bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
+        LedgerHandle lh1 = bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
 
         Set<LedgerFragment> result = getUnderReplicatedFragments(lh1);
@@ -420,7 +419,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         killBookie(lastBookieFromEnsemble);
 
         //Open ledger separately for Ledger checker.
-        LedgerHandle lh1 =bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
+        LedgerHandle lh1 = bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
 
         Set<LedgerFragment> result = getUnderReplicatedFragments(lh1);
@@ -449,7 +448,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         killBookie(lastBookieFromEnsemble);
 
         //Open ledger separately for Ledger checker.
-        LedgerHandle lh1 =bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
+        LedgerHandle lh1 = bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
 
         Set<LedgerFragment> result = getUnderReplicatedFragments(lh1);
@@ -466,7 +465,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         startNewBookie();
 
         //Open ledger separately for Ledger checker.
-        lh1 =bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
+        lh1 = bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
 
         result = getUnderReplicatedFragments(lh1);
@@ -485,7 +484,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         startNewBookie();
 
         //Open ledger separately for Ledger checker.
-        lh1 =bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
+        lh1 = bkc.openLedgerNoRecovery(lh.getId(), BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
 
         result = getUnderReplicatedFragments(lh1);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
@@ -19,7 +19,12 @@
  */
 package org.apache.bookkeeper.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.google.common.collect.Sets;
+
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -27,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.CountDownLatch;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
@@ -34,8 +40,6 @@ import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests BKAdmin that it should be able to replicate the failed bookie fragments
@@ -45,7 +49,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
 
     private static final byte[] TEST_PSSWD = "testpasswd".getBytes();
     private static final DigestType TEST_DIGEST_TYPE = BookKeeper.DigestType.CRC32;
-    private final static Logger LOG = LoggerFactory
+    private static final Logger LOG = LoggerFactory
             .getLogger(TestLedgerFragmentReplication.class);
 
     public TestLedgerFragmentReplication() {
@@ -186,7 +190,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
 
     /**
      * Tests that ReplicateLedgerFragment should return false if replication
-     * fails
+     * fails.
      */
     @Test
     public void testReplicateLFShouldReturnFalseIfTheReplicationFails()
@@ -227,7 +231,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
 
     /**
      * Tests that splitIntoSubFragment should be able to split the original
-     * passed fragment into sub fragments at correct boundaries
+     * passed fragment into sub fragments at correct boundaries.
      */
     @Test
     public void testSplitIntoSubFragmentsWithDifferentFragmentBoundaries()
@@ -257,7 +261,9 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         testSplitIntoSubFragments(11, 101, 3, 31, lh);
     }
 
-    /** assert the sub-fragment boundaries */
+    /**
+     * Assert the sub-fragment boundaries.
+     */
     void testSplitIntoSubFragments(final long oriFragmentFirstEntry,
             final long oriFragmentLastEntry, long entriesPerSubFragment,
             long expectedSubFragments, LedgerHandle lh) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestMaxSizeWorkersQueue.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestMaxSizeWorkersQueue.java
@@ -31,7 +31,9 @@ import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 
-
+/**
+ * Test the maximum size of a worker queue.
+ */
 public class TestMaxSizeWorkersQueue extends BookKeeperClusterTestCase {
     DigestType digestType = DigestType.CRC32;
 
@@ -51,9 +53,9 @@ public class TestMaxSizeWorkersQueue extends BookKeeperClusterTestCase {
         LedgerHandle lh = bkc.createLedger(1, 1, digestType, new byte[0]);
         byte[] content = new byte[100];
 
-        final int N = 1000;
+        final int n = 1000;
         // Write few entries
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             lh.addEntry(content);
         }
 
@@ -75,7 +77,7 @@ public class TestMaxSizeWorkersQueue extends BookKeeperClusterTestCase {
 
         final AtomicInteger rcSecondReadOperation = new AtomicInteger();
 
-        lh.asyncReadEntries(0, N - 1, new ReadCallback() {
+        lh.asyncReadEntries(0, n - 1, new ReadCallback() {
             @Override
             public void readComplete(int rc, LedgerHandle lh, Enumeration<LedgerEntry> seq, Object ctx) {
                 rcSecondReadOperation.set(rc);
@@ -94,16 +96,16 @@ public class TestMaxSizeWorkersQueue extends BookKeeperClusterTestCase {
         LedgerHandle lh = bkc.createLedger(1, 1, digestType, new byte[0]);
         byte[] content = new byte[100];
 
-        final int N = 1000;
+        final int n = 1000;
 
         // Write asynchronously, and expect at least few writes to have failed with NotEnoughBookies,
         // because when we get the TooManyRequestException, the client will try to form a new ensemble and that
         // operation will fail since we only have 1 bookie available
-        final CountDownLatch counter = new CountDownLatch(N);
+        final CountDownLatch counter = new CountDownLatch(n);
         final AtomicBoolean receivedTooManyRequestsException = new AtomicBoolean();
 
         // Write few entries
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             lh.asyncAddEntry(content, new AddCallback() {
                 @Override
                 public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
@@ -42,11 +42,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Unit tests for parallel reading
+ * Unit tests for parallel reading.
  */
 public class TestParallelRead extends BookKeeperClusterTestCase {
 
-    static Logger LOG = LoggerFactory.getLogger(TestParallelRead.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestParallelRead.class);
 
     final DigestType digestType;
     final byte[] passwd = "parallel-read".getBytes();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestPiggybackLAC.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestPiggybackLAC.java
@@ -22,17 +22,20 @@ package org.apache.bookkeeper.client;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Enumeration;
+
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Enumeration;
-
+/**
+ * Test a piggyback LAC.
+ */
 public class TestPiggybackLAC extends BookKeeperClusterTestCase {
 
-    static Logger LOG = LoggerFactory.getLogger(TestPiggybackLAC.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestPiggybackLAC.class);
 
     final DigestType digestType;
 
@@ -46,7 +49,7 @@ public class TestPiggybackLAC extends BookKeeperClusterTestCase {
         int numEntries = 10;
         LedgerHandle lh = bkc.createLedger(3, 3, 3, digestType, "".getBytes());
         // tried to add entries
-        for (int i=0; i<numEntries; i++) {
+        for (int i = 0; i < numEntries; i++) {
             lh.addEntry(("data" + i).getBytes());
             LOG.info("Added entry {}.", i);
         }
@@ -54,7 +57,7 @@ public class TestPiggybackLAC extends BookKeeperClusterTestCase {
         long lastLAC = readLh.getLastAddConfirmed();
         assertEquals(numEntries - 2, lastLAC);
         // write add entries
-        for (int i=0; i<numEntries; i++) {
+        for (int i = 0; i < numEntries; i++) {
             lh.addEntry(("data" + (i + numEntries)).getBytes());
             LOG.info("Added entry {}.", (i + numEntries));
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicyUsingScript.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicyUsingScript.java
@@ -27,8 +27,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import io.netty.util.HashedWheelTimer;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -47,11 +51,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
-import io.netty.util.HashedWheelTimer;
-import java.util.Optional;
-
 /**
  * In this testsuite, ScriptBasedMapping is used as DNS_RESOLVER_CLASS for
  * mapping nodes to racks. Shell Script -
@@ -59,14 +58,14 @@ import java.util.Optional;
  * resolving racks. This script maps HostAddress to rack depending on the last
  * character of the HostAddress string. for eg. 127.0.0.1 :- /1, 127.0.0.2 :-
  * /2, 99.12.34.21 :- /1
- * 
- * This testsuite has same testscenarios as in
+ *
+ * <p>This testsuite has same testscenarios as in
  * TestRackawareEnsemblePlacementPolicy.java.
- * 
- * For now this Testsuite works only on Unix based OS.
+ *
+ * <p>For now this Testsuite works only on Unix based OS.
  */
 public class TestRackawareEnsemblePlacementPolicyUsingScript {
-    
+
     static final Logger LOG = LoggerFactory.getLogger(TestRackawareEnsemblePlacementPolicyUsingScript.class);
 
     HashedWheelTimer timer;
@@ -82,7 +81,7 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
                 new ThreadFactoryBuilder().setNameFormat("TestTimer-%d").build(),
                 conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
                 conf.getTimeoutTimerNumTicks());
-        
+
         repp = new RackawareEnsemblePlacementPolicy();
         repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer, DISABLE_ALL, NullStatsLogger.INSTANCE);
     }
@@ -112,7 +111,7 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         addrs.add(addr4);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         // replace node under r2
-        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<BookieSocketAddress>(), addr2, new HashSet<BookieSocketAddress>());
+        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<>(), addr2, new HashSet<>());
         assertEquals(addr3, replacedBookie);
     }
 
@@ -134,7 +133,7 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         // replace node under r2
         Set<BookieSocketAddress> excludedAddrs = new HashSet<BookieSocketAddress>();
         excludedAddrs.add(addr1);
-        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<BookieSocketAddress>(), addr2, excludedAddrs);
+        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<>(), addr2, excludedAddrs);
 
         assertFalse(addr1.equals(replacedBookie));
         assertTrue(addr3.equals(replacedBookie) || addr4.equals(replacedBookie));
@@ -169,11 +168,11 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
     }
 
     /*
-     * Test that even in case of script mapping error 
+     * Test that even in case of script mapping error
      * we are getting default rack that makes sense for the policy.
-     * i.e. if all nodes in rack-aware policy use /rack format 
-     * but one gets node /default-region/default-rack the node addition to topology will fail. 
-     * 
+     * i.e. if all nodes in rack-aware policy use /rack format
+     * but one gets node /default-region/default-rack the node addition to topology will fail.
+     *
      * This case adds node with non-default rack, then adds nodes with one on default rack.
      */
     @Test
@@ -186,9 +185,9 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         // Update cluster, add node that maps to non-default rack
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
-        
+
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
-        
+
         addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr0);
         addrs.add(addr1);
@@ -198,7 +197,7 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         // replace node under r2
         Set<BookieSocketAddress> excludedAddrs = new HashSet<BookieSocketAddress>();
         excludedAddrs.add(addr1);
-        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<BookieSocketAddress>(), addr2, excludedAddrs);
+        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<>(), addr2, excludedAddrs);
 
         assertFalse(addr1.equals(replacedBookie));
         assertFalse(addr2.equals(replacedBookie));
@@ -206,11 +205,11 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
     }
 
     /*
-     * Test that even in case of script mapping error 
+     * Test that even in case of script mapping error
      * we are getting default rack that makes sense for the policy.
-     * i.e. if all nodes in rack-aware policy use /rack format 
-     * but one gets node /default-region/default-rack the node addition to topology will fail. 
-     * 
+     * i.e. if all nodes in rack-aware policy use /rack format
+     * but one gets node /default-region/default-rack the node addition to topology will fail.
+     *
      * This case adds node with default rack, then adds nodes with non-default rack.
      * Almost the same as testReplaceBookieWithScriptMappingError but different order of addition.
      */
@@ -224,9 +223,9 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         // Update cluster, add node that maps to default rack first
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr0);
-        
+
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
-        
+
         addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr0);
         addrs.add(addr1);
@@ -236,13 +235,13 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         // replace node under r2
         Set<BookieSocketAddress> excludedAddrs = new HashSet<BookieSocketAddress>();
         excludedAddrs.add(addr1);
-        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<BookieSocketAddress>(), addr2, excludedAddrs);
+        BookieSocketAddress replacedBookie = repp.replaceBookie(1, 1, 1, null, new HashSet<>(), addr2, excludedAddrs);
 
         assertFalse(addr1.equals(replacedBookie));
         assertFalse(addr2.equals(replacedBookie));
         assertTrue(addr0.equals(replacedBookie));
     }
-    
+
     @Test
     public void testNewEnsembleWithSingleRack() throws Exception {
         ignoreTestIfItIsWindowsOS();
@@ -258,9 +257,9 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         addrs.add(addr4);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null, new HashSet<>());
             assertEquals(0, getNumCoveredWriteQuorums(ensemble, 2));
-            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<>());
             assertEquals(0, getNumCoveredWriteQuorums(ensemble2, 2));
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
@@ -282,10 +281,10 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         addrs.add(addr4);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null, new HashSet<>());
             int numCovered = getNumCoveredWriteQuorums(ensemble, 2);
             assertTrue(numCovered == 2);
-            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<>());
             numCovered = getNumCoveredWriteQuorums(ensemble2, 2);
             assertTrue(numCovered == 2);
         } catch (BKNotEnoughBookiesException bnebe) {
@@ -316,9 +315,9 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         addrs.add(addr8);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble1 = repp.newEnsemble(3, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble1 = repp.newEnsemble(3, 2, 2, null, new HashSet<>());
             assertEquals(3, getNumCoveredWriteQuorums(ensemble1, 2));
-            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<BookieSocketAddress>());
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<>());
             assertEquals(4, getNumCoveredWriteQuorums(ensemble2, 2));
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception.");
@@ -326,7 +325,7 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
     }
 
     /**
-     * Test for BOOKKEEPER-633
+     * Test for BOOKKEEPER-633.
      */
 
     @Test
@@ -364,5 +363,5 @@ public class TestRackawareEnsemblePlacementPolicyUsingScript {
         }
         return numCoveredWriteQuorums;
     }
-    
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -17,7 +17,14 @@
  */
 package org.apache.bookkeeper.client;
 
-import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.*;
+import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy
+        .REPP_DISALLOW_BOOKIE_PLACEMENT_IN_REGION_FEATURE_NAME;
+import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_DNS_RESOLVER_CLASS;
+import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy
+        .REPP_ENABLE_DURABILITY_ENFORCEMENT_IN_REPLACE;
+import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_ENABLE_VALIDATION;
+import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_MINIMUM_REGIONS_FOR_DURABILITY;
+import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_REGIONS_TO_WRITE;
 import static org.apache.bookkeeper.client.RoundRobinDistributionSchedule.writeSetFromValues;
 import static org.apache.bookkeeper.feature.SettableFeatureProvider.DISABLE_ALL;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
@@ -41,17 +41,16 @@ import org.apache.bookkeeper.client.MockBookKeeperTestCase;
 import org.junit.Test;
 
 /**
- * Unit tests of classes in this package
+ * Unit tests of classes in this package.
  */
 public class BookKeeperApiTest extends MockBookKeeperTestCase {
 
-    final static byte[] data = "foo".getBytes(UTF_8);
-    final static byte[] password = "password".getBytes(UTF_8);
+    private static final byte[] data = "foo".getBytes(UTF_8);
+    private static final byte[] password = "password".getBytes(UTF_8);
 
     @Test
     public void testWriteHandle() throws Exception {
-        try (WriteHandle writer
-            = result(newCreateLedgerOp()
+        try (WriteHandle writer = result(newCreateLedgerOp()
                 .withAckQuorumSize(1)
                 .withWriteQuorumSize(2)
                 .withEnsembleSize(3)
@@ -73,8 +72,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
     public void testWriteAdvHandle() throws Exception {
         long ledgerId = 12345;
         setNewGeneratedLedgerId(ledgerId);
-        try (WriteAdvHandle writer
-            = result(newCreateLedgerOp()
+        try (WriteAdvHandle writer = result(newCreateLedgerOp()
                 .withAckQuorumSize(1)
                 .withWriteQuorumSize(2)
                 .withEnsembleSize(3)
@@ -96,8 +94,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
     @Test
     public void testWriteAdvHandleWithFixedLedgerId() throws Exception {
         setNewGeneratedLedgerId(12345);
-        try (WriteAdvHandle writer
-            = result(newCreateLedgerOp()
+        try (WriteAdvHandle writer = result(newCreateLedgerOp()
                 .withAckQuorumSize(1)
                 .withWriteQuorumSize(2)
                 .withEnsembleSize(3)
@@ -119,8 +116,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
 
     @Test(expected = BKDuplicateEntryIdException.class)
     public void testWriteAdvHandleBKDuplicateEntryId() throws Exception {
-        try (WriteAdvHandle writer
-            = result(newCreateLedgerOp()
+        try (WriteAdvHandle writer = result(newCreateLedgerOp()
                 .withAckQuorumSize(1)
                 .withWriteQuorumSize(2)
                 .withEnsembleSize(3)
@@ -139,8 +135,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
     @Test(expected = BKUnauthorizedAccessException.class)
     public void testOpenLedgerUnauthorized() throws Exception {
         long lId;
-        try (WriteHandle writer
-            = result(newCreateLedgerOp()
+        try (WriteHandle writer = result(newCreateLedgerOp()
                 .withAckQuorumSize(1)
                 .withWriteQuorumSize(2)
                 .withEnsembleSize(3)
@@ -149,8 +144,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
             lId = writer.getId();
             assertEquals(-1L, writer.getLastAddPushed());
         }
-        try (ReadHandle ignored
-            = result(newOpenLedgerOp()
+        try (ReadHandle ignored = result(newOpenLedgerOp()
                 .withPassword("bad-password".getBytes(UTF_8))
                 .withLedgerId(lId)
                 .execute())) {
@@ -160,8 +154,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
     @Test(expected = BKDigestMatchException.class)
     public void testOpenLedgerDigestUnmatched() throws Exception {
         long lId;
-        try (WriteHandle writer
-            = result(newCreateLedgerOp()
+        try (WriteHandle writer = result(newCreateLedgerOp()
                 .withAckQuorumSize(1)
                 .withWriteQuorumSize(2)
                 .withEnsembleSize(3)
@@ -181,8 +174,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
 
     @Test
     public void testOpenLedgerNoSealed() throws Exception {
-        try (WriteHandle writer
-            = result(newCreateLedgerOp()
+        try (WriteHandle writer = result(newCreateLedgerOp()
                 .withEnsembleSize(3)
                 .withWriteQuorumSize(3)
                 .withAckQuorumSize(2)
@@ -193,8 +185,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
             result(writer.append(ByteBuffer.wrap(data)));
             result(writer.append(ByteBuffer.wrap(data)));
 
-            try (ReadHandle reader
-                = result(newOpenLedgerOp()
+            try (ReadHandle reader = result(newOpenLedgerOp()
                     .withPassword(password)
                     .withRecovery(false)
                     .withLedgerId(lId)
@@ -207,8 +198,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
     @Test
     public void testOpenLedgerRead() throws Exception {
         long lId;
-        try (WriteHandle writer
-            = result(newCreateLedgerOp()
+        try (WriteHandle writer = result(newCreateLedgerOp()
                 .withAckQuorumSize(1)
                 .withWriteQuorumSize(2)
                 .withEnsembleSize(3)
@@ -348,7 +338,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
     private static void checkEntries(LedgerEntries entries, byte[] data)
         throws InterruptedException, BKException {
         Iterator<LedgerEntry> iterator = entries.iterator();
-        while(iterator.hasNext()) {
+        while (iterator.hasNext()) {
             LedgerEntry entry = iterator.next();
             assertArrayEquals(data, entry.getEntryBytes());
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
@@ -27,31 +27,30 @@ import static org.junit.Assert.fail;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.bookkeeper.client.BKException.BKClientClosedException;
-import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.client.BKException.BKIncorrectParameterException;
 import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerMetadata;
 import org.apache.bookkeeper.client.MockBookKeeperTestCase;
-
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.proto.BookieProtocol;
 
 import org.junit.Test;
 
 /**
- * Unit tests of builders
+ * Unit tests of builders.
  */
 public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
 
-    private final static int ensembleSize = 3;
-    private final static int writeQuorumSize = 2;
-    private final static int ackQuorumSize = 1;
-    private final static long ledgerId = 12342L;
-    private final static Map<String, byte[]> customMetadata = new HashMap<>();
-    private final static byte[] password = new byte[3];
-    private final static byte[] entryData = new byte[32];
+    private static final int ensembleSize = 3;
+    private static final int writeQuorumSize = 2;
+    private static final int ackQuorumSize = 1;
+    private static final long ledgerId = 12342L;
+    private static final Map<String, byte[]> customMetadata = new HashMap<>();
+    private static final byte[] password = new byte[3];
+    private static final byte[] entryData = new byte[32];
 
     @Test
     public void testCreateLedger() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/impl/LedgerEntriesImplTest.java
@@ -50,7 +50,7 @@ public class LedgerEntriesImplTest {
     private final ArrayList<ByteBuf> bufs = Lists.newArrayListWithExpectedSize(entryNumber);
 
     public LedgerEntriesImplTest () {
-        for(int i = 0; i < entryNumber; i++) {
+        for (int i = 0; i < entryNumber; i++) {
             ByteBuf buf = Unpooled.wrappedBuffer(dataBytes);
             bufs.add(buf);
 
@@ -87,7 +87,7 @@ public class LedgerEntriesImplTest {
 
     @Test
     public void testGetEntry() {
-        for(int i = 0; i < entryNumber; i ++) {
+        for (int i = 0; i < entryNumber; i++) {
             LedgerEntry entry = ledgerEntriesImpl.getEntry(entryId + i);
             assertEquals(entryList.get(i).getLedgerId(),  entry.getLedgerId());
             assertEquals(entryList.get(i).getEntryId(),  entry.getEntryId());

--- a/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/server-suppressions.xml
@@ -21,7 +21,6 @@
     <suppress checks="JavadocPackage" files=".*[\\/]maven-archetypes[\\/].*"/>
     <suppress checks="JavadocPackage" files=".*[\\/]examples[\\/].*"/>
     <!-- suppress packages by packages -->
-    <suppress checks=".*" files=".*[\\/]test[\\/].*[\\/]client[\\/]"/>
     <suppress checks=".*" files=".*[\\/]test[\\/].*[\\/]bookie[\\/]"/>
 
     <!-- suppress all checks in the generated directories -->


### PR DESCRIPTION

Descriptions of the changes in this PR:

This enables checkstyle verification on the client test
code in the bookkeeper-server module.

These changes are almost entirely related to whitespace, javadocs and import order.

Master Issue: #230

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> 
> - [X] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [X] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [X] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
