### PR TITLE
Misc fixes

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -440,7 +440,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                 ForceWriteRequest req = null;
                 try {
                     req = forceWriteRequests.take();
-
                     // Force write the file and then notify the write completions
                     //
                     if (!req.isMarker) {
@@ -460,8 +459,8 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                                 numReqInLastForceWrite = 0;
                             }
                         }
-                        numReqInLastForceWrite += req.process(shouldForceWrite);
                     }
+                    numReqInLastForceWrite += req.process(shouldForceWrite);
 
                     if (enableGroupForceWrites
                             // if its a marker we should switch back to flushing

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * are between {@code firstSpeculativeRequestTimeout} and {@code maxSpeculativeRequestTimeout}.
  */
 public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequestExecutionPolicy {
-    private static final Logger LOG = LoggerFactory.getLogger(PendingReadOp.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultSpeculativeRequestExecutionPolicy.class);
     final int firstSpeculativeRequestTimeout;
     final int maxSpeculativeRequestTimeout;
     final float backoffMultiplier;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -322,7 +322,9 @@ abstract class AbstractZkLedgerManager implements LedgerManager, Watcher {
     @Override
     public void registerLedgerMetadataListener(long ledgerId, LedgerMetadataListener listener) {
         if (null != listener) {
-            LOG.debug("Registered ledger metadata listener {} on ledger {}.", listener, ledgerId);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Registered ledger metadata listener {} on ledger {}.", listener, ledgerId);
+            }
             Set<LedgerMetadataListener> listenerSet = listeners.get(ledgerId);
             if (listenerSet == null) {
                 Set<LedgerMetadataListener> newListenerSet = new HashSet<LedgerMetadataListener>();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -385,6 +385,9 @@ public class BookieProtoEncoding {
 
         @Override
         protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Encode request {} to channel {}.", msg, ctx.channel());
+            }
             if (msg instanceof BookkeeperProtocol.Request) {
                 out.add(reqV3.encode(msg, ctx.alloc()));
             } else if (msg instanceof BookieProtocol.Request) {
@@ -413,8 +416,8 @@ public class BookieProtoEncoding {
 
         @Override
         protected void decode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Received request {} from channel {} to decode.", msg, ctx.channel());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Received request {} from channel {} to decode.", msg, ctx.channel());
             }
             if (!(msg instanceof ByteBuf)) {
                 out.add(msg);
@@ -453,8 +456,8 @@ public class BookieProtoEncoding {
         @Override
         protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out)
                 throws Exception {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Encode response {} to channel {}.", msg, ctx.channel());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Encode response {} to channel {}.", msg, ctx.channel());
             }
             if (msg instanceof BookkeeperProtocol.Response) {
                 out.add(repV3.encode(msg, ctx.alloc()));
@@ -484,8 +487,8 @@ public class BookieProtoEncoding {
 
         @Override
         protected void decode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Received response {} from channel {} to decode.", msg, ctx.channel());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Received response {} from channel {} to decode.", msg, ctx.channel());
             }
             if (!(msg instanceof ByteBuf)) {
                 out.add(msg);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -80,6 +80,8 @@ public class EntryLogTest {
 
         int gcWaitTime = 1000;
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setJournalDirName(tmpDir.toString());
+
         conf.setGcWaitTime(gcWaitTime);
         conf.setLedgerDirNames(new String[] {tmpDir.toString()});
         Bookie bookie = new Bookie(conf);
@@ -120,6 +122,7 @@ public class EntryLogTest {
         Bookie.checkDirectoryStructure(curDir);
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setJournalDirName(tmpDir.toString());
         conf.setLedgerDirNames(new String[] {tmpDir.toString()});
         Bookie bookie = new Bookie(conf);
         // create some entries
@@ -206,6 +209,7 @@ public class EntryLogTest {
         File ledgerDir1 = createTempDir("bkTest", ".dir");
         File ledgerDir2 = createTempDir("bkTest", ".dir");
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setJournalDirName(ledgerDir1.toString());
         conf.setLedgerDirNames(new String[] { ledgerDir1.getAbsolutePath(),
                 ledgerDir2.getAbsolutePath() });
         Bookie bookie = new Bookie(conf);
@@ -240,6 +244,8 @@ public class EntryLogTest {
 
         int gcWaitTime = 1000;
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setJournalDirName(tmpDir.toString());
+
         conf.setGcWaitTime(gcWaitTime);
         conf.setLedgerDirNames(new String[] {tmpDir.toString()});
         Bookie bookie = new Bookie(conf);
@@ -276,6 +282,7 @@ public class EntryLogTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setGcWaitTime(gcWaitTime);
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
+        conf.setJournalDirName(tmpDir.toString());
         Bookie bookie = new Bookie(conf);
 
         // create some entries

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -272,6 +272,7 @@ public class LedgerCacheTest {
         File ledgerDir2 = createTempDir("bkTest", ".dir");
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setLedgerDirNames(new String[] { ledgerDir1.getAbsolutePath(), ledgerDir2.getAbsolutePath() });
+        conf.setJournalDirName(ledgerDir1.toString());
 
         Bookie bookie = new Bookie(conf);
         InterleavedLedgerStorage ledgerStorage = ((InterleavedLedgerStorage) bookie.ledgerStorage);
@@ -517,6 +518,7 @@ public class LedgerCacheTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setGcWaitTime(gcWaitTime);
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
+        conf.setJournalDirName(tmpDir.toString());
         conf.setLedgerStorageClass(FlushTestSortedLedgerStorage.class.getName());
 
         Bookie bookie = new Bookie(conf);


### PR DESCRIPTION
Author: Dustin <dcastor@salesforce.com>
Date:   Thu Sep 1 13:57:43 2016 -0700

    Journal: Fix journal write queue so it decrements properly.

    (@bug W-3169683@)
    Signed-off-by: Dustin <dcastor@salesforce.com>

Author: Samuel Just <sjust@salesforce.com>
Date:   Mon Aug 28 11:40:29 2017 -0700

    EntryLogTest,LedgerCacheTest: use correct tmp dir

    These tests weren't overriding the journal dir and so weren't using
    an IOUtils tmp dir for the journal.

    (@bug W-4267131@)
    Signed-off-by: Samuel Just <sjust@salesforce.com>

Author: Samuel Just <sjust@salesforce.com>
Date:   Tue Dec 12 11:06:00 2017 -0800

    AbstractZkLedgerManager: wrap Log.debug in an isDebugEnabled check

    Signed-off-by: Samuel Just <sjust@salesforce.com>

Author: Samuel Just <sjust@salesforce.com>
Date:   Mon Dec 11 18:08:56 2017 -0800

    DefaultSpeculativeRequestExecutionPolicy: fix logger instantiation

    Signed-off-by: Samuel Just <sjust@salesforce.com>

Author: Samuel Just <sjust@salesforce.com>
Date:   Wed Jun 21 15:55:07 2017 -0700

    BookieProtoEncoding: log messages at TRACE rather than DEBUG

    Logging them at debug tends to make logging at DEBUG level pretty
    intractable, log them at TRACE instead.

    (@bug W-4166441@)
    Signed-off-by: Samuel Just <sjust@salesforce.com>