### PR TITLE
ISSUE #947: ZK configs for LocalBookkeeper

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/IOUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/IOUtils.java
@@ -116,7 +116,25 @@ public class IOUtils {
      */
     public static File createTempDir(String prefix, String suffix)
             throws IOException {
-        File tmpDir = File.createTempFile(prefix, suffix);
+        return createTempDir(prefix, suffix, null);
+    }
+
+    /**
+     * Create a temp directory with given <i>prefix</i> and <i>suffix</i> in the specified <i>dir</i>.
+     *
+     * @param prefix
+     *          prefix of the directory name
+     * @param suffix
+     *          suffix of the directory name
+     * @param dir
+     *          The directory in which the file is to be created,
+     *          or null if the default temporary-file directory is to be used
+     * @return directory created
+     * @throws IOException
+     */
+    public static File createTempDir(String prefix, String suffix, File dir)
+            throws IOException {
+        File tmpDir = File.createTempFile(prefix, suffix, dir);
         if (!tmpDir.delete()) {
             throw new IOException("Couldn't delete directory " + tmpDir);
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Master Issue: #947 

- make ZK's data directory configurable for local bookie
- Localbookie to use ledgersrootpath from conf file

e032218a910113b0e4de561a76da8bdf61ba3db7
(@bug W-2887104@) make ZK's data directory configurable for local bookie

Author: Andrey Yegorov <ayegorov@salesforce.com>
Signed-off-by: Samuel Just <sjust@salesforce.com>



> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---

  