### PR TITLE
DoubleByteBuf fix for Netty > 4.1.12

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
@@ -17,6 +17,7 @@
 */
 package org.apache.bookkeeper.util;
 
+import com.google.common.collect.ObjectArrays;
 import io.netty.buffer.AbstractReferenceCountedByteBuf;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -361,7 +362,7 @@ public final class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
-        ByteBuffer dst = ByteBuffer.allocate(length);
+        ByteBuffer dst = isDirect() ? ByteBuffer.allocateDirect(length) : ByteBuffer.allocate(length);
         ByteBuf b = Unpooled.wrappedBuffer(dst);
         b.writerIndex(0);
         getBytes(index, b, length);
@@ -387,7 +388,10 @@ public final class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuffer[] nioBuffers() {
-        return nioBuffers(readerIndex(), readableBytes());
+        if (b1.nioBufferCount() == 1 && b2.nioBufferCount() == 1) {
+            return new ByteBuffer[] { b1.nioBuffer(), b2.nioBuffer() };
+        }
+        return ObjectArrays.concat(b1.nioBuffers(), b2.nioBuffers(), ByteBuffer.class);
     }
 
     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/DoubleByteBufTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/DoubleByteBufTest.java
@@ -19,6 +19,8 @@ package org.apache.bookkeeper.util;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -121,6 +123,54 @@ public class DoubleByteBufTest {
         ByteBuf b = DoubleByteBuf.get(b1, b2);
 
         assertEquals(ByteBuffer.wrap(new byte[] { 1, 2, 3, 4 }), b.nioBuffer());
+    }
+
+    @Test
+    public void testNonDirectNioBuffer() {
+        ByteBuf b1 = Unpooled.wrappedBuffer(new byte[] { 1, 2 });
+        ByteBuf b2 = Unpooled.wrappedBuffer(new byte[] { 3, 4 });
+        ByteBuf b = DoubleByteBuf.get(b1, b2);
+        assertFalse(b1.isDirect());
+        assertFalse(b2.isDirect());
+        assertFalse(b.isDirect());
+        ByteBuffer nioBuffer = b.nioBuffer();
+        assertFalse(nioBuffer.isDirect());
+    }
+
+    @Test
+    public void testNonDirectPlusDirectNioBuffer() {
+        ByteBuf b1 = Unpooled.wrappedBuffer(new byte[] { 1, 2 });
+        ByteBuf b2 = Unpooled.directBuffer(2);
+        ByteBuf b = DoubleByteBuf.get(b1, b2);
+        assertFalse(b1.isDirect());
+        assertTrue(b2.isDirect());
+        assertFalse(b.isDirect());
+        ByteBuffer nioBuffer = b.nioBuffer();
+        assertFalse(nioBuffer.isDirect());
+    }
+
+    @Test
+    public void testDirectPlusNonDirectNioBuffer() {
+        ByteBuf b1 = Unpooled.directBuffer(2);
+        ByteBuf b2 = Unpooled.wrappedBuffer(new byte[] { 1, 2 });
+        ByteBuf b = DoubleByteBuf.get(b1, b2);
+        assertTrue(b1.isDirect());
+        assertFalse(b2.isDirect());
+        assertFalse(b.isDirect());
+        ByteBuffer nioBuffer = b.nioBuffer();
+        assertFalse(nioBuffer.isDirect());
+    }
+
+    @Test
+    public void testDirectNioBuffer() {
+        ByteBuf b1 = Unpooled.directBuffer(2);
+        ByteBuf b2 = Unpooled.directBuffer(2);
+        ByteBuf b = DoubleByteBuf.get(b1, b2);
+        assertTrue(b1.isDirect());
+        assertTrue(b2.isDirect());
+        assertTrue(b.isDirect());
+        ByteBuffer nioBuffer = b.nioBuffer();
+        assertTrue(nioBuffer.isDirect());
     }
 
     /**


### PR DESCRIPTION
This is a port from Pulsar, DoubleByteBuf has problems with Netty Native Transport.
Original author is  @sschepens 

see https://github.com/apache/incubator-pulsar/pull/1056