### PR TITLE
Tag all-versions-image with latest

### DIFF
--- a/tests/docker-all-versions-image/pom.xml
+++ b/tests/docker-all-versions-image/pom.xml
@@ -51,8 +51,17 @@
                 <id>default</id>
                 <goals>
                   <goal>build</goal>
-                  <goal>push</goal>
                 </goals>
+              </execution>
+              <execution>
+                <id>add-latest-tag</id>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
+                <configuration>
+                  <repository>apachebookkeeper/bookkeeper-all-versions</repository>
+                  <tag>latest</tag>
+                </configuration>
               </execution>
             </executions>
             <configuration>


### PR DESCRIPTION
So that scripts using it don't have to bump version each time.