### PR TITLE
ISSUE #950: EntryLogger.extractEntryLogMetadataByScanning: fix check

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1339,7 +1339,7 @@ public class EntryLogger {
 
             @Override
             public boolean accept(long ledgerId) {
-                return ledgerId > 0;
+                return ledgerId >= 0;
             }
         });
 


### PR DESCRIPTION
0 is a valid ledger id. Seems to be causing
test2RWsShouldCompeteForReplicationOf2FragmentsAndCompleteReplication to
fail in cases where the gc runs before the recovery reads happen. The gc
winds up believing the entry log to be empty and deletes it erroneously.

Introduced in 143bd1952851ac70ace9d16c3708ae30dad2a0aa.

(@bug W-4596080@)
Signed-off-by: Samuel Just <sjust@salesforce.com>
