### PR TITLE
Issue 778: Make build pass using JDK9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,12 @@ matrix:
   include:
     - os: osx
       osx_image: xcode8
+    - os: osx
+      osx_image: xcode9.2
     - os: linux
       env: CUSTOM_JDK="oraclejdk8"
+    - os: linux
+      env: CUSTOM_JDK="oraclejdk9"
     - os: linux
       dist: trusty
       env: CUSTOM_JDK="openjdk8"

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/Retries.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/Retries.java
@@ -94,13 +94,15 @@ public final class Retries {
                 scheduler,
                 null);
         } else {
-            scheduler.submitOrdered(key, () -> execute(
-                future,
-                backoffs.iterator(),
-                retryPredicate,
-                task,
-                scheduler,
-                key));
+            scheduler.submitOrdered(key, () -> {
+                execute(
+                    future,
+                    backoffs.iterator(),
+                    retryPredicate,
+                    task,
+                    scheduler,
+                    key);
+            });
         }
         return future;
     }

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -335,7 +335,7 @@
         <configuration>
           <!-- Avoid for missing javadoc comments to be marked as errors -->
           <additionalparam>-Xdoclint:none</additionalparam>
-          <subpackages>org.apache.bookkeeper.client:org.apache.bookkeeper.common.annotation:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature:org.apache.bookkeeper.stats</subpackages>
+          <subpackages>org.apache.bookkeeper.client:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature</subpackages>
           <groups>
             <group>
               <title>Bookkeeper</title>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityProviderFactoryFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityProviderFactoryFactory.java
@@ -17,6 +17,7 @@
  */
 package org.apache.bookkeeper.tls;
 
+import org.apache.bookkeeper.util.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,15 +33,15 @@ public abstract class SecurityProviderFactoryFactory {
             return null;
         }
 
-        ClassLoader classLoader = SecurityProviderFactoryFactory.class.getClassLoader();
-        SecurityHandlerFactory shFactory = null;
+        SecurityHandlerFactory shFactory;
         try {
-            Class<?> shFactoryClass = classLoader.loadClass(securityHandler);
-            shFactory = (SecurityHandlerFactory) shFactoryClass.newInstance();
+            Class<? extends SecurityHandlerFactory> shFactoryClass =
+                ReflectionUtils.forName(securityHandler, SecurityHandlerFactory.class);
+            shFactory = ReflectionUtils.newInstance(shFactoryClass);
             LOG.info("Loaded security handler for {}", securityHandler);
-        } catch (Exception e) {
-            LOG.error("Unable to load security handler for {}: ", securityHandler, e);
-            throw new SecurityException(e);
+        } catch (RuntimeException re) {
+            LOG.error("Unable to load security handler for {}: ", securityHandler, re.getCause());
+            throw new SecurityException(re.getCause());
         }
         return shFactory;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
@@ -19,6 +19,7 @@ package org.apache.bookkeeper.tls;
 
 import com.google.common.base.Strings;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.OpenSsl;
@@ -58,16 +59,17 @@ public class TLSContextFactory implements SecurityHandlerFactory {
 
     private String getPasswordFromFile(String path) throws IOException {
         byte[] pwd;
-        try (FileInputStream pwdin = new FileInputStream(path)) {
-            File passwdFile = new File(path);
-            if (passwdFile.length() == 0) {
-                return "";
-            }
-            pwd = FileUtils.readFileToByteArray(passwdFile);
+        File passwdFile = new File(path);
+        if (passwdFile.length() == 0) {
+            return "";
         }
+        pwd = FileUtils.readFileToByteArray(passwdFile);
         return new String(pwd, "UTF-8");
     }
 
+    @SuppressFBWarnings(
+        value = "OBL_UNSATISFIED_OBLIGATION",
+        justification = "work around for java 9: https://github.com/spotbugs/spotbugs/issues/493")
     private KeyStore loadKeyStore(String keyStoreType, String keyStoreLocation, String keyStorePassword)
             throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
         KeyStore ks = KeyStore.getInstance(keyStoreType);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/EntryFormatter.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/EntryFormatter.java
@@ -59,11 +59,10 @@ public abstract class EntryFormatter {
 
     public static EntryFormatter newEntryFormatter(Configuration conf, String clsProperty) {
         String cls = conf.getString(clsProperty, StringEntryFormatter.class.getName());
-        ClassLoader classLoader = EntryFormatter.class.getClassLoader();
         EntryFormatter formatter;
         try {
-            Class aCls = classLoader.loadClass(cls);
-            formatter = (EntryFormatter) aCls.newInstance();
+            Class<? extends EntryFormatter> aCls = ReflectionUtils.forName(cls, EntryFormatter.class);
+            formatter = ReflectionUtils.newInstance(aCls);
             formatter.setConf(conf);
         } catch (Exception e) {
             LOG.warn("No formatter class found : " + cls, e);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSkipListArena.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSkipListArena.java
@@ -188,7 +188,7 @@ public class TestSkipListArena {
                     treeMap = new TreeMap<Integer, AllocBuffer>();
                     mapsByArray.put(ptr, treeMap);
                 }
-                AllocBuffer other = treeMap.put(new Integer(buf.alloc.getOffset()), buf);
+                AllocBuffer other = treeMap.put(buf.alloc.getOffset(), buf);
                 if (other != null) {
                     fail("Buffer " + other.toString() + " overlapped with " + buf.toString());
                 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/TestMetaStore.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/metastore/TestMetaStore.java
@@ -110,7 +110,7 @@ public class TestMetaStore {
             name = getFieldFromValue(value, FIELD_NAME);
             String c = getFieldFromValue(value, FIELD_COUNTER);
             if (c != null) {
-                counter = new Integer(c);
+                counter = Integer.parseInt(c);
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <jmh.version>1.19</jmh.version>
     <junit.version>4.12</junit.version>
-    <lombok.version>1.16.12</lombok.version>
+    <lombok.version>1.16.18</lombok.version>
     <mockito-core.version>2.8.9</mockito-core.version>
     <powermock.version>1.7.3</powermock.version>
     <protobuf.version>3.4.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,13 +108,14 @@
     <junit.version>4.12</junit.version>
     <lombok.version>1.16.18</lombok.version>
     <mockito-core.version>2.8.9</mockito-core.version>
-    <powermock.version>1.7.3</powermock.version>
-    <protobuf.version>3.4.0</protobuf.version>
     <netty.version>4.1.12.Final</netty.version>
     <netty-boringssl.version>2.0.3.Final</netty-boringssl.version>
-    <slf4j.version>1.7.25</slf4j.version>
-    <zookeeper.version>3.5.3-beta</zookeeper.version>
+    <powermock.version>1.7.3</powermock.version>
+    <protobuf.version>3.4.0</protobuf.version>
     <rocksdb.version>5.8.6</rocksdb.version>
+    <slf4j.version>1.7.25</slf4j.version>
+    <spotbugs-annotations.version>3.1.1</spotbugs-annotations.version>
+    <zookeeper.version>3.5.3-beta</zookeeper.version>
     <!-- plugin dependencies -->
     <spotbugs-maven-plugin.version>3.1.0-RC6</spotbugs-maven-plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
@@ -141,6 +142,12 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>${spotbugs-annotations.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Descriptions of the changes in this PR:

- make bookkeeper can be compiled with java 9
- add java9 to travis ci to make sure it can be built for both java8 and java9