### PR TITLE
Issue-1004 Client of BookKeeper 4.6.1 imports dependencies to netty-common

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -33,6 +33,13 @@
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
+      <exclusions>
+        <!-- exclude "netty-common" since "netty-all" already introduces it -->
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Change "netty-common" to "netty-all" in order to simplify packaging of poms