### PR TITLE
Issue 865: LongHierarchicalLedgerManager: refactor to fix races

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManager.java
@@ -27,6 +27,7 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.Processor;
 import org.apache.bookkeeper.util.StringUtils;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,6 +110,8 @@ class FlatLedgerManager extends AbstractZkLedgerManager {
                     zkActiveLedgers = ledgerListToSet(
                             ZkUtils.getChildrenInSingleNode(zk, ledgerRootPath), ledgerRootPath);
                     nextRange = new LedgerRange(zkActiveLedgers);
+                } catch (KeeperException.NoNodeException e) {
+                    throw new IOException("Path does not exist: " + ledgerRootPath, e);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                     throw new IOException("Error when get child nodes from zk", ie);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
@@ -202,7 +202,7 @@ public interface LedgerManager extends Closeable {
         /**
          * Get the next element.
          *
-         * @return the next element.
+         * @return the next element, the LedgerRange returned must be non-empty
          * @throws IOException thrown when there is a problem accessing the ledger
          * metadata store. It is critical that it doesn't return false in the case
          * in the case it fails to access the ledger metadata store. Otherwise it

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManager.java
@@ -261,6 +261,8 @@ class LegacyHierarchicalLedgerManager extends AbstractHierarchicalLedgerManager 
             List<String> ledgerNodes = null;
             try {
                 ledgerNodes = ZkUtils.getChildrenInSingleNode(zk, nodePath);
+            } catch (KeeperException.NoNodeException e) {
+                throw new IOException("Path does not exist: " + nodePath, e);
             } catch (InterruptedException e) {
                 throw new IOException("Error when get child nodes from zk", e);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManager.java
@@ -18,6 +18,7 @@
 package org.apache.bookkeeper.meta;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -262,7 +263,9 @@ class LegacyHierarchicalLedgerManager extends AbstractHierarchicalLedgerManager 
             try {
                 ledgerNodes = ZkUtils.getChildrenInSingleNode(zk, nodePath);
             } catch (KeeperException.NoNodeException e) {
-                throw new IOException("Path does not exist: " + nodePath, e);
+                /* If the node doesn't exist, we must have raced with a recursive node removal, just
+                 * return an empty list. */
+                ledgerNodes = new ArrayList<>();
             } catch (InterruptedException e) {
                 throw new IOException("Error when get child nodes from zk", e);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
@@ -223,7 +223,7 @@ public class ZkUtils {
      * @throws IOException
      */
     public static List<String> getChildrenInSingleNode(final ZooKeeper zk, final String node)
-            throws InterruptedException, IOException {
+            throws InterruptedException, IOException, KeeperException.NoNodeException {
         final GetChildrenCtx ctx = new GetChildrenCtx();
         getChildrenInSingleNode(zk, node, new GenericCallback<List<String>>() {
             @Override
@@ -244,11 +244,12 @@ public class ZkUtils {
                 ctx.wait();
             }
         }
-        if (Code.OK.intValue() != ctx.rc) {
+        if (Code.NONODE.intValue() == ctx.rc) {
+            throw new KeeperException.NoNodeException("Got NoNode on call to getChildren on path " + node);
+        } else if (Code.OK.intValue() != ctx.rc) {
             throw new IOException("Error on getting children from node " + node);
         }
         return ctx.children;
-
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerIteratorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerIteratorTest.java
@@ -50,7 +50,6 @@ import org.apache.bookkeeper.versioning.Version;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Test;
 
 
@@ -354,11 +353,6 @@ public class LedgerManagerIteratorTest extends LedgerManagerTestCase {
 
     @Test
     public void checkConcurrentModifications() throws Throwable {
-        // Fails at this time on LegacyHLM, see next patch
-        Assume.assumeFalse(
-                baseConf.getLedgerManagerFactoryClass() == HierarchicalLedgerManagerFactory.class);
-        Assume.assumeFalse(
-                baseConf.getLedgerManagerFactoryClass() == LegacyHierarchicalLedgerManagerFactory.class);
         final int numWriters = 10;
         final int numCheckers = 10;
         final int numLedgers = 100;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerIteratorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerIteratorTest.java
@@ -22,10 +22,37 @@
 package org.apache.bookkeeper.meta;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.LedgerMetadata;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
+import org.apache.bookkeeper.util.MathUtils;
+import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.bookkeeper.versioning.Version;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
+import org.junit.After;
+import org.junit.Assume;
 import org.junit.Test;
+
 
 /**
  * Test the ledger manager iterator.
@@ -33,6 +60,104 @@ import org.junit.Test;
 public class LedgerManagerIteratorTest extends LedgerManagerTestCase {
     public LedgerManagerIteratorTest(Class<? extends LedgerManagerFactory> lmFactoryCls) {
         super(lmFactoryCls);
+    }
+
+    final Queue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
+
+    Runnable safeWrapper(Runnable r) {
+        return () -> {
+            try {
+                r.run();
+            } catch (Throwable e) {
+                exceptions.add(e);
+            }
+        };
+    }
+
+    @After
+    public void throwAsyncErrors() throws Throwable {
+        while (exceptions.peek() != null) {
+            throw exceptions.remove();
+        }
+    }
+
+    class RCCheckCB implements GenericCallback<Void> {
+        private final String opType;
+        private final CountDownLatch latch;
+        private final Optional<Integer> rcExpected;
+        private final long ledgerId;
+
+        public RCCheckCB(String opType, CountDownLatch latch, Optional<Integer> rcExpected, long ledgerId) {
+            this.opType = opType;
+            this.latch = latch;
+            this.rcExpected = rcExpected;
+            this.ledgerId = ledgerId;
+        }
+
+        @Override
+        public void operationComplete(int rc, Void result) {
+            safeWrapper(() -> {
+                try {
+                    rcExpected.map((Integer expected) -> {
+                        assertEquals(
+                                "Incorrect rc on ledger: " + ledgerId + ", op type: " + opType,
+                                expected.longValue(), rc);
+                        return null;
+                    });
+                } finally {
+                    latch.countDown();
+                }
+            }).run();
+        }
+    }
+
+    /**
+     * Remove ledger using lm syncronously.
+     *
+     * @param lm
+     * @param ledgerId
+     * @param rcExpected return value expected, -1 to ignore
+     * @throws InterruptedException
+     */
+    void removeLedger(LedgerManager lm, Long ledgerId, Optional<Integer> rcExpected) throws Throwable {
+        CountDownLatch latch = new CountDownLatch(1);
+        lm.removeLedgerMetadata(
+                ledgerId, Version.ANY, new RCCheckCB("removeLedger", latch, rcExpected, ledgerId));
+        latch.await();
+        throwAsyncErrors();
+
+    }
+
+    /**
+     * Create ledger using lm syncronously.
+     *
+     * @param lm
+     * @param ledgerId
+     * @param rcExpected return value expected, -1 to ignore
+     * @throws InterruptedException
+     */
+    void createLedger(LedgerManager lm, Long ledgerId, Optional<Integer> rcExpected) throws Throwable {
+        LedgerMetadata meta = new LedgerMetadata(
+                3, 3, 2,
+                BookKeeper.DigestType.CRC32, "passwd".getBytes());
+        CountDownLatch latch = new CountDownLatch(1);
+        lm.createLedgerMetadata(
+                ledgerId, meta, new RCCheckCB("createLedger", latch, rcExpected, ledgerId));
+        latch.await();
+        throwAsyncErrors();
+    }
+
+    static Set<Long> ledgerRangeToSet(LedgerRangeIterator lri) throws IOException {
+        Set<Long> ret = new TreeSet<>();
+        long last = -1;
+        while (lri.hasNext()) {
+            LedgerManager.LedgerRange lr = lri.next();
+            assertFalse("ledger range must not be empty", lr.getLedgers().isEmpty());
+            assertTrue("ledger ranges must not overlap", last < lr.start());
+            ret.addAll(lr.getLedgers());
+            last = lr.end();
+        }
+        return ret;
     }
 
     @Test
@@ -45,6 +170,275 @@ public class LedgerManagerIteratorTest extends LedgerManagerTestCase {
         }
 
         assertEquals(false, lri.hasNext());
-        assertEquals(false, lri.hasNext());
+    }
+
+    @Test
+    public void testSingleLedger() throws Throwable {
+        LedgerManager lm = getLedgerManager();
+
+        long id = 2020202;
+        createLedger(lm, id, Optional.of(BKException.Code.OK));
+
+        LedgerRangeIterator lri = lm.getLedgerRanges();
+        assertNotNull(lri);
+        Set<Long> lids = ledgerRangeToSet(lri);
+        assertEquals(lids.size(), 1);
+        assertEquals(lids.iterator().next().longValue(), id);
+    }
+
+    @Test
+    public void testTwoLedgers() throws Throwable {
+        LedgerManager lm = getLedgerManager();
+
+        Set<Long> ids = new TreeSet<>(Arrays.asList(101010101L, 2020340302L));
+        for (Long id: ids) {
+            createLedger(lm, id, Optional.of(BKException.Code.OK));
+        }
+
+        LedgerRangeIterator lri = lm.getLedgerRanges();
+        assertNotNull(lri);
+        Set<Long> returnedIds = ledgerRangeToSet(lri);
+        assertEquals(ids, returnedIds);
+    }
+
+    @Test
+    public void testSeveralContiguousLedgers() throws Throwable {
+        LedgerManager lm = getLedgerManager();
+
+        Set<Long> ids = new TreeSet<>();
+        for (long i = 0; i < 2000; ++i) {
+            createLedger(lm, i, Optional.of(BKException.Code.OK));
+            ids.add(i);
+        }
+
+        LedgerRangeIterator lri = lm.getLedgerRanges();
+        assertNotNull(lri);
+        Set<Long> returnedIds = ledgerRangeToSet(lri);
+        assertEquals(ids, returnedIds);
+    }
+
+    @Test
+    public void testRemovalOfNodeJustTraversed() throws Throwable {
+        if (baseConf.getLedgerManagerFactoryClass()
+                != LongHierarchicalLedgerManagerFactory.class) {
+            return;
+        }
+        LedgerManager lm = getLedgerManager();
+
+        /* For LHLM, first two should be leaves on the same node, second should be on adjacent level 4 node
+         * Removing all 3 once the iterator hits the first should result in the whole tree path ending
+         * at that node disappearing.  If this happens after the iterator stops at that leaf, it should
+         * result in a few NodeExists errors (handled silently) as the iterator fails back up the tree
+         * to the next path.
+         */
+        Set<Long> toRemove = new TreeSet<>(
+                Arrays.asList(
+                        3394498498348983841L,
+                        3394498498348983842L,
+                        3394498498348993841L));
+
+        long first = 2345678901234567890L;
+        // Nodes which should be listed anyway
+        Set<Long> mustHave = new TreeSet<>(
+                Arrays.asList(
+                        first,
+                        6334994393848474732L));
+
+        Set<Long> ids = new TreeSet<>();
+        ids.addAll(toRemove);
+        ids.addAll(mustHave);
+        for (Long id: ids) {
+            createLedger(lm, id, Optional.of(BKException.Code.OK));
+        }
+
+        Set<Long> found = new TreeSet<>();
+        LedgerRangeIterator lri = lm.getLedgerRanges();
+        while (lri.hasNext()) {
+            LedgerManager.LedgerRange lr = lri.next();
+            found.addAll(lr.getLedgers());
+
+            if (lr.getLedgers().contains(first)) {
+                for (long id: toRemove) {
+                    removeLedger(lm, id, Optional.of(BKException.Code.OK));
+                }
+                toRemove.clear();
+            }
+        }
+
+        for (long id: mustHave) {
+            assertTrue(found.contains(id));
+        }
+    }
+
+    @Test
+    public void validateEmptyL4PathSkipped() throws Throwable {
+        if (baseConf.getLedgerManagerFactoryClass()
+                != LongHierarchicalLedgerManagerFactory.class) {
+            return;
+        }
+        LedgerManager lm = getLedgerManager();
+
+        Set<Long> ids = new TreeSet<>(
+                Arrays.asList(
+                        2345678901234567890L,
+                        3394498498348983841L,
+                        6334994393848474732L,
+                        7349370101927398483L));
+        for (Long id: ids) {
+            createLedger(lm, id, Optional.of(BKException.Code.OK));
+        }
+
+        String paths[] = {
+                "/ledgers/633/4994/3938/4948", // Empty L4 path, must be skipped
+
+        };
+
+        for (String path : paths) {
+            ZkUtils.createFullPathOptimistic(
+                    zkc,
+                    path, "data".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        }
+
+        LedgerRangeIterator lri = lm.getLedgerRanges();
+        assertNotNull(lri);
+        Set<Long> returnedIds = ledgerRangeToSet(lri);
+        assertEquals(ids, returnedIds);
+
+        lri = lm.getLedgerRanges();
+        int emptyRanges = 0;
+        while (lri.hasNext()) {
+            if (lri.next().getLedgers().isEmpty()) {
+                emptyRanges++;
+            }
+        }
+        assertEquals(0, emptyRanges);
+    }
+
+    @Test
+    public void testWithSeveralIncompletePaths() throws Throwable {
+        if (baseConf.getLedgerManagerFactoryClass()
+                != LongHierarchicalLedgerManagerFactory.class) {
+            return;
+        }
+        LedgerManager lm = getLedgerManager();
+
+        Set<Long> ids = new TreeSet<>(
+                Arrays.asList(
+                        2345678901234567890L,
+                        3394498498348983841L,
+                        6334994393848474732L,
+                        7349370101927398483L));
+        for (Long id: ids) {
+            createLedger(lm, id, Optional.of(BKException.Code.OK));
+        }
+
+        String paths[] = {
+                "/ledgers/000/0000/0000", // top level, W-4292762
+                "/ledgers/234/5678/9999", // shares two path segments with the first one, comes after
+                "/ledgers/339/0000/0000", // shares one path segment with the second one, comes first
+                "/ledgers/633/4994/3938/0000", // shares three path segments with the third one, comes first
+                "/ledgers/922/3372/0000/0000", // close to max long, at end
+
+        };
+        for (String path : paths) {
+            ZkUtils.createFullPathOptimistic(
+                    zkc,
+                    path, "data".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        }
+
+        LedgerRangeIterator lri = lm.getLedgerRanges();
+        assertNotNull(lri);
+        Set<Long> returnedIds = ledgerRangeToSet(lri);
+        assertEquals(ids, returnedIds);
+    }
+
+    @Test
+    public void checkConcurrentModifications() throws Throwable {
+        // Fails at this time on LegacyHLM, see next patch
+        Assume.assumeFalse(
+                baseConf.getLedgerManagerFactoryClass() == HierarchicalLedgerManagerFactory.class);
+        Assume.assumeFalse(
+                baseConf.getLedgerManagerFactoryClass() == LegacyHierarchicalLedgerManagerFactory.class);
+        final int numWriters = 10;
+        final int numCheckers = 10;
+        final int numLedgers = 100;
+        final long runtime = TimeUnit.NANOSECONDS.convert(2, TimeUnit.SECONDS);
+        final boolean longRange =
+                baseConf.getLedgerManagerFactoryClass() == LongHierarchicalLedgerManagerFactory.class;
+
+        final Set<Long> mustExist = new TreeSet<>();
+        LedgerManager lm = getLedgerManager();
+        Random rng = new Random();
+        for (int i = 0; i < numLedgers; ++i) {
+            long lid = Math.abs(rng.nextLong());
+            if (!longRange) {
+                lid %= 1000000;
+            }
+            createLedger(lm, lid, Optional.of(BKException.Code.OK));
+            mustExist.add(lid);
+        }
+
+        final long start = MathUtils.nowInNano();
+        final CountDownLatch latch = new CountDownLatch(1);
+        ArrayList<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < numWriters; ++i) {
+            Thread thread = new Thread(safeWrapper(() -> {
+                LedgerManager writerLM = getIndependentLedgerManager();
+                Random writerRNG = new Random(rng.nextLong());
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    fail("Checker interrupted");
+                }
+                while (MathUtils.elapsedNanos(start) < runtime) {
+                    long candidate = 0;
+                    do {
+                        candidate = Math.abs(writerRNG.nextLong());
+                        if (!longRange) {
+                            candidate %= 1000000;
+                        }
+                    } while (mustExist.contains(candidate));
+                    try {
+                        createLedger(writerLM, candidate, Optional.empty());
+                        removeLedger(writerLM, candidate, Optional.empty());
+                    } catch (Throwable e) {
+                        fail("Got exception thrashing store: " + e.toString());
+                    }
+                }
+            }));
+            thread.start();
+            threads.add(thread);
+        }
+
+        for (int i = 0; i < numCheckers; ++i) {
+            Thread thread = new Thread(safeWrapper(() -> {
+                LedgerManager checkerLM = getIndependentLedgerManager();
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    fail("Checker interrupted");
+                    e.printStackTrace();
+                }
+                while (MathUtils.elapsedNanos(start) < runtime) {
+                    try {
+                        LedgerRangeIterator lri = checkerLM.getLedgerRanges();
+                        Set<Long> returnedIds = ledgerRangeToSet(lri);
+                        for (long id: mustExist) {
+                            assertTrue(returnedIds.contains(id));
+                        }
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        fail("Got exception scanning ledgers: " + e.toString());
+                    }
+                }
+            }));
+            thread.start();
+            threads.add(thread);
+        }
+
+        latch.countDown();
+        for (Thread thread: threads) {
+            thread.join();
+        }
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -69,6 +69,10 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         baseClientConf.setLedgerManagerFactoryClass(lmFactoryCls);
     }
 
+    public LedgerManager getIndependentLedgerManager() {
+        return ledgerManagerFactory.newLedgerManager();
+    }
+
     public LedgerManager getLedgerManager() {
         if (null == ledgerManager) {
             ledgerManager = ledgerManagerFactory.newLedgerManager();
@@ -88,6 +92,7 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         return Arrays.asList(new Object[][] {
             { FlatLedgerManagerFactory.class },
             { HierarchicalLedgerManagerFactory.class },
+            { LegacyHierarchicalLedgerManagerFactory.class },
             { LongHierarchicalLedgerManagerFactory.class },
             { MSLedgerManagerFactory.class },
         });


### PR DESCRIPTION
LongHierarchicalLedgerRangeIterator.initialize() could erroneously exit
with iteratorDone if the lexicographically first path in zk had fewer
than 4 levels.  This can happen for a few reasons including a case where
a client creating a ledger on that path crashed during the zk updates or
the iterator.hasNext() call simply raced with an in-progress node
creation or removal.  ScanAndCompareGarbageCollector is hasNext()
returns false will delete all ledgers on the bookie, so this is a fairly
serious bug.

Ruling out other such bugs was fairly dificult with the structure of the
code as written, so instead use a simpler recursive iterator design with
simpler pre/post conditions.

Also, surface KeeperException.NoNodeException from
ZkUtils.getChildrenInSingleNode so that we can actually handle it in
LHLM.

Master Issue: #865
