### PR TITLE
Fix tight loop in getFileInfo

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
@@ -52,7 +52,8 @@ class FileInfoBackingCache {
                 // have been able to get a reference to it here.
                 // The caller of loadFileInfo owns the refence, and is
                 // responsible for calling the corresponding #release().
-                assert(fi.tryRetain());
+                boolean retained = fi.tryRetain();
+                assert(retained);
                 return fi;
             }
         } finally {
@@ -67,7 +68,8 @@ class FileInfoBackingCache {
             fileInfos.put(ledgerId, fi);
 
             // see comment above for why we assert
-            assert(fi.tryRetain());
+            boolean retained = fi.tryRetain();
+            assert(retained);
             return fi;
         } finally {
             lock.writeLock().unlock();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -225,10 +225,12 @@ public class IndexPersistenceMgr {
                     // cache. They shouldn't if refcounting is correct, but if someone
                     // does a double release, the fileinfo will be cleaned up, while
                     // remaining in the cache, which could cause a tight loop in this method.
-                    if (writeFileInfoCache.asMap().remove(ledger, fi)
-                        || readFileInfoCache.asMap().remove(ledger, fi)) {
-                        LOG.error("Dead fileinfo({}) forced out of cache. Must have been double-released somewhere.",
-                                  fi);
+                    boolean inWriteMap = writeFileInfoCache.asMap().remove(ledger, fi);
+                    boolean inReadMap = readFileInfoCache.asMap().remove(ledger, fi);
+                    if (inWriteMap || inReadMap) {
+                        LOG.error("Dead fileinfo({}) forced out of cache (write:{}, read:{}). "
+                                  + "It must have been double-released somewhere.",
+                                  fi, inWriteMap, inReadMap);
                     }
                     fi = null;
                 }


### PR DESCRIPTION
The argument to assertions is not evaluated if assertions is disabled,
which was messing up the refcounting for the fileinfo backing
cache. We ended up with dead fileinfo objects in the guava caches,
which triggered an infinite loop.

This patch fixes that by moving the tryRetain() out of the assert. It
also adds defensive code to getFileInfo to ensure that if a fileinfo
object is dead, that it doesn't exist any longer in the caches.