### PR TITLE
ISSUE #935: tests/bookkeeeper-server-shaded-*test/pom.xml: exclude pulsar

### DIFF
--- a/tests/bookkeeper-server-shaded-artifact-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-artifact-test/pom.xml
@@ -42,6 +42,10 @@
           <groupId>org.apache.bookkeeper</groupId>
           <artifactId>bookkeeper-proto</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>pulsar-checksum</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/tests/bookkeeper-server-shaded-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-test/pom.xml
@@ -45,6 +45,10 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>pulsar-checksum</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This prevents the test artifact from pulling in guava via pulsar.

Signed-off-by: Samuel Just <sjust@salesforce.com>