### PR TITLE
Issue 620: Close the fileChannels for read when they are idle

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -213,6 +213,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -25,6 +25,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static org.apache.bookkeeper.bookie.TransactionalEntryLogCompactor.COMPACTING_SUFFIX;
 import static org.apache.bookkeeper.util.BookKeeperConstants.MAX_LOG_SIZE_LIMIT;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -368,16 +369,16 @@ public class EntryLogger {
 
 
     static class ReferenceCountedFileChannel extends AbstractReferenceCounted {
-        FileChannel getFc() {
-            return fc;
-        }
-
         private final FileChannel fc;
 
         public ReferenceCountedFileChannel(FileChannel fileChannel) {
             this.fc = fileChannel;
         }
 
+        @VisibleForTesting
+        FileChannel getFileChannel(){
+            return fc;
+        }
 
         @Override
         public ReferenceCounted touch(Object hint) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -419,8 +419,9 @@ public class EntryLogger {
         Cache<Long, BufferedReadChannel> threadCahe = logid2Channel.get();
         threadCahe.invalidate(logId);
 
-        //remove the fileChannel from logId2FileChannel
-        logid2FileChannel.remove(logId);
+        //remove the fileChannel from logId2FileChannel and close it
+        logid2FileChannel.remove(logId).deallocate();
+
     }
 
     public BufferedReadChannel getFromChannels(long logId) {
@@ -1415,6 +1416,8 @@ public class EntryLogger {
             for (ReferenceCountedFileChannel rfc : logid2FileChannel.values()) {
                 rfc.deallocate();
             }
+            // clear the mapping, so we don't need to go through the channels again in finally block in normal case.
+            logid2FileChannel.clear();
             // close current writing log file
             closeFileChannel(logChannel);
             synchronized (compactionLogLock) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -347,10 +347,7 @@ public class EntryLogger {
             return CacheBuilder.newBuilder().concurrencyLevel(1)
                     .expireAfterAccess(expireReadChannelCache, TimeUnit.MILLISECONDS)
                     //decrease the refCnt
-                    .removalListener(removal -> {
-                        LOG.info("refCnt for {} is {} ", removal.getKey(), logid2FileChannel.get(removal.getKey()).refCnt());
-                        logid2FileChannel.get(removal.getKey()).release();
-                    })
+                    .removalListener(removal -> logid2FileChannel.get(removal.getKey()).release())
                     .build(readChannelLoader);
         }
     };

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -293,7 +293,7 @@ public class EntryLogger {
         flushIntervalInBytes = conf.getFlushIntervalInBytes();
         doRegularFlushes = flushIntervalInBytes > 0;
 
-        expireReadChannelCache = conf.getExpireReadChannelCache();
+        expireReadChannelCache = conf.getReadChannelCacheExpireTimeMs();
         initialize();
     }
 
@@ -353,7 +353,7 @@ public class EntryLogger {
         }
     };
 
-    // only used for test.
+    @VisibleForTesting
     ThreadLocal<Cache<Long, BufferedReadChannel>> getLogid2Channel() {
         return logid2Channel;
     }
@@ -408,7 +408,7 @@ public class EntryLogger {
      */
     private ConcurrentMap<Long, ReferenceCountedFileChannel>
             logid2FileChannel = new ConcurrentHashMap<>();
-    // only for test.
+    @VisibleForTesting
     ConcurrentMap<Long, ReferenceCountedFileChannel> getLogid2FileChannel() {
         return logid2FileChannel;
     }
@@ -1178,7 +1178,6 @@ public class EntryLogger {
         // so that there are no overlaps with the write buffer while reading
         brc = new BufferedReadChannel(newFc, conf.getReadBufferBytes());
         putInReadChannels(entryLogId, brc);
-        LOG.info("put readChannel: {}, corresponding to: {} ", brc, entryLogId);
         return brc;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelBackingCache.java
@@ -21,6 +21,7 @@
 
 package org.apache.bookkeeper.bookie;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
@@ -58,7 +59,7 @@ class FileChannelBackingCache {
             CachedFileChannel cachedFileChannel = fileChannels.get(logId);
             if (cachedFileChannel != null) {
                 boolean retained = cachedFileChannel.tryRetain();
-                assert(retained);
+                checkArgument(retained);
                 return cachedFileChannel;
             }
         } finally {
@@ -74,7 +75,7 @@ class FileChannelBackingCache {
             CachedFileChannel cachedFileChannel = new CachedFileChannel(logId, newFc);
             fileChannels.put(logId, cachedFileChannel);
             boolean retained = cachedFileChannel.tryRetain();
-            assert(retained);
+            checkArgument(retained);
             return cachedFileChannel;
         } finally {
             lock.writeLock().unlock();
@@ -134,7 +135,7 @@ class FileChannelBackingCache {
     CachedFileChannel get(Long logId) {
         lock.readLock().lock();
         try {
-        return fileChannels.get(logId);
+            return fileChannels.get(logId);
         } finally {
             lock.readLock().unlock();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelBackingCache.java
@@ -1,0 +1,208 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.bookkeeper.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FileChannelBackingCache used to cache RefCntFileChannels for read.
+ * In order to avoid get released file, adopt design of FileInfoBackingCache.
+ * @see FileInfoBackingCache
+ */
+class FileChannelBackingCache {
+    private static final Logger LOG = LoggerFactory.getLogger(FileChannelBackingCache.class);
+    static final int DEAD_REF = -0xdead;
+    final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    final FileLoader fileLoader;
+
+    FileChannelBackingCache(FileLoader fileLoader) {
+        this.fileLoader = fileLoader;
+    }
+
+    final ConcurrentHashMap<Long, CachedFileChannel> fileChannels = new ConcurrentHashMap<>();
+
+    CachedFileChannel loadFileChannel(long logId) throws IOException {
+        lock.readLock().lock();
+        try {
+            CachedFileChannel cachedFileChannel = fileChannels.get(logId);
+            if (cachedFileChannel != null) {
+                boolean retained = cachedFileChannel.tryRetain();
+                assert(retained);
+                return cachedFileChannel;
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        lock.writeLock().lock();
+        try {
+            File file = fileLoader.load(logId);
+            // get channel is used to open an existing entry log file
+            // it would be better to open using read mode
+            FileChannel newFc = new RandomAccessFile(file, "r").getChannel();
+            CachedFileChannel cachedFileChannel = new CachedFileChannel(logId, newFc);
+            fileChannels.put(logId, cachedFileChannel);
+            boolean retained = cachedFileChannel.tryRetain();
+            assert(retained);
+            return cachedFileChannel;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * close FileChannel and remove from cache when possible.
+     * @param logId
+     * @param cachedFileChannel
+     */
+    private void releaseFileChannel(long logId, CachedFileChannel cachedFileChannel) {
+        if (cachedFileChannel.markDead()) {
+            try {
+                cachedFileChannel.fileChannel.close();
+            } catch (IOException e) {
+                LOG.warn("Exception occurred in ReferenceCountedFileChannel"
+                        + " while closing channel for log file: {}", cachedFileChannel);
+            } finally {
+                IOUtils.close(LOG, cachedFileChannel.fileChannel);
+            }
+            // to guarantee the removed cachedFileChannel is what we want to remove.
+            fileChannels.remove(logId, cachedFileChannel);
+        }
+    }
+
+    /**
+     * Remove all entries for this log file in each thread's cache.
+     * @param logId
+     */
+    public void removeFromChannelsAndClose(long logId) {
+        //remove the fileChannel from FileChannelBackingCache and close it
+        CachedFileChannel fileChannel = fileChannels.remove(logId);
+        fileChannel.release();
+        try {
+            fileChannel.fileChannel.close();
+        } catch (IOException e) {
+            LOG.warn("Exception occurred in CachedFileChannel"
+                    + " while closing channel for log file: {}", logId);
+        } finally {
+            IOUtils.close(LOG, fileChannel.fileChannel);
+        }
+    }
+
+    void closeAllFileChannels() throws IOException {
+        for (Map.Entry<Long, CachedFileChannel> entry : fileChannels.entrySet()) {
+            entry.getValue().fileChannel.close();
+        }
+    }
+
+    public CachedFileChannel get(Long logId) {
+        lock.readLock().lock();
+        try {
+        return fileChannels.get(logId);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    class CachedFileChannel {
+        private final long entryLogId;
+        final AtomicInteger refCount;
+        final FileChannel fileChannel;
+
+        CachedFileChannel(long entryLogId, FileChannel fileChannel) throws IOException{
+            this.fileChannel = fileChannel;
+            this.entryLogId = entryLogId;
+            this.refCount = new AtomicInteger(0);
+        }
+
+        /**
+         * Mark this fileinfo as dead. We can only mark a fileinfo as
+         * dead if noone currently holds a reference to it.
+         *
+         * @return true if we marked as dead, false otherwise
+         */
+        private boolean markDead() {
+            return refCount.compareAndSet(0, DEAD_REF);
+        }
+
+        /**
+         * Attempt to retain the file channel.
+         * When a client obtains a file channel from a container object,
+         * but that container object may release the file channel before
+         * the client has a chance to call retain. In this case, the
+         * file channel could be released and the destroyed before we ever
+         * get a chance to use it.
+         *
+         * <p>tryRetain avoids this problem, by doing a compare-and-swap on
+         * the reference count. If the refCount is negative, it means that
+         * the file channel is being cleaned up, and this file channel object should
+         * not be used. This works in tandem with #markDead, which will only
+         * set the refCount to negative if noone currently has it retained
+         * (i.e. the refCount is 0).
+         *
+         * @return true if we managed to increment the refcount, false otherwise
+         */
+        boolean tryRetain() {
+            while (true) {
+                int count = refCount.get();
+                if (count < 0) {
+                    return false;
+                } else if (refCount.compareAndSet(count, count + 1)) {
+                    return true;
+                }
+            }
+        }
+
+        @VisibleForTesting
+        int getRefCount() {
+            return refCount.get();
+        }
+
+        void release() {
+            if (refCount.decrementAndGet() == 0) {
+                releaseFileChannel(entryLogId, this);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "CachedFileChannel(logId=" + entryLogId
+                    + ",refCount=" + refCount.get()
+                    + ",id=" + System.identityHashCode(this) + ")";
+        }
+    }
+    interface FileLoader {
+        File load(long logId) throws IOException;
+    }
+}
+

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelBackingCache.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -104,30 +103,6 @@ class FileChannelBackingCache {
             }
         } finally {
             lock.writeLock().unlock();
-        }
-    }
-
-    /**
-     * Remove all entries for this log file in each thread's cache.
-     * @param logId
-     */
-    public void removeFromChannelsAndClose(long logId) {
-        //remove the fileChannel from FileChannelBackingCache and close it
-        CachedFileChannel fileChannel = fileChannels.remove(logId);
-        fileChannel.release();
-        try {
-            fileChannel.fileChannel.close();
-        } catch (IOException e) {
-            LOG.warn("Exception occurred in CachedFileChannel"
-                    + " while closing channel for log file: {}", logId);
-        } finally {
-            IOUtils.close(LOG, fileChannel.fileChannel);
-        }
-    }
-
-    void closeAllFileChannels() throws IOException {
-        for (Map.Entry<Long, CachedFileChannel> entry : fileChannels.entrySet()) {
-            entry.getValue().fileChannel.close();
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -47,6 +47,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String COMPACTION_RATE = "compactionRate";
     protected static final String COMPACTION_RATE_BY_ENTRIES = "compactionRateByEntries";
     protected static final String COMPACTION_RATE_BY_BYTES = "compactionRateByBytes";
+    protected static final String EXPIRE_READ_CHANNEL_CACHE = "expireReadChannelCache";
 
     // Gc Parameters
     protected static final String GC_WAIT_TIME = "gcWaitTime";
@@ -235,6 +236,27 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setEntryLogFilePreAllocationEnabled(boolean enabled) {
         this.setProperty(ENTRY_LOG_FILE_PREALLOCATION_ENABLED, enabled);
+        return this;
+    }
+
+    /**
+     * get ReadChannelCache expire time.
+     *
+     * @return server configuration object.
+     */
+    public long getExpireReadChannelCache() {
+        return this.getLong(EXPIRE_READ_CHANNEL_CACHE, 3600000);
+    }
+
+    /**
+     * set ReadChannelCache expire time. Default value is 1h.
+     *
+     * @param millis
+     *          expire time.
+     * @return server configuration object.
+     */
+    public ServerConfiguration setExpireReadChannelCache(long millis) {
+        this.setProperty(EXPIRE_READ_CHANNEL_CACHE, millis);
         return this;
     }
 
@@ -2633,4 +2655,5 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected ServerConfiguration getThis() {
         return this;
     }
+
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -240,7 +240,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * get ReadChannelCache expire time.
+     * Get ReadChannelCache expire time.
      *
      * @return server configuration object.
      */
@@ -249,8 +249,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * set ReadChannelCache expire time. Default value is 1h.
-     *
+     * Set ReadChannelCache expire time. Default value is 1h.
+     * After ReadChannel expire from cache, its corresponding fileChannel will be closed.
      * @param millis
      *          expire time.
      * @return server configuration object.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -47,7 +47,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String COMPACTION_RATE = "compactionRate";
     protected static final String COMPACTION_RATE_BY_ENTRIES = "compactionRateByEntries";
     protected static final String COMPACTION_RATE_BY_BYTES = "compactionRateByBytes";
-    protected static final String EXPIRE_READ_CHANNEL_CACHE = "expireReadChannelCache";
+    protected static final String READ_CHANNEL_CACHE_EXPIRE_TIME_MS = "expireReadChannelCache";
 
     // Gc Parameters
     protected static final String GC_WAIT_TIME = "gcWaitTime";
@@ -245,7 +245,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return server configuration object.
      */
     public long getExpireReadChannelCache() {
-        return this.getLong(EXPIRE_READ_CHANNEL_CACHE, 3600000);
+        return this.getLong(READ_CHANNEL_CACHE_EXPIRE_TIME_MS, 3600000);
     }
 
     /**
@@ -256,7 +256,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return server configuration object.
      */
     public ServerConfiguration setExpireReadChannelCache(long millis) {
-        this.setProperty(EXPIRE_READ_CHANNEL_CACHE, millis);
+        this.setProperty(READ_CHANNEL_CACHE_EXPIRE_TIME_MS, millis);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -47,7 +47,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String COMPACTION_RATE = "compactionRate";
     protected static final String COMPACTION_RATE_BY_ENTRIES = "compactionRateByEntries";
     protected static final String COMPACTION_RATE_BY_BYTES = "compactionRateByBytes";
-    protected static final String READ_CHANNEL_CACHE_EXPIRE_TIME_MS = "expireReadChannelCache";
+    protected static final String READ_CHANNEL_CACHE_EXPIRE_TIME_MS = "readChannelCacheExpireTimeMs";
 
     // Gc Parameters
     protected static final String GC_WAIT_TIME = "gcWaitTime";
@@ -244,7 +244,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      *
      * @return server configuration object.
      */
-    public long getExpireReadChannelCache() {
+    public long getReadChannelCacheExpireTimeMs() {
         return this.getLong(READ_CHANNEL_CACHE_EXPIRE_TIME_MS, 3600000);
     }
 
@@ -255,7 +255,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      *          expire time.
      * @return server configuration object.
      */
-    public ServerConfiguration setExpireReadChannelCache(long millis) {
+    public ServerConfiguration setReadChannelCacheExpireTimeMs(long millis) {
         this.setProperty(READ_CHANNEL_CACHE_EXPIRE_TIME_MS, millis);
         return this;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -35,6 +35,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
@@ -405,7 +407,18 @@ public class EntryLogTest {
         assertEquals(0, logid2FileChannel.get(2L).refCnt());
         assertEquals(1, logid2FileChannel.get(3L).refCnt());
         assertEquals(1, logid2FileChannel.get(4L).refCnt());
-//        assertNull(logid2FileChannel.get(2L).getFc());
+        try {
+            logid2FileChannel.get(1L).getFileChannel().write(ByteBuffer.allocate(5));
+            fail("FileChannel has been closed, should not come here");
+        } catch (ClosedChannelException exception){
+
+        }
+        try {
+            logid2FileChannel.get(2L).getFileChannel().write(ByteBuffer.allocate(5));
+            fail("FileChannel has been closed, should not come here");
+        } catch (ClosedChannelException exception){
+
+        }
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import com.google.common.base.Ticker;
-import com.google.common.cache.Cache;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
 import com.google.common.testing.FakeTicker;
 import io.netty.buffer.ByteBuf;
@@ -369,7 +369,8 @@ public class EntryLogTest {
         FakeTicker t = new FakeTicker();
         FakeEntryLogger logger = new FakeEntryLogger(conf, ledgerDirsManager, t);
         // create some read for the entry log
-        ThreadLocal<Cache<Long, EntryLogger.EntryLogBufferedReadChannel>>  cacheThreadLocal = logger.logid2ReadChannel;
+        ThreadLocal<LoadingCache<Long, EntryLogger.EntryLogBufferedReadChannel>>  cacheThreadLocal =
+                logger.logid2ReadChannel;
         FileChannelBackingCache logid2FileChannel = logger.fileChannelBackingCache;
         for (int j = 0; j < numEntries; j++) {
             logger.readEntry(0, j, positions[0][j]);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -336,16 +336,15 @@ public class EntryLogTest {
         File curDir = Bookie.getCurrentDirectory(tmpDir);
         Bookie.checkDirectoryStructure(curDir);
 
-        int gcWaitTime = 1000;
         int expireTime = 1000;
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
-        conf.setGcWaitTime(gcWaitTime);
         conf.setLedgerDirNames(new String[] {tmpDir.toString()});
         //since last access, expire after 1s
         conf.setReadChannelCacheExpireTimeMs(expireTime);
         conf.setEntryLogFilePreAllocationEnabled(false);
+        // try to avoid failure when the disk is over 95% full
         LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
-                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
+                new DiskChecker(0.99f, 0.99f));
         // create some entries
         int numLogs = 4;
         int numEntries = 10;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestFileChannelBackingCache.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestFileChannelBackingCache.java
@@ -1,0 +1,222 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.bookie.FileChannelBackingCache.CachedFileChannel;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for FileChannelBackingCache.
+ */
+@Slf4j
+public class TestFileChannelBackingCache {
+    final File baseDir;
+    final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+            .setNameFormat("backing-cache-test-%d").setDaemon(true).build();
+    ExecutorService executor;
+
+    public TestFileChannelBackingCache() throws Exception {
+        baseDir = File.createTempFile("foo", "bar");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        Assert.assertTrue(baseDir.delete());
+        Assert.assertTrue(baseDir.mkdirs());
+        baseDir.deleteOnExit();
+        executor = Executors.newCachedThreadPool(threadFactory);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (executor != null) {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void basicTest() throws Exception {
+        FileChannelBackingCache cache = new FileChannelBackingCache(this::findFile);
+        CachedFileChannel fileChannel = cache.loadFileChannel(1);
+        Assert.assertEquals(fileChannel.getRefCount(), 1);
+        CachedFileChannel fileChannel2 = cache.loadFileChannel(2);
+        Assert.assertEquals(fileChannel2.getRefCount(), 1);
+        CachedFileChannel fileChannel3 = cache.loadFileChannel(1);
+        Assert.assertEquals(fileChannel, fileChannel3);
+        Assert.assertEquals(fileChannel3.getRefCount(), 2);
+
+        // check that it expires correctly
+        fileChannel.release();
+        fileChannel3.release();
+
+        Assert.assertEquals(fileChannel.getRefCount(), FileChannelBackingCache.DEAD_REF);
+        CachedFileChannel fileChannel4 = cache.loadFileChannel(1);
+        Assert.assertFalse(fileChannel4 == fileChannel);
+        Assert.assertEquals(fileChannel.getRefCount(), FileChannelBackingCache.DEAD_REF);
+        Assert.assertEquals(fileChannel4.getRefCount(), 1);
+        Assert.assertFalse(fileChannel.fileChannel == fileChannel4.fileChannel);
+    }
+
+    @Test
+    public void testRefCountRace() throws Exception {
+        AtomicBoolean done = new AtomicBoolean(false);
+        FileChannelBackingCache cache = new FileChannelBackingCache(this::findFile);
+        Iterable<Future<Set<CachedFileChannel>>> futures =
+                IntStream.range(0, 2).mapToObj(
+                        (i) -> {
+                            Callable<Set<CachedFileChannel>> c = () -> {
+                                Set<CachedFileChannel> allFileChannels = new HashSet<>();
+                                while (!done.get()) {
+                                    CachedFileChannel fileChannel = cache.loadFileChannel(i);
+                                    allFileChannels.add(fileChannel);
+                                    fileChannel.release();
+                                }
+                                return allFileChannels;
+                            };
+                            return executor.submit(c);
+                        }).collect(Collectors.toList());
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+        done.set(true);
+
+        // ensure all threads are finished operating on cache, before checking any
+        for (Future<Set<CachedFileChannel>> f : futures) {
+            f.get();
+        }
+
+        for (Future<Set<CachedFileChannel>> f : futures) {
+            for (CachedFileChannel fileChannel : f.get()) {
+                Assert.assertEquals(FileChannelBackingCache.DEAD_REF, fileChannel.getRefCount());
+            }
+        }
+    }
+
+    private void guavaEvictionListener(RemovalNotification<Long, CachedFileChannel> notification) {
+        notification.getValue().release();
+    }
+
+    FileChannelBackingCache cache;
+    ThreadLocal<Cache<Long, BufferedReadChannel>> logid2ReadChannel;
+    Set<CachedFileChannel> allCachedFileChannels = new HashSet<>();
+
+
+    @Test
+    public void testRaceBufferedReadChannelEvictAndReleaseBeforeRetain() throws Exception {
+        AtomicBoolean done = new AtomicBoolean(false);
+        cache = new FileChannelBackingCache(this::findFile);
+        logid2ReadChannel =
+                new ThreadLocal<Cache<Long, BufferedReadChannel>>() {
+                    @Override
+                    public Cache<Long, BufferedReadChannel> initialValue() {
+                        // Since this is thread local there only one modifier
+                        // We dont really need the concurrency, but we need to use
+                        // the weak values. Therefore using the concurrency level of 1
+                        return CacheBuilder.newBuilder().concurrencyLevel(1)
+                                .maximumSize(1)
+                                //decrease the refCnt
+                                .removalListener(removal -> cache.get((Long) removal.getKey()).release())
+                                .build();
+                    }
+                };
+
+        Iterable<Future<Set<CachedFileChannel>>> futures =
+                LongStream.range(0L, 2L).mapToObj(
+                        (i) -> {
+                            Callable<Set<CachedFileChannel>> c = () -> {
+                                while (!done.get()) {
+                                    logid2ReadChannel.get().get(i, () -> getChannelForLogId(i));
+                                }
+                                return allCachedFileChannels;
+                            };
+                            return executor.submit(c);
+                        }).collect(Collectors.toList());
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+        done.set(true);
+
+        // ensure all threads are finished operating on cache, before checking any
+        for (Future<Set<CachedFileChannel>> f : futures) {
+            f.get();
+        }
+        logid2ReadChannel.get().invalidateAll();
+
+        for (Future<Set<CachedFileChannel>> f : futures) {
+            for (CachedFileChannel cachedFileChannel : f.get()) {
+                Assert.assertEquals(FileChannelBackingCache.DEAD_REF, cachedFileChannel.getRefCount());
+            }
+        }
+
+    }
+
+    private File findFile(long logId) throws IOException{
+        File f = new File(baseDir, Long.toHexString(logId) + ".log");
+        if (!f.exists()) {
+            f.createNewFile();
+        }
+        f.deleteOnExit();
+        return f;
+    }
+
+    private BufferedReadChannel getChannelForLogId(long entryLogId) throws IOException {
+        BufferedReadChannel brc = logid2ReadChannel.get().getIfPresent(entryLogId);
+        if (brc != null) {
+            return brc;
+        }
+        FileChannelBackingCache.CachedFileChannel cachedFileChannel = null;
+        try {
+            do {
+                cachedFileChannel = cache.loadFileChannel(entryLogId);
+            } while (!cachedFileChannel.tryRetain());
+        } finally {
+            if (null != cachedFileChannel) {
+                cachedFileChannel.release();
+            }
+        }
+        allCachedFileChannels.add(cachedFileChannel);
+        brc = new BufferedReadChannel(cachedFileChannel.fileChannel, 512);
+        Cache<Long, BufferedReadChannel> threadCache = logid2ReadChannel.get();
+        threadCache.put(entryLogId, brc);
+        return brc;
+    }
+
+}
+

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -435,6 +435,9 @@ ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFa
 # The number of bytes used as capacity for the write buffer. Default is 64KB.
 # writeBufferSizeBytes=65536
 
+#The expire time of read channel cache. Default is 1h.
+#readChannelCacheExpireTimeMs=3600000
+
 #############################################################################
 ## Entry log compaction settings
 #############################################################################

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -435,7 +435,7 @@ ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFa
 # The number of bytes used as capacity for the write buffer. Default is 64KB.
 # writeBufferSizeBytes=65536
 
-#The expire time of read channel cache. Default is 1h.
+# The expire time of read channel cache. Default is 1h.
 #readChannelCacheExpireTimeMs=3600000
 
 #############################################################################

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -436,7 +436,7 @@ ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFa
 # writeBufferSizeBytes=65536
 
 # The expire time of read channel cache. Default is 1h.
-#readChannelCacheExpireTimeMs=3600000
+# readChannelCacheExpireTimeMs=3600000
 
 #############################################################################
 ## Entry log compaction settings

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -300,6 +300,9 @@ groups:
   - param: writeBufferSizeBytes
     description: The number of bytes used as capacity for the write buffer.
     default: 65536
+  - param: readChannelCacheExpireTimeMs
+    description: The expire time of read channel cache.
+    default: 3600000
 
 - name: Entry log compaction settings
   params:


### PR DESCRIPTION
Descriptions of the changes in this PR:

use guava cache to replace concurrentMap for logid2fileChannel, as guava cache has a eviction way, so we can use it to close the idle fileChannel

Master Issue: #620 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
