### PR TITLE
Issue 952:  Split the multiple-jdk-versions ci jobs into two 

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -41,6 +41,7 @@ class common_job_properties {
   // Sets common top-level job properties for main repository jobs.
   static void setTopLevelMainJobProperties(context,
                                            String branch = 'master',
+                                           String jdkVersion = 'JDK 1.8 (latest)',
                                            int timeout = 100,
                                            String jenkinsExecutorLabel = 'ubuntu') {
     // GitHub project.
@@ -63,9 +64,10 @@ class common_job_properties {
                                                String scmUrl,
                                                String defaultBranch,
                                                String jenkinsExecutorLabel,
-                                               int defaultTimeout) {
+                                               int defaultTimeout,
+                                               String jdkVersion = 'JDK 1.8 (latest)') {
     // Set JDK version.
-    context.jdk('JDK 1.8 (latest)')
+    context.jdk(jdkVersion)
 
     // Restrict this project to run only on Jenkins executors as specified
     context.label(jenkinsExecutorLabel)

--- a/.test-infra/jenkins/job_bookkeeper_postcommit_master_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_postcommit_master_java8.groovy
@@ -18,19 +18,13 @@
 
 import common_job_properties
 
-// This job runs the Java postcommit tests cross multiple JDK versions.
-matrixJob('bookkeeper_postcommit_master_jdkversions') {
-  description('Runs nightly build for bookkeeper in multiple Jdk versions.')
+// This job runs the Java postcommit tests on Java 8
+mavenJob('bookkeeper_postcommit_master_java8') {
+  description('Runs nightly build for bookkeeper in Java 8.')
 
   // Set common parameters.
-  common_job_properties.setTopLevelMainJobProperties(delegate)
-
-  // Set JDK versions.
-  axes {
-    label('label', 'ubuntu')
-    jdk('JDK 1.8 (latest)',
-        'JDK 1.9 (latest)')
-  }
+  common_job_properties.setTopLevelMainJobProperties(
+    delegate, 'master', 'JDK 1.8 (latest)')
 
   // Sets that this is a PostCommit job.
   common_job_properties.setPostCommit(
@@ -41,17 +35,12 @@ matrixJob('bookkeeper_postcommit_master_jdkversions') {
   // Allows triggering this build against pull requests.
   common_job_properties.enablePhraseTriggeringFromPullRequest(
       delegate,
-      'JDK Version Test',
-      '/test-jdks')
+      'Java 8 Test',
+      '/test-java8')
 
-  // Maven build for this job.
-  steps {
-    maven {
-      // Set maven parameters.
-      common_job_properties.setMavenConfig(delegate)
+  // Set maven parameters.
+  common_job_properties.setMavenConfig(delegate)
 
-      // Maven build project.
-      goals('clean apache-rat:check package spotbugs:check')
-    }
-  }
+  // Maven build project.
+  goals('clean apache-rat:check package spotbugs:check')
 }

--- a/.test-infra/jenkins/job_bookkeeper_postcommit_master_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_postcommit_master_java9.groovy
@@ -18,26 +18,29 @@
 
 import common_job_properties
 
-// This is the Java precommit which runs a maven install, and the current set of precommit tests.
-mavenJob('bookkeeper_precommit_pullrequest_java9') {
-  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 9.')
-
-  // Execute concurrent builds if necessary.
-  concurrentBuild()
+// This job runs the Java postcommit tests on Java 9
+mavenJob('bookkeeper_postcommit_master_java9') {
+  description('Runs nightly build for bookkeeper in Java 9.')
 
   // Set common parameters.
   common_job_properties.setTopLevelMainJobProperties(
-    delegate,
-    'master',
-    'JDK 1.9 (latest)',
-    120)
+    delegate, 'master', 'JDK 1.9 (latest)')
 
-  // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, 'Maven clean install')
+  // Sets that this is a PostCommit job.
+  common_job_properties.setPostCommit(
+      delegate,
+      'H 12 * * *',
+      false)
 
-  // Set Maven parameters.
+  // Allows triggering this build against pull requests.
+  common_job_properties.enablePhraseTriggeringFromPullRequest(
+      delegate,
+      'Java 9 Test',
+      '/test-java9')
+
+  // Set maven parameters.
   common_job_properties.setMavenConfig(delegate)
 
-  // Maven build project
+  // Maven build project.
   goals('clean apache-rat:check package spotbugs:check')
 }

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -33,7 +33,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java8') {
     120)
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, 'Maven clean install')
+  common_job_properties.setPreCommit(delegate, 'Maven clean install (Java 8)')
 
   // Set Maven parameters.
   common_job_properties.setMavenConfig(delegate)

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -19,8 +19,8 @@
 import common_job_properties
 
 // This is the Java precommit which runs a maven install, and the current set of precommit tests.
-mavenJob('bookkeeper_precommit_pullrequest_java9') {
-  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 9.')
+mavenJob('bookkeeper_precommit_pullrequest_java8') {
+  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 8.')
 
   // Execute concurrent builds if necessary.
   concurrentBuild()
@@ -29,7 +29,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   common_job_properties.setTopLevelMainJobProperties(
     delegate,
     'master',
-    'JDK 1.9 (latest)',
+    'JDK 1.8 (latest)',
     120)
 
   // Sets that this is a PreCommit job.

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
@@ -33,7 +33,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
     120)
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, 'Maven clean install')
+  common_job_properties.setPreCommit(delegate, 'Maven clean install (Java 9)')
 
   // Set Maven parameters.
   common_job_properties.setMavenConfig(delegate)

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
@@ -19,8 +19,8 @@
 import common_job_properties
 
 // This is the Java precommit which runs a maven install, and the current set of precommit tests.
-matrixJob('bookkeeper_precommit_pullrequest') {
-  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a>.')
+mavenJob('bookkeeper_precommit_pullrequest_java8') {
+  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 8.')
 
   // Execute concurrent builds if necessary.
   concurrentBuild()
@@ -29,26 +29,15 @@ matrixJob('bookkeeper_precommit_pullrequest') {
   common_job_properties.setTopLevelMainJobProperties(
     delegate,
     'master',
+    'JDK 1.8 (latest)',
     120)
-
-  // Set JDK versions.
-  axes {
-    label('label', 'ubuntu')
-    jdk('JDK 1.8 (latest)',
-        'JDK 1.9 (latest)')
-  }
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(delegate, 'Maven clean install')
 
-  // Maven build for this job.
-  steps {
-    maven {
-      // Set Maven parameters.
-      common_job_properties.setMavenConfig(delegate)
+  // Set Maven parameters.
+  common_job_properties.setMavenConfig(delegate)
 
-      // Maven build project
-      goals('clean apache-rat:check package spotbugs:check')
-    }
-  }
+  // Maven build project
+  goals('clean apache-rat:check package spotbugs:check')
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

When using a matrix job to define a CI job running on both java 9 and java 8, the workspace file path will be added with "jdk name" (e.g. "JDK 1.8 latest" and "JDK 9 latest"). This will cause file paths contain spaces, and fail the builds. 

for example, #879 #880 is one of the examples. #937 can't pass ci because g++ fails when the file path contains spaces.

*Solution*

Splitting the matrix job into two separate jobs suffixed with "java8" and "java9", so it won't contains any space in workspace.
  