### PR TITLE
Race in PCBC connection if channel inactive before callback

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1911,7 +1911,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             Queue<GenericCallback<PerChannelBookieClient>> oldPendingOps;
 
             synchronized (PerChannelBookieClient.this) {
-                if (future.isSuccess() && state == ConnectionState.CONNECTING) {
+                if (future.isSuccess() && state == ConnectionState.CONNECTING && future.channel().isActive()) {
                     LOG.info("Successfully connected to bookie: {}", future.channel());
                     rc = BKException.Code.OK;
                     channel = future.channel();


### PR DESCRIPTION
There's a race in PCBC where if the channel is errored before the
connection callback occurs, the channel will hang around as a zombie
forever.

This caused a flake in
TestDisableEnsembleChange#testRetryFailureBookie, but the problem
itself could affect production code. This test hit it because it tries
to reconnect in a tight loop as a bookie is booting.

The error occurs because we only change state with channelInactive if
the channelInactive occurred on the channel that matches the currently
assigned this.channel. If the channel connects successfully, but
channelInactive occurs before the connect callback runs, the channel
will be closed, but the state will be transitioned to CONNECTED. No
more events will occur on the channel, so it'll hang around forever,
and all requests on the channel will timeout.

The fix is to check that the channel is active before assigning it to
this.channel and setting state to CONNECTED. If the channel is not
active at this point, then the else clause of this block will run
which closes the channel, and sets state to DISCONNECTED. In this
case, the next request will trigger a new connection attempt.
