### PR TITLE
Introduce MockClock and MockExecutorController to improve timer-based testing

### DIFF
--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockClock.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockClock.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.common.testing.executors;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+/**
+ * A mock implementation of {@link Clock}.
+ */
+public class MockClock extends Clock {
+
+    private final ZoneId zoneId;
+    private Instant now = Instant.ofEpochMilli(0);
+
+    public MockClock() {
+        this(ZoneId.systemDefault());
+    }
+
+    private MockClock(ZoneId zoneId) {
+        this.zoneId = zoneId;
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return zoneId;
+    }
+
+    @Override
+    public MockClock withZone(ZoneId zone) {
+        return new MockClock(zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return now;
+    }
+
+    /**
+     * Advance the clock by the given amount of time.
+     *
+     * @param duration duration to advance.
+     */
+    public void advance(Duration duration) {
+        now = now.plus(duration);
+    }
+}

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockClockTest.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockClockTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.common.testing.executors;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test {@link MockClock}.
+ */
+public class MockClockTest {
+
+    private MockClock clock;
+
+    @Before
+    public void setup() {
+        this.clock = new MockClock();
+    }
+
+    @Test
+    public void testAdvance() {
+        assertEquals(0L, clock.millis());
+        clock.advance(Duration.ofMillis(10));
+        assertEquals(10L, clock.millis());
+    }
+
+}

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockExecutorController.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockExecutorController.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.common.testing.executors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.SettableFuture;
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.mockito.stubbing.Answer;
+
+/**
+ * A mocked scheduled executor that records scheduled tasks and executes them when the clock is
+ * advanced past their execution time.
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class MockExecutorController {
+
+    @Data
+    @Getter
+    private class DeferredTask implements ScheduledFuture<Void> {
+
+        private final Runnable runnable;
+        private final long scheduledAtMillis;
+        @Getter
+        private final CompletableFuture<Void> future;
+
+        public DeferredTask(Runnable runnable,
+                            long delayTimeMs) {
+            this.runnable = runnable;
+            this.scheduledAtMillis = delayTimeMs + clock.millis();
+            this.future = FutureUtils.createFuture();
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return unit.convert(scheduledAtMillis - clock.millis(), TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            return Long.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return future.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return future.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return future.isDone();
+        }
+
+        @Override
+        public Void get() throws InterruptedException, ExecutionException {
+            future.get();
+            return null;
+        }
+
+        @Override
+        public Void get(long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            future.get(timeout, unit);
+            return null;
+        }
+
+        void run() {
+            runnable.run();
+            FutureUtils.complete(future, null);
+        }
+
+    }
+
+    @Getter
+    private final MockClock clock = new MockClock();
+    private final List<DeferredTask> deferredTasks = Lists.newArrayList();
+
+    public MockExecutorController controlSubmit(ScheduledExecutorService service) {
+        doAnswer(answerNow()).when(service).submit(any(Runnable.class));
+        return this;
+    }
+
+    public MockExecutorController controlExecute(ScheduledExecutorService service) {
+        doAnswer(answerNow()).when(service).execute(any(Runnable.class));
+        return this;
+    }
+
+    public MockExecutorController controlSchedule(ScheduledExecutorService service) {
+        doAnswer(answerDelay(this)).when(service).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        return this;
+    }
+
+    public MockExecutorController controlScheduleAtFixedRate(ScheduledExecutorService service,
+                                                             int maxInvocations) {
+        doAnswer(answerAtFixedRate(this, maxInvocations))
+            .when(service)
+            .scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+        return this;
+    }
+
+    private static Answer<ScheduledFuture<?>> answerAtFixedRate(MockExecutorController controller, int numTimes) {
+        return invocationOnMock -> {
+            Runnable task = invocationOnMock.getArgument(0);
+            long initialDelay = invocationOnMock.getArgument(1);
+            long delay = invocationOnMock.getArgument(2);
+            TimeUnit unit = invocationOnMock.getArgument(3);
+
+            DeferredTask deferredTask = null;
+            for (int i = 0; i < numTimes; i++) {
+                long delayMs = unit.toMillis(initialDelay) + i * unit.toMillis(delay);
+
+                deferredTask = controller.addDelayedTask(
+                    controller,
+                    delayMs,
+                    task);
+            }
+            return deferredTask;
+        };
+    }
+
+    private static Answer<ScheduledFuture<?>> answerDelay(MockExecutorController executor) {
+        return invocationOnMock -> {
+
+           Runnable task = invocationOnMock.getArgument(0);
+           long value = invocationOnMock.getArgument(1);
+           TimeUnit unit = invocationOnMock.getArgument(2);
+           DeferredTask deferredTask = executor.addDelayedTask(executor, unit.toMillis(value), task);
+           if (value <= 0) {
+               task.run();
+               FutureUtils.complete(deferredTask.future, null);
+           }
+           return deferredTask;
+       };
+    }
+
+    private static Answer<Future<?>> answerNow() {
+        return invocationOnMock -> {
+
+           Runnable task = invocationOnMock.getArgument(0);
+           task.run();
+           SettableFuture<Void> future = SettableFuture.create();
+           future.set(null);
+           return future;
+       };
+    }
+
+    private DeferredTask addDelayedTask(
+            MockExecutorController executor,
+            long delayTimeMs,
+            Runnable task) {
+        checkArgument(delayTimeMs >= 0);
+        DeferredTask deferredTask = new DeferredTask(task, delayTimeMs);
+        executor.deferredTasks.add(deferredTask);
+        return deferredTask;
+    }
+
+    public void advance(Duration duration) {
+        clock.advance(duration);
+        Iterator<DeferredTask> entries = deferredTasks.iterator();
+        List<DeferredTask> toExecute = Lists.newArrayList();
+        while (entries.hasNext()) {
+            DeferredTask next = entries.next();
+            if (next.getDelay(TimeUnit.MILLISECONDS) <= 0) {
+                entries.remove();
+                toExecute.add(next);
+            }
+        }
+        for (DeferredTask task : toExecute) {
+            task.run();
+        }
+    }
+
+}

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockExecutorControllerTest.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockExecutorControllerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.common.testing.executors;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test {@link MockExecutorController}.
+ */
+public class MockExecutorControllerTest {
+
+    private static final int MAX_SCHEDULES = 5;
+
+    private ScheduledExecutorService executor;
+    private MockExecutorController mockExecutorControl;
+
+    @Before
+    public void setup() {
+        this.executor = mock(ScheduledExecutorService.class);
+        this.mockExecutorControl = new MockExecutorController()
+            .controlExecute(executor)
+            .controlSubmit(executor)
+            .controlSchedule(executor)
+            .controlScheduleAtFixedRate(executor, MAX_SCHEDULES);
+    }
+
+    @Test
+    public void testSubmit() {
+        Runnable task = mock(Runnable.class);
+        doNothing().when(task).run();
+        executor.submit(task);
+        verify(task, times(1)).run();
+    }
+
+    @Test
+    public void testExecute() {
+        Runnable task = mock(Runnable.class);
+        doNothing().when(task).run();
+        executor.execute(task);
+        verify(task, times(1)).run();
+    }
+
+    @Test
+    public void testDelay() {
+        Runnable task = mock(Runnable.class);
+        doNothing().when(task).run();
+        executor.schedule(task, 10, TimeUnit.MILLISECONDS);
+        mockExecutorControl.advance(Duration.ofMillis(5));
+        verify(task, times(0)).run();
+        mockExecutorControl.advance(Duration.ofMillis(10));
+        verify(task, times(1)).run();
+    }
+
+    @Test
+    public void testScheduleAtFixedRate() {
+        Runnable task = mock(Runnable.class);
+        doNothing().when(task).run();
+        executor.scheduleAtFixedRate(task, 5, 10, TimeUnit.MILLISECONDS);
+
+        // first delay
+        mockExecutorControl.advance(Duration.ofMillis(2));
+        verify(task, times(0)).run();
+        mockExecutorControl.advance(Duration.ofMillis(3));
+        verify(task, times(1)).run();
+
+        // subsequent delays
+        for (int i = 1; i < MAX_SCHEDULES; i++) {
+            mockExecutorControl.advance(Duration.ofMillis(2));
+            verify(task, times(i)).run();
+            mockExecutorControl.advance(Duration.ofMillis(8));
+            verify(task, times(i + 1)).run();
+        }
+
+        // no more invocations
+        mockExecutorControl.advance(Duration.ofMillis(500));
+        verify(task, times(MAX_SCHEDULES)).run();
+    }
+
+}

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -167,6 +167,13 @@
       <version>${netty.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-common</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minikdc</artifactId>
       <version>2.7.3</version>

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestLedgerDirsManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestLedgerDirsManager.java
@@ -24,16 +24,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.LedgerDirsListener;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
+import org.apache.bookkeeper.common.testing.executors.MockExecutorController;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.util.DiskChecker;
@@ -42,14 +46,17 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Test LedgerDirsManager.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(LedgerDirsMonitor.class)
 public class TestLedgerDirsManager {
-    private static final Logger LOG = LoggerFactory.getLogger(TestLedgerDirsManager.class);
 
     ServerConfiguration conf;
     File curDir;
@@ -62,6 +69,10 @@ public class TestLedgerDirsManager {
 
     final List<File> tempDirs = new ArrayList<File>();
 
+    // Thread used by monitor
+    ScheduledExecutorService executor;
+    MockExecutorController executorController;
+
     File createTempDir(String prefix, String suffix) throws IOException {
         File dir = IOUtils.createTempDir(prefix, suffix);
         tempDirs.add(dir);
@@ -70,6 +81,8 @@ public class TestLedgerDirsManager {
 
     @Before
     public void setUp() throws Exception {
+        PowerMockito.mockStatic(Executors.class);
+
         File tmpDir = createTempDir("bkTest", ".dir");
         curDir = Bookie.getCurrentDirectory(tmpDir);
         Bookie.checkDirectoryStructure(curDir);
@@ -79,6 +92,12 @@ public class TestLedgerDirsManager {
         conf.setDiskLowWaterMarkUsageThreshold(conf.getDiskUsageThreshold());
         conf.setDiskCheckInterval(diskCheckInterval);
         conf.setIsForceGCAllowWhenNoSpace(true);
+
+        executor = PowerMockito.mock(ScheduledExecutorService.class);
+        executorController = new MockExecutorController()
+            .controlScheduleAtFixedRate(executor, 10);
+        PowerMockito.when(Executors.newSingleThreadScheduledExecutor(any()))
+            .thenReturn(executor);
 
         mockDiskChecker = new MockDiskChecker(threshold, warnThreshold);
         dirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
@@ -152,7 +171,6 @@ public class TestLedgerDirsManager {
 
     @Test
     public void testLedgerDirsMonitorDuringTransition() throws Exception {
-
         MockLedgerDirsListener mockLedgerDirsListener = new MockLedgerDirsListener();
         dirsManager.addLedgerDirsListener(mockLedgerDirsListener);
         ledgerMonitor.start();
@@ -160,12 +178,11 @@ public class TestLedgerDirsManager {
         assertFalse(mockLedgerDirsListener.readOnly);
         mockDiskChecker.setUsage(threshold + 0.05f);
 
-        Thread.sleep((diskCheckInterval * 2) + 100);
-
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
         assertTrue(mockLedgerDirsListener.readOnly);
-        mockDiskChecker.setUsage(threshold - 0.05f);
 
-        Thread.sleep(diskCheckInterval + 100);
+        mockDiskChecker.setUsage(threshold - 0.05f);
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
 
         assertFalse(mockLedgerDirsListener.readOnly);
     }
@@ -195,36 +212,36 @@ public class TestLedgerDirsManager {
         dirsManager.addLedgerDirsListener(mockLedgerDirsListener);
         ledgerMonitor.start();
 
-        Thread.sleep((diskCheckInterval * 2) + 100);
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
         assertFalse(mockLedgerDirsListener.readOnly);
 
         // go above LWM but below threshold
         // should still be writable
         mockDiskChecker.setUsage(lwm2nospace);
-        Thread.sleep((diskCheckInterval * 2) + 100);
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
         assertFalse(mockLedgerDirsListener.readOnly);
 
         // exceed the threshold, should go to readonly
         mockDiskChecker.setUsage(nospaceExceeded);
-        Thread.sleep(diskCheckInterval + 100);
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
         assertTrue(mockLedgerDirsListener.readOnly);
 
         // drop below threshold but above LWM
         // should stay read-only
         mockDiskChecker.setUsage(lwm2nospace);
-        Thread.sleep((diskCheckInterval * 2) + 100);
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
         assertTrue(mockLedgerDirsListener.readOnly);
 
         // drop below LWM
         // should become writable
         mockDiskChecker.setUsage(lwm2warn);
-        Thread.sleep((diskCheckInterval * 2) + 100);
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
         assertFalse(mockLedgerDirsListener.readOnly);
 
         // go above LWM but below threshold
         // should still be writable
         mockDiskChecker.setUsage(lwm2nospace);
-        Thread.sleep((diskCheckInterval * 2) + 100);
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
         assertFalse(mockLedgerDirsListener.readOnly);
     }
 
@@ -319,7 +336,7 @@ public class TestLedgerDirsManager {
         usageMap.put(dir1, dir1Usage);
         usageMap.put(dir2, dir2Usage);
         mockDiskChecker.setUsageMap(usageMap);
-        Thread.sleep((diskCheckInterval * 2) + 100);
+        executorController.advance(Duration.ofMillis(diskCheckInterval));
         if (verifyReadOnly) {
             assertTrue(mockLedgerDirsListener.readOnly);
         } else {


### PR DESCRIPTION
Descriptions of the changes in this PR:

- introduce MockClock and MockExecutorController to control time advancing to trigger execution on tasks
- convert LedgerDirsMonitor from using Thread to use ScheduledExecutorService (moved the logic in `run` method to `check` without code changes)
- change TestLedgerDirsManager to use MockClock and MockExecutorController to remove the usage of `Thread.sleep`

Master Issue:  #943 
  