### PR TITLE
Issue 922: changes to shading bookkeeper-server jar for branch-4.6

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -66,7 +66,7 @@
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
-		</exclusion>
+	</exclusion>
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty</artifactId>
@@ -204,52 +204,26 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>true</createDependencyReducedPom>
-              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>
               <minimizeJar>true</minimizeJar>
               <shadeTestJar>true</shadeTestJar>
               <artifactSet>
                 <includes>
-                  <include>org.apache.bookkeeper:bookkeeper-proto</include>
-                  <include>com.google.protobuf:protobuf-java</include>
                   <include>com.google.guava:guava</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+                  <include>org.apache.bookkeeper:bookkeeper-common</include>
+                  <include>org.apache.bookkeeper:bookkeeper-proto</include>
+                  <include>org.apache.bookkeeper.stats:bookkeeper-stats-api</include>
                 </includes>
               </artifactSet>
               <relocations>
                 <relocation>
-                  <pattern>com.google.protobuf</pattern>
-                  <shadedPattern>bk-shade.com.google.proto_${protobuf.version}</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>com.google</pattern>
-                  <shadedPattern>bk-shade.com.google</shadedPattern>
+                  <shadedPattern>org.apache.bookkeeper.shaded.com.google</shadedPattern>
                 </relocation>
               </relocations>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <version>1.6</version>
-        <configuration>
-          <canUpdateCopyright>false</canUpdateCopyright>
-          <roots><root>${project.basedir}</root></roots>
-        </configuration>
-        <executions>
-          <execution>
-            <id>update-pom-license</id>
-            <goals>
-              <goal>update-file-header</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <licenseName>apache_v2</licenseName>
-              <includes>
-                <include>dependency-reduced-pom.xml</include>
-              </includes>
             </configuration>
           </execution>
         </executions>
@@ -316,12 +290,6 @@
             <fileset>
               <directory>${project.libdir}</directory>
               <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>${project.basedir}</directory>
-              <includes>
-                <include>dependency-reduced-pom.xml</include>
-              </includes>
             </fileset>
           </filesets>
 	</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <module>bookkeeper-benchmark</module>
     <module>bookkeeper-stats-providers</module>
     <module>bookkeeper-http</module>
+    <module>shaded</module>
     <module>tests</module>
     <module>bookkeeper-dist</module>
   </modules>

--- a/shaded/bookkeeper-server-shaded/pom.xml
+++ b/shaded/bookkeeper-server-shaded/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.bookkeeper</groupId>
+    <artifactId>shaded-parent</artifactId>
+    <version>4.7.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>bookkeeper-server-shaded</artifactId>
+  <name>Apache BookKeeper :: Shaded :: bookkeeper-server-shaded</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <minimizeJar>false</minimizeJar>
+              <artifactSet>
+                <includes>
+                  <include>com.google.guava:guava</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+                  <include>org.apache.bookkeeper:bookkeeper-common</include>
+                  <include>org.apache.bookkeeper:bookkeeper-proto</include>
+                  <include>org.apache.bookkeeper:bookkeeper-server</include>
+                  <include>org.apache.bookkeeper.stats:bookkeeper-stats-api</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>org.apache.bookkeeper.shaded.com.google</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin> 
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>1.6</version>
+        <configuration>
+          <canUpdateCopyright>false</canUpdateCopyright>
+          <roots><root>${project.basedir}</root></roots>
+        </configuration>
+        <executions>
+          <execution>
+            <id>update-pom-license</id>
+            <goals>
+              <goal>update-file-header</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <licenseName>apache_v2</licenseName>
+              <includes>
+                <include>dependency-reduced-pom.xml</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.5</version>
+	<configuration>
+	  <filesets>
+            <fileset>
+              <directory>${project.basedir}</directory>
+              <includes>
+                <include>dependency-reduced-pom.xml</include>
+              </includes>
+            </fileset>
+          </filesets>
+	</configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/shaded/bookkeeper-server-shaded/pom.xml
+++ b/shaded/bookkeeper-server-shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>shaded-parent</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-shaded</artifactId>
@@ -81,7 +81,7 @@
             </configuration>
           </execution>
         </executions>
-      </plugin> 
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>

--- a/shaded/bookkeeper-server-tests-shaded/pom.xml
+++ b/shaded/bookkeeper-server-tests-shaded/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.bookkeeper</groupId>
+    <artifactId>shaded-parent</artifactId>
+    <version>4.7.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>bookkeeper-server-tests-shaded</artifactId>
+  <name>Apache BookKeeper :: Shaded :: bookkeeper-server-tests-shaded</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server-shaded</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server</artifactId>
+      <type>test-jar</type>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>bookkeeper-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>bookkeeper-proto</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>bookkeeper-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper.stats</groupId>
+          <artifactId>bookkeeper-stats-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <minimizeJar>false</minimizeJar>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.bookkeeper:bookkeeper-server:test-jar:tests</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>org.apache.bookkeeper.shaded.com.google</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin> 
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>1.6</version>
+        <configuration>
+          <canUpdateCopyright>false</canUpdateCopyright>
+          <roots><root>${project.basedir}</root></roots>
+        </configuration>
+        <executions>
+          <execution>
+            <id>update-pom-license</id>
+            <goals>
+              <goal>update-file-header</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <licenseName>apache_v2</licenseName>
+              <includes>
+                <include>dependency-reduced-pom.xml</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.5</version>
+	<configuration>
+	  <filesets>
+            <fileset>
+              <directory>${project.basedir}</directory>
+              <includes>
+                <include>dependency-reduced-pom.xml</include>
+              </includes>
+            </fileset>
+          </filesets>
+	</configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/shaded/bookkeeper-server-tests-shaded/pom.xml
+++ b/shaded/bookkeeper-server-tests-shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>shaded-parent</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-tests-shaded</artifactId>
@@ -98,7 +98,7 @@
             </configuration>
           </execution>
         </executions>
-      </plugin> 
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -15,36 +15,20 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.6.0-SNAPSHOT</version>
+    <version>4.7.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.bookkeeper.tests</groupId>
-  <artifactId>tests-parent</artifactId>
-  <name>Apache BookKeeper :: Tests</name>
+  <groupId>org.apache.bookkeeper</groupId>
+  <artifactId>shaded-parent</artifactId>
+  <name>Apache BookKeeper :: Shaded :: Parent</name>
   <modules>
-    <module>bookkeeper-server-compat-4.0.0</module>
-    <module>bookkeeper-server-compat-4.1.0</module>
-    <module>bookkeeper-server-compat-4.2.0</module>
-    <module>backward</module>
-    <module>bookkeeper-server-shaded-artifact-test</module>
-    <module>bookkeeper-server-shaded-test</module>
-    <module>bookkeeper-server-tests-shaded-test</module>
+    <module>bookkeeper-server-shaded</module>
+    <module>bookkeeper-server-tests-shaded</module>
   </modules>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>
   <artifactId>shaded-parent</artifactId>

--- a/site/docs/latest/api/ledger-api.md
+++ b/site/docs/latest/api/ledger-api.md
@@ -30,6 +30,51 @@ If you're using [Maven](https://maven.apache.org/), add this to your [`pom.xml`]
 </dependency>
 ```
 
+BookKeeper uses google [protobuf](https://github.com/google/protobuf/tree/master/java) and [guava](https://github.com/google/guava) libraries
+a lot. If your application might include different versions of protobuf or guava introduced by other dependencies, you can choose to use the
+shaded library, which relocate classes of protobuf and guava into a different namespace to avoid conflicts.
+
+You can use the shaded artifact of `bookkeeper-server`. Please note that [maven-shade-plugin](https://maven.apache.org/plugins/maven-shade-plugin) doesn't generate
+a dependency-reduced pom file for shaded artifact using [shadedArtifactAttached](https://maven.apache.org/plugins/maven-shade-plugin/examples/attached-artifact.html). You need to manually to exclude relocated packages when using the shaded artifact. Full example of how to use this is
+showed as below.
+
+```xml
+<!-- in your <properties> block -->
+<bookkeeper.version>{{ site.latest_version }}</bookkeeper.version>
+
+<!-- in your <dependencies> block -->
+<dependency>
+  <groupId>org.apache.bookkeeper</groupId>
+  <artifactId>bookkeeper-server</artifactId>
+  <version>${bookkeeper.version}</version>
+  <classifier>shaded</classifier> <!-- specify "shaded" classifier to use shaded artifact -->
+  <exclusions>
+    <exclusion>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-common</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-proto</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+```
+
+Or you can use a separate shaded artifact `bookkeeper-server-shaded`.
+
+```xml
+<!-- in your <properties> block -->
+<bookkeeper.version>{{ site.latest_version }}</bookkeeper.version>
+
+<!-- in your <dependencies> block -->
+<dependency>
+  <groupId>org.apache.bookkeeper</groupId>
+  <artifactId>bookkeeper-server-shaded</artifactId>
+  <version>${bookkeeper.version}</version>
+</dependency>
+```
+
 ### Gradle
 
 If you're using [Gradle](https://gradle.org/), add this to your [`build.gradle`](https://spring.io/guides/gs/gradle/) build configuration file:
@@ -42,6 +87,24 @@ dependencies {
 // Alternatively:
 dependencies {
     compile 'org.apache.bookkeeper:bookkeeper-server:{{ site.latest_version }}'
+}
+```
+
+Similarly as using maven, you can also configure to use the shaded jars.
+
+```groovy
+// use the shaded artifact of `bookkeeper-server` jar
+dependencies {
+    compile ('org.apache.bookkeeper:bookkeeper-server:{{ site.latest-version }}:shaded') {
+        exclude group: 'org.apache.bookkeeper', module: "bookkeeper-common'
+        exclude group: 'org.apache.bookkeeper', module: 'bookkeeper-proto'
+    }
+}
+
+
+// use the `bookkeeper-server-shaded` jar
+dependencies {
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
 }
 ```
 

--- a/tests/bookkeeper-server-shaded-artifact-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-artifact-test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-shaded-artifact-test</artifactId>

--- a/tests/bookkeeper-server-shaded-artifact-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-artifact-test/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.bookkeeper.tests</groupId>
+    <artifactId>tests-parent</artifactId>
+    <version>4.7.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>bookkeeper-server-shaded-artifact-test</artifactId>
+  <name>Apache BookKeeper :: Tests :: bookkeeper-server shaded artifact test</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server</artifactId>
+      <version>${project.version}</version>
+      <classifier>shaded</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>bookkeeper-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>bookkeeper-proto</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${puppycrawl.checkstyle.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.bookkeeper</groupId>
+            <artifactId>buildtools</artifactId>
+            <version>${project.parent.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configLocation>bookkeeper/checkstyle.xml</configLocation>
+          <suppressionsLocation>bookkeeper/suppressions.xml</suppressionsLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <includeResources>false</includeResources>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/bookkeeper-server-shaded-artifact-test/src/test/java/org/apache/bookkeeper/tests/shaded/BookKeeperServerShadedArtifactTest.java
+++ b/tests/bookkeeper-server-shaded-artifact-test/src/test/java/org/apache/bookkeeper/tests/shaded/BookKeeperServerShadedArtifactTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tests.shaded;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Test whether the shaded artifact of `bookkeeper-server` is generated correctly.
+ */
+public class BookKeeperServerShadedArtifactTest {
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testProtobufIsShaded() throws Exception {
+        Class.forName("com.google.protobuf.Message");
+    }
+
+    @Test
+    public void testProtobufShadedPath() throws Exception {
+        Class.forName("org.apache.bookkeeper.shaded.com.google.protobuf.Message");
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testGuavaIsShaded() throws Exception {
+        Class.forName("com.google.common.cache.Cache");
+    }
+
+    @Test
+    public void testGuavaShadedPath() throws Exception {
+        Class.forName("org.apache.bookkeeper.shaded.com.google.common.cache.Cache");
+        assertTrue(true);
+    }
+
+    @Test
+    public void testBookKeeperCommon() throws Exception {
+        Class.forName("org.apache.bookkeeper.util.OrderedSafeExecutor");
+        assertTrue(true);
+    }
+
+    @Test
+    public void testBookKeeperProto() throws Exception {
+        Class.forName("org.apache.bookkeeper.proto.BookkeeperProtocol");
+        assertTrue(true);
+    }
+}

--- a/tests/bookkeeper-server-shaded-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-test/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.bookkeeper.tests</groupId>
+    <artifactId>tests-parent</artifactId>
+    <version>4.7.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>bookkeeper-server-shaded-test</artifactId>
+  <name>Apache BookKeeper :: Tests :: bookkeeper-server-shaded test</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server-shaded</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <!-- when running `mvn install` in the whole project,
+           it will still reference none dependency-reduced
+           pom file. so exclude these dependencies explicitly
+           to verify protobuf and guava classes have been relocated -->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${puppycrawl.checkstyle.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.bookkeeper</groupId>
+            <artifactId>buildtools</artifactId>
+            <version>${project.parent.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configLocation>bookkeeper/checkstyle.xml</configLocation>
+          <suppressionsLocation>bookkeeper/suppressions.xml</suppressionsLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <includeResources>false</includeResources>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/bookkeeper-server-shaded-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-shaded-test</artifactId>

--- a/tests/bookkeeper-server-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/BookKeeperServerShadedJarTest.java
+++ b/tests/bookkeeper-server-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/BookKeeperServerShadedJarTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tests.shaded;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Test whether the bookkeeper-server-shaded jar is generated correctly.
+ */
+public class BookKeeperServerShadedJarTest {
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testProtobufIsShaded() throws Exception {
+        Class.forName("com.google.protobuf.Message");
+    }
+
+    @Test
+    public void testProtobufShadedPath() throws Exception {
+        Class.forName("org.apache.bookkeeper.shaded.com.google.protobuf.Message");
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testGuavaIsShaded() throws Exception {
+        Class.forName("com.google.common.cache.Cache");
+    }
+
+    @Test
+    public void testGuavaShadedPath() throws Exception {
+        Class.forName("org.apache.bookkeeper.shaded.com.google.common.cache.Cache");
+        assertTrue(true);
+    }
+
+    @Test
+    public void testBookKeeperCommon() throws Exception {
+        Class.forName("org.apache.bookkeeper.util.OrderedSafeExecutor");
+        assertTrue(true);
+    }
+
+    @Test
+    public void testBookKeeperProto() throws Exception {
+        Class.forName("org.apache.bookkeeper.proto.BookkeeperProtocol");
+        assertTrue(true);
+    }
+}

--- a/tests/bookkeeper-server-tests-shaded-test/pom.xml
+++ b/tests/bookkeeper-server-tests-shaded-test/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.bookkeeper.tests</groupId>
+    <artifactId>tests-parent</artifactId>
+    <version>4.7.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>bookkeeper-server-tests-shaded-test</artifactId>
+  <name>Apache BookKeeper :: Tests :: bookkeeper-server-tests-shaded test</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server-shaded</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <!-- when running `mvn install` in the whole project,
+           it will still reference none dependency-reduced
+           pom file. so exclude these dependencies explicitly
+           to verify protobuf and guava classes have been relocated -->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server-tests-shaded</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <!-- when running `mvn install` in the whole project,
+           it will still reference none dependency-reduced
+           pom file. so exclude these dependencies explicitly
+           to verify protobuf and guava classes have been relocated -->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${puppycrawl.checkstyle.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.bookkeeper</groupId>
+            <artifactId>buildtools</artifactId>
+            <version>${project.parent.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configLocation>bookkeeper/checkstyle.xml</configLocation>
+          <suppressionsLocation>bookkeeper/suppressions.xml</suppressionsLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <includeResources>false</includeResources>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/bookkeeper-server-tests-shaded-test/pom.xml
+++ b/tests/bookkeeper-server-tests-shaded-test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-tests-shaded-test</artifactId>

--- a/tests/bookkeeper-server-tests-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/BookKeeperServerTestsShadedJarTest.java
+++ b/tests/bookkeeper-server-tests-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/BookKeeperServerTestsShadedJarTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tests.shaded;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Test whether the bookkeeper-server-tests-shaded jar is generated correctly.
+ */
+public class BookKeeperServerTestsShadedJarTest {
+
+    @Test
+    public void testTestBKConfiguration() throws Exception {
+        Class.forName("org.apache.bookkeeper.conf.TestBKConfiguration");
+        assertTrue(true);
+    }
+
+    /**
+     * TestPerChannelBookieClient imports protobuf classes.
+     */
+    @Test
+    public void testTestPerChannelBookieClient() throws Exception {
+        Class.forName("org.apache.bookkeeper.proto.TestPerChannelBookieClient");
+        assertTrue(true);
+    }
+
+    /**
+     * BookieShellTest imports guava classes.
+     */
+    @Test
+    public void testBookieShellTest() throws Exception {
+        Class.forName("org.apache.bookkeeper.bookie.BookieShellTest");
+        assertTrue(true);
+    }
+
+}


### PR DESCRIPTION
This is a cherry-pick for branch-4.6.

Descriptions of the changes in this PR:
**Problem:**

`shadedArtifactAttached` was introduced in 4.6.0 to generate plain and shaded artifact for `bookkeeper-server`. Because for projects (e.g. distributedlog) that would use same protobuf and guava version as bookkeeper, they will use the plain artifact (to avoid shading protobuf/guava multiple times). However there are a few problems with that:

1) bookkeeper-common is not included in the shading include set.
2) `shadedArtifactAttached` only generate a shaded artifact (with relocated classes), but doesn't generate a dependency-reduced pom file. so you have to manually exclude relocated dependencies.

**Solutions:**

- for shaded artifact of `bookkeeper-server`, include all the bookkeeper submodules that bookkeeper-server depends on. so the shaded artifact includes all the classes that need to be relocated.
- introduce a `shaded` module for keeping new shaded libraries. Currently `bookkeeper-server-shaded` is a shaded module of `bookkeeper-server`, while `bookkeeper-server-tests-shaded` is a shaded moulde of the tests jar of `bookkeeper-server`.
- update the client api documentation about the instructions on how to use shaded artifact of `bookkeeper-server` and the new shaded module `bookkeeper-server-shaded`.
- add test cases to verify the shaded artifact and the new shaded modules generate the right artifacts.

**This change doesn't address:**

Currently both client and server are bundled in one `bookkeeper-server`. this change will not introduce any shaded client-only jar. that would be deferred until we split `bookkeeper-server` module.
