### PR TITLE
ISSUE #954: dir_*_usage stats are always 0

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -72,9 +72,9 @@ public class LedgerDirsManager {
         this.forceGCAllowWhenNoSpace = conf.getIsForceGCAllowWhenNoSpace();
         this.entryLogSize = conf.getEntryLogSizeLimit();
         this.minUsableSizeForIndexFileCreation = conf.getMinUsableSizeForIndexFileCreation();
-        for (File dir : dirs) {
+        for (File dir : ledgerDirectories) {
             diskUsages.put(dir, 0f);
-            String statName = "dir_" + dir.getPath().replace('/', '_') + "_usage";
+            String statName = "dir_" + dir.getParent().replace('/', '_') + "_usage";
             final File targetDir = dir;
             statsLogger.registerGauge(statName, new Gauge<Number>() {
                 @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
@@ -192,7 +192,7 @@ public class TestStatsProvider implements StatsProvider {
     private Map<String, Gauge<? extends Number>> gaugeMap = new ConcurrentHashMap<>();
 
     @Override
-    public StatsLogger getStatsLogger(String scope) {
+    public TestStatsLogger getStatsLogger(String scope) {
         return new TestStatsLogger(scope);
     }
 


### PR DESCRIPTION
due to mismatch between the way they are initialized in `LedgerDirsManager` and
the way the `diskUsages` is populated subsequently in `LedgerDirsMonitor`

Decisions potentially worth some attention:
- stat names are kept `dir_{dir}_usage` while the actual dirs being checked have been changed to `{dir}/current`;
- the stats aren't being updated if the bookie is in a readonly mode -- uncovered while testing, not sure if it's worth addressing at all, kept the fix minimalistic for now.

(@bug W-4594204@)