### PR TITLE
ISSUE #986: in LocalBK.main do Sys.exit in the case of an Exc

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -407,41 +407,49 @@ public class LocalBookKeeper {
     }
 
     public static void main(String[] args) throws Exception, SecurityException {
-        if (args.length < 1) {
-            usage();
+        try {
+            if (args.length < 1) {
+                usage();
+                System.exit(-1);
+            }
+
+            int numBookies = Integer.parseInt(args[0]);
+
+            ServerConfiguration conf = new ServerConfiguration();
+            conf.setAllowLoopback(true);
+            if (args.length >= 2) {
+                String confFile = args[1];
+                try {
+                    conf.loadConf(new File(confFile).toURI().toURL());
+                    LOG.info("Using configuration file " + confFile);
+                } catch (Exception e) {
+                    // load conf failed
+                    LOG.warn("Error loading configuration file " + confFile, e);
+                }
+            }
+
+            String zkDataDir = null;
+            if (args.length >= 3) {
+                zkDataDir = args[2];
+            }
+
+            String localBookiesConfigDirName = defaultLocalBookiesConfigDir;
+            if (args.length >= 4) {
+                localBookiesConfigDirName = args[3];
+            }
+
+            startLocalBookiesInternal(conf, zooKeeperDefaultHost, zooKeeperDefaultPort, numBookies, true,
+                    bookieDefaultInitialPort, false, "test", zkDataDir, localBookiesConfigDirName);
+        } catch (Exception e) {
+            LOG.error("Exiting LocalBookKeeper because of exception in main method", e);
+            e.printStackTrace();
+            /*
+             * This is needed because, some non-daemon thread (probably in ZK or
+             * some other dependent service) is preventing the JVM from exiting, though
+             * there is exception in main thread.
+             */
             System.exit(-1);
         }
-
-        int numBookies = Integer.parseInt(args[0]);
-
-        ServerConfiguration conf = new ServerConfiguration();
-        conf.setAllowLoopback(true);
-        if (args.length >= 2) {
-            String confFile = args[1];
-            try {
-                conf.loadConf(new File(confFile).toURI().toURL());
-                LOG.info("Using configuration file " + confFile);
-            } catch (Exception e) {
-                // load conf failed
-                LOG.warn("Error loading configuration file " + confFile, e);
-            }
-        }
-
-        String zkDataDir = null;
-        if (args.length >= 3) {
-            zkDataDir = args[2];
-        }
-
-        String localBookiesConfigDirName = defaultLocalBookiesConfigDir;
-        if (args.length >= 4) {
-            localBookiesConfigDirName = args[3];
-        }
-
-        startLocalBookiesInternal(
-                conf, zooKeeperDefaultHost, zooKeeperDefaultPort,
-                numBookies, true, bookieDefaultInitialPort,
-                false, "test",
-                zkDataDir, localBookiesConfigDirName);
     }
 
     private static void usage() {


### PR DESCRIPTION
Descriptions of the changes in this PR:

in LocalBookKeeper.main method if there is any exception then it should do System.exit. This is needed,  because, some non-daemon thread (probably in ZK or some other dependent service) is preventing the JVM from exiting, though there is exception in main thread.

Master Issue: #986

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
