### PR TITLE
Issue 879: TestTLS fails when project path contains spaces

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -84,28 +84,28 @@ public class TestTLS extends BookKeeperClusterTestCase {
         baseClientConf.setTLSClientAuthentication(true);
         baseClientConf.setTLSKeyStoreType("JKS");
         baseClientConf.setTLSKeyStore(
-            this.getClass().getClassLoader().getResource("client.jks").toURI().getRawPath());
+            this.getClass().getClassLoader().getResource("client.jks").toURI().getPath());
         baseClientConf.setTLSKeyStorePasswordPath(
-            this.getClass().getClassLoader().getResource("keyStoreClientPassword.txt").toURI().getRawPath());
+            this.getClass().getClassLoader().getResource("keyStoreClientPassword.txt").toURI().getPath());
         baseClientConf.setTLSTrustStoreType("JKS");
         baseClientConf.setTLSTrustStore(
-            this.getClass().getClassLoader().getResource("cacerts").toURI().getRawPath());
+            this.getClass().getClassLoader().getResource("cacerts").toURI().getPath());
         baseClientConf.setTLSTrustStorePasswordPath(
-            this.getClass().getClassLoader().getResource("trustStorePassword.txt").toURI().getRawPath());
+            this.getClass().getClassLoader().getResource("trustStorePassword.txt").toURI().getPath());
 
         /* server configuration */
         baseConf.setTLSProviderFactoryClass(TLSContextFactory.class.getName());
         baseConf.setTLSClientAuthentication(true);
         baseConf.setTLSKeyStoreType("JKS");
         baseConf.setTLSKeyStore(
-            this.getClass().getClassLoader().getResource("server.jks").toURI().getRawPath());
+            this.getClass().getClassLoader().getResource("server.jks").toURI().getPath());
         baseConf.setTLSKeyStorePasswordPath(
-            this.getClass().getClassLoader().getResource("keyStoreServerPassword.txt").toURI().getRawPath());
+            this.getClass().getClassLoader().getResource("keyStoreServerPassword.txt").toURI().getPath());
         baseConf.setTLSTrustStoreType("JKS");
         baseConf.setTLSTrustStore(
-            this.getClass().getClassLoader().getResource("cacerts").toURI().getRawPath());
+            this.getClass().getClassLoader().getResource("cacerts").toURI().getPath());
         baseConf.setTLSTrustStorePasswordPath(
-            this.getClass().getClassLoader().getResource("trustStorePassword.txt").toURI().getRawPath());
+            this.getClass().getClassLoader().getResource("trustStorePassword.txt").toURI().getPath());
 
         super.setUp();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -83,25 +83,29 @@ public class TestTLS extends BookKeeperClusterTestCase {
         baseClientConf.setTLSProviderFactoryClass(TLSContextFactory.class.getName());
         baseClientConf.setTLSClientAuthentication(true);
         baseClientConf.setTLSKeyStoreType("JKS");
-        baseClientConf.setTLSKeyStore(this.getClass().getClassLoader().getResource("client.jks").getPath());
+        baseClientConf.setTLSKeyStore(
+            this.getClass().getClassLoader().getResource("client.jks").toURI().getRawPath());
         baseClientConf.setTLSKeyStorePasswordPath(
-                this.getClass().getClassLoader().getResource("keyStoreClientPassword.txt").getPath());
+            this.getClass().getClassLoader().getResource("keyStoreClientPassword.txt").toURI().getRawPath());
         baseClientConf.setTLSTrustStoreType("JKS");
-        baseClientConf.setTLSTrustStore(this.getClass().getClassLoader().getResource("cacerts").getPath());
+        baseClientConf.setTLSTrustStore(
+            this.getClass().getClassLoader().getResource("cacerts").toURI().getRawPath());
         baseClientConf.setTLSTrustStorePasswordPath(
-                this.getClass().getClassLoader().getResource("trustStorePassword.txt").getPath());
+            this.getClass().getClassLoader().getResource("trustStorePassword.txt").toURI().getRawPath());
 
         /* server configuration */
         baseConf.setTLSProviderFactoryClass(TLSContextFactory.class.getName());
         baseConf.setTLSClientAuthentication(true);
         baseConf.setTLSKeyStoreType("JKS");
-        baseConf.setTLSKeyStore(this.getClass().getClassLoader().getResource("server.jks").getPath());
+        baseConf.setTLSKeyStore(
+            this.getClass().getClassLoader().getResource("server.jks").toURI().getRawPath());
         baseConf.setTLSKeyStorePasswordPath(
-                this.getClass().getClassLoader().getResource("keyStoreServerPassword.txt").getPath());
+            this.getClass().getClassLoader().getResource("keyStoreServerPassword.txt").toURI().getRawPath());
         baseConf.setTLSTrustStoreType("JKS");
-        baseConf.setTLSTrustStore(this.getClass().getClassLoader().getResource("cacerts").getPath());
+        baseConf.setTLSTrustStore(
+            this.getClass().getClassLoader().getResource("cacerts").toURI().getRawPath());
         baseConf.setTLSTrustStorePasswordPath(
-                this.getClass().getClassLoader().getResource("trustStorePassword.txt").getPath());
+            this.getClass().getClassLoader().getResource("trustStorePassword.txt").toURI().getRawPath());
 
         super.setUp();
     }

--- a/site/community/testing.md
+++ b/site/community/testing.md
@@ -47,7 +47,7 @@ Postcommit test results can be found in [Jenkins](https://builds.apache.org/job/
 
 All the precommit and postcommit CI jobs are managed either by Jenkins or Travis CI.
 
-For Jenkins jobs, they are now all written and managed using [Jenkin-DSL](https://github.com/jenkinsci/job-dsl-plugin/wiki).
+For Jenkins jobs, they are all written and managed using [Jenkin-DSL](https://github.com/jenkinsci/job-dsl-plugin/wiki).
 The DSL scripts are maintained under [.test-infra](https://github.com/apache/bookkeeper/tree/master/.test-infra/jenkins).
 Any jenkins changes should be made in these files and reviewed by the community.
 

--- a/site/community/testing.md
+++ b/site/community/testing.md
@@ -1,0 +1,55 @@
+---
+title: BookKeeper Testing Guide
+---
+
+* TOC
+{:toc}
+
+## Overview
+
+Apache BookKeeper is a well adopted software project with a strong commitment to testing.
+Consequently, it has many testing-related needs. It requires precommit tests to ensure
+code going to the repository meets a certain quality bar and it requires ongoing postcommit
+tests to make sure that more subtle changes which escape precommit are nonetheless caught.
+This document outlines how to write tests, which tests are appropriate where, and when tests
+are run, with some additional information about the testing systems at the bottom.
+
+## Testing Scenarios
+
+With the tools at our disposal, we have a good set of utilities which we can use to verify
+BookKeeper correctness. To ensure an ongoing high quality of code, we use precommit and postcommit
+testing.
+
+### Precommit
+
+For precommit testing, BookKeeper uses [Jenkins](https://builds.apache.org/job/bookkeeper-seed/) and
+[Travis CI](https://travis-ci.org/apache/bookkeeper), hooked up to
+[Github](https://github.com/apache/bookkeeper), to ensure that pull requests meet a certain quality bar.
+These precommits verify correctness via unit/integration tests.
+
+Precommit tests are kicked off when a user makes a Pull Request against the `apache/bookkeeper` repository,
+and the Jenkins and Travis CI statuses are displayed at the bottom of the pull request page. Clicking on
+"Details" will open the status page in the selected tool; there, test status and output can be viewed.
+
+For retriggering precommit testing for a given Pull Request, you can comment "retest this please" for
+jenkins jobs and close/reopen the Pull Request for travis jobs.
+
+### Postcommit
+
+Running in postcommit removes as stringent of a time constraint, which gives us the ability to do some
+more comprehensive testing. Currently in postcommit, we run unit/integration tests against both master and
+the most recent release branch, publish website for any changes related to website and documentation, and
+deploy a snapshot of latest master to artifactory.
+
+Postcommit test results can be found in [Jenkins](https://builds.apache.org/job/bookkeeper-seed/).
+
+### Configuration
+
+All the precommit and postcommit CI jobs are managed either by Jenkins or Travis CI.
+
+For Jenkins jobs, they are now all written and managed using [Jenkin-DSL](https://github.com/jenkinsci/job-dsl-plugin/wiki).
+The DSL scripts are maintained under [.test-infra](https://github.com/apache/bookkeeper/tree/master/.test-infra/jenkins).
+Any jenkins changes should be made in these files and reviewed by the community.
+
+For Travis CI jobs, they are defined in [.travis.yml](https://github.com/apache/bookkeeper/blob/master/.travis.yml).
+Any travis CI changes should be made in this file and reviewed by the community.


### PR DESCRIPTION
Descriptions of the changes in this PR:

Use `URI` rather than `URL`, so it won't use url-encoded path as the file path.