### PR TITLE
Add descriptive message for TooManyRequestsException

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
@@ -126,6 +126,8 @@ public abstract class BKException extends Exception {
             return "Attempting to use an unclosed fragment; This is not safe";
         case Code.WriteOnReadOnlyBookieException:
             return "Attempting to write on ReadOnly bookie";
+        case Code.TooManyRequestsException:
+            return "Too many requests to the same Bookie";
         case Code.LedgerIdOverflowException:
             return "Next ledgerID is too large.";
         case Code.ReplicationException:

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BKExceptionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BKExceptionTest.java
@@ -37,9 +37,9 @@ public class BKExceptionTest {
                 int code = f.getInt(null);
                 String msg = BKException.getMessage(code);
                 if (code == UnexpectedConditionException) {
-                    assertEquals(msg, "Unexpected condition");
+                    assertEquals("Unexpected condition", msg);
                 } else {
-                    assertNotEquals("failure on code " + f.getName(), msg, "Unexpected condition");
+                    assertNotEquals("failure on code " + f.getName(), "Unexpected condition", msg);
                 }
                 count++;
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BKExceptionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BKExceptionTest.java
@@ -17,6 +17,7 @@ package org.apache.bookkeeper.client.api;
 
 import static org.apache.bookkeeper.client.api.BKException.Code.UnexpectedConditionException;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
@@ -31,6 +32,7 @@ public class BKExceptionTest {
     @Test
     public void testGetMessage() throws Exception {
         Field[] fields = BKException.Code.class.getFields();
+        int count = 0;
         for (Field f : fields) {
             if (f.getType() == Integer.TYPE && !f.getName().equals("UNINITIALIZED")) {
                 int code = f.getInt(null);
@@ -41,7 +43,10 @@ public class BKExceptionTest {
                     assertThat("failure on code " + f.getName(), msg,
                                not(equalTo("Unexpected condition")));
                 }
+                count++;
             }
         }
+        // assert that we found at least 1 code other than UnexpectedConditionException
+        assertThat(count, greaterThan(2));
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BKExceptionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BKExceptionTest.java
@@ -16,10 +16,9 @@
 package org.apache.bookkeeper.client.api;
 
 import static org.apache.bookkeeper.client.api.BKException.Code.UnexpectedConditionException;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
 import org.junit.Test;
@@ -38,15 +37,14 @@ public class BKExceptionTest {
                 int code = f.getInt(null);
                 String msg = BKException.getMessage(code);
                 if (code == UnexpectedConditionException) {
-                    assertThat(msg, equalTo("Unexpected condition"));
+                    assertEquals(msg, "Unexpected condition");
                 } else {
-                    assertThat("failure on code " + f.getName(), msg,
-                               not(equalTo("Unexpected condition")));
+                    assertNotEquals("failure on code " + f.getName(), msg, "Unexpected condition");
                 }
                 count++;
             }
         }
         // assert that we found at least 1 code other than UnexpectedConditionException
-        assertThat(count, greaterThan(2));
+        assertTrue(count > 2);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BKExceptionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BKExceptionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client.api;
+
+import static org.apache.bookkeeper.client.api.BKException.Code.UnexpectedConditionException;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.Field;
+import org.junit.Test;
+
+/**
+ * Tests for BKException methods.
+ */
+public class BKExceptionTest {
+
+    @Test
+    public void testGetMessage() throws Exception {
+        Field[] fields = BKException.Code.class.getFields();
+        for (Field f : fields) {
+            if (f.getType() == Integer.TYPE && !f.getName().equals("UNINITIALIZED")) {
+                int code = f.getInt(null);
+                String msg = BKException.getMessage(code);
+                if (code == UnexpectedConditionException) {
+                    assertThat(msg, equalTo("Unexpected condition"));
+                } else {
+                    assertThat("failure on code " + f.getName(), msg,
+                               not(equalTo("Unexpected condition")));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
After upgrading from 4.5 to 4.6 I found a lot of "Unexpected condition" in some benchmarks.

TooManyRequestsException is a new error introduced in 4.6, there is not description, so the default description is "Unexpected condition", without a debugger it is not possible to understand the cause of the error.
