### PR TITLE
Refactor FileInfo locking and refcounting out IndexPersistenceMgr

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -137,6 +137,10 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
         return true;
     }
 
+    public boolean isClosed() {
+        return isClosed;
+    }
+
     public synchronized File getLf() {
         return lf;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
@@ -1,0 +1,114 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class FileInfoBackingCache {
+    final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    final ConcurrentHashMap<Long, CachedFileInfo> fileInfos = new ConcurrentHashMap<>();
+    final FileLoader fileLoader;
+
+    FileInfoBackingCache(FileLoader fileLoader) {
+        this.fileLoader = fileLoader;
+    }
+
+    CachedFileInfo loadFileInfo(long ledgerId, byte[] masterKey) throws IOException {
+        lock.readLock().lock();
+        try {
+            CachedFileInfo fi = fileInfos.get(ledgerId);
+            if (fi != null) {
+                fi.retain();  // caller of loadFileInfo owns this reference
+                return fi;
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        // else FileInfo not found, create it under write lock
+        lock.writeLock().lock();
+        try {
+            File backingFile = fileLoader.load(ledgerId, masterKey != null);
+            CachedFileInfo fi = new CachedFileInfo(ledgerId, backingFile, masterKey);
+            fileInfos.put(ledgerId, fi);
+
+            fi.retain(); // caller of loadFileInfo owns this reference
+            return fi;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    void releaseFileInfo(long ledgerId, FileInfo fileInfo) {
+        lock.writeLock().lock();
+        try {
+            fileInfo.close(true);
+            fileInfos.remove(ledgerId, fileInfo);
+        } catch (IOException ioe) {
+            log.error("Error evicting file info({}) for ledger {} from backing cache",
+                      fileInfo, ledgerId, ioe);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    void closeAllWithoutFlushing() throws IOException {
+        for (Map.Entry<Long, CachedFileInfo> entry : fileInfos.entrySet()) {
+            entry.getValue().close(false);
+        }
+    }
+
+    class CachedFileInfo extends FileInfo {
+        final long ledgerId;
+        final AtomicInteger refCount;
+
+        CachedFileInfo(long ledgerId, File lf, byte[] masterKey) throws IOException {
+            super(lf, masterKey);
+            this.ledgerId = ledgerId;
+            this.refCount = new AtomicInteger(0);
+        }
+
+        void retain() {
+            refCount.incrementAndGet();
+        }
+
+        int getRefCount() {
+            return refCount.get();
+        }
+
+        void release() {
+            if (refCount.decrementAndGet() == 0) {
+                releaseFileInfo(ledgerId, this);
+            }
+        }
+    }
+
+    interface FileLoader {
+        File load(long ledgerId, boolean createIfMissing) throws IOException;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
@@ -64,7 +64,7 @@ class FileInfoBackingCache {
         }
     }
 
-    void releaseFileInfo(long ledgerId, FileInfo fileInfo) {
+    private void releaseFileInfo(long ledgerId, FileInfo fileInfo) {
         lock.writeLock().lock();
         try {
             fileInfo.close(true);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
@@ -120,7 +120,7 @@ class FileInfoBackingCache {
          * When a client obtains a fileinfo from a container object,
          * but that container object may release the fileinfo before
          * the client has a chance to call retain. In this case, the
-         * file info could be releases and the destroyed before we ever
+         * file info could be released and the destroyed before we ever
          * get a chance to use it.
          *
          * <p>tryRetain avoids this problem, by doing a compare-and-swap on

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -211,7 +211,9 @@ public class IndexPersistenceMgr {
             CachedFileInfo fi;
             pendingGetFileInfoCounter.inc();
             Callable<CachedFileInfo> loader = () -> {
-                return fileInfoBackingCache.loadFileInfo(ledger, masterKey);
+                CachedFileInfo fileInfo = fileInfoBackingCache.loadFileInfo(ledger, masterKey);
+                activeLedgers.put(ledger, true);
+                return fileInfo;
             };
             if (null != masterKey) {
                 fi = writeFileInfoCache.get(ledger, loader);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -215,12 +215,14 @@ public class IndexPersistenceMgr {
                 activeLedgers.put(ledger, true);
                 return fileInfo;
             };
-            if (null != masterKey) {
-                fi = writeFileInfoCache.get(ledger, loader);
-            } else {
-                fi = readFileInfoCache.get(ledger, loader);
-            }
-            fi.retain();
+            do {
+                if (null != masterKey) {
+                    fi = writeFileInfoCache.get(ledger, loader);
+                } else {
+                    fi = readFileInfoCache.get(ledger, loader);
+                }
+            } while (!fi.tryRetain());
+
             return fi;
         } catch (ExecutionException | UncheckedExecutionException ee) {
             if (ee.getCause() instanceof IOException) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -189,7 +189,6 @@ public class IndexPersistenceMgr {
      */
     private void handleLedgerEviction(RemovalNotification<Long, CachedFileInfo> notification) {
         CachedFileInfo fileInfo = notification.getValue();
-        Long ledgerId = notification.getKey();
         if (null == fileInfo || null == notification.getKey()) {
             return;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -38,13 +38,10 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.bookkeeper.bookie.FileInfoBackingCache.CachedFileInfo;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.LedgerDirsListener;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.common.util.Watcher;
@@ -80,15 +77,13 @@ public class IndexPersistenceMgr {
     }
 
     // use two separate cache for write and read
-    final Cache<Long, FileInfo> writeFileInfoCache;
-    final Cache<Long, FileInfo> readFileInfoCache;
+    final Cache<Long, CachedFileInfo> writeFileInfoCache;
+    final Cache<Long, CachedFileInfo> readFileInfoCache;
+    final FileInfoBackingCache fileInfoBackingCache;
+
     final int openFileLimit;
     final int pageSize;
     final int entriesPerPage;
-    // Lock
-    final ReentrantReadWriteLock fileInfoLock = new ReentrantReadWriteLock();
-    // ThreadPool
-    final ScheduledExecutorService evictionThreadPool = Executors.newSingleThreadScheduledExecutor();
 
     // Manage all active ledgers in LedgerManager
     // so LedgerManager has knowledge to garbage collect inactive/deleted ledgers
@@ -117,7 +112,8 @@ public class IndexPersistenceMgr {
 
         // build the file info cache
         int concurrencyLevel = Math.max(1, Math.max(conf.getNumAddWorkerThreads(), conf.getNumReadWorkerThreads()));
-        RemovalListener<Long, FileInfo> fileInfoEvictionListener = this::handleLedgerEviction;
+        fileInfoBackingCache = new FileInfoBackingCache(this::createFileInfoBackingFile);
+        RemovalListener<Long, CachedFileInfo> fileInfoEvictionListener = this::handleLedgerEviction;
         writeFileInfoCache = buildCache(
             concurrencyLevel,
             conf.getFileInfoCacheInitialCapacity(),
@@ -158,12 +154,12 @@ public class IndexPersistenceMgr {
         });
     }
 
-    private static Cache<Long, FileInfo> buildCache(int concurrencyLevel,
-                                            int initialCapacity,
-                                            int maximumSize,
-                                            long expireAfterAccessSeconds,
-                                            RemovalListener<Long, FileInfo> removalListener) {
-        CacheBuilder<Long, FileInfo> builder = CacheBuilder.newBuilder()
+    private static Cache<Long, CachedFileInfo> buildCache(int concurrencyLevel,
+                                                          int initialCapacity,
+                                                          int maximumSize,
+                                                          long expireAfterAccessSeconds,
+                                                          RemovalListener<Long, CachedFileInfo> removalListener) {
+        CacheBuilder<Long, CachedFileInfo> builder = CacheBuilder.newBuilder()
             .concurrencyLevel(concurrencyLevel)
             .initialCapacity(initialCapacity)
             .maximumSize(maximumSize)
@@ -174,65 +170,33 @@ public class IndexPersistenceMgr {
         return builder.build();
     }
 
+    private File createFileInfoBackingFile(long ledger, boolean createIfMissing) throws IOException {
+        File lf = findIndexFile(ledger);
+        if (null == lf) {
+            if (!createIfMissing) {
+                throw new Bookie.NoLedgerException(ledger);
+            }
+            // We don't have a ledger index file on disk or in cache, so create it.
+            lf = getNewLedgerIndexFile(ledger, null);
+        }
+        return lf;
+    }
+
     /**
      * When a ledger is evicted, we need to make sure there's no other thread
      * trying to get FileInfo for that ledger at the same time when we close
      * the FileInfo.
      */
-    private void handleLedgerEviction(RemovalNotification<Long, FileInfo> notification) {
-        FileInfo fileInfo = notification.getValue();
+    private void handleLedgerEviction(RemovalNotification<Long, CachedFileInfo> notification) {
+        CachedFileInfo fileInfo = notification.getValue();
         Long ledgerId = notification.getKey();
         if (null == fileInfo || null == notification.getKey()) {
             return;
         }
         if (notification.wasEvicted()) {
             evictedLedgersCounter.inc();
-            // we need to acquire the write lock in another thread,
-            // otherwise there could be dead lock happening.
-            evictionThreadPool.execute(() -> {
-                fileInfoLock.writeLock().lock();
-                try {
-                    // We only close the fileInfo when we evict the FileInfo from both cache
-                    if (!readFileInfoCache.asMap().containsKey(ledgerId)
-                            && !writeFileInfoCache.asMap().containsKey(ledgerId)) {
-                        fileInfo.close(true);
-                    }
-                } catch (IOException e) {
-                    LOG.error("Exception closing file info when ledger {} is evicted from file info cache.",
-                        ledgerId, e);
-                } finally {
-                    fileInfoLock.writeLock().unlock();
-                }
-            });
         }
         fileInfo.release();
-    }
-
-    class FileInfoLoader implements Callable<FileInfo> {
-
-        final long ledger;
-        final byte[] masterKey;
-
-        FileInfoLoader(long ledger, byte[] masterKey) {
-            this.ledger = ledger;
-            this.masterKey = masterKey;
-        }
-
-        @Override
-        public FileInfo call() throws IOException {
-            File lf = findIndexFile(ledger);
-            if (null == lf) {
-                if (null == masterKey) {
-                    throw new Bookie.NoLedgerException(ledger);
-                }
-                // We don't have a ledger index file on disk or in cache, so create it.
-                lf = getNewLedgerIndexFile(ledger, null);
-                activeLedgers.put(ledger, true);
-            }
-            FileInfo fi = new FileInfo(lf, masterKey);
-            fi.use();
-            return fi;
-        }
     }
 
     /**
@@ -242,22 +206,19 @@ public class IndexPersistenceMgr {
      * the FileInfo from cache, that FileInfo is then evicted and closed before we
      * could even increase the reference counter.
      */
-    FileInfo getFileInfo(final Long ledger, final byte masterKey[]) throws IOException {
+    CachedFileInfo getFileInfo(final Long ledger, final byte masterKey[]) throws IOException {
         try {
-            FileInfo fi;
+            CachedFileInfo fi;
             pendingGetFileInfoCounter.inc();
-            fileInfoLock.readLock().lock();
+            Callable<CachedFileInfo> loader = () -> {
+                return fileInfoBackingCache.loadFileInfo(ledger, masterKey);
+            };
             if (null != masterKey) {
-                fi = writeFileInfoCache.get(ledger,
-                    new FileInfoLoader(ledger, masterKey));
-                if (null == readFileInfoCache.asMap().putIfAbsent(ledger, fi)) {
-                    fi.use();
-                }
+                fi = writeFileInfoCache.get(ledger, loader);
             } else {
-                fi = readFileInfoCache.get(ledger,
-                    new FileInfoLoader(ledger, null));
+                fi = readFileInfoCache.get(ledger, loader);
             }
-            fi.use();
+            fi.retain();
             return fi;
         } catch (ExecutionException | UncheckedExecutionException ee) {
             if (ee.getCause() instanceof IOException) {
@@ -267,7 +228,6 @@ public class IndexPersistenceMgr {
             }
         } finally {
             pendingGetFileInfoCounter.dec();
-            fileInfoLock.readLock().unlock();
         }
     }
 
@@ -354,8 +314,7 @@ public class IndexPersistenceMgr {
      */
     void removeLedger(Long ledgerId) throws IOException {
         // Delete the ledger's index file and close the FileInfo
-        FileInfo fi = null;
-        fileInfoLock.writeLock().lock();
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             // Don't force flush. There's no need since we're deleting the ledger
@@ -364,18 +323,14 @@ public class IndexPersistenceMgr {
             fi.close(false);
             fi.delete();
         } finally {
-            try {
-                if (fi != null) {
-                    // should release use count
-                    fi.release();
-                    // Remove it from the active ledger manager
-                    activeLedgers.remove(ledgerId);
-                    // Now remove it from cache
-                    writeFileInfoCache.invalidate(ledgerId);
-                    readFileInfoCache.invalidate(ledgerId);
-                }
-            } finally {
-                fileInfoLock.writeLock().unlock();
+            if (fi != null) {
+                // should release use count
+                fi.release();
+                // Remove it from the active ledger manager
+                activeLedgers.remove(ledgerId);
+                // Now remove it from cache
+                writeFileInfoCache.invalidate(ledgerId);
+                readFileInfoCache.invalidate(ledgerId);
             }
         }
     }
@@ -399,29 +354,13 @@ public class IndexPersistenceMgr {
         // Don't force create the file. We may have many dirty ledgers and file create/flush
         // can be quite expensive as a result. We can use this optimization in this case
         // because metadata will be recovered from the journal when we restart anyway.
-        try {
-            fileInfoLock.writeLock().lock();
-            for (Map.Entry<Long, FileInfo> entry : writeFileInfoCache.asMap().entrySet()) {
-                entry.getValue().close(false);
-            }
-            for (Map.Entry<Long, FileInfo> entry : readFileInfoCache.asMap().entrySet()) {
-                entry.getValue().close(false);
-            }
-            writeFileInfoCache.invalidateAll();
-            readFileInfoCache.invalidateAll();
-        } finally {
-            fileInfoLock.writeLock().unlock();
-        }
-        evictionThreadPool.shutdown();
-        try {
-            evictionThreadPool.awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            //ignore
-        }
+        fileInfoBackingCache.closeAllWithoutFlushing();
+        writeFileInfoCache.invalidateAll();
+        readFileInfoCache.invalidateAll();
     }
 
     Long getLastAddConfirmed(long ledgerId) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             return fi.getLastAddConfirmed();
@@ -435,7 +374,7 @@ public class IndexPersistenceMgr {
     boolean waitForLastAddConfirmedUpdate(long ledgerId,
                                           long previousLAC,
                                           Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             return fi.waitForLastAddConfirmedUpdate(previousLAC, watcher);
@@ -447,7 +386,7 @@ public class IndexPersistenceMgr {
     }
 
     long updateLastAddConfirmed(long ledgerId, long lac) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             return fi.setLastAddConfirmed(lac);
@@ -459,7 +398,7 @@ public class IndexPersistenceMgr {
     }
 
     byte[] readMasterKey(long ledgerId) throws IOException, BookieException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             return fi.getMasterKey();
@@ -471,7 +410,7 @@ public class IndexPersistenceMgr {
     }
 
     void setMasterKey(long ledgerId, byte[] masterKey) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, masterKey);
         } finally {
@@ -482,7 +421,7 @@ public class IndexPersistenceMgr {
     }
 
     boolean setFenced(long ledgerId) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             return fi.setFenced();
@@ -494,7 +433,7 @@ public class IndexPersistenceMgr {
     }
 
     boolean isFenced(long ledgerId) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             return fi.isFenced();
@@ -506,7 +445,7 @@ public class IndexPersistenceMgr {
     }
 
     void setExplicitLac(long ledgerId, ByteBuf lac) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             fi.setExplicitLac(lac);
@@ -519,7 +458,7 @@ public class IndexPersistenceMgr {
     }
 
     public ByteBuf getExplicitLac(long ledgerId) {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledgerId, null);
             return fi.getExplicitLac();
@@ -600,7 +539,7 @@ public class IndexPersistenceMgr {
     }
 
     void flushLedgerHeader(long ledger) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(ledger, null);
             relocateIndexFileAndFlushHeader(ledger, fi);
@@ -616,7 +555,7 @@ public class IndexPersistenceMgr {
     }
 
     void flushLedgerEntries(long l, List<LedgerEntryPage> entries) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             Collections.sort(entries, new Comparator<LedgerEntryPage>() {
                 @Override
@@ -711,7 +650,7 @@ public class IndexPersistenceMgr {
         if (!lep.isClean()) {
             throw new IOException("Trying to update a dirty page");
         }
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         try {
             fi = getFileInfo(lep.getLedger(), null);
             long pos = lep.getFirstEntryPosition();
@@ -730,7 +669,7 @@ public class IndexPersistenceMgr {
     }
 
     long getPersistEntryBeyondInMem(long ledgerId, long lastEntryInMem) throws IOException {
-        FileInfo fi = null;
+        CachedFileInfo fi = null;
         long lastEntry = lastEntryInMem;
         try {
             fi = getFileInfo(ledgerId, null);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.bookie.Bookie.NoLedgerException;
+import org.apache.bookkeeper.bookie.FileInfoBackingCache.CachedFileInfo;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
@@ -272,7 +273,6 @@ public class LedgerCacheTest {
         File ledgerDir2 = createTempDir("bkTest", ".dir");
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setLedgerDirNames(new String[] { ledgerDir1.getAbsolutePath(), ledgerDir2.getAbsolutePath() });
-        conf.setJournalDirName(ledgerDir1.toString());
 
         Bookie bookie = new Bookie(conf);
         InterleavedLedgerStorage ledgerStorage = ((InterleavedLedgerStorage) bookie.ledgerStorage);
@@ -280,12 +280,13 @@ public class LedgerCacheTest {
         // Create ledger index file
         ledgerStorage.setMasterKey(1, "key".getBytes());
 
-        FileInfo fileInfo = ledgerCache.getIndexPersistenceManager().getFileInfo(Long.valueOf(1), null);
+        CachedFileInfo fileInfo = ledgerCache.getIndexPersistenceManager().getFileInfo(Long.valueOf(1), null);
+        fileInfo.release();
 
-        // Simulate the flush failure
-        FileInfo newFileInfo = new FileInfo(fileInfo.getLf(), fileInfo.getMasterKey());
-        ledgerCache.getIndexPersistenceManager().writeFileInfoCache.put(Long.valueOf(1), newFileInfo);
-        ledgerCache.getIndexPersistenceManager().readFileInfoCache.put(Long.valueOf(1), newFileInfo);
+        // Simulate the flush failure (force the caches to release their refcount on the fileinfo)
+        ledgerCache.getIndexPersistenceManager().writeFileInfoCache.put(Long.valueOf(1), fileInfo);
+        ledgerCache.getIndexPersistenceManager().readFileInfoCache.put(Long.valueOf(1), fileInfo);
+
         // Add entries
         ledgerStorage.addEntry(generateEntry(1, 1));
         ledgerStorage.addEntry(generateEntry(1, 2));
@@ -294,13 +295,13 @@ public class LedgerCacheTest {
         ledgerStorage.addEntry(generateEntry(1, 3));
         // add the dir to failed dirs
         bookie.getIndexDirsManager().addToFilledDirs(
-                newFileInfo.getLf().getParentFile().getParentFile().getParentFile());
-        File before = newFileInfo.getLf();
+                fileInfo.getLf().getParentFile().getParentFile().getParentFile());
+        File before = fileInfo.getLf();
         // flush after disk is added as failed.
         ledgerStorage.flush();
-        File after = newFileInfo.getLf();
+        File after = fileInfo.getLf();
 
-        assertEquals("Reference counting for the file info should be zero.", 0, newFileInfo.getUseCount());
+        assertEquals("Reference counting for the file info should be zero.", 0, fileInfo.getRefCount());
 
         assertFalse("After flush index file should be changed", before.equals(after));
         // Verify written entries

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -281,11 +281,6 @@ public class LedgerCacheTest {
         ledgerStorage.setMasterKey(1, "key".getBytes());
 
         CachedFileInfo fileInfo = ledgerCache.getIndexPersistenceManager().getFileInfo(Long.valueOf(1), null);
-        fileInfo.release();
-
-        // Simulate the flush failure (force the caches to release their refcount on the fileinfo)
-        ledgerCache.getIndexPersistenceManager().writeFileInfoCache.put(Long.valueOf(1), fileInfo);
-        ledgerCache.getIndexPersistenceManager().readFileInfoCache.put(Long.valueOf(1), fileInfo);
 
         // Add entries
         ledgerStorage.addEntry(generateEntry(1, 1));
@@ -300,8 +295,6 @@ public class LedgerCacheTest {
         // flush after disk is added as failed.
         ledgerStorage.flush();
         File after = fileInfo.getLf();
-
-        assertEquals("Reference counting for the file info should be zero.", 0, fileInfo.getRefCount());
 
         assertFalse("After flush index file should be changed", before.equals(after));
         // Verify written entries

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestFileInfoBackingCache.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestFileInfoBackingCache.java
@@ -1,0 +1,148 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.bookie.FileInfoBackingCache.CachedFileInfo;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for FileInfoBackingCache.
+ */
+@Slf4j
+public class TestFileInfoBackingCache {
+    final byte[] masterKey = new byte[0];
+    final File baseDir;
+
+    public TestFileInfoBackingCache() throws Exception {
+        baseDir = File.createTempFile("foo", "bar");
+    }
+
+    @Before
+    public void setupDir() throws Exception {
+        Assert.assertTrue(baseDir.delete());
+        Assert.assertTrue(baseDir.mkdirs());
+        baseDir.deleteOnExit();
+    }
+
+    @Test
+    public void basicTest() throws Exception {
+        FileInfoBackingCache cache = new FileInfoBackingCache(
+                (ledgerId, createIfNotFound) -> {
+                    File f = new File(baseDir, String.valueOf(ledgerId));
+                    f.deleteOnExit();
+                    return f;
+                });
+        CachedFileInfo fi = cache.loadFileInfo(1, masterKey);
+        Assert.assertEquals(fi.getRefCount(), 1);
+        CachedFileInfo fi2 = cache.loadFileInfo(2, masterKey);
+        Assert.assertEquals(fi2.getRefCount(), 1);
+        CachedFileInfo fi3 = cache.loadFileInfo(1, null);
+        Assert.assertEquals(fi, fi3);
+        Assert.assertEquals(fi3.getRefCount(), 2);
+
+        // check that it expires correctly
+        fi.release();
+        fi3.release();
+
+        Assert.assertEquals(fi.getRefCount(), 0);
+        CachedFileInfo fi4 = cache.loadFileInfo(1, null);
+        Assert.assertFalse(fi4 == fi);
+        Assert.assertEquals(fi.getRefCount(), 0);
+        Assert.assertEquals(fi4.getRefCount(), 1);
+        Assert.assertEquals(fi.getLf(), fi4.getLf());
+    }
+
+    @Test(expected = IOException.class)
+    public void testNoKey() throws Exception {
+        FileInfoBackingCache cache = new FileInfoBackingCache(
+                (ledgerId, createIfNotFound) -> {
+                    Assert.assertFalse(createIfNotFound);
+                    throw new Bookie.NoLedgerException(ledgerId);
+                });
+        cache.loadFileInfo(1, null);
+    }
+
+    /**
+     * Of course this can't prove they don't exist, but
+     * try to shake them out none the less.
+     */
+    @Test
+    public void testForDeadlocks() throws Exception {
+        int numThreads = 20;
+        int maxLedgerId = 10;
+        AtomicBoolean done = new AtomicBoolean(false);
+        CountDownLatch success = new CountDownLatch(numThreads);
+        FileInfoBackingCache cache = new FileInfoBackingCache(
+                (ledgerId, createIfNotFound) -> {
+                    File f = new File(baseDir, String.valueOf(ledgerId));
+                    f.deleteOnExit();
+                    return f;
+                });
+        for (int i = 0; i < numThreads; i++) {
+            Thread t = new Thread(() -> {
+                    try {
+                        Random r = new Random();
+                        List<CachedFileInfo> fileInfos = new ArrayList<>();
+                        while (!done.get()) {
+                            if (r.nextBoolean() && fileInfos.size() < 5) { // take a reference
+                                fileInfos.add(cache.loadFileInfo(r.nextInt(maxLedgerId), masterKey));
+                            } else { // release a reference
+                                Collections.shuffle(fileInfos);
+                                if (!fileInfos.isEmpty()) {
+                                    fileInfos.remove(0).release();
+                                }
+                            }
+                        }
+                        for (CachedFileInfo fi : fileInfos) {
+                            fi.release();
+                        }
+                        success.countDown();
+                    } catch (Exception e) {
+                        log.error("Something nasty happened, success will never complete", e);
+                    }
+                }, "HammerThread-" + i);
+            t.setDaemon(true);
+            t.start();
+        }
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+        done.set(true);
+        Assert.assertTrue(success.await(5, TimeUnit.SECONDS));
+
+        // try to load all ledgers again.
+        // They should be loaded fresh (i.e. this load should be only reference)
+        for (int i = 0; i < maxLedgerId; i++) {
+            Assert.assertEquals(1, cache.loadFileInfo(i, masterKey).getRefCount());
+        }
+    }
+}


### PR DESCRIPTION
There is a number of bugs in index persistence mgr related to how
refcounts are handled and how FileInfos are freed, due to the locking
mechanism. These can result in the fencing bit being lost in ledgers,
which is a serious issue. They also cause flakes in
IndexPersistenceMgrTest#testEvictFileInfoWhenUnderlyingFileExists.

For details see the discussion at:
https://github.com/apache/bookkeeper/pull/513/files/8075b0#r156676238

There are two key problems.

1. FileInfos are flushed asynchronously on eviction. If another thread
tries to read the FileInfo after the flush has been scheduled, but
before it runs, it will read stale date (and we'll possibly lose the
fence bit).
2. FileInfos can be closed while it is still references in the
IndexPersistenceMgr. This means that it can be fenced, but this will
very be flushed to disk because the FileInfo is already closed.

The patch solves this by moving FileInfo locking and refcount into a
separate class, FileInfoBackingCache. When either the write cache or
read cache load a file info, it tries to load it from this backing
cache. All writes to the the backing cache are done under a write
lock. This class also takes care of reference counting. It hands out
CachedFileInfo objects, which will be flushed to disk when all
references are released.
