### PR TITLE
BookieRequestProcessor: shutdown the longPollThreadPool as well

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -189,6 +189,7 @@ public class BookieRequestProcessor implements RequestProcessor {
     public void close() {
         shutdownExecutor(writeThreadPool);
         shutdownExecutor(readThreadPool);
+        shutdownExecutor(longPollThreadPool);
     }
 
     private OrderedSafeExecutor createExecutor(int numThreads, String nameFormat, int maxTasksInQueue) {


### PR DESCRIPTION
Signed-off-by: Samuel Just <sjust@salesforce.com>