### PR TITLE
BookieNettyServer: add contextHandler to the local transport pipeline

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -372,6 +372,7 @@ class BookieNettyServer {
                             : new RejectRequestHandler();
                     pipeline.addLast("bookieRequestHandler", requestHandler);
 
+                    pipeline.addLast("contextHandler", contextHandler);
                 }
             });
 


### PR DESCRIPTION
Left off of 8e0bd2c3d81b522e97434d8646915f36422a104b.  In fact,
authentication is already enabled on LocalTransport.  This extra line is
needed for the machinery which allows auth plugins to access ssl state.
Currently, the only plugin which uses that machinery is in TestTLS.
Adds test cases to validate that functionality with Local Transport
enabled.

Signed-off-by: Samuel Just <sjust@salesforce.com>
  