### PR TITLE
ISSUE #841: Unnecessary new Object[] {}, new String[] {} etc calls

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
@@ -161,7 +161,7 @@ public class OrderedScheduler {
             taskExecutionStats.registerSuccessfulEvent(elapsedMicroSec, TimeUnit.MICROSECONDS);
             if (elapsedMicroSec >= warnTimeMicroSec) {
                 LOGGER.warn("Runnable {}:{} took too long {} micros to execute.",
-                            new Object[] { runnable, runnable.getClass(), elapsedMicroSec });
+                        runnable, runnable.getClass(), elapsedMicroSec);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -211,7 +211,7 @@ public class Bookie extends BookieCriticalThread {
                                   BookieSocketAddress addr, Object ctx) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Finished writing entry {} @ ledger {} for {} : {}",
-                          new Object[] { entryId, ledgerId, addr, rc });
+                        entryId, ledgerId, addr, rc);
             }
         }
     }
@@ -1377,7 +1377,7 @@ public class Bookie extends BookieCriticalThread {
                                   BookieSocketAddress addr, Object ctx) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Finished writing entry {} @ ledger {} for {} : {}",
-                          new Object[] { entryId, ledgerId, addr, rc });
+                        entryId, ledgerId, addr, rc);
             }
 
             result.set(0 == rc);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1569,10 +1569,9 @@ public class BookieShell implements Tool {
                     return -1;
                 }
                 LOG.info("Auditor: {}/{}:{}",
-                         new Object[] {
-                             bookieId.getSocketAddress().getAddress().getCanonicalHostName(),
-                             bookieId.getSocketAddress().getAddress().getHostAddress(),
-                             bookieId.getSocketAddress().getPort() });
+                        bookieId.getSocketAddress().getAddress().getCanonicalHostName(),
+                        bookieId.getSocketAddress().getAddress().getHostAddress(),
+                        bookieId.getSocketAddress().getPort());
             } finally {
                 if (zk != null) {
                     zk.close();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1177,7 +1177,7 @@ public class EntryLogger {
                 int rc = readFromLogChannel(entryLogId, bc, data, pos);
                 if (rc != entrySize) {
                     LOG.warn("Short read for ledger entry from entryLog {}@{} ({} != {})",
-                            new Object[] { entryLogId, pos, rc, entrySize });
+                            entryLogId, pos, rc, entrySize);
                     return;
                 }
                 // process the entry
@@ -1262,7 +1262,7 @@ public class EntryLogger {
 
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Recovering ledgers maps for log {} -- Found ledger: {} with size: {}",
-                                new Object[] { entryLogId, ledgerId, size });
+                                entryLogId, ledgerId, size);
                     }
                     meta.addLedgerSize(ledgerId, size);
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexInMemPageMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexInMemPageMgr.java
@@ -375,7 +375,7 @@ class IndexInMemPageMgr {
             this.pageLimit = conf.getPageLimit();
         }
         LOG.info("maxDirectMemory = {}, pageSize = {}, pageLimit = {}",
-                new Object[] { maxDirectMemory, pageSize, pageLimit });
+                maxDirectMemory, pageSize, pageLimit);
         // Expose Stats
         this.ledgerCacheHitCounter = statsLogger.getCounter(LEDGER_CACHE_HIT);
         this.ledgerCacheMissCounter = statsLogger.getCounter(LEDGER_CACHE_MISS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -55,8 +55,8 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
     @Override
     void checkAccess(byte masterKey[]) throws BookieException, IOException {
         if (!Arrays.equals(this.masterKey, masterKey)) {
-            LOG.error("[{}] Requested master key {} does not match the cached master key {}", new Object[] {
-                    this.ledgerId, Arrays.toString(masterKey), Arrays.toString(this.masterKey) });
+            LOG.error("[{}] Requested master key {} does not match the cached master key {}",
+                    this.ledgerId, Arrays.toString(masterKey), Arrays.toString(this.masterKey));
             throw BookieException.create(BookieException.Code.UnauthorizedAccessException);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerEntryPage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerEntryPage.java
@@ -187,14 +187,14 @@ public class LedgerEntryPage {
                     + " tried to get " + page.capacity() + " from position "
                     + getFirstEntryPosition() + " still need " + page.remaining(), sre);
         } catch (IllegalArgumentException iae) {
-            LOG.error("IllegalArgumentException when trying to read ledger {} from position {}"
-                , new Object[]{getLedger(), getFirstEntryPosition(), iae});
+            LOG.error("IllegalArgumentException when trying to read ledger {} from position {}",
+                    getLedger(), getFirstEntryPosition(), iae);
             throw iae;
         }
         // make sure we don't include partial index entry
         if (page.remaining() != 0) {
             LOG.info("Short page read of ledger {} : tried to read {} bytes from position {}, but only {} bytes read.",
-                     new Object[] { getLedger(), page.capacity(), getFirstEntryPosition(), page.position() });
+                    getLedger(), page.capacity(), getFirstEntryPosition(), page.position());
             if (page.position() % indexEntrySize != 0) {
                 int partialIndexEntryStart = page.position() - page.position() % indexEntrySize;
                 page.putLong(partialIndexEntryStart, 0L);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -181,7 +181,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                         if (lid != ledgerId || entryId < -1) {
                             LOG.warn("Scanning expected ledgerId {}, but found invalid entry "
                                     + "with ledgerId {} entryId {} at offset {}",
-                                new Object[]{ledgerId, lid, entryId, offset});
+                                    ledgerId, lid, entryId, offset);
                             throw new IOException("Invalid entry found @ offset " + offset);
                         }
                         long newOffset = entryLogger.addEntryForCompaction(ledgerId, entry);
@@ -189,7 +189,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
 
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Compact add entry : lid = {}, eid = {}, offset = {}",
-                                new Object[]{ledgerId, entryId, newOffset});
+                                    ledgerId, entryId, newOffset);
                         }
                     }
                 }
@@ -362,7 +362,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                     if (lid != ledgerId || entryId < -1) {
                         LOG.warn("Scanning expected ledgerId {}, but found invalid entry "
                                 + "with ledgerId {} entryId {} at offset {}",
-                            new Object[]{ledgerId, lid, entryId, offset});
+                                ledgerId, lid, entryId, offset);
                         throw new IOException("Invalid entry found @ offset " + offset);
                     }
                     long location = (compactedLogId << 32L) | (offset + 4);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
@@ -96,7 +96,7 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
 
                         public void onFailure(Throwable thrown) {
                             LOG.warn("Failed to issue speculative request for {}, speculativeReadTimeout = {} : ",
-                                new Object[] { requestExecutor, speculativeRequestTimeout, thrown });
+                                    requestExecutor, speculativeRequestTimeout, thrown);
                         }
                     });
                 }
@@ -104,7 +104,7 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
         } catch (RejectedExecutionException re) {
             if (!scheduler.isShutdown()) {
                 LOG.warn("Failed to schedule speculative request for {}, speculativeReadTimeout = {} : ",
-                        new Object[]{requestExecutor, speculativeRequestTimeout, re});
+                        requestExecutor, speculativeRequestTimeout, re);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -270,7 +270,7 @@ public class LedgerFragmentReplicator {
             public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx) {
                 if (rc != BKException.Code.OK) {
                     LOG.error("BK error writing entry for ledgerId: {}, entryId: {}, bookie: {}",
-                              new Object[] { ledgerId, entryId, addr, BKException.create(rc) });
+                            ledgerId, entryId, addr, BKException.create(rc));
                     if (completed.compareAndSet(false, true)) {
                         ledgerFragmentEntryMcb.processResult(rc, null, null);
                     }
@@ -281,7 +281,7 @@ public class LedgerFragmentReplicator {
                     }
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Success writing ledger id {}, entry id {} to a new bookie {}!",
-                                  new Object[] { ledgerId, entryId, addr });
+                                ledgerId, entryId, addr);
                     }
                     if (numCompleted.incrementAndGet() == newBookies.size() && completed.compareAndSet(false, true)) {
                         ledgerFragmentEntryMcb.processResult(rc, null, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -592,14 +592,14 @@ public class LedgerHandle implements WriteHandle {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
-                    new Object[] { ledgerId, firstEntry, lastEntry });
+                    ledgerId, firstEntry, lastEntry);
             cb.readComplete(BKException.Code.IncorrectParameterException, this, null, ctx);
             return;
         }
 
         if (lastEntry > lastAddConfirmed) {
             LOG.error("ReadException on ledgerId:{} firstEntry:{} lastEntry:{}",
-                    new Object[] { ledgerId, firstEntry, lastEntry });
+                    ledgerId, firstEntry, lastEntry);
             cb.readComplete(BKException.Code.ReadException, this, null, ctx);
             return;
         }
@@ -638,7 +638,7 @@ public class LedgerHandle implements WriteHandle {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
-                    new Object[] { ledgerId, firstEntry, lastEntry });
+                    ledgerId, firstEntry, lastEntry);
             cb.readComplete(BKException.Code.IncorrectParameterException, this, null, ctx);
             return;
         }
@@ -659,13 +659,13 @@ public class LedgerHandle implements WriteHandle {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
-                    new Object[] { ledgerId, firstEntry, lastEntry });
+                    ledgerId, firstEntry, lastEntry);
             return FutureUtils.exception(new BKIncorrectParameterException());
         }
 
         if (lastEntry > lastAddConfirmed) {
             LOG.error("ReadException on ledgerId:{} firstEntry:{} lastEntry:{}",
-                    new Object[] { ledgerId, firstEntry, lastEntry });
+                    ledgerId, firstEntry, lastEntry);
             return FutureUtils.exception(new BKReadException());
         }
 
@@ -700,7 +700,7 @@ public class LedgerHandle implements WriteHandle {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} lastEntry:{}",
-                    new Object[] { ledgerId, firstEntry, lastEntry });
+                    ledgerId, firstEntry, lastEntry);
             return FutureUtils.exception(new BKIncorrectParameterException());
         }
 
@@ -1465,7 +1465,7 @@ public class LedgerHandle implements WriteHandle {
                 BookieSocketAddress addr = entry.getValue();
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("[EnsembleChange-L{}-{}] : replacing bookie: {} index: {}",
-                        new Object[]{getId(), ensembleChangeIdx, addr, idx});
+                            getId(), ensembleChangeIdx, addr, idx);
                 }
                 if (!newEnsemble.get(idx).equals(addr)) {
                     // ensemble has already changed, failure of this addr is immaterial
@@ -1498,8 +1498,8 @@ public class LedgerHandle implements WriteHandle {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("[EnsembleChange-L{}-{}] : changing ensemble from: {} to: {} starting at entry: {},"
                     + " failed bookies: {}, replaced bookies: {}",
-                      new Object[] { ledgerId, ensembleChangeIdx, metadata.currentEnsemble, newEnsemble,
-                              (getLastAddConfirmed() + 1), failedBookies, replacedBookies });
+                        ledgerId, ensembleChangeIdx, metadata.currentEnsemble, newEnsemble,
+                        (getLastAddConfirmed() + 1), failedBookies, replacedBookies);
             }
             metadata.addEnsemble(newEnsembleStartEntry, newEnsemble);
         }
@@ -1530,7 +1530,7 @@ public class LedgerHandle implements WriteHandle {
                 }
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("[EnsembleChange-L{}-{}] : writing new ensemble info = {}, block add completions = {}",
-                        new Object[]{getId(), curNumEnsembleChanges, ensembleInfo, curBlockAddCompletions});
+                            getId(), curNumEnsembleChanges, ensembleInfo, curBlockAddCompletions);
                 }
                 writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions, curNumEnsembleChanges));
             } catch (BKException.BKNotEnoughBookiesException e) {
@@ -1601,7 +1601,7 @@ public class LedgerHandle implements WriteHandle {
                 return;
             } else if (rc != BKException.Code.OK) {
                 LOG.error("[EnsembleChange-L{}-{}] : could not persist ledger metadata : info = {}, "
-                        + "closing ledger : {}.", new Object[] { getId(), ensembleChangeIdx, ensembleInfo, rc });
+                        + "closing ledger : {}.", getId(), ensembleChangeIdx, ensembleInfo, rc);
                 handleUnrecoverableErrorDuringAdd(rc);
                 return;
             }
@@ -1609,7 +1609,7 @@ public class LedgerHandle implements WriteHandle {
 
             if (LOG.isDebugEnabled()) {
                 LOG.info("[EnsembleChange-L{}-{}] : completed ensemble change, block add completion {} => {}",
-                    new Object[]{getId(), ensembleChangeIdx, curBlockAddCompletions, newBlockAddCompletions});
+                        getId(), ensembleChangeIdx, curBlockAddCompletions, newBlockAddCompletions);
             }
 
             // We've successfully changed an ensemble
@@ -1649,14 +1649,14 @@ public class LedgerHandle implements WriteHandle {
         public void safeOperationComplete(int newrc, LedgerMetadata newMeta) {
             if (newrc != BKException.Code.OK) {
                 LOG.error("[EnsembleChange-L{}-{}] : error re-reading metadata to address ensemble change conflicts,"
-                        + " code=", new Object[] { ledgerId, ensembleChangeIdx, newrc });
+                        + " code=", ledgerId, ensembleChangeIdx, newrc);
                 handleUnrecoverableErrorDuringAdd(rc);
             } else {
                 if (!resolveConflict(newMeta)) {
                     LOG.error("[EnsembleChange-L{}-{}] : could not resolve ledger metadata conflict"
                             + " while changing ensemble to: {}, local meta data is \n {} \n,"
                             + " zk meta data is \n {} \n, closing ledger",
-                            new Object[] { ledgerId, ensembleChangeIdx, ensembleInfo.newEnsemble, metadata, newMeta });
+                            ledgerId, ensembleChangeIdx, ensembleInfo.newEnsemble, metadata, newMeta);
                     handleUnrecoverableErrorDuringAdd(rc);
                 }
             }
@@ -1679,14 +1679,14 @@ public class LedgerHandle implements WriteHandle {
         private boolean resolveConflict(LedgerMetadata newMeta) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("[EnsembleChange-L{}-{}] : resolving conflicts - local metadata = \n {} \n,"
-                    + " zk metadata = \n {} \n", new Object[]{ledgerId, ensembleChangeIdx, metadata, newMeta});
+                    + " zk metadata = \n {} \n", ledgerId, ensembleChangeIdx, metadata, newMeta);
             }
             // make sure the ledger isn't closed by other ones.
             if (metadata.getState() != newMeta.getState()) {
                 if (LOG.isDebugEnabled()) {
                     LOG.info("[EnsembleChange-L{}-{}] : resolving conflicts but state changed,"
                             + " local metadata = \n {} \n, zk metadata = \n {} \n",
-                        new Object[]{ledgerId, ensembleChangeIdx, metadata, newMeta});
+                            ledgerId, ensembleChangeIdx, metadata, newMeta);
                 }
                 return false;
             }
@@ -1702,7 +1702,7 @@ public class LedgerHandle implements WriteHandle {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("[EnsembleChange-L{}-{}] : resolving conflicts but ensembles have {} differences,"
                             + " local metadata = \n {} \n, zk metadata = \n {} \n",
-                        new Object[]{ledgerId, ensembleChangeIdx, diff, metadata, newMeta});
+                            ledgerId, ensembleChangeIdx, diff, metadata, newMeta);
                 }
                 if (-1 == diff) {
                     // Case 1: metadata is changed by other ones (e.g. Recovery)
@@ -1733,7 +1733,7 @@ public class LedgerHandle implements WriteHandle {
                 unsetSuccessAndSendWriteRequest(ensembleInfo.replacedBookies);
                 if (LOG.isDebugEnabled()) {
                     LOG.info("[EnsembleChange-L{}-{}] : resolved conflicts, block add complectiosn {} => {}.",
-                        new Object[]{ledgerId, ensembleChangeIdx, curBlockAddCompletions, newBlockAddCompletions});
+                            ledgerId, ensembleChangeIdx, curBlockAddCompletions, newBlockAddCompletions);
                 }
             }
             return true;
@@ -1773,14 +1773,14 @@ public class LedgerHandle implements WriteHandle {
             if (metadata.isConflictWith(newMeta)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("[EnsembleChange-L{}-{}] : metadata is conflicted, local metadata = \n {} \n,"
-                        + " zk metadata = \n {} \n", new Object[]{ledgerId, ensembleChangeIdx, metadata, newMeta});
+                        + " zk metadata = \n {} \n", ledgerId, ensembleChangeIdx, metadata, newMeta);
                 }
                 return false;
             }
             if (LOG.isDebugEnabled()) {
                 LOG.info("[EnsembleChange-L{}-{}] : resolved ledger metadata conflict and writing to zookeeper,"
                         + " local meta data is \n {} \n, zk meta data is \n {}.",
-                    new Object[]{ledgerId, ensembleChangeIdx, metadata, newMeta});
+                        ledgerId, ensembleChangeIdx, metadata, newMeta);
             }
             // update znode version
             metadata.setVersion(newMeta.getVersion());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -200,7 +200,7 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
                 // check whether entry id is expected, so we won't overwritten any entries by mistake
                 if (entry.getEntryId() != lh.lastAddPushed + 1) {
                     LOG.error("Unexpected to recovery add entry {} as entry {} for ledger {}.",
-                              new Object[] { entry.getEntryId(), (lh.lastAddPushed + 1), lh.getId() });
+                            entry.getEntryId(), (lh.lastAddPushed + 1), lh.getId());
                     rc = BKException.Code.UnexpectedConditionException;
                 }
             }
@@ -226,13 +226,13 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
         // otherwise, some other error, we can't handle
         if (BKException.Code.OK != rc && callbackDone.compareAndSet(false, true)) {
             LOG.error("Failure {} while reading entries: ({} - {}), ledger: {} while recovering ledger",
-                      new Object[] { BKException.getMessage(rc), startEntryToRead, endEntryToRead, lh.getId() });
+                    BKException.getMessage(rc), startEntryToRead, endEntryToRead, lh.getId());
             submitCallback(rc);
         } else if (BKException.Code.OK == rc) {
             // we are here is because we successfully read an entry but readDone was already set to true.
             // this would happen on recovery a ledger than has gaps in the tail.
             LOG.warn("Successfully read entry {} for ledger {}, but readDone is already {}",
-                     new Object[] { entry.getEntryId(), lh.getId(), readDone });
+                    entry.getEntryId(), lh.getId(), readDone);
         }
         return;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -288,12 +288,12 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
             return;
         case BKException.Code.LedgerFencedException:
             LOG.warn("Fencing exception on write: L{} E{} on {}",
-                     new Object[] { ledgerId, entryId, addr });
+                    ledgerId, entryId, addr);
             lh.handleUnrecoverableErrorDuringAdd(rc);
             return;
         case BKException.Code.UnauthorizedAccessException:
             LOG.warn("Unauthorized access exception on write: L{} E{} on {}",
-                     new Object[] { ledgerId, entryId, addr });
+                    ledgerId, entryId, addr);
             lh.handleUnrecoverableErrorDuringAdd(rc);
             return;
         default:
@@ -302,19 +302,19 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
                         || rc == BKException.Code.WriteOnReadOnlyBookieException) {
                     Map<Integer, BookieSocketAddress> failedBookies = ackSet.getFailedBookies();
                     LOG.warn("Failed to write entry ({}, {}) to bookies {}, handling failures.",
-                             new Object[] { ledgerId, entryId, failedBookies });
+                            ledgerId, entryId, failedBookies);
                     // we can't meet ack quorum requirement, trigger ensemble change.
                     lh.handleBookieFailure(failedBookies);
                 } else {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Failed to write entry ({}, {}) to bookie ({}, {}),"
                                   + " but it didn't break ack quorum, delaying ensemble change : {}",
-                                  new Object[] { ledgerId, entryId, bookieIndex, addr, BKException.getMessage(rc) });
+                                ledgerId, entryId, bookieIndex, addr, BKException.getMessage(rc));
                     }
                 }
             } else {
                 LOG.warn("Failed to write entry ({}, {}): {}",
-                         new Object[] { ledgerId, entryId, BKException.getMessage(rc) });
+                        ledgerId, entryId, BKException.getMessage(rc));
                 lh.handleBookieFailure(ImmutableMap.of(bookieIndex, addr));
             }
             return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -197,12 +197,12 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
                 ++numMissedEntryReads;
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("No such entry found on bookie.  L{} E{} bookie: {}",
-                        new Object[] { lh.ledgerId, entryImpl.getEntryId(), host });
+                            lh.ledgerId, entryImpl.getEntryId(), host);
                 }
             } else {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(errMsg + " while reading L{} E{} from bookie: {}",
-                        new Object[]{lh.ledgerId, entryImpl.getEntryId(), host});
+                            lh.ledgerId, entryImpl.getEntryId(), host);
                 }
             }
         }
@@ -254,7 +254,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
                     if (!isComplete() && null != maybeSendSpeculativeRead(heardFromHostsBitSet)) {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Send speculative read for {}. Hosts heard are {}, ensemble is {}.",
-                                new Object[] { this, heardFromHostsBitSet, ensemble });
+                                    this, heardFromHostsBitSet, ensemble);
                         }
                         return true;
                     }
@@ -565,8 +565,8 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
         }
 
         if (numPendingEntries < 0) {
-            LOG.error("Read too many values for ledger {} : [{}, {}].", new Object[] { ledgerId,
-                    startEntryId, endEntryId });
+            LOG.error("Read too many values for ledger {} : [{}, {}].",
+                    ledgerId, startEntryId, endEntryId);
         }
     }
 
@@ -595,8 +595,8 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
                 }
             }
             LOG.error("Read of ledger entry failed: L{} E{}-E{}, Heard from {} : bitset = {}. First unread entry is {}",
-                    new Object[] { lh.getId(), startEntryId, endEntryId, heardFromHosts, heardFromHostsBitSet,
-                        firstUnread });
+                    lh.getId(), startEntryId, endEntryId, heardFromHosts, heardFromHostsBitSet,
+                    firstUnread);
             readOpLogger.registerFailedEvent(latencyNanos, TimeUnit.NANOSECONDS);
             // release the entries
             seq.forEach(LedgerEntryRequest::close);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -251,8 +251,8 @@ class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsemblePlacemen
         }
         localNode = bn;
         LOG.info("Initialize rackaware ensemble placement policy @ {} @ {} : {}.",
-            new Object[] { localNode, null == localNode ? "Unknown" : localNode.getNetworkLocation(),
-                dnsResolver.getClass().getName() });
+                localNode, null == localNode ? "Unknown" : localNode.getNetworkLocation(),
+                dnsResolver.getClass().getName());
 
         this.isWeighted = isWeighted;
         if (this.isWeighted) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
@@ -451,7 +451,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                         && (null != request.maybeSendSpeculativeRead(heardFromHostsBitSet))) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Send speculative ReadLAC {} for ledger {} (previousLAC: {}). Hosts heard are {}.",
-                            new Object[] {request, lh.getId(), lastAddConfirmed, heardFromHostsBitSet });
+                                request, lh.getId(), lastAddConfirmed, heardFromHostsBitSet);
                     }
                     return true;
                 }
@@ -476,7 +476,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
     void sendReadTo(int bookieIndex, BookieSocketAddress to, ReadLACAndEntryRequest entry) throws InterruptedException {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Calling Read LAC and Entry with {} and long polling interval {} on Bookie {} - Parallel {}",
-                    new Object[] { prevEntryId, timeOutInMillis, to, parallelRead });
+                    prevEntryId, timeOutInMillis, to, parallelRead);
         }
         lh.bk.getBookieClient().readEntryWaitForLACUpdate(to,
             lh.ledgerId,
@@ -520,7 +520,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
     public void readEntryComplete(int rc, long ledgerId, long entryId, ByteBuf buffer, Object ctx) {
         if (LOG.isTraceEnabled()) {
             LOG.trace("{} received response for (lid={}, eid={}) : {}",
-                new Object[] { getClass().getName(), ledgerId, entryId, rc });
+                    getClass().getName(), ledgerId, entryId, rc);
         }
         ReadLastConfirmedAndEntryContext rCtx = (ReadLastConfirmedAndEntryContext) ctx;
         BookieSocketAddress bookie = rCtx.getBookieAddress();
@@ -528,7 +528,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
         if (BKException.Code.OK == rc) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Received lastAddConfirmed (lac={}) from bookie({}) for (lid={}).",
-                    new Object[] { rCtx.getLastAddConfirmed(), bookie, ledgerId });
+                        rCtx.getLastAddConfirmed(), bookie, ledgerId);
             }
 
             if (rCtx.getLastAddConfirmed() > lastAddConfirmed) {
@@ -562,16 +562,16 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Completed readLACAndEntry(lid = {}, previousEntryId = {}) "
                                 + "after received {} empty responses ('{}').",
-                                new Object[]{ledgerId, prevEntryId, emptyResponsesFromHostsBitSet.cardinality(),
-                                    emptyResponsesFromHostsBitSet});
+                                ledgerId, prevEntryId, emptyResponsesFromHostsBitSet.cardinality(),
+                                emptyResponsesFromHostsBitSet);
                     }
                     completeRequest();
                 } else {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Received empty response for readLACAndEntry(lid = {}, previousEntryId = {}) from"
                                         + " bookie {} @ {}, reattempting reading next bookie : lac = {}",
-                                new Object[]{ledgerId, prevEntryId, rCtx.getBookieAddress(),
-                                        rCtx.getBookieAddress(), lastAddConfirmed});
+                                ledgerId, prevEntryId, rCtx.getBookieAddress(),
+                                rCtx.getBookieAddress(), lastAddConfirmed);
                     }
                     request.logErrorAndReattemptRead(rCtx.getBookieIndex(), bookie, "Empty Response", rc);
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
@@ -155,7 +155,7 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
                 this.metadata.getVersion().compare(newMetadata.getVersion());
         if (LOG.isDebugEnabled()) {
             LOG.debug("Try to update metadata from {} to {} : {}",
-                    new Object[] { this.metadata, newMetadata, occurred });
+                    this.metadata, newMetadata, occurred);
         }
         if (Version.Occurred.BEFORE == occurred) { // the metadata is updated
             try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -355,11 +355,11 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                                 regionsToAllocate--;
                                 LOG.info("Region {} allocating bookies with ensemble size {} "
                                         + "and write quorum size {} : {}",
-                                    new Object[]{region, newEnsembleSize, newWriteQuorumSize, allocated});
+                                        region, newEnsembleSize, newWriteQuorumSize, allocated);
                                 break;
                             } catch (BKException.BKNotEnoughBookiesException exc) {
                                 LOG.warn("Could not allocate {} bookies in region {}, try allocating {} bookies",
-                                         new Object[] {newEnsembleSize, region, (newEnsembleSize - 1) });
+                                        newEnsembleSize, region, (newEnsembleSize - 1));
                                 addToEnsembleSize--;
                             }
                         }
@@ -374,7 +374,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                     if (regionsReachedMaxAllocation.contains(region)) {
                         if (currentAllocation.getLeft() > 0) {
                             LOG.info("Allocating {} bookies in region {} : ensemble {} exclude {}",
-                                new Object[]{currentAllocation.getLeft(), region, excludeBookies, ensemble});
+                                    currentAllocation.getLeft(), region, excludeBookies, ensemble);
                             policyWithinRegion.newEnsemble(
                                     currentAllocation.getLeft(),
                                     currentAllocation.getRight(),
@@ -383,7 +383,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                                     ensemble,
                                     ensemble);
                             LOG.info("Allocated {} bookies in region {} : {}",
-                                new Object[]{currentAllocation.getLeft(), region, ensemble});
+                                    currentAllocation.getLeft(), region, ensemble);
                         }
                     }
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryReadLastConfirmedOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryReadLastConfirmedOp.java
@@ -62,7 +62,7 @@ class TryReadLastConfirmedOp implements ReadEntryCallback {
     public void readEntryComplete(int rc, long ledgerId, long entryId, ByteBuf buffer, Object ctx) {
         if (LOG.isTraceEnabled()) {
             LOG.trace("TryReadLastConfirmed received response for (lid={}, eid={}) : {}",
-                    new Object[] { ledgerId, entryId, rc });
+                    ledgerId, entryId, rc);
         }
 
         int bookieIndex = (Integer) ctx;
@@ -72,7 +72,7 @@ class TryReadLastConfirmedOp implements ReadEntryCallback {
                 RecoveryData recoveryData = lh.macManager.verifyDigestAndReturnLastConfirmed(buffer);
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("Received lastAddConfirmed (lac={}, length={}) from bookie({}) for (lid={}).",
-                            new Object[] { recoveryData.lastAddConfirmed, recoveryData.length, bookieIndex, ledgerId });
+                            recoveryData.lastAddConfirmed, recoveryData.length, bookieIndex, ledgerId);
                 }
                 if (recoveryData.lastAddConfirmed > maxRecoveredData.lastAddConfirmed) {
                     maxRecoveredData = recoveryData;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/StabilizeNetworkTopology.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/StabilizeNetworkTopology.java
@@ -91,7 +91,7 @@ public class StabilizeNetworkTopology implements NetworkTopology {
                 long millisSinceLastSeen = MathUtils.now() - status.getLastPresentTime();
                 if (millisSinceLastSeen >= stabilizePeriodMillis) {
                     logger.info("Node {} (seen @ {}) becomes stale for {} ms, remove it from the topology.",
-                            new Object[] { node, status.getLastPresentTime(), millisSinceLastSeen });
+                            node, status.getLastPresentTime(), millisSinceLastSeen);
                     impl.remove(node);
                     nodeStatuses.remove(node, status);
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3.java
@@ -109,7 +109,7 @@ class LongPollReadEntryProcessorV3 extends ReadEntryProcessorV3 implements Obser
                         requestProcessor.readLastEntryNoEntryErrorCounter.inc();
                         logger.info(
                                 "No entry found while piggyback reading entry {} from ledger {} : previous lac = {}",
-                                new Object[] { entryId, ledgerId, previousLAC });
+                                entryId, ledgerId, previousLAC);
                         // piggy back is best effort and this request can fail genuinely because of striping
                         // entries across the ensemble
                         return buildResponse(readResponseBuilder, StatusCode.EOK, startTimeSw);
@@ -119,7 +119,7 @@ class LongPollReadEntryProcessorV3 extends ReadEntryProcessorV3 implements Obser
                         if (logger.isDebugEnabled()) {
                             logger.debug("Found smaller lac when piggy back reading lac and entry from ledger {} :"
                                     + " previous lac = {}, known lac = {}",
-                                    new Object[]{ ledgerId, previousLAC, knownLAC });
+                                    ledgerId, previousLAC, knownLAC);
                         }
                     }
                     return buildResponse(readResponseBuilder, StatusCode.EOK, startTimeSw);
@@ -154,7 +154,7 @@ class LongPollReadEntryProcessorV3 extends ReadEntryProcessorV3 implements Obser
                 return buildErrorResponse(StatusCode.ENOLEDGER, startTimeSw);
             } catch (IOException ioe) {
                 logger.error("IOException while longpoll reading ledger {}, previous lac = {} : ",
-                        new Object[] { ledgerId, previousLAC, ioe });
+                        ledgerId, previousLAC, ioe);
                 return buildErrorResponse(StatusCode.EIO, startTimeSw);
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1217,7 +1217,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                             return; // pendingOps should have been completed when other channel connected
                         } else {
                             LOG.error("TLS handshake failed with bookie: {}/{}, current state {} : ",
-                                    new Object[] { future.get(), addr, state, future.cause() });
+                                    future.get(), addr, state, future.cause());
                             rc = BKException.Code.SecurityException;
                             closeChannel(future.get());
                             channel = null;
@@ -1949,7 +1949,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                     return; // pendingOps should have been completed when other channel connected
                 } else {
                     LOG.error("Could not connect to bookie: {}/{}, current state {} : ",
-                            new Object[] { future.channel(), addr, state, future.cause() });
+                            future.channel(), addr, state, future.cause());
                     rc = BKException.Code.BookieHandleNotAvailableException;
                     closeChannel(future.channel());
                     channel = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -117,7 +117,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
                 @Override
                 public void onFailure(Throwable t) {
                     LOG.error("Fence request for ledgerId {} entryId {} encountered exception",
-                        new Object[] { ledgerId, entryId, t });
+                            ledgerId, entryId, t);
                     sendFenceResponse(readResponseBuilder, entryBody, false, startTimeSw);
                 }
             }, fenceThreadPool);
@@ -127,7 +127,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
                 success = fenceResult.get(1000, TimeUnit.MILLISECONDS);
             } catch (Throwable t) {
                 LOG.error("Fence request for ledgerId {} entryId {} encountered exception : ",
-                    new Object[]{ readRequest.getLedgerId(), readRequest.getEntryId(), t });
+                        readRequest.getLedgerId(), readRequest.getEntryId(), t);
             }
             sendFenceResponse(readResponseBuilder, entryBody, success, startTimeSw);
         }
@@ -226,12 +226,12 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
             }
             return buildResponse(readResponse, StatusCode.ENOENTRY, startTimeSw);
         } catch (IOException e) {
-            LOG.error("IOException while reading entry: {} from ledger {} ", new Object[] { entryId, ledgerId, e });
+            LOG.error("IOException while reading entry: {} from ledger {} ", entryId, ledgerId, e);
             return buildResponse(readResponse, StatusCode.EIO, startTimeSw);
         } catch (BookieException e) {
             LOG.error(
                 "Unauthorized access to ledger:{} while reading entry:{} in request from address: {}",
-                new Object[] { ledgerId, entryId, channel.remoteAddress() });
+                    ledgerId, entryId, channel.remoteAddress());
             return buildResponse(readResponse, StatusCode.EUA, startTimeSw);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
@@ -113,7 +113,7 @@ class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
             status = StatusCode.EOK;
         } catch (IOException e) {
             logger.error("Error writing entry:{} to ledger:{}",
-                         new Object[] { entryId, ledgerId, e });
+                    entryId, ledgerId, e);
             status = StatusCode.EIO;
         } catch (BookieException.LedgerFencedException e) {
             logger.debug("Ledger fenced while writing entry:{} to ledger:{}",
@@ -125,7 +125,7 @@ class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
             status = StatusCode.EUA;
         } catch (Throwable t) {
             logger.error("Unexpected exception while writing {}@{} : ",
-                         new Object[] { entryId, ledgerId, t });
+                    entryId, ledgerId, t);
             // some bad request which cause unexpected exception
             status = StatusCode.EBADREQ;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -74,7 +74,7 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             status = StatusCode.EOK;
         } catch (IOException e) {
             logger.error("Error saving lac for ledger:{}",
-                          new Object[] { lac, ledgerId, e });
+                    lac, ledgerId, e);
             status = StatusCode.EIO;
         } catch (BookieException e) {
             logger.error("Unauthorized access to ledger:{} while adding lac:{}",

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
@@ -154,14 +154,14 @@ public class DiskChecker {
             float used = 1f - free;
             if (used > diskUsageThreshold) {
                 LOG.error("Space left on device {} : {}, Used space fraction: {} < threshold {}.",
-                        new Object[] { dir, usableSpace, used, diskUsageThreshold });
+                        dir, usableSpace, used, diskUsageThreshold);
                 throw new DiskOutOfSpaceException("Space left on device "
                         + usableSpace + " Used space fraction:" + used + " < threshold " + diskUsageThreshold, used);
             }
             // Warn should be triggered only if disk usage threshold doesn't trigger first.
             if (used > diskUsageWarnThreshold) {
                 LOG.warn("Space left on device {} : {}, Used space fraction: {} < WarnThreshold {}.",
-                        new Object[] { dir, usableSpace, used, diskUsageThreshold });
+                        dir, usableSpace, used, diskUsageThreshold);
                 throw new DiskWarnThresholdException("Space left on device:"
                         + usableSpace + " Used space fraction:" + used + " < WarnThreshold:" + diskUsageWarnThreshold,
                         used);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -304,7 +304,7 @@ public class LocalBookKeeper {
             }
         } catch (Exception e) {
             LOG.error("Failed to run {} bookies : zk ensemble = '{}:{}'",
-                new Object[] { numBookies, zkHost, zkPort, e });
+                    numBookies, zkHost, zkPort, e);
             throw e;
         } finally {
             if (stopOnExit) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/NativeIO.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/NativeIO.java
@@ -108,13 +108,13 @@ public final class NativeIO {
             // if JNA is unavailable just skipping Direct I/O
             // instance of this class will act like normal RandomAccessFile
             LOG.warn("Unsatisfied Link error: posix_fadvise failed on file descriptor {}, offset {} : ",
-                    new Object[] { fd, offset, ule });
+                    fd, offset, ule);
             fadvisePossible = false;
         } catch (Exception e) {
             // This is best effort anyway so lets just log that there was an
             // exception and forget
             LOG.warn("Unknown exception: posix_fadvise failed on file descriptor {}, offset {} : ",
-                    new Object[] { fd, offset, e });
+                    fd, offset, e);
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
@@ -131,8 +131,8 @@ public class RoundRobinDistributionScheduleTest {
             boolean canGetAck = canGetAckQuorum(ensemble, writeQuorum, ackQuorum, nodesAvailable);
             if (canGetAck == covSetSays) {
                 LOG.error("e{}:w{}:a{} available {}    canGetAck {} covSetSays {}",
-                          new Object[] { ensemble, writeQuorum, ackQuorum,
-                                         nodesAvailable, canGetAck, covSetSays });
+                        ensemble, writeQuorum, ackQuorum,
+                        nodesAvailable, canGetAck, covSetSays);
                 errors++;
             }
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
@@ -82,11 +82,11 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
                 numSuccess.incrementAndGet();
             } else if (rc == BKException.Code.NoSuchEntryException
                     || rc == BKException.Code.NoSuchLedgerExistsException) {
-                logger.error("Missed entry({}, {}) from host {}.", new Object[] { ledgerId, entryId, ctx });
+                logger.error("Missed entry({}, {}) from host {}.", ledgerId, entryId, ctx);
                 numMissing.incrementAndGet();
             } else {
                 logger.error("Failed to get entry({}, {}) from host {} : {}",
-                             new Object[] { ledgerId, entryId, ctx, rc });
+                        ledgerId, entryId, ctx, rc);
                 numFailure.incrementAndGet();
             }
             latch.countDown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/TestMetaStore.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/TestMetaStore.java
@@ -32,7 +32,7 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -314,7 +314,7 @@ public class TestMetaStore {
 
         // get partial field
         Set<String> fields =
-            new HashSet<String>(Arrays.asList(new String[] { FIELD_COUNTER }));
+            new HashSet<String>(Collections.singletonList(FIELD_COUNTER));
         try {
             myTable.get(RECORDID, fields);
             fail("Should fail to get a non-existent key with specified fields");
@@ -337,7 +337,7 @@ public class TestMetaStore {
         Versioned<Value> vv;
 
         final Set<String> fields =
-            new HashSet<String>(Arrays.asList(new String[] { FIELD_NAME }));
+            new HashSet<String>(Collections.singletonList(FIELD_NAME));
 
         final String name = "get";
         final Integer counter = getRandom();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/MultipleThreadReadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/MultipleThreadReadTest.java
@@ -159,7 +159,7 @@ public class MultipleThreadReadTest extends BookKeeperClusterTestCase {
                             long curEid = eid++;
                             if (e.getEntryId() != curEid) {
                                 LOG.error("Expected entry id {} for ledger {} but {} found.",
-                                          new Object[] { curEid, lh.getId(), e.getEntryId() });
+                                        curEid, lh.getId(), e.getEntryId());
                                 success = false;
                                 break;
                             }
@@ -175,17 +175,17 @@ public class MultipleThreadReadTest extends BookKeeperClusterTestCase {
                             success = !list.hasMoreElements();
                             if (!success) {
                                 LOG.error("Found more entries returned on reading ({}-{}) from ledger {}.",
-                                          new Object[] { startEntryId, endEntryId, lh.getId() });
+                                        startEntryId, endEntryId, lh.getId());
                             }
                         }
                     } catch (InterruptedException ie) {
                         LOG.error("Interrupted on reading entries ({} - {}) from ledger {} : ",
-                                  new Object[] { startEntryId, endEntryId, lh.getId(), ie });
+                                startEntryId, endEntryId, lh.getId(), ie);
                         Thread.currentThread().interrupt();
                         success = false;
                     } catch (BKException bke) {
                         LOG.error("Failed on reading entries ({} - {}) from ledger {} : ",
-                                  new Object[] { startEntryId, endEntryId, lh.getId(), bke });
+                                startEntryId, endEntryId, lh.getId(), bke);
                         success = false;
                     }
                     resultHolder.set(success);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestCallbacks.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestCallbacks.java
@@ -70,7 +70,7 @@ public class TestCallbacks {
         @Override
         public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {
             logger.info("Add entry {} completed : entryId = {}, rc = {}",
-                    new Object[] { expectedEntryId, entryId, rc });
+                    expectedEntryId, entryId, rc);
             if (rc != BKException.Code.OK) {
                 setException(BKException.create(rc));
             } else {


### PR DESCRIPTION
This takes care of a few new Object[] {}, new String[] {} etc calls,
mostly leftovers from the older slf4j's LOG API which used to lack
the Object... "vararg" method overloads, making it easier to read
and maintain.