### PR TITLE
Issue280: Add StateManager to manage Bookie's state, and use it to turn bookie into readonly when sortedLedgerStorage failed to flush data

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -229,13 +229,13 @@ public class Bookie extends BookieCriticalThread {
     }
 
     @VisibleForTesting
-    public void setRegistrationManager(RegistrationManager rm) {
+    public synchronized void setRegistrationManager(RegistrationManager rm) {
             this.registrationManager = rm;
             this.getStateManager().setRegistrationManager(rm);
     }
 
     @VisibleForTesting
-    public RegistrationManager getRegistrationManager() {
+    public synchronized RegistrationManager getRegistrationManager() {
         return this.registrationManager;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -227,13 +227,13 @@ public class Bookie extends BookieCriticalThread {
     }
 
     @VisibleForTesting
-    public void setRegistrationManager(RegistrationManager rm) {
+    public synchronized void setRegistrationManager(RegistrationManager rm) {
             this.registrationManager = rm;
             this.getStateManager().setRegistrationManager(rm);
     }
 
     @VisibleForTesting
-    public RegistrationManager getRegistrationManager() {
+    public synchronized RegistrationManager getRegistrationManager() {
         return this.registrationManager;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -131,7 +131,7 @@ public class Bookie extends BookieCriticalThread {
 
     private final ConcurrentLongHashMap<byte[]> masterKeyCache = new ConcurrentLongHashMap<>();
 
-    StateManager stateManager;
+    protected StateManager stateManager;
 
     // Expose Stats
     private final StatsLogger statsLogger;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -244,12 +244,12 @@ public class Bookie extends BookieCriticalThread {
     }
 
     @VisibleForTesting
-    public void setRegistrationManager(RegistrationManager rm) {
-        this.registrationManager = rm;
+    public synchronized void setRegistrationManager(RegistrationManager rm) {
+            this.registrationManager = rm;
     }
 
     @VisibleForTesting
-    public RegistrationManager getRegistrationManager() {
+    public synchronized RegistrationManager getRegistrationManager() {
         return this.registrationManager;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -2331,8 +2331,8 @@ public class BookieShell implements Tool {
             };
 
             interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager,
-                    checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
-            dbStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager,
+                    null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
+            dbStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager, null,
                     checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
 
             int convertedLedgers = 0;
@@ -2420,10 +2420,10 @@ public class BookieShell implements Tool {
                 }
             };
 
-            dbStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager,
+            dbStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager, null,
                         checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
             interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager,
-                    checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
+                    null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
             LedgerCache interleavedLedgerCache = interleavedStorage.ledgerCache;
 
             EntryLocationIndex dbEntryLocationIndex = dbStorage.getEntryLocationIndex();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -1,0 +1,271 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.discover.RegistrationManager;
+import org.apache.bookkeeper.discover.ZKRegistrationManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A implementation of StateManager.
+ */
+public class BookieStateManager implements StateManager {
+    private static final Logger LOG = LoggerFactory.getLogger(BookieStateManager.class);
+    private final ServerConfiguration conf;
+    private final LedgerDirsManager ledgerDirsManager;
+
+
+    // use an executor to execute the state changes task
+    final ExecutorService stateService = Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder().setNameFormat("BookieStateManagerService-%d").build());
+
+    // Running flag
+    private volatile boolean running = false;
+    // Flag identify whether it is in shutting down progress
+    private volatile boolean shuttingdown = false;
+    // Bookie status
+    private final BookieStatus bookieStatus = new BookieStatus();
+    private final AtomicBoolean rmRegistered = new AtomicBoolean(false);
+    private final AtomicBoolean forceReadOnly = new AtomicBoolean(false);
+
+    private final String bookieId;
+    private ShutdownHandler shutdownHandler;
+    private RegistrationManager registrationManager;
+
+
+    public BookieStateManager(ServerConfiguration conf, RegistrationManager registrationManager,
+                              LedgerDirsManager ledgerDirsManager) throws IOException {
+        this.conf = conf;
+        this.registrationManager = registrationManager;
+        this.ledgerDirsManager = ledgerDirsManager;
+        // ZK ephemeral node for this Bookie.
+        this.bookieId = getMyId();
+    }
+
+    @Override
+    public void initState(){
+        if (forceReadOnly.get()) {
+            this.bookieStatus.setToReadOnlyMode();
+        } else if (conf.isPersistBookieStatusEnabled()) {
+            this.bookieStatus.readFromDirectories(ledgerDirsManager.getAllLedgerDirs());
+        }
+        running = true;
+    }
+
+    @Override
+    public void forceToShuttingDown(){
+        // mark bookie as in shutting down progress
+        shuttingdown = true;
+    }
+
+    @Override
+    public void forceToReadOnly(){
+        this.forceReadOnly.set(true);
+    }
+
+    @Override
+    public void forceToShutDown(){
+        this.running = false;
+    }
+
+    @Override
+    public void forceToUnregistered(){
+        this.rmRegistered.set(false);
+    }
+
+    // 1 : up, 0 : readonly, -1 : unregistered, used for stats
+    @Override
+    public int getState(){
+        if (!rmRegistered.get()){
+            return -1;
+        } else if (forceReadOnly.get() || bookieStatus.isInReadOnlyMode()) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+
+    @Override
+    public boolean isReadOnly(){
+        return forceReadOnly.get() || bookieStatus.isInReadOnlyMode();
+    }
+
+    @Override
+    public boolean isRunning(){
+        return running;
+    }
+    @Override
+    public boolean isShuttingDown(){
+        return shuttingdown;
+    }
+
+    @Override
+    public void close() {
+        stateService.shutdown();
+    }
+
+    @Override
+    public Future<Void> registerBookie(final boolean throwException) {
+        return stateService.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws IOException {
+                try {
+                    doRegisterBookie();
+                } catch (IOException ioe) {
+                    if (throwException) {
+                        throw ioe;
+                    } else {
+                        LOG.error("Couldn't register bookie with zookeeper, shutting down : ", ioe);
+                        shutdownHandler.shutdown(ExitCode.ZK_REG_FAIL);
+                    }
+                }
+                return (Void) null;
+            }
+        });
+    }
+
+    @Override
+    public void transitionToWritableMode() {
+        stateService.execute(() -> doTransitionToWritableMode());
+    }
+
+    @Override
+    public void transitionToReadOnlyMode() {
+        stateService.execute(() -> doTransitionToReadOnlyMode());
+    }
+
+    void doRegisterBookie() throws IOException {
+        doRegisterBookie(forceReadOnly.get() || bookieStatus.isInReadOnlyMode());
+    }
+
+    private void doRegisterBookie(boolean isReadOnly) throws IOException {
+        if (null == registrationManager || ((ZKRegistrationManager) this.registrationManager).getZk() == null) {
+            // registration manager is null, means not register itself to zk.
+            // ZooKeeper is null existing only for testing.
+            LOG.info("null zk while do register");
+            return;
+        }
+
+        rmRegistered.set(false);
+        try {
+            registrationManager.registerBookie(bookieId, isReadOnly);
+            rmRegistered.set(true);
+        } catch (BookieException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @VisibleForTesting
+    public void doTransitionToWritableMode() {
+        if (shuttingdown || forceReadOnly.get()) {
+            return;
+        }
+
+        if (!bookieStatus.setToWritableMode()) {
+            // do nothing if already in writable mode
+            return;
+        }
+        LOG.info("Transitioning Bookie to Writable mode and will serve read/write requests.");
+        if (conf.isPersistBookieStatusEnabled()) {
+            bookieStatus.writeToDirectories(ledgerDirsManager.getAllLedgerDirs());
+        }
+        // change zookeeper state only when using zookeeper
+        if (null == registrationManager) {
+            return;
+        }
+        try {
+            doRegisterBookie(false);
+        } catch (IOException e) {
+            LOG.warn("Error in transitioning back to writable mode : ", e);
+            transitionToReadOnlyMode();
+            return;
+        }
+        // clear the readonly state
+        try {
+            registrationManager.unregisterBookie(bookieId, true);
+        } catch (BookieException e) {
+            // if we failed when deleting the readonly flag in zookeeper, it is OK since client would
+            // already see the bookie in writable list. so just log the exception
+            LOG.warn("Failed to delete bookie readonly state in zookeeper : ", e);
+            return;
+        }
+    }
+    @VisibleForTesting
+    public void doTransitionToReadOnlyMode() {
+        if (shuttingdown) {
+            return;
+        }
+        if (!bookieStatus.setToReadOnlyMode()) {
+            return;
+        }
+        if (!conf.isReadOnlyModeEnabled()) {
+            LOG.warn("ReadOnly mode is not enabled. "
+                    + "Can be enabled by configuring "
+                    + "'readOnlyModeEnabled=true' in configuration."
+                    + " Shutting down bookie");
+            shutdownHandler.shutdown(ExitCode.BOOKIE_EXCEPTION);
+            return;
+        }
+        LOG.info("Transitioning Bookie to ReadOnly mode,"
+                + " and will serve only read requests from clients!");
+        // persist the bookie status if we enable this
+        if (conf.isPersistBookieStatusEnabled()) {
+            this.bookieStatus.writeToDirectories(ledgerDirsManager.getAllLedgerDirs());
+        }
+        // change zookeeper state only when using zookeeper
+        if (null == registrationManager) {
+            return;
+        }
+        try {
+            registrationManager.registerBookie(bookieId, true);
+        } catch (BookieException e) {
+            LOG.error("Error in transition to ReadOnly Mode."
+                    + " Shutting down", e);
+            shutdownHandler.shutdown(ExitCode.BOOKIE_EXCEPTION);
+            return;
+        }
+    }
+    public void setShutdownHandler(ShutdownHandler handler){
+        shutdownHandler = handler;
+    }
+
+    @VisibleForTesting
+    public void setRegistrationManager(RegistrationManager rm) {
+        this.registrationManager = rm;
+    }
+    private String getMyId() throws UnknownHostException {
+        return Bookie.getBookieAddress(conf).toString();
+    }
+
+}
+

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -21,7 +21,6 @@
 
 package org.apache.bookkeeper.bookie;
 
-import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_LEDGER_SCOPE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.SERVER_STATUS;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -104,7 +103,8 @@ public class BookieStateManager implements StateManager {
         this.conf = conf;
         this.registrationManager = registrationManager;
         this.statsLogger = null;
-        this.ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(), new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()),
+        this.ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()),
                 NullStatsLogger.INSTANCE);
         // ZK ephemeral node for this Bookie.
         this.bookieId = getMyId();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -100,14 +100,9 @@ public class BookieStateManager implements StateManager {
 
     @VisibleForTesting
     BookieStateManager(ServerConfiguration conf, RegistrationManager registrationManager) throws IOException {
-        this.conf = conf;
-        this.registrationManager = registrationManager;
-        this.statsLogger = null;
-        this.ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+        this(conf, NullStatsLogger.INSTANCE, registrationManager, new LedgerDirsManager(conf, conf.getLedgerDirs(),
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()),
-                NullStatsLogger.INSTANCE);
-        // ZK ephemeral node for this Bookie.
-        this.bookieId = getMyId();
+                NullStatsLogger.INSTANCE));
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -140,13 +140,10 @@ public class BookieStateManager implements StateManager {
     public boolean isRunning(){
         return running;
     }
+
     @Override
     public boolean isShuttingDown(){
         return shuttingdown;
-    }
-    @VisibleForTesting
-    boolean isRegistered(){
-        return rmRegistered.get();
     }
 
     @Override
@@ -253,6 +250,7 @@ public class BookieStateManager implements StateManager {
             return;
         }
     }
+
     @VisibleForTesting
     public void doTransitionToReadOnlyMode() {
         if (shuttingdown) {
@@ -292,6 +290,10 @@ public class BookieStateManager implements StateManager {
         shutdownHandler = handler;
     }
 
+    private String getMyId() throws UnknownHostException {
+        return Bookie.getBookieAddress(conf).toString();
+    }
+
     @VisibleForTesting
     public void setRegistrationManager(RegistrationManager rm) {
         this.registrationManager = rm;
@@ -300,9 +302,9 @@ public class BookieStateManager implements StateManager {
     public ShutdownHandler getShutdownHandler(){
         return shutdownHandler;
     }
-    private String getMyId() throws UnknownHostException {
-        return Bookie.getBookieAddress(conf).toString();
+    @VisibleForTesting
+    boolean isRegistered(){
+        return rmRegistered.get();
     }
-
 }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -90,6 +90,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
                            LedgerManager ledgerManager,
                            LedgerDirsManager ledgerDirsManager,
                            LedgerDirsManager indexDirsManager,
+                           StateManager stateManager,
                            CheckpointSource checkpointSource,
                            Checkpointer checkpointer,
                            StatsLogger statsLogger)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -45,6 +45,7 @@ public interface LedgerStorage {
                     LedgerManager ledgerManager,
                     LedgerDirsManager ledgerDirsManager,
                     LedgerDirsManager indexDirsManager,
+                    StateManager stateManager,
                     CheckpointSource checkpointSource,
                     Checkpointer checkpointer,
                     StatsLogger statsLogger)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyBookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyBookie.java
@@ -41,7 +41,7 @@ public class ReadOnlyBookie extends Bookie {
     public ReadOnlyBookie(ServerConfiguration conf, StatsLogger statsLogger)
             throws IOException, KeeperException, InterruptedException, BookieException {
         super(conf, statsLogger);
-        stateManager = new BookieStateManager(conf, registrationManager, getLedgerDirsManager()) {
+        stateManager = new BookieStateManager(conf, statsLogger, registrationManager, getLedgerDirsManager()) {
 
             @Override
             public void doTransitionToWritableMode() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyBookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyBookie.java
@@ -41,7 +41,7 @@ public class ReadOnlyBookie extends Bookie {
     public ReadOnlyBookie(ServerConfiguration conf, StatsLogger statsLogger)
             throws IOException, KeeperException, InterruptedException, BookieException {
         super(conf, statsLogger);
-        stateManager = new BookieStateManager(bookieStatus, registrationManager){
+        stateManager = new BookieStateManager(conf, registrationManager, getLedgerDirsManager()) {
 
             @Override
             public void doTransitionToWritableMode() {
@@ -56,7 +56,7 @@ public class ReadOnlyBookie extends Bookie {
             }
         };
         if (conf.isReadOnlyModeEnabled()) {
-            forceReadOnly.set(true);
+            stateManager.forceToReadOnly();
         } else {
             String err = "Try to init ReadOnly Bookie, while ReadOnly mode is not enabled";
             LOG.error(err);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyBookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyBookie.java
@@ -22,7 +22,6 @@
 package org.apache.bookkeeper.bookie;
 
 import java.io.IOException;
-
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.zookeeper.KeeperException;
@@ -42,6 +41,20 @@ public class ReadOnlyBookie extends Bookie {
     public ReadOnlyBookie(ServerConfiguration conf, StatsLogger statsLogger)
             throws IOException, KeeperException, InterruptedException, BookieException {
         super(conf, statsLogger);
+        stateManager = new BookieStateManager(bookieStatus, registrationManager){
+
+            @Override
+            public void doTransitionToWritableMode() {
+                // no-op
+                LOG.info("Skip transition to writable mode for readonly bookie");
+            }
+
+            @Override
+            public void doTransitionToReadOnlyMode() {
+                // no-op
+                LOG.info("Skip transition to readonly mode for readonly bookie");
+            }
+        };
         if (conf.isReadOnlyModeEnabled()) {
             forceReadOnly.set(true);
         } else {
@@ -50,17 +63,5 @@ public class ReadOnlyBookie extends Bookie {
             throw new IOException(err);
         }
         LOG.info("Running bookie in force readonly mode.");
-    }
-
-    @Override
-    public void doTransitionToWritableMode() {
-        // no-op
-        LOG.info("Skip transition to writable mode for readonly bookie");
-    }
-
-    @Override
-    public void doTransitionToReadOnlyMode() {
-        // no-op
-        LOG.info("Skip transition to readonly mode for readonly bookie");
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -237,7 +237,6 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
         // flushed to the entry log file.
     }
 
-    @VisibleForTesting
     BookieStateManager getStateManager(){
         return (BookieStateManager) stateManager;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -68,7 +68,7 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
             ledgerManager,
             ledgerDirsManager,
             indexDirsManager,
-                stateManager,
+            stateManager,
             checkpointSource,
             checkpointer,
             statsLogger);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -237,4 +237,9 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
         // flushed to the entry log file.
     }
 
+    @VisibleForTesting
+    BookieStateManager getStateManager(){
+        return (BookieStateManager) stateManager;
+    }
+
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
@@ -32,11 +32,6 @@ public interface StateManager extends AutoCloseable {
     void initState();
 
     /**
-     * Get current state of Bookie.
-     */
-    int getState();
-
-    /**
      * Check is ReadOnly.
      */
     boolean isReadOnly();
@@ -76,11 +71,6 @@ public interface StateManager extends AutoCloseable {
     void forceToReadOnly();
 
     /**
-     * Turn state to not running, just the flag.
-     */
-    void forceToShutDown();
-
-    /**
      * Turn state to not registered, just the flag.
      */
     void forceToUnregistered();
@@ -88,12 +78,12 @@ public interface StateManager extends AutoCloseable {
     /**
      * Change the state of bookie to Writable mode.
      */
-    void transitionToWritableMode();
+    Future<Void> transitionToWritableMode();
 
     /**
      * Change the state of bookie to ReadOnly mode.
      */
-    void transitionToReadOnlyMode();
+    Future<Void> transitionToReadOnlyMode();
 
     /**
      * ShutdownHandler used to shutdown bookie.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import java.util.concurrent.Future;
+
+/**
+ * State management of Bookie, including register, turn bookie to w/r mode.
+ */
+public interface StateManager extends AutoCloseable {
+
+
+    /**
+     * Close the manager, release its resources.
+     */
+    @Override
+    void close();
+
+    /**
+     * Register the bookie to RegistrationManager.
+     * @params throwException, whether throwException or not
+     */
+    Future<Void> registerBookie(boolean throwException);
+
+    /**
+     * Change the state of bookie to Writable mode.
+     */
+    void transitionToWritableMode();
+
+    /**
+     * Change the state of bookie to ReadOnly mode.
+     */
+    void transitionToReadOnlyMode();
+
+}
+

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
@@ -27,6 +27,31 @@ public interface StateManager extends AutoCloseable {
 
 
     /**
+     * Init state of Bookie when launch bookie.
+     */
+    void initState();
+
+    /**
+     * Get current state of Bookie.
+     */
+    int getState();
+
+    /**
+     * Check is ReadOnly.
+     */
+    boolean isReadOnly();
+
+    /**
+     * Check is Running.
+     */
+    boolean isRunning();
+
+    /**
+     * Check is Shutting down.
+     */
+    boolean isShuttingDown();
+
+    /**
      * Close the manager, release its resources.
      */
     @Override
@@ -38,6 +63,28 @@ public interface StateManager extends AutoCloseable {
      */
     Future<Void> registerBookie(boolean throwException);
 
+    // forceTos methods below should be called inside Bookie,
+    // which indicates important state of bookie and should be visible fast.
+    /**
+     * Turn state to the shutting down progress,just the flag.
+     */
+    void forceToShuttingDown();
+
+    /**
+     * Turn state to the read only, just flag.
+     */
+    void forceToReadOnly();
+
+    /**
+     * Turn state to not running, just the flag.
+     */
+    void forceToShutDown();
+
+    /**
+     * Turn state to not registered, just the flag.
+     */
+    void forceToUnregistered();
+
     /**
      * Change the state of bookie to Writable mode.
      */
@@ -48,5 +95,13 @@ public interface StateManager extends AutoCloseable {
      */
     void transitionToReadOnlyMode();
 
+    /**
+     * ShutdownHandler used to shutdown bookie.
+     */
+    interface ShutdownHandler {
+        void shutdown(int code);
+    }
+
+    void setShutdownHandler(ShutdownHandler handler);
 }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -53,6 +53,7 @@ import org.apache.bookkeeper.bookie.EntryLogger;
 import org.apache.bookkeeper.bookie.GarbageCollectorThread;
 import org.apache.bookkeeper.bookie.LastAddConfirmedUpdateNotification;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
+import org.apache.bookkeeper.bookie.StateManager;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorageDataFormats.LedgerData;
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorage.Batch;
 import org.apache.bookkeeper.common.util.Watcher;
@@ -136,8 +137,8 @@ public class DbLedgerStorage implements CompactableLedgerStorage {
 
     @Override
     public void initialize(ServerConfiguration conf, LedgerManager ledgerManager, LedgerDirsManager ledgerDirsManager,
-            LedgerDirsManager indexDirsManager, CheckpointSource checkpointSource, Checkpointer checkpointer,
-            StatsLogger statsLogger) throws IOException {
+        LedgerDirsManager indexDirsManager, StateManager stateManager, CheckpointSource checkpointSource,
+                           Checkpointer checkpointer, StatsLogger statsLogger) throws IOException {
         checkArgument(ledgerDirsManager.getAllLedgerDirs().size() == 1,
                 "Db implementation only allows for one storage dir");
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -38,6 +38,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import org.apache.bookkeeper.bookie.Bookie.BookieStateManager;
 import org.apache.bookkeeper.bookie.BookieException.DiskPartitionDuplicationException;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -109,8 +110,14 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         }
 
         void testRegisterBookie(ServerConfiguration conf) throws IOException {
-            super.doRegisterBookie();
+            ((BookieStateManager) super.getStateManager()).doRegisterBookie();
         }
+
+        void updateRegistration(RegistrationManager newRm){
+            registrationManager = newRm;
+            stateManager = new BookieStateManager(bookieStatus, newRm);
+        }
+
     }
 
     /**
@@ -134,6 +141,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
                 MockBookie bookie = new MockBookie(conf);
                 rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
                 bookie.registrationManager = rm;
+                bookie.updateRegistration(rm);
                 ((ZKRegistrationManager) bookie.registrationManager).setZk(zkc);
                 ((ZKRegistrationManager) bookie.registrationManager).getZk().close();
                 return bookie;
@@ -162,8 +170,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         MockBookie b = new MockBookie(conf);
         conf.setZkServers(zkUtil.getZooKeeperConnectString());
         rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.registrationManager = rm;
-
+        b.updateRegistration(rm);
         b.testRegisterBookie(conf);
         ZooKeeper zooKeeper = ((ZKRegistrationManager) rm).getZk();
         assertNotNull("Bookie registration node doesn't exists!",
@@ -196,8 +203,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
 
         conf.setZkServers(zkUtil.getZooKeeperConnectString());
         rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.registrationManager = rm;
-
+        b.updateRegistration(rm);
         b.testRegisterBookie(conf);
 
         Stat bkRegNode1 = ((ZKRegistrationManager) rm).getZk().exists(bkRegPath, false);
@@ -208,7 +214,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // zkclient and doing the registration.
         RegistrationManager newRm = new ZKRegistrationManager();
         newRm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.registrationManager = newRm;
+        b.updateRegistration(newRm);
 
         try (ZooKeeperClient newZk = createNewZKClient()) {
             // deleting the znode, so that the bookie registration should
@@ -308,8 +314,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
 
         conf.setZkServers(zkUtil.getZooKeeperConnectString());
         rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.registrationManager = rm;
-
+        b.updateRegistration(rm);
         b.testRegisterBookie(conf);
         Stat bkRegNode1 = zkc.exists(bkRegPath, false);
         assertNotNull("Bookie registration node doesn't exists!",
@@ -320,7 +325,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         ZooKeeperClient newzk = createNewZKClient();
         RegistrationManager newRm = new ZKRegistrationManager();
         newRm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.registrationManager = newRm;
+        b.updateRegistration(newRm);
         try {
             b.testRegisterBookie(conf);
             fail("Should throw NodeExistsException as the znode is not getting expired");
@@ -814,7 +819,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         Bookie bookie = bookieServer.getBookie();
         assertFalse(bookie.isReadOnly());
         // transition to readonly mode, bookie status should be persisted in ledger disks
-        bookie.doTransitionToReadOnlyMode();
+        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToReadOnlyMode();
         assertTrue(bookie.isReadOnly());
 
         // restart bookie should start in read only mode
@@ -824,7 +829,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         bookie = bookieServer.getBookie();
         assertTrue(bookie.isReadOnly());
         // transition to writable mode
-        bookie.doTransitionToWritableMode();
+        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToWritableMode();
         // restart bookie should start in writable mode
         bookieServer.shutdown();
         bookieServer = new BookieServer(conf);
@@ -850,8 +855,8 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         bookieServer.start();
         Bookie bookie = bookieServer.getBookie();
         // persist bookie status
-        bookie.doTransitionToReadOnlyMode();
-        bookie.doTransitionToWritableMode();
+        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToReadOnlyMode();
+        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToWritableMode();
         assertFalse(bookie.isReadOnly());
         bookieServer.shutdown();
         // start read only bookie
@@ -863,7 +868,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         bookie = bookieServer.getBookie();
         assertTrue(bookie.isReadOnly());
         // transition to writable should fail
-        bookie.doTransitionToWritableMode();
+        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToWritableMode();
         assertTrue(bookie.isReadOnly());
         bookieServer.shutdown();
     }
@@ -892,7 +897,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // transition in to read only and persist the status on disk
         Bookie bookie = bookieServer.getBookie();
         assertFalse(bookie.isReadOnly());
-        bookie.doTransitionToReadOnlyMode();
+        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToReadOnlyMode();
         assertTrue(bookie.isReadOnly());
         // corrupt status file
         List<File> ledgerDirs = bookie.getLedgerDirsManager().getAllLedgerDirs();
@@ -931,7 +936,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // transition in to read only and persist the status on disk
         Bookie bookie = bookieServer.getBookie();
         assertFalse(bookie.isReadOnly());
-        bookie.doTransitionToReadOnlyMode();
+        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToReadOnlyMode();
         assertTrue(bookie.isReadOnly());
         // Manually update a status file, so it becomes the latest
         Thread.sleep(1);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -38,7 +37,6 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import org.apache.bookkeeper.bookie.Bookie.BookieStateManager;
 import org.apache.bookkeeper.bookie.BookieException.DiskPartitionDuplicationException;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -110,12 +108,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         }
 
         void testRegisterBookie(ServerConfiguration conf) throws IOException {
-            ((BookieStateManager) super.getStateManager()).doRegisterBookie();
-        }
-
-        void updateRegistration(RegistrationManager newRm){
-            registrationManager = newRm;
-            stateManager = new BookieStateManager(bookieStatus, newRm);
+            super.getStateManager().doRegisterBookie();
         }
 
     }
@@ -140,8 +133,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
                     BookieException {
                 MockBookie bookie = new MockBookie(conf);
                 rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-                bookie.registrationManager = rm;
-                bookie.updateRegistration(rm);
+                bookie.setRegistrationManager(rm);
                 ((ZKRegistrationManager) bookie.registrationManager).setZk(zkc);
                 ((ZKRegistrationManager) bookie.registrationManager).getZk().close();
                 return bookie;
@@ -170,7 +162,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         MockBookie b = new MockBookie(conf);
         conf.setZkServers(zkUtil.getZooKeeperConnectString());
         rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.updateRegistration(rm);
+        b.setRegistrationManager(rm);
         b.testRegisterBookie(conf);
         ZooKeeper zooKeeper = ((ZKRegistrationManager) rm).getZk();
         assertNotNull("Bookie registration node doesn't exists!",
@@ -203,7 +195,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
 
         conf.setZkServers(zkUtil.getZooKeeperConnectString());
         rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.updateRegistration(rm);
+        b.setRegistrationManager(rm);
         b.testRegisterBookie(conf);
 
         Stat bkRegNode1 = ((ZKRegistrationManager) rm).getZk().exists(bkRegPath, false);
@@ -214,7 +206,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // zkclient and doing the registration.
         RegistrationManager newRm = new ZKRegistrationManager();
         newRm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.updateRegistration(newRm);
+        b.setRegistrationManager(newRm);
 
         try (ZooKeeperClient newZk = createNewZKClient()) {
             // deleting the znode, so that the bookie registration should
@@ -314,7 +306,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
 
         conf.setZkServers(zkUtil.getZooKeeperConnectString());
         rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.updateRegistration(rm);
+        b.setRegistrationManager(rm);
         b.testRegisterBookie(conf);
         Stat bkRegNode1 = zkc.exists(bkRegPath, false);
         assertNotNull("Bookie registration node doesn't exists!",
@@ -325,7 +317,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         ZooKeeperClient newzk = createNewZKClient();
         RegistrationManager newRm = new ZKRegistrationManager();
         newRm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
-        b.updateRegistration(newRm);
+        b.setRegistrationManager(newRm);
         try {
             b.testRegisterBookie(conf);
             fail("Should throw NodeExistsException as the znode is not getting expired");
@@ -819,7 +811,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         Bookie bookie = bookieServer.getBookie();
         assertFalse(bookie.isReadOnly());
         // transition to readonly mode, bookie status should be persisted in ledger disks
-        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToReadOnlyMode();
+        bookie.getStateManager().doTransitionToReadOnlyMode();
         assertTrue(bookie.isReadOnly());
 
         // restart bookie should start in read only mode
@@ -829,7 +821,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         bookie = bookieServer.getBookie();
         assertTrue(bookie.isReadOnly());
         // transition to writable mode
-        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToWritableMode();
+        bookie.getStateManager().doTransitionToWritableMode();
         // restart bookie should start in writable mode
         bookieServer.shutdown();
         bookieServer = new BookieServer(conf);
@@ -855,8 +847,8 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         bookieServer.start();
         Bookie bookie = bookieServer.getBookie();
         // persist bookie status
-        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToReadOnlyMode();
-        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToWritableMode();
+        bookie.getStateManager().doTransitionToReadOnlyMode();
+        bookie.getStateManager().doTransitionToWritableMode();
         assertFalse(bookie.isReadOnly());
         bookieServer.shutdown();
         // start read only bookie
@@ -868,7 +860,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         bookie = bookieServer.getBookie();
         assertTrue(bookie.isReadOnly());
         // transition to writable should fail
-        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToWritableMode();
+        bookie.getStateManager().doTransitionToWritableMode();
         assertTrue(bookie.isReadOnly());
         bookieServer.shutdown();
     }
@@ -897,7 +889,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // transition in to read only and persist the status on disk
         Bookie bookie = bookieServer.getBookie();
         assertFalse(bookie.isReadOnly());
-        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToReadOnlyMode();
+        bookie.getStateManager().doTransitionToReadOnlyMode();
         assertTrue(bookie.isReadOnly());
         // corrupt status file
         List<File> ledgerDirs = bookie.getLedgerDirsManager().getAllLedgerDirs();
@@ -936,7 +928,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // transition in to read only and persist the status on disk
         Bookie bookie = bookieServer.getBookie();
         assertFalse(bookie.isReadOnly());
-        ((Bookie.BookieStateManager) bookie.getStateManager()).doTransitionToReadOnlyMode();
+        bookie.getStateManager().doTransitionToReadOnlyMode();
         assertTrue(bookie.isReadOnly());
         // Manually update a status file, so it becomes the latest
         Thread.sleep(1);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -235,7 +235,6 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
                 // Do nothing.
             }
         };
-
         for (File journalDir : conf.getJournalDirs()) {
             Bookie.checkDirectoryStructure(journalDir);
         }
@@ -248,6 +247,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             LedgerManagerFactory.newLedgerManagerFactory(conf, zkc).newLedgerManager(),
             dirManager,
             dirManager,
+                new SimpleStateManger(),
             cp,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
@@ -636,7 +636,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-            checkpointSource,
+                new SimpleStateManger(),
+                checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
         ledgers.add(1L);
@@ -660,8 +661,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         storage.initialize(
             conf,
             manager,
-            dirs, dirs,
-            checkpointSource,
+            dirs, dirs, new SimpleStateManger(),
+                checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
         storage.start();
@@ -684,7 +685,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-            checkpointSource,
+                new SimpleStateManger(),
+                checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
         storage.getEntry(1, 1); // entry should exist
@@ -788,7 +790,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-            checkpointSource,
+                new SimpleStateManger(),
+                checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
 
@@ -843,7 +846,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             LedgerManagerFactory.newLedgerManagerFactory(conf, zkc).newLedgerManager(),
             dirManager,
             dirManager,
-            cp,
+                new SimpleStateManger(),
+                cp,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
         storage.start();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -64,7 +64,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * This class tests the entry log compaction functionality.
  */

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -25,10 +25,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +38,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -66,6 +63,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * This class tests the entry log compaction functionality.
@@ -247,7 +245,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             LedgerManagerFactory.newLedgerManagerFactory(conf, zkc).newLedgerManager(),
             dirManager,
             dirManager,
-                new SimpleStateManager(),
+            null,
             cp,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
@@ -636,8 +634,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-                new SimpleStateManager(),
-                checkpointSource,
+            null,
+            checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
         ledgers.add(1L);
@@ -661,8 +659,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         storage.initialize(
             conf,
             manager,
-            dirs, dirs, new SimpleStateManager(),
-                checkpointSource,
+            dirs, dirs, null,
+            checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
         storage.start();
@@ -685,8 +683,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-                new SimpleStateManager(),
-                checkpointSource,
+            null,
+            checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
         storage.getEntry(1, 1); // entry should exist
@@ -790,8 +788,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-                new SimpleStateManager(),
-                checkpointSource,
+            null,
+            checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
 
@@ -846,8 +844,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             LedgerManagerFactory.newLedgerManagerFactory(conf, zkc).newLedgerManager(),
             dirManager,
             dirManager,
-                new SimpleStateManager(),
-                cp,
+            null,
+            cp,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
         storage.start();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -247,7 +247,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             LedgerManagerFactory.newLedgerManagerFactory(conf, zkc).newLedgerManager(),
             dirManager,
             dirManager,
-                new SimpleStateManger(),
+                new SimpleStateManager(),
             cp,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
@@ -636,7 +636,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-                new SimpleStateManger(),
+                new SimpleStateManager(),
                 checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
@@ -661,7 +661,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         storage.initialize(
             conf,
             manager,
-            dirs, dirs, new SimpleStateManger(),
+            dirs, dirs, new SimpleStateManager(),
                 checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
@@ -685,7 +685,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-                new SimpleStateManger(),
+                new SimpleStateManager(),
                 checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
@@ -790,7 +790,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             manager,
             dirs,
             dirs,
-                new SimpleStateManger(),
+                new SimpleStateManager(),
                 checkpointSource,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);
@@ -846,7 +846,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             LedgerManagerFactory.newLedgerManagerFactory(conf, zkc).newLedgerManager(),
             dirManager,
             dirManager,
-                new SimpleStateManger(),
+                new SimpleStateManager(),
                 cp,
             Checkpointer.NULL,
             NullStatsLogger.INSTANCE);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.bookkeeper.bookie.Bookie.NoLedgerException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
@@ -483,6 +482,7 @@ public class LedgerCacheTest {
                                LedgerManager ledgerManager,
                                LedgerDirsManager ledgerDirsManager,
                                LedgerDirsManager indexDirsManager,
+                               StateManager stateManager,
                                CheckpointSource checkpointSource,
                                Checkpointer checkpointer,
                                StatsLogger statsLogger) throws IOException {
@@ -491,7 +491,8 @@ public class LedgerCacheTest {
                 ledgerManager,
                 ledgerDirsManager,
                 indexDirsManager,
-                checkpointSource,
+                    stateManager,
+                    checkpointSource,
                 checkpointer,
                 statsLogger);
             this.memTable = new EntryMemTable(conf, checkpointSource, statsLogger) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -568,6 +568,7 @@ public class LedgerCacheTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setGcWaitTime(gcWaitTime)
             .setLedgerDirNames(new String[] { tmpDir.toString() })
+            .setJournalDirName(tmpDir.toString())
             .setLedgerStorageClass(FlushTestSortedLedgerStorage.class.getName());
 
         Bookie bookie = new Bookie(conf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -491,8 +491,8 @@ public class LedgerCacheTest {
                 ledgerManager,
                 ledgerDirsManager,
                 indexDirsManager,
-                    stateManager,
-                    checkpointSource,
+                stateManager,
+                checkpointSource,
                 checkpointer,
                 statsLogger);
             this.memTable = new EntryMemTable(conf, checkpointSource, statsLogger) {
@@ -566,9 +566,9 @@ public class LedgerCacheTest {
 
         int gcWaitTime = 1000;
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
-        conf.setGcWaitTime(gcWaitTime);
-        conf.setLedgerDirNames(new String[] { tmpDir.toString() });
-        conf.setLedgerStorageClass(FlushTestSortedLedgerStorage.class.getName());
+        conf.setGcWaitTime(gcWaitTime)
+            .setLedgerDirNames(new String[] { tmpDir.toString() })
+            .setLedgerStorageClass(FlushTestSortedLedgerStorage.class.getName());
 
         Bookie bookie = new Bookie(conf);
         bookie.start();
@@ -589,6 +589,7 @@ public class LedgerCacheTest {
         // since we simulated sizeLimitReached, snapshot shouldn't be empty
         assertFalse("EntryMemTable SnapShot is not expected to be empty", memTable.snapshot.isEmpty());
         // after flush failure, the bookie is set to readOnly
+        LOG.info("state is {}", bookie.getStateManager().getState());
         assertTrue("Bookie is expected to be in Read mode", bookie.isReadOnly());
         // write fail
         bookie.addEntry(generateEntry(1, 3), new BookkeeperInternalCallbacks.WriteCallback(){
@@ -599,6 +600,7 @@ public class LedgerCacheTest {
 
         }, null, "passwd".getBytes());
         bookie.shutdown();
+
     }
 
     private ByteBuf generateEntry(long ledger, long entry) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -21,6 +21,7 @@
 
 package org.apache.bookkeeper.bookie;
 
+import static org.apache.bookkeeper.bookie.BookieException.Code.OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -42,6 +43,8 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.bookkeeper.util.IOUtils;
@@ -529,7 +532,6 @@ public class LedgerCacheTest {
         // without the fileinfo, 'flushTestSortedLedgerStorage.addEntry' calls will fail
         // because of BOOKKEEPER-965 change.
         bookie.addEntry(generateEntry(1, 1), new Bookie.NopWriteCallback(), null, "passwd".getBytes());
-
         flushTestSortedLedgerStorage.addEntry(generateEntry(1, 2));
         assertFalse("Bookie is expected to be in ReadWrite mode", bookie.isReadOnly());
         assertTrue("EntryMemTable SnapShot is expected to be empty", memTable.snapshot.isEmpty());
@@ -552,6 +554,50 @@ public class LedgerCacheTest {
         // since we expect memtable flush to succeed, memtable snapshot should be empty
         assertTrue("EntryMemTable SnapShot is expected to be empty, because of successful flush",
                 memTable.snapshot.isEmpty());
+    }
+
+    @Test
+    public void testSortedLedgerFlushFailure() throws Exception {
+        // most of the code is same to the testEntryMemTableFlushFailure
+        File tmpDir = createTempDir("bkTest", ".dir");
+        File curDir = Bookie.getCurrentDirectory(tmpDir);
+        Bookie.checkDirectoryStructure(curDir);
+
+        int gcWaitTime = 1000;
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setGcWaitTime(gcWaitTime);
+        conf.setLedgerDirNames(new String[] { tmpDir.toString() });
+        conf.setLedgerStorageClass(FlushTestSortedLedgerStorage.class.getName());
+
+        Bookie bookie = new Bookie(conf);
+        bookie.start();
+        FlushTestSortedLedgerStorage flushTestSortedLedgerStorage = (FlushTestSortedLedgerStorage) bookie.ledgerStorage;
+        EntryMemTable memTable = flushTestSortedLedgerStorage.memTable;
+
+        bookie.addEntry(generateEntry(1, 1), new Bookie.NopWriteCallback(), null, "passwd".getBytes());
+        flushTestSortedLedgerStorage.addEntry(generateEntry(1, 2));
+        assertFalse("Bookie is expected to be in ReadWrite mode", bookie.isReadOnly());
+        assertTrue("EntryMemTable SnapShot is expected to be empty", memTable.snapshot.isEmpty());
+
+        // set flags, so that FlushTestSortedLedgerStorage simulates FlushFailure scenario
+        flushTestSortedLedgerStorage.setInjectMemTableSizeLimitReached(true);
+        flushTestSortedLedgerStorage.setInjectFlushException(true);
+        flushTestSortedLedgerStorage.addEntry(generateEntry(1, 2));
+        Thread.sleep(1000);
+
+        // since we simulated sizeLimitReached, snapshot shouldn't be empty
+        assertFalse("EntryMemTable SnapShot is not expected to be empty", memTable.snapshot.isEmpty());
+        // after flush failure, the bookie is set to readOnly
+        assertTrue("Bookie is expected to be in Read mode", bookie.isReadOnly());
+        // write fail
+        bookie.addEntry(generateEntry(1, 3), new BookkeeperInternalCallbacks.WriteCallback(){
+            public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx){
+                LOG.info("fail write to bk");
+                assertTrue(rc != OK);
+            };
+
+        }, null, "passwd".getBytes());
+        bookie.shutdown();
     }
 
     private ByteBuf generateEntry(long ledger, long entry) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -38,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.stats.NullStatsLogger;
-import org.apache.bookkeeper.test.BookKeeperClusterTestCase.SimpleStateManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -120,13 +119,14 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
                 log.error("Failed to checkpoint at {}", checkpoint, e);
             }
         });
+        // if the SortedLedgerStorage need not to change bookie's state, pass StateManager==null is ok
         this.storage.initialize(
             conf,
             mock(LedgerManager.class),
             ledgerDirsManager,
             ledgerDirsManager,
-                new SimpleStateManager(),
-                checkpointSrc,
+            null,
+            checkpointSrc,
             checkpointer,
             NullStatsLogger.INSTANCE);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -38,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase.SimpleStateManger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -124,7 +125,8 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
             mock(LedgerManager.class),
             ledgerDirsManager,
             ledgerDirsManager,
-            checkpointSrc,
+                new SimpleStateManger(),
+                checkpointSrc,
             checkpointer,
             NullStatsLogger.INSTANCE);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.stats.NullStatsLogger;
-import org.apache.bookkeeper.test.BookKeeperClusterTestCase.SimpleStateManger;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase.SimpleStateManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -125,7 +125,7 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
             mock(LedgerManager.class),
             ledgerDirsManager,
             ledgerDirsManager,
-                new SimpleStateManger(),
+                new SimpleStateManager(),
                 checkpointSrc,
             checkpointer,
             NullStatsLogger.INSTANCE);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/StateManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/StateManagerTest.java
@@ -190,7 +190,6 @@ public class StateManagerTest extends BookKeeperClusterTestCase {
         // different dimension of bookie state: running <--> down, read <--> write, unregistered <--> registered
         // bookie2 is set to readOnly when shutdown
         assertTrue(stateManager.isReadOnly());
-
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/StateManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/StateManagerTest.java
@@ -1,0 +1,207 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.io.IOException;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.discover.ZKRegistrationManager;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.zookeeper.KeeperException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Testing StateManager cases.
+ */
+public class StateManagerTest extends BookKeeperClusterTestCase {
+    private static final Logger LOG = LoggerFactory
+            .getLogger(StateManagerTest.class);
+
+    @Rule
+    public final TestName runtime = new TestName();
+    MockZKRegistrationManager rm;
+
+    public StateManagerTest() {
+        super(0);
+        String ledgersPath = "/" + "ledgers" + runtime.getMethodName();
+        baseClientConf.setZkLedgersRootPath(ledgersPath);
+        baseConf.setZkLedgersRootPath(ledgersPath);
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        zkUtil.createBKEnsemble("/" + runtime.getMethodName());
+        rm = new MockZKRegistrationManager();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if (rm != null) {
+            rm.close();
+        }
+    }
+
+    private static class MockZKRegistrationManager extends ZKRegistrationManager {
+        boolean registerFailed = false;
+        void setRegisterFail(boolean failOrNot){
+            registerFailed = failOrNot;
+        }
+        @Override
+        public void registerBookie(String bookieId, boolean readOnly) throws BookieException {
+            if (registerFailed) {
+                throw BookieException.create(-100);
+            }
+            super.registerBookie(bookieId, readOnly);
+        }
+
+    }
+
+    /**
+     * Bookie should shutdown when it register to Registration service fail.
+     * On ZooKeeper exception, should return exit code ZK_REG_FAIL = 4
+     */
+    @Test
+    public void testShutdown() throws Exception {
+        File tmpDir = createTempDir("stateManger", "test");
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setJournalDirName(tmpDir.getPath())
+            .setLedgerDirNames(new String[] { tmpDir.getPath() })
+            .setZkServers(zkUtil.getZooKeeperConnectString());
+
+        BookieServer bkServer = new BookieServer(conf) {
+            protected Bookie newBookie(ServerConfiguration conf)
+                    throws IOException, KeeperException, InterruptedException,
+                    BookieException {
+                Bookie bookie = new Bookie(conf);
+                rm.setRegisterFail(true);
+                rm.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
+                LOG.info(" is {} ", zkc == null);
+                bookie.setRegistrationManager(rm);
+                return bookie;
+            }
+        };
+        bkServer.start();
+        bkServer.join();
+        assertTrue("Failed to return failCode ZK_REG_FAIL",
+                ExitCode.ZK_REG_FAIL == bkServer.getExitCode());
+    }
+
+    /**
+     * StateManager can transition between writable mode and readOnly mode if it was not created with readOnly mode.
+     */
+    @Test
+    public void testBookieTransitions() throws Exception {
+        File tmpDir = createTempDir("stateManger", "test");
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setZkServers(zkUtil.getZooKeeperConnectString());
+        Bookie bookie = new Bookie(conf);
+        bookie.start();
+        assertTrue(bookie.isRunning());
+
+        bookie.getStateManager().transitionToReadOnlyMode();
+        //sleep a little to wait transition finish
+        Thread.sleep(1000);
+        assertTrue(bookie.isRunning());
+        assertTrue(bookie.isReadOnly());
+
+        bookie.getStateManager().transitionToWritableMode();
+        Thread.sleep(1000);
+        assertTrue(bookie.isRunning());
+        assertFalse(bookie.isReadOnly());
+
+        bookie.shutdown();
+        assertFalse(bookie.isRunning());
+
+        // readOnly disabled bk
+        conf.setReadOnlyModeEnabled(false);
+        Bookie bookie2 = new Bookie(conf);
+        bookie2.start();
+        assertTrue(bookie2.isRunning());
+
+        bookie2.getStateManager().transitionToReadOnlyMode();
+        //sleep a little to wait transition finish
+        Thread.sleep(1000);
+        // bookie2 will shutdown
+        assertFalse(bookie2.isRunning());
+        // different dimension of bookie state: running <--> down, read <--> write, unregistered <--> registered
+        // bookie2 is set to readOnly when shutdown
+        assertTrue(bookie2.isReadOnly());
+
+        // readOnlybk
+        final ServerConfiguration readOnlyConf = TestBKConfiguration.newServerConfiguration();
+        readOnlyConf.setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setForceReadOnlyBookie(true);
+        ReadOnlyBookie readOnlyBookie = new ReadOnlyBookie(readOnlyConf, NullStatsLogger.INSTANCE);
+        readOnlyBookie.start();
+        assertTrue(readOnlyBookie.isRunning());
+        assertTrue(readOnlyBookie.isReadOnly());
+
+        // transition has no effect if bookie start with readOnly mode
+        readOnlyBookie.getStateManager().transitionToWritableMode();
+        Thread.sleep(1000);
+        assertTrue(readOnlyBookie.isRunning());
+        assertTrue(readOnlyBookie.isReadOnly());
+        readOnlyBookie.shutdown();
+
+    }
+
+    /**
+     * Verify the bookie reg.
+     */
+    @Test
+    public void testRegistration() throws Exception {
+        File tmpDir = createTempDir("stateManger", "test");
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setZkServers(zkUtil.getZooKeeperConnectString());
+        Bookie bookie = new Bookie(conf);
+        // -1: unregistered
+        assertEquals(-1, bookie.getStateManager().getState());
+        bookie.start();
+        assertTrue(bookie.isRunning());
+        // 1: up
+        assertEquals(1, bookie.getStateManager().getState());
+        bookie.shutdown();
+        // 0: readOnly
+        assertEquals(0, bookie.getStateManager().getState());
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
@@ -271,6 +271,7 @@ public class TestSyncThread {
             LedgerManager ledgerManager,
             LedgerDirsManager ledgerDirsManager,
             LedgerDirsManager indexDirsManager,
+            StateManager stateManager,
             CheckpointSource checkpointSource,
             Checkpointer checkpointer,
             StatsLogger statsLogger)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionRollbackTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionRollbackTest.java
@@ -88,7 +88,7 @@ public class ConversionRollbackTest {
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
 
         DbLedgerStorage dbStorage = new DbLedgerStorage();
-        dbStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, checkpointSource, checkpointer,
+        dbStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, null, checkpointSource, checkpointer,
                 NullStatsLogger.INSTANCE);
 
         // Insert some ledger & entries in the dbStorage
@@ -118,8 +118,8 @@ public class ConversionRollbackTest {
 
         // Verify that interleaved storage index has the same entries
         InterleavedLedgerStorage interleavedStorage = new InterleavedLedgerStorage();
-        interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, checkpointSource, checkpointer,
-                NullStatsLogger.INSTANCE);
+        interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager,
+                null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
 
         Set<Long> ledgers = Sets.newTreeSet(interleavedStorage.getActiveLedgersInRange(0, Long.MAX_VALUE));
         Assert.assertEquals(Sets.newTreeSet(Lists.newArrayList(0L, 1L, 2L, 3L, 4L)), ledgers);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionTest.java
@@ -85,8 +85,8 @@ public class ConversionTest {
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
 
         InterleavedLedgerStorage interleavedStorage = new InterleavedLedgerStorage();
-        interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, checkpointSource, checkpointer,
-                NullStatsLogger.INSTANCE);
+        interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager,
+                null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
 
         // Insert some ledger & entries in the interleaved storage
         for (long ledgerId = 0; ledgerId < 5; ledgerId++) {
@@ -115,12 +115,12 @@ public class ConversionTest {
 
         // Verify that db index has the same entries
         DbLedgerStorage dbStorage = new DbLedgerStorage();
-        dbStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, checkpointSource, checkpointer,
-                NullStatsLogger.INSTANCE);
+        dbStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager,
+                null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
 
         interleavedStorage = new InterleavedLedgerStorage();
-        interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, checkpointSource, checkpointer,
-                NullStatsLogger.INSTANCE);
+        interleavedStorage.initialize(conf, null, ledgerDirsManager,
+                ledgerDirsManager, null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
 
         Set<Long> ledgers = Sets.newTreeSet(dbStorage.getActiveLedgersInRange(0, Long.MAX_VALUE));
         Assert.assertEquals(Sets.newTreeSet(Lists.newArrayList(0L, 1L, 2L, 3L, 4L)), ledgers);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildTest.java
@@ -86,7 +86,7 @@ public class LocationsIndexRebuildTest {
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
 
         DbLedgerStorage ledgerStorage = new DbLedgerStorage();
-        ledgerStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, checkpointSource, checkpointer,
+        ledgerStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, null, checkpointSource, checkpointer,
                 NullStatsLogger.INSTANCE);
 
         // Insert some ledger & entries in the storage
@@ -116,7 +116,7 @@ public class LocationsIndexRebuildTest {
 
         // Verify that db index has the same entries
         ledgerStorage = new DbLedgerStorage();
-        ledgerStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, checkpointSource, checkpointer,
+        ledgerStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager, null, checkpointSource, checkpointer,
                 NullStatsLogger.INSTANCE);
 
         Set<Long> ledgers = Sets.newTreeSet(ledgerStorage.getActiveLedgersInRange(0, Long.MAX_VALUE));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -56,6 +56,7 @@ import org.apache.bookkeeper.bookie.GarbageCollector;
 import org.apache.bookkeeper.bookie.LastAddConfirmedUpdateNotification;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
 import org.apache.bookkeeper.bookie.ScanAndCompareGarbageCollector;
+import org.apache.bookkeeper.bookie.StateManager;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerMetadata;
@@ -547,6 +548,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
             LedgerManager ledgerManager,
             LedgerDirsManager ledgerDirsManager,
             LedgerDirsManager indexDirsManager,
+            StateManager stateManager,
             CheckpointSource checkpointSource,
             Checkpointer checkpointer,
             StatsLogger statsLogger) throws IOException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -36,6 +36,7 @@ import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.EntryLogger;
 import org.apache.bookkeeper.bookie.LastAddConfirmedUpdateNotification;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
+import org.apache.bookkeeper.bookie.StateManager;
 import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -126,6 +127,7 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
             LedgerManager ledgerManager,
             LedgerDirsManager ledgerDirsManager,
             LedgerDirsManager indexDirsManager,
+            StateManager stateManager,
             CheckpointSource checkpointSource,
             Checkpointer checkpointer,
             StatsLogger statsLogger) throws IOException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -43,6 +43,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -295,7 +297,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = bsConfs.get(2);
         BookieServer bk = bs.get(2);
         bookieConf.setReadOnlyModeEnabled(true);
-        bk.getBookie().doTransitionToReadOnlyMode();
+        ((Bookie.BookieStateManager) bk.getBookie().getStateManager()).doTransitionToReadOnlyMode();
 
         // grace period for publishing the bk-ledger
         LOG.debug("Waiting for Auditor to finish ledger check.");
@@ -321,7 +323,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = bsConfs.get(bkIndex);
         BookieServer bk = bs.get(bkIndex);
         bookieConf.setReadOnlyModeEnabled(true);
-        bk.getBookie().doTransitionToReadOnlyMode();
+        ((Bookie.BookieStateManager) bk.getBookie().getStateManager()).doTransitionToReadOnlyMode();
 
         // grace period for publishing the bk-ledger
         LOG.debug("Waiting for Auditor to finish ledger check.");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -43,8 +42,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -70,6 +67,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * Tests publishing of under replicated ledgers by the Auditor bookie node when
@@ -297,7 +295,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = bsConfs.get(2);
         BookieServer bk = bs.get(2);
         bookieConf.setReadOnlyModeEnabled(true);
-        ((Bookie.BookieStateManager) bk.getBookie().getStateManager()).doTransitionToReadOnlyMode();
+        bk.getBookie().getStateManager().doTransitionToReadOnlyMode();
 
         // grace period for publishing the bk-ledger
         LOG.debug("Waiting for Auditor to finish ledger check.");
@@ -323,7 +321,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = bsConfs.get(bkIndex);
         BookieServer bk = bs.get(bkIndex);
         bookieConf.setReadOnlyModeEnabled(true);
-        ((Bookie.BookieStateManager) bk.getBookie().getStateManager()).doTransitionToReadOnlyMode();
+        bk.getBookie().getStateManager().doTransitionToReadOnlyMode();
 
         // grace period for publishing the bk-ledger
         LOG.debug("Waiting for Auditor to finish ledger check.");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -36,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.StateManager;
 import org.apache.bookkeeper.client.BookKeeperTestClient;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -327,7 +326,7 @@ public abstract class BookKeeperClusterTestCase {
     public void setBookieToReadOnly(BookieSocketAddress addr) throws InterruptedException, UnknownHostException {
         for (BookieServer server : bs) {
             if (server.getLocalAddress().equals(addr)) {
-                ((Bookie.BookieStateManager) server.getBookie().getStateManager()).doTransitionToReadOnlyMode();
+                server.getBookie().getStateManager().doTransitionToReadOnlyMode();
                 break;
             }
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.bookie.StateManager;
 import org.apache.bookkeeper.client.BookKeeperTestClient;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -326,7 +327,7 @@ public abstract class BookKeeperClusterTestCase {
     public void setBookieToReadOnly(BookieSocketAddress addr) throws InterruptedException, UnknownHostException {
         for (BookieServer server : bs) {
             if (server.getLocalAddress().equals(addr)) {
-                server.getBookie().doTransitionToReadOnlyMode();
+                ((Bookie.BookieStateManager) server.getBookie().getStateManager()).doTransitionToReadOnlyMode();
                 break;
             }
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -260,7 +260,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         killBookie(1);
         baseConf.setReadOnlyModeEnabled(true);
         startNewBookie();
-        bs.get(1).getBookie().doTransitionToReadOnlyMode();
+        ((Bookie.BookieStateManager) bs.get(1).getBookie().getStateManager()).doTransitionToReadOnlyMode();
         try {
             bkc.waitForReadOnlyBookie(Bookie.getBookieAddress(bsConfs.get(1)))
                 .get(30, TimeUnit.SECONDS);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -24,11 +24,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.util.Enumeration;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
@@ -260,7 +258,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         killBookie(1);
         baseConf.setReadOnlyModeEnabled(true);
         startNewBookie();
-        ((Bookie.BookieStateManager) bs.get(1).getBookie().getStateManager()).doTransitionToReadOnlyMode();
+        bs.get(1).getBookie().getStateManager().doTransitionToReadOnlyMode();
         try {
             bkc.waitForReadOnlyBookie(Bookie.getBookieAddress(bsConfs.get(1)))
                 .get(30, TimeUnit.SECONDS);


### PR DESCRIPTION
Descriptions of the changes in this PR:

Add SortedLedgerStorageListener to implement, and add a test case to verify it.

Master Issue: #280 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---

  