### PR TITLE
Remove unused import from DoubleByteBuf

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
@@ -17,7 +17,6 @@
 */
 package org.apache.bookkeeper.util;
 
-import com.google.common.collect.ObjectArrays;
 import io.netty.buffer.AbstractReferenceCountedByteBuf;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;


### PR DESCRIPTION
9fca59 left behind an import, which triggers a failure in checkstyle.
Fix is to remove the import.