### PR TITLE
ISSUE #931,#907: Add option to track task execution time

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
@@ -154,7 +154,9 @@ public class OrderedScheduler {
 
         @Override
         public void safeRun() {
-            taskPendingStats.registerSuccessfulEvent(initNanos, TimeUnit.NANOSECONDS);
+            taskPendingStats.registerSuccessfulEvent(
+                    MathUtils.elapsedNanos(initNanos),
+                    TimeUnit.NANOSECONDS);
             long startNanos = MathUtils.nowInNano();
             this.runnable.safeRun();
             long elapsedMicroSec = MathUtils.elapsedMicroSec(startNanos);
@@ -325,7 +327,7 @@ public class OrderedScheduler {
      * @param r
      */
     public void submitOrdered(long orderingKey, SafeRunnable r) {
-        chooseThread(orderingKey).execute(r);
+        chooseThread(orderingKey).execute(timedRunnable(r));
     }
 
     /**
@@ -335,7 +337,7 @@ public class OrderedScheduler {
      * @param r
      */
     public void submitOrdered(int orderingKey, SafeRunnable r) {
-        chooseThread(orderingKey).execute(r);
+        chooseThread(orderingKey).execute(timedRunnable(r));
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -182,6 +182,9 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     // Registration
     protected static final String REGISTRATION_MANAGER_CLASS = "registrationManagerClass";
 
+    // Stats
+    protected static final String ENABLE_TASK_EXECUTION_STATS = "enableTaskExecutionStats";
+
     /**
      * Construct a default configuration object.
      */
@@ -2409,6 +2412,28 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setTLSTrustStorePasswordPath(String arg) {
         setProperty(TLS_TRUSTSTORE_PASSWORD_PATH, arg);
+        return this;
+    }
+
+
+    /**
+     * Whether to enable recording task execution stats.
+     *
+     * @return flag to enable/disable recording task execution stats.
+     */
+    public boolean getEnableTaskExecutionStats() {
+        return getBoolean(ENABLE_TASK_EXECUTION_STATS, false);
+    }
+
+    /**
+     * Enable/Disable recording task execution stats.
+     *
+     * @param enabled
+     *          flag to enable/disable recording task execution stats.
+     * @return client configuration.
+     */
+    public ServerConfiguration setEnableTaskExecutionStats(boolean enabled) {
+        setProperty(ENABLE_TASK_EXECUTION_STATS, enabled);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
@@ -1,0 +1,125 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.test;
+
+import static org.apache.bookkeeper.bookie.BookKeeperServerStats.SERVER_SCOPE;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.BiConsumer;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.util.MathUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Basic tests to verify that stats are being updated as expected.
+ */
+public class OpStatTest extends BookKeeperClusterTestCase {
+    private LedgerHandle lh;
+
+    public OpStatTest() {
+        super(1);
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        lh = bkc.createLedger(1, 1, BookKeeper.DigestType.CRC32, "".getBytes());
+        resetBookieOpLoggers();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        lh.close();
+        lh = null;
+        super.tearDown();
+    }
+
+    private void validateOpStat(TestStatsProvider stats, String path, BiConsumer<Long, Double> f) {
+        assertTrue(stats != null);
+        TestStatsProvider.TestOpStatsLogger logger = stats.getOpStatsLogger(path);
+        assertTrue(logger != null);
+        f.accept(logger.getSuccessCount(), logger.getSuccessAverage());
+    }
+
+    private void validateOpStat(TestStatsProvider stats, String paths[], BiConsumer<Long, Double> f) {
+        for (String path : paths) {
+            validateOpStat(stats, path, f);
+        }
+    }
+
+    @Test
+    public void testTopLevelBookieWriteCounters() throws Exception {
+        long startNanos = MathUtils.nowInNano();
+        lh.addEntry("test".getBytes());
+        long elapsed = MathUtils.elapsedNanos(startNanos);
+        TestStatsProvider stats = getStatsProvider(0);
+        validateOpStat(stats, new String[]{
+                SERVER_SCOPE + ".ADD_ENTRY",
+                SERVER_SCOPE + ".ADD_ENTRY_REQUEST",
+                SERVER_SCOPE + ".BookieWriteThreadPool.task_queued",
+                SERVER_SCOPE + ".BookieWriteThreadPool.task_execution",
+                SERVER_SCOPE + ".CHANNEL_WRITE"
+        }, (count, average) -> {
+            assertTrue(count == 1);
+            assertTrue(average > 0);
+            assertTrue(average <= elapsed);
+        });
+        validateOpStat(stats, new String[]{
+                SERVER_SCOPE + ".CHANNEL_WRITE"
+        }, (count, average) -> {
+            assertTrue(count > 0);
+            assertTrue(average > 0);
+            assertTrue(average <= elapsed);
+        });
+    }
+
+    @Test
+    public void testTopLevelBookieReadCounters() throws Exception {
+        long startNanos = MathUtils.nowInNano();
+        lh.addEntry("test".getBytes());
+        lh.readEntries(0, 0);
+        long elapsed = MathUtils.elapsedNanos(startNanos);
+        TestStatsProvider stats = getStatsProvider(0);
+        validateOpStat(stats, new String[]{
+                SERVER_SCOPE + ".READ_ENTRY",
+                SERVER_SCOPE + ".READ_ENTRY_REQUEST",
+                SERVER_SCOPE + ".BookieReadThreadPool.task_queued",
+                SERVER_SCOPE + ".BookieReadThreadPool.task_execution",
+        }, (count, average) -> {
+            assertTrue(count == 1);
+            assertTrue(average > 0);
+            assertTrue(average <= elapsed);
+        });
+        validateOpStat(stats, new String[]{
+                SERVER_SCOPE + ".CHANNEL_WRITE"
+        }, (count, average) -> {
+            assertTrue(count > 0);
+            assertTrue(average > 0);
+            assertTrue(average <= elapsed);
+        });
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
@@ -1,0 +1,245 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.Gauge;
+import org.apache.bookkeeper.stats.OpStatsData;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.stats.StatsProvider;
+import org.apache.commons.configuration.Configuration;
+
+/**
+ * Simple in-memory stat provider for use in unit tests.
+ */
+public class TestStatsProvider implements StatsProvider {
+    /**
+     * In-memory counter.
+     */
+    public class TestCounter implements Counter {
+        private AtomicLong val = new AtomicLong(0);
+
+        @Override
+        public void clear() {
+            val.set(0);
+        }
+
+        @Override
+        public void inc() {
+            val.incrementAndGet();
+        }
+
+        @Override
+        public void dec() {
+            val.decrementAndGet();
+        }
+
+        @Override
+        public void add(long delta) {
+            val.addAndGet(delta);
+        }
+
+        @Override
+        public Long get() {
+            return val.get();
+        }
+    }
+
+    /**
+     * In-memory StatsLogger.
+     */
+    public class TestOpStatsLogger implements OpStatsLogger {
+        private long successCount;
+        private long successValue;
+
+        private long failureCount;
+        private long failureValue;
+
+        TestOpStatsLogger() {
+            clear();
+        }
+
+        @Override
+        public void registerFailedEvent(long eventLatency, TimeUnit unit) {
+            registerFailedValue(unit.convert(eventLatency, TimeUnit.NANOSECONDS));
+        }
+
+        @Override
+        public void registerSuccessfulEvent(long eventLatency, TimeUnit unit) {
+            registerSuccessfulValue(unit.convert(eventLatency, TimeUnit.NANOSECONDS));
+        }
+
+        @Override
+        public synchronized void registerSuccessfulValue(long value) {
+            successCount++;
+            successValue += value;
+        }
+
+        @Override
+        public synchronized void registerFailedValue(long value) {
+            failureCount++;
+            failureValue += value;
+        }
+
+        @Override
+        public OpStatsData toOpStatsData() {
+            // Not supported at this time
+            return null;
+        }
+
+        @Override
+        public synchronized void clear() {
+            successCount = 0;
+            successValue = 0;
+            failureCount = 0;
+            failureValue = 0;
+        }
+
+        public synchronized double getSuccessAverage() {
+            if (successCount == 0) {
+                return 0;
+            }
+            return successValue / (double) successCount;
+        }
+
+        public synchronized long getSuccessCount() {
+            return successCount;
+        }
+    }
+
+    /**
+     * In-memory Logger.
+     */
+    public class TestStatsLogger implements StatsLogger {
+        private String path;
+
+        TestStatsLogger(String path) {
+            this.path = path;
+        }
+
+        private String getSubPath(String name) {
+            if (path.isEmpty()) {
+                return name;
+            } else {
+                return path + "." + name;
+            }
+        }
+
+        @Override
+        public OpStatsLogger getOpStatsLogger(String name) {
+            return TestStatsProvider.this.getOrCreateOpStatsLogger(getSubPath(name));
+        }
+
+        @Override
+        public Counter getCounter(String name) {
+            return TestStatsProvider.this.getOrCreateCounter(getSubPath(name));
+        }
+
+        @Override
+        public <T extends Number> void registerGauge(String name, Gauge<T> gauge) {
+            TestStatsProvider.this.registerGauge(getSubPath(name), gauge);
+        }
+
+        @Override
+        public <T extends Number> void unregisterGauge(String name, Gauge<T> gauge) {
+            TestStatsProvider.this.unregisterGauge(getSubPath(name), gauge);
+        }
+
+        @Override
+        public StatsLogger scope(String name) {
+            return new TestStatsLogger(getSubPath(name));
+        }
+
+        @Override
+        public void removeScope(String name, StatsLogger statsLogger) {}
+    }
+
+    @Override
+    public void start(Configuration conf) {
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    private Map<String, TestOpStatsLogger> opStatLoggerMap = new ConcurrentHashMap<>();
+    private Map<String, TestCounter> counterMap = new ConcurrentHashMap<>();
+    private Map<String, Gauge<? extends Number>> gaugeMap = new ConcurrentHashMap<>();
+
+    @Override
+    public StatsLogger getStatsLogger(String scope) {
+        return new TestStatsLogger(scope);
+    }
+
+    public TestOpStatsLogger getOpStatsLogger(String path) {
+        return opStatLoggerMap.get(path);
+    }
+
+    public TestCounter getCounter(String path) {
+        return counterMap.get(path);
+    }
+
+    public Gauge<? extends Number> getGauge(String path) {
+        return gaugeMap.get(path);
+    }
+
+    public void forEachOpStatLogger(BiConsumer<String, TestOpStatsLogger> f) {
+        for (Map.Entry<String, TestOpStatsLogger> entry : opStatLoggerMap.entrySet()) {
+            f.accept(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public void clear() {
+        for (TestOpStatsLogger logger : opStatLoggerMap.values()) {
+            logger.clear();
+        }
+        for (TestCounter counter : counterMap.values()) {
+            counter.clear();
+        }
+    }
+
+    private TestOpStatsLogger getOrCreateOpStatsLogger(String path) {
+        return opStatLoggerMap.computeIfAbsent(
+                path,
+                (String s) -> new TestOpStatsLogger());
+    }
+
+    private TestCounter getOrCreateCounter(String path) {
+        return counterMap.computeIfAbsent(
+                path,
+                (String s) -> new TestCounter());
+    }
+
+    private <T extends Number> void registerGauge(String name, Gauge<T> gauge) {
+        gaugeMap.put(name, gauge);
+    }
+
+    private <T extends Number> void unregisterGauge(String name, Gauge<T> gauge) {
+        gaugeMap.remove(name, gauge);
+    }
+}


### PR DESCRIPTION
Fixes a bug in OrderedScheduler introduced in
e33ec10aa400f32c2e0278c15ea80a0f624e5919 which failed to track execution
time with some calls and adds an option to enable it in the bookie.  Also
fixes a bug with task_queued duration.

Add a simple mock for remembering stats long enough to verify that
counters are actually used and sensible in unit tests and bake it into
BookKeeperClusterTestCase so that we can write tests to ensure that the
stats are actually counted and make sense.  Use said mock to add simple
tests for top level read and write stats validating this fix.

(@bug W-4276826@)
(@bug W-4268290@)
Signed-off-by: Samuel Just <sjust@salesforce.com>
  