### PR TITLE
BookieProtoEncoding: use retainedSlice() to reduce garbage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -289,8 +289,8 @@ public class BookieProtoEncoding {
                 entryId = buffer.readLong();
 
                 if (rc == BookieProtocol.EOK) {
-                    ByteBuf content = buffer.slice();
-                    return new BookieProtocol.ReadResponse(version, rc, ledgerId, entryId, content.retain());
+                    return new BookieProtocol.ReadResponse(version, rc,
+                                                           ledgerId, entryId, buffer.retainedSlice());
                 } else {
                     return new BookieProtocol.ReadResponse(version, rc, ledgerId, entryId);
                 }


### PR DESCRIPTION

Signed-off-by: Samuel Just <sjust@salesforce.com>
  