### PR TITLE
BookieProtoEncoding: log messages at TRACE rather than DEBUG

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -385,6 +385,9 @@ public class BookieProtoEncoding {
 
         @Override
         protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Encode request {} to channel {}.", msg, ctx.channel());
+            }
             if (msg instanceof BookkeeperProtocol.Request) {
                 out.add(reqV3.encode(msg, ctx.alloc()));
             } else if (msg instanceof BookieProtocol.Request) {
@@ -413,8 +416,8 @@ public class BookieProtoEncoding {
 
         @Override
         protected void decode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Received request {} from channel {} to decode.", msg, ctx.channel());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Received request {} from channel {} to decode.", msg, ctx.channel());
             }
             if (!(msg instanceof ByteBuf)) {
                 out.add(msg);
@@ -453,8 +456,8 @@ public class BookieProtoEncoding {
         @Override
         protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out)
                 throws Exception {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Encode response {} to channel {}.", msg, ctx.channel());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Encode response {} to channel {}.", msg, ctx.channel());
             }
             if (msg instanceof BookkeeperProtocol.Response) {
                 out.add(repV3.encode(msg, ctx.alloc()));
@@ -484,8 +487,8 @@ public class BookieProtoEncoding {
 
         @Override
         protected void decode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Received response {} from channel {} to decode.", msg, ctx.channel());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Received response {} from channel {} to decode.", msg, ctx.channel());
             }
             if (!(msg instanceof ByteBuf)) {
                 out.add(msg);


### PR DESCRIPTION
Logging them at debug tends to make logging at DEBUG level pretty
intractable, log them at TRACE instead.

(@bug W-4166441@)
Signed-off-by: Samuel Just <sjust@salesforce.com>