### PR TITLE
During journal replay, force to re-insert the master key in ledger storage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -767,6 +767,9 @@ public class Bookie extends BookieCriticalThread {
 
                             recBuff.get(masterKey);
                             masterKeyCache.put(ledgerId, masterKey);
+
+                            // Force to re-insert the master key in ledger storage
+                            handles.getHandle(ledgerId, masterKey);
                         } else {
                             throw new IOException("Invalid journal. Contains journalKey "
                                     + " but layout version (" + journalVersion


### PR DESCRIPTION
When the bookie crashes and restart, it will replay the entries from the journal. In the case of ledgers that were created, but their metadata was not flushed on disk, the ledger metadata might be lost. 

This is more evident in `DbLedgerStorage`, since the ledger metadata is cached in memory and it's only inserted in the db at the checkpoint time, though it applies as well for `InterleavedLedgerStorage` where the ledger metadata was inserted in the cache but not fsynced on disk. 

If the page cache content is gone, when replaying the journal content, the ledger will be tracked in memory but the bookie won't have the metadata on disk anymore.

Merging from yahoo branch: https://github.com/yahoo/bookkeeper/commit/d3626396ecf1a2b98c782bb30a7b9c00c75c6cdf 