### PR TITLE
Issue #328 - Add docker compose example file

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -32,7 +32,55 @@ then run test command, such as:
 ```
 ## TL;DR -- BookKeeper cluster 
 
-If you want to setup cluster, you can play with Makefile hosted in this project and check its targets for a fairly complex set up example:
+If you want to setup cluster, you can play with Makefile or docker-compose hosted in this project and check its targets for a fairly complex set up example:
+
+### Docker compose
+
+```
+git clone https://github.com/apache/bookkeeper
+cd bookkeeper/docker
+docker-compose up -d
+```
+
+and it spawns and ensemble of 3 bookies with 1 dice:
+
+```
+bookie1_1    | 2017-12-08 23:18:11,315 - INFO  -
+[bookie-io-1:BookieRequestHandler@51] - Channel connected  [id: 0x405d690e,
+L:/172.19.0.3:3181 - R:/172.19.0.6:34922]
+bookie2_1    | 2017-12-08 23:18:11,326 - INFO  -
+[bookie-io-1:BookieRequestHandler@51] - Channel connected  [id: 0x7fa8645d,
+L:/172.19.0.4:3181 - R:/172.19.0.6:38862]
+dice_1       | Value = 1, epoch = 5, leading
+dice_1       | Value = 2, epoch = 5, leading
+dice_1       | Value = 4, epoch = 5, leading
+dice_1       | Value = 3, epoch = 5, leading
+```
+
+If you want to see how it behaves with more dices you only need to use
+`docker-compose up -d --scale dice=3`:
+
+```sh
+dice_3       | Value = 3, epoch = 5, following
+dice_2       | Value = 3, epoch = 5, following
+dice_1       | Value = 2, epoch = 5, leading
+dice_3       | Value = 2, epoch = 5, following
+dice_2       | Value = 2, epoch = 5, following
+dice_1       | Value = 1, epoch = 5, leading
+dice_3       | Value = 2, epoch = 5, following
+dice_2       | Value = 2, epoch = 5, following
+```
+
+You can scale the numbers of bookkeepers too selecting one of the bookies and
+using `docker-compose up -d --scale bookie1=3`
+
+Remember to shutdown the docker-compose service with `docker-compose down` to
+remove the containers and avoid errors with leftovers in next executions of the
+service.
+
+
+### Makefile
+
 ```
 git clone https://github.com/apache/bookkeeper
 cd bookkeeper/docker

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '2'
+
+services:
+
+  zookeeper:
+    image: zookeeper
+    hostname: zookeeper
+
+  bookie1:
+    image: apache/bookkeeper
+    hostname: bookie1
+    links:
+      - zookeeper
+    environment:
+      - JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+      - BK_zkServers=zookeeper:2181
+      - BK_zkLedgersRootPath = /ledgers
+
+  bookie2:
+    image: apache/bookkeeper
+    hostname: bookie2
+    links:
+      - zookeeper
+    environment:
+      - JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+      - BK_zkServers=zookeeper:2181
+      - BK_zkLedgersRootPath = /ledgers
+
+  bookie3:
+    image: apache/bookkeeper
+    hostname: bookie3
+    links:
+      - zookeeper
+    environment:
+      - JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+      - BK_zkServers=zookeeper:2181
+      - BK_zkLedgersRootPath = /ledgers
+
+  dice:
+    image: caiok/bookkeeper-tutorial
+    depends_on:
+      - zookeeper
+    links:
+      - zookeeper
+      - bookie3
+    environment:
+      - ZOOKEEPER_SERVERS=zookeeper:2181
+      - BOOKKEEPER_SERVER=bookie3
+


### PR DESCRIPTION
This patch adds a docker-compose example file for helping new
users to use bookkeeper.

It runs by default an ensemble with 3 bookies and a client
application based in the following tutorial, but you can leverage docker
compose features to scale up the number of instances.

https://bookkeeper.apache.org/archives/docs/master/bookkeeperTutorial.html

Ref: Issue #328

Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>
