### PR TITLE
Fix Flaky CreateNewLogTest

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
@@ -89,7 +89,6 @@ public class CreateNewLogTest {
         conf.setLedgerDirNames(ledgerDirs);
         LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
-        EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
 
         // Extracted from createNewLog()
         String logFileName = Long.toHexString(1) + ".log";
@@ -98,6 +97,7 @@ public class CreateNewLogTest {
         File newLogFile = new File(dir, logFileName);
         newLogFile.createNewFile();
 
+        EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
         // Calls createNewLog, and with the number of directories we
         // are using, if it picks one at random it will fail.
         el.createNewLog();
@@ -114,7 +114,6 @@ public class CreateNewLogTest {
         conf.setIsForceGCAllowWhenNoSpace(true);
         LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
-        EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
 
         // Extracted from createNewLog()
         String logFileName = Long.toHexString(1) + ".log";
@@ -129,6 +128,7 @@ public class CreateNewLogTest {
             ledgerDirsManager.addToFilledDirs(tdir);
         }
 
+        EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
         // Calls createNewLog, and with the number of directories we
         // are using, if it picks one at random it will fail.
         el.createNewLog();


### PR DESCRIPTION
Descriptions of the changes in this PR:

CreateNewLogTest becomes flaky after fixing #568 because preallocation can happen in the background. Changing the sequence of creating entry logger and entry log file injection to make the test sequence deterministic. 