### PR TITLE
DefaultSpeculativeRequestExecutionPolicy: fix logger instantiation

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * are between {@code firstSpeculativeRequestTimeout} and {@code maxSpeculativeRequestTimeout}.
  */
 public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequestExecutionPolicy {
-    private static final Logger LOG = LoggerFactory.getLogger(PendingReadOp.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultSpeculativeRequestExecutionPolicy.class);
     final int firstSpeculativeRequestTimeout;
     final int maxSpeculativeRequestTimeout;
     final float backoffMultiplier;


### PR DESCRIPTION
Signed-off-by: Samuel Just <sjust@salesforce.com>