### PR TITLE
ISSUE #904: short hostname for bookieid

### DIFF
--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -437,6 +437,10 @@ ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFa
 # Set the rate at which compaction will readd entries. The unit is adds per second.
 # compactionRate=1000
 
+# If bookie is using hostname for registration and in ledger metadata then
+# whether to use short hostname or FQDN hostname. Defaults to false.
+# useShortHostName=false
+
 # Threshold of minor compaction
 # For those entry log files whose remaining size percentage reaches below
 # this threshold will be compacted in a minor compaction.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1244,6 +1244,8 @@ public class BookieShell implements Tool {
             super(CMD_LISTBOOKIES);
             opts.addOption("rw", "readwrite", false, "Print readwrite bookies");
             opts.addOption("ro", "readonly", false, "Print readonly bookies");
+            // @deprecated 'rw'/'ro' option print both hostname and ip, so this option is not needed anymore
+            opts.addOption("h", "hostnames", false, "Also print hostname of the bookie");
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -135,6 +135,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     // Whether the bookie should use its hostname or ipaddress for the
     // registration.
     protected static final String USE_HOST_NAME_AS_BOOKIE_ID = "useHostNameAsBookieID";
+    protected static final String USE_SHORT_HOST_NAME = "useShortHostName";
     protected static final String ENABLE_LOCAL_TRANSPORT = "enableLocalTransport";
     protected static final String DISABLE_SERVER_SOCKET_BIND = "disableServerSocketBind";
 
@@ -2065,6 +2066,34 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setUseHostNameAsBookieID(boolean useHostName) {
         setProperty(USE_HOST_NAME_AS_BOOKIE_ID, useHostName);
+        return this;
+    }
+
+    /**
+     * If bookie is using hostname for registration and in ledger metadata then
+     * whether to use short hostname or FQDN hostname. Defaults to false.
+     *
+     * @return true, then bookie will be registered with its short hostname and
+     *         short hostname will be used in ledger metadata. Otherwise bookie
+     *         will use its FQDN hostname
+     */
+    public boolean getUseShortHostName() {
+        return getBoolean(USE_SHORT_HOST_NAME, false);
+    }
+
+    /**
+     * Configure the bookie to use its short hostname or FQDN hostname to
+     * register with the co-ordination service(eg: zookeeper) and in ledger
+     * metadata.
+     *
+     * @see #getUseShortHostName
+     * @param useShortHostName
+     *            whether to use short hostname for registration and in
+     *            ledgermetadata
+     * @return server configuration
+     */
+    public ServerConfiguration setUseShortHostName(boolean useShortHostName) {
+        setProperty(USE_SHORT_HOST_NAME, useShortHostName);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpdateCookieCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpdateCookieCmdTest.java
@@ -78,6 +78,14 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
     }
 
     /**
+     * updatecookie to short hostname.
+     */
+    @Test
+    public void testUpdateCookieIpAddressToShortHostname() throws Exception {
+        updateCookie("-bookieId", "hostname", true, true);
+    }
+
+    /**
      * updatecookie to ipaddress.
      */
     @Test
@@ -190,6 +198,11 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
     }
 
     private void updateCookie(String option, String optionVal, boolean useHostNameAsBookieID) throws Exception {
+        updateCookie(option, optionVal, useHostNameAsBookieID, false);
+    }
+
+    private void updateCookie(String option, String optionVal, boolean useHostNameAsBookieID, boolean useShortHostName)
+            throws Exception {
         ServerConfiguration conf = new ServerConfiguration(bsConfs.get(0));
         BookieServer bks = bs.get(0);
         bks.shutdown();
@@ -202,12 +215,14 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
         LOG.info("Perform updatecookie command");
         ServerConfiguration newconf = new ServerConfiguration(conf);
         newconf.setUseHostNameAsBookieID(useHostNameAsBookieID);
+        newconf.setUseShortHostName(useShortHostName);
         BookieShell bkShell = new BookieShell();
         bkShell.setConf(newconf);
         String[] argv = new String[] { "updatecookie", option, optionVal };
         Assert.assertEquals("Failed to return exit code!", 0, bkShell.run(argv));
 
         newconf.setUseHostNameAsBookieID(useHostNameAsBookieID);
+        newconf.setUseShortHostName(useShortHostName);
         cookie = Cookie.readFromRegistrationManager(rm, newconf).getValue();
         Assert.assertEquals("Wrongly updated cookie!", previousBookieID, !cookie.isBookieHostCreatedFromIp());
         Assert.assertEquals("Wrongly updated cookie!", useHostNameAsBookieID, !cookie.isBookieHostCreatedFromIp());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
@@ -72,10 +72,22 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
     };
 
     /**
-     * Tests verifies update bookie id when there are many ledgers.
+     * Tests verifies update bookie id to FQDN hostname when there are many ledgers.
      */
     @Test
-    public void testManyLedgers() throws Exception {
+    public void testManyLedgersWithFQDNHostname() throws Exception {
+        testManyLedgers(false);
+    }
+
+    /**
+     * Tests verifies update bookie id to short hostname when there are many ledgers.
+     */
+    @Test(timeout = 120000)
+    public void testManyLedgersWithShortHostname() throws Exception {
+        testManyLedgers(true);
+    }
+
+    public void testManyLedgers(boolean useShortHostName) throws Exception {
         BookKeeper bk = new BookKeeper(baseClientConf, zkc);
         BookKeeperAdmin bkadmin = new BookKeeperAdmin(bk);
 
@@ -91,6 +103,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
 
         BookieSocketAddress curBookieAddr = ensemble.get(0);
         baseConf.setUseHostNameAsBookieID(true);
+        baseConf.setUseShortHostName(useShortHostName);
         BookieSocketAddress curBookieId = Bookie.getBookieAddress(baseConf);
         BookieSocketAddress toBookieAddr = new BookieSocketAddress(curBookieId.getHostName() + ":"
                 + curBookieAddr.getPort());
@@ -156,11 +169,24 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Tests verifies the ensemble reformation after updating the bookie id in
-     * the existing ensemble.
+     * Tests verifies the ensemble reformation after updating the bookie id to
+     * FQDN hostname in the existing ensemble.
      */
     @Test
-    public void testChangeEnsembleAfterRenaming() throws Exception {
+    public void testChangeEnsembleAfterRenamingToFQDNHostname() throws Exception {
+        testChangeEnsembleAfterRenaming(false);
+    }
+
+    /**
+     * Tests verifies the ensemble reformation after updating the bookie id to
+     * short hostname in the existing ensemble.
+     */
+    @Test(timeout = 120000)
+    public void testChangeEnsembleAfterRenamingToShortHostname() throws Exception {
+        testChangeEnsembleAfterRenaming(true);
+    }
+
+    public void testChangeEnsembleAfterRenaming(boolean useShortHostName) throws Exception {
 
         BookKeeper bk = new BookKeeper(baseClientConf, zkc);
         BookKeeperAdmin bkadmin = new BookKeeperAdmin(bk);
@@ -178,6 +204,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
         }
         assertNotNull("Couldn't find the bookie in ledger metadata!", curBookieAddr);
         baseConf.setUseHostNameAsBookieID(true);
+        baseConf.setUseShortHostName(useShortHostName);
         BookieSocketAddress toBookieId = Bookie.getBookieAddress(baseConf);
         BookieSocketAddress toBookieAddr = new BookieSocketAddress(toBookieId.getHostName() + ":"
                 + curBookieAddr.getPort());


### PR DESCRIPTION
Descriptions of the changes in this PR:

- provide useShortHostName config to use short hostName for bookieId
- corresponding testcases
- For BKShell commands print appropriate string representation (hostname and ipaddress)
and port number of bookies

Master Issue: #904

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
