### PR TITLE
BP-25: MovingChecksumToProto--Refactor the checksum part of bookkeeper

### DIFF
--- a/site/bps/BP-25-MovingChecksumToProto.md
+++ b/site/bps/BP-25-MovingChecksumToProto.md
@@ -1,7 +1,7 @@
 ---
 title: "BP-25: MovingChecksumToProto--Refactor the checksum part of bookkeeper"
 issue: https://github.com/apache/bookkeeper/issues/1007
-state: "Under Discussion"
+state: "Accepted"
 release: "N/A"
 ---
 

--- a/site/bps/BP-25-MovingChecksumToProto.md
+++ b/site/bps/BP-25-MovingChecksumToProto.md
@@ -1,0 +1,27 @@
+---
+title: "BP-25: MovingChecksumToProto--Refactor the checksum part of bookkeeper"
+issue: https://github.com/apache/bookkeeper/issues/1007
+state: "Under Discussion"
+release: "N/A"
+---
+
+### Motivation
+
+Current the checksum implementation is in client module while the checksum semantic is more close to protocol. Moreover, moving the checksum implementation to protocol will avoid server module's dependency to client module when doing checksum in server side.
+
+### Public Interfaces
+
+An internal refactor not affecting public interfaces.
+
+### Proposed Changes
+
+Move the DigestManager and related classes to proto module
+
+### Compatibility, Deprecation, and Migration Plan
+N/A
+
+### Test Plan
+The original all tests should work as before.
+
+### Rejected Alternatives
+N/A

--- a/site/community/bookkeeper_proposals.md
+++ b/site/community/bookkeeper_proposals.md
@@ -85,7 +85,7 @@ using Google Doc.
 
 This section lists all the _bookkeeper proposals_ made to BookKeeper.
 
-*Next Proposal Number: 23*
+*Next Proposal Number: 26*
 
 ### Inprogress
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Current the checksum implementation is in client module while the checksum semantic is more close to protocol. Moreover, moving the checksum implementation to protocol will avoid server module's dependency to client module when doing checksum in server side.

Master Issue: #1007 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
