### PR TITLE
ISSUE #945: Enabling BookieShell for LocalBookKeeper

### DIFF
--- a/bookkeeper-server/bin/bookkeeper
+++ b/bookkeeper-server/bin/bookkeeper
@@ -56,6 +56,8 @@ DEFAULT_LOG_CONF=$BK_HOME/conf/log4j.properties
 
 source $BK_HOME/conf/bkenv.sh
 
+LOCALBOOKIES_CONFIG_DIR="${LOCALBOOKIES_CONFIG_DIR:-/tmp/localbookies-config}"
+
 # Check for the java to use
 if [[ -z $JAVA_HOME ]]; then
   JAVA=$(which java)
@@ -184,6 +186,16 @@ shift
 
 if [ $COMMAND == "shell" ]; then
   DEFAULT_LOG_CONF=$BK_HOME/conf/log4j.shell.properties
+    if [[ $1 == "-localbookie"  ]]; then
+        if [[ $2 == *:* ]];
+        then
+            BOOKIE_CONF=$LOCALBOOKIES_CONFIG_DIR/$2.conf
+            shift 2
+        else
+            BOOKIE_CONF=$LOCALBOOKIES_CONFIG_DIR/baseconf.conf
+            shift
+        fi
+    fi
 fi
 
 if [ -z "$BOOKIE_CONF" ]; then

--- a/bookkeeper-server/conf/bkenv.sh
+++ b/bookkeeper-server/conf/bkenv.sh
@@ -48,3 +48,6 @@
 
 #Entry formatter class to format entries.
 #ENTRY_FORMATTER_CLASS=
+
+# this default config dir should match the 'localBookiesConfigDirectory' config value in the conf file of LocalBookKeeper
+#LOCALBOOKIES_CONFIG_DIR=/tmp/localbookies-config

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -2559,7 +2559,7 @@ public class BookieShell implements Tool {
     }
 
     private void printShellUsage() {
-        System.err.println("Usage: bookkeeper shell [-ledgeridformat <hex/long/uuid>] "
+        System.err.println("Usage: bookkeeper shell [-localbookie [<host:port>]] [-ledgeridformat <hex/long/uuid>] "
                 + "[-entryformat <hex/string>] [-conf configuration] <command>");
         System.err.println("where command is one of:");
         List<String> commandNames = new ArrayList<String>();


### PR DESCRIPTION
Descriptions of the changes in this PR:

We should be able to execute BookieShell commands against bookies of LocalBookkeeper

eg. for Zookeeper/Metadata Operation
./bookkeeper shell -localbookie listbookies -rw

eg. for Bookie operation
./bookkeeper shell -localbookie 10.3.27.190:5000 lastmark
./bookkeeper shell -localbookie 10.3.27.190:5000 listfilesondisc

Master Issue: #945 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
