### PR TITLE
Issue-1003 bookkeeper-server shaded artifact test fail on branch-4.6

### DIFF
--- a/tests/bookkeeper-server-shaded-artifact-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-artifact-test/pom.xml
@@ -41,6 +41,13 @@
           <groupId>org.apache.bookkeeper</groupId>
           <artifactId>bookkeeper-proto</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- actually on branch 4.6 the dependency tree is different from 4.7, in which we have bookkeeper-proto module
+               in order to make tests pass on 4.6 we have to exclude this dependency manually
+               it is only important that the main artifact bookkeeper-server:shaded:jar contains the relocated version of protobuf -->
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Fix the pom in order to clean up compatibility tests for branch-4.6. BookKeeper server shaded stuff was picked from 4.7 branch but the structure of the project is very different so the dependency tree of test modules is not exactly the same