### PR TITLE
Fix: fail create-ledger callback on ledgerId generation failure

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongZkLedgerIdGenerator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongZkLedgerIdGenerator.java
@@ -110,6 +110,10 @@ public class LongZkLedgerIdGenerator implements LedgerIdGenerator {
                         cb.operationComplete(BKException.Code.IllegalOpException, null);
                     }
 
+                } else {
+                    LOG.error("Failed to create long ledger ID path",
+                            KeeperException.create(KeeperException.Code.get(rc)));
+                    cb.operationComplete(BKException.Code.ZKException, null);
                 }
             }
 


### PR DESCRIPTION
### Motivation

Recently, we have seen that when bk-client tries to create-ledger and if bk-client lost the zk-connection then bk-client doesn't complete the createLedger-callback. We can see following exception when bk-client fails to generate ledgerId from zookeeper.
```
05:43:35.364 [main-EventThread] ERROR o.a.b.meta.ZkLedgerIdGenerator       - Could not generate new ledger id
org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss for /ledgers/idgen-long/HOB-0000000001/ID-
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:99) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:51) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.bookkeeper.meta.ZkLedgerIdGenerator$1.processResult(ZkLedgerIdGenerator.java:78) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.util.ZkUtils$1.processResult(ZkUtils.java:79) [bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient$9$1.processResult(ZooKeeperClient.java:527) [bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:605) [zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:498) [zookeeper-3.4.6.jar:3.4.6-1569965]
```

### Modifications

- Bk-client handles and completes ledger-request callback on ledgerId-generation failure.
