### PR TITLE
[Merge Yahoo repo] CMS-1437: use BookieSocketAddress in DNSToSwitchMapping

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -110,9 +110,9 @@ class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsemblePlacemen
         }
 
         @Override
-        public List<String> resolve(List<String> names) {
-            List<String> rNames = new ArrayList<String>(names.size());
-            for (@SuppressWarnings("unused") String name : names) {
+        public List<String> resolve(List<BookieSocketAddress> bookieSocketAddresses) {
+            List<String> rNames = new ArrayList<String>(bookieSocketAddresses.size());
+            for (@SuppressWarnings("unused") BookieSocketAddress name : bookieSocketAddresses) {
                 final String defaultRack = defaultRackSupplier.get();
                 checkNotNull(defaultRack, "defaultRack cannot be null");
                 rNames.add(defaultRack);
@@ -143,30 +143,30 @@ class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsemblePlacemen
             this.resolver = resolver;
         }
 
-        public List<String> resolve(List<String> names) {
-            if (names == null) {
+        public List<String> resolve(List<BookieSocketAddress> bookieSocketAddresses) {
+            if (bookieSocketAddresses == null) {
                 return Collections.emptyList();
             }
             final String defaultRack = defaultRackSupplier.get();
             checkNotNull(defaultRack, "Default rack cannot be null");
 
-            List<String> rNames = resolver.resolve(names);
-            if (rNames != null && rNames.size() == names.size()) {
+            List<String> rNames = resolver.resolve(bookieSocketAddresses);
+            if (rNames != null && rNames.size() == bookieSocketAddresses.size()) {
                 for (int i = 0; i < rNames.size(); ++i) {
                     if (rNames.get(i) == null) {
                         LOG.warn("Failed to resolve network location for {}, using default rack for it : {}.",
-                                names.get(i), defaultRack);
+                                bookieSocketAddresses.get(i), defaultRack);
                         rNames.set(i, defaultRack);
                     }
                 }
                 return rNames;
             }
 
-            LOG.warn("Failed to resolve network location for {}, using default rack for them : {}.", names,
-                    defaultRack);
-            rNames = new ArrayList<>(names.size());
+            LOG.warn("Failed to resolve network location for {}, using default rack for them : {}.",
+                bookieSocketAddresses, defaultRack);
+            rNames = new ArrayList<>(bookieSocketAddresses.size());
 
-            for (int i = 0; i < names.size(); ++i) {
+            for (int i = 0; i < bookieSocketAddresses.size(); ++i) {
                 rNames.add(defaultRack);
             }
             return rNames;
@@ -333,7 +333,7 @@ class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsemblePlacemen
     }
 
     protected String resolveNetworkLocation(BookieSocketAddress addr) {
-        return NetUtils.resolveNetworkLocation(dnsResolver, addr.getSocketAddress());
+        return NetUtils.resolveNetworkLocation(dnsResolver, addr);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
@@ -86,7 +86,7 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
      * Get a copy of the map (for diagnostics).
      * @return a clone of the map or null for none known
      */
-    public Map<String, String> getSwitchMap() {
+    public Map<BookieSocketAddress, String> getSwitchMap() {
         return null;
     }
 
@@ -98,13 +98,13 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
      * debug messages.
      */
     public String dumpTopology() {
-        Map<String, String> rack = getSwitchMap();
+        Map<BookieSocketAddress, String> rack = getSwitchMap();
         StringBuilder builder = new StringBuilder();
         builder.append("Mapping: ").append(toString()).append("\n");
         if (rack != null) {
             builder.append("Map:\n");
             Set<String> switches = new HashSet<String>();
-            for (Map.Entry<String, String> entry : rack.entrySet()) {
+            for (Map.Entry<BookieSocketAddress, String> entry : rack.entrySet()) {
                 builder.append("  ").append(entry.getKey()).append(" -> ").append(entry.getValue()).append("\n");
                 switches.add(entry.getValue());
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
@@ -29,25 +29,24 @@ import java.util.List;
 @Beta
 public interface DNSToSwitchMapping {
     /**
-     * Resolves a list of DNS-names/IP-addresses and returns back a list of
+     * Resolves a list of {@link BookieSocketAddress} and returns back a list of
      * switch information (network paths). One-to-one correspondence must be
      * maintained between the elements in the lists.
      * Consider an element in the argument list - x.y.com. The switch information
      * that is returned must be a network path of the form /foo/rack,
      * where / is the root, and 'foo' is the switch where 'rack' is connected.
-     * Note the hostname/ip-address is not part of the returned path.
+     * Note the {@link BookieSocketAddress} is not part of the returned path.
      * The network topology of the cluster would determine the number of
      * components in the network path.
-     *
-     * <p>If a name cannot be resolved to a rack, the implementation
-     * should return {@link NetworkTopology#DEFAULT_REGION_AND_RACK}. This
+     * If a {@link BookieSocketAddress} cannot be resolved to a rack, the implementation
+     * should return {@link NetworkTopology#DEFAULT_RACK}. This
      * is what the bundled implementations do, though it is not a formal requirement
      *
-     * @param names the list of hosts to resolve (can be empty)
+     * @param bookieAddressList the list of hosts to resolve (can be empty)
      * @return list of resolved network paths.
-     * If <i>names</i> is empty, the returned list is also empty
+     * If <i>bookieAddressList</i> is empty, the returned list is also empty
      */
-    List<String> resolve(List<String> names);
+    List<String> resolve(List<BookieSocketAddress> bookieAddressList);
 
     /**
      * Reload all of the cached mappings.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
@@ -21,18 +21,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Network Utilities.
  */
+@Slf4j
 public class NetUtils {
     private static final Logger logger = LoggerFactory.getLogger(NetUtils.class);
 
@@ -68,18 +68,14 @@ public class NetUtils {
         return hostNames;
     }
 
-    public static String resolveNetworkLocation(DNSToSwitchMapping dnsResolver, InetSocketAddress addr) {
-        List<String> names = new ArrayList<String>(1);
-
-        if (dnsResolver.useHostName()) {
-            names.add(addr.getHostName());
-        } else {
-            names.add(addr.getAddress().getHostAddress());
-        }
-
+    public static String resolveNetworkLocation(DNSToSwitchMapping dnsResolver, BookieSocketAddress addr) {
+        List<BookieSocketAddress> bookieSocketAddresses = new ArrayList<BookieSocketAddress>(1);
+        bookieSocketAddresses.add(addr);
         // resolve network addresses
-        List<String> rNames = dnsResolver.resolve(names);
+        List<String> rNames = dnsResolver.resolve(bookieSocketAddresses);
         checkNotNull(rNames, "DNS Resolver should not return null response.");
+        rNames.forEach(name -> log.error("++++++++ rNames: " + name));
+
         checkState(rNames.size() == 1, "Expected exactly one element");
 
         return rNames.get(0);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
@@ -25,14 +25,12 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Network Utilities.
  */
-@Slf4j
 public class NetUtils {
     private static final Logger logger = LoggerFactory.getLogger(NetUtils.class);
 
@@ -74,7 +72,6 @@ public class NetUtils {
         // resolve network addresses
         List<String> rNames = dnsResolver.resolve(bookieSocketAddresses);
         checkNotNull(rNames, "DNS Resolver should not return null response.");
-        rNames.forEach(name -> log.error("++++++++ rNames: " + name));
 
         checkState(rNames.size() == 1, "Expected exactly one element");
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/ScriptBasedMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/ScriptBasedMapping.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
-
 import org.apache.bookkeeper.util.Shell.ShellCommandExecutor;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.logging.Log;
@@ -155,10 +154,10 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
         }
 
         @Override
-        public List<String> resolve(List<String> names) {
-            List<String> m = new ArrayList<String>(names.size());
+        public List<String> resolve(List<BookieSocketAddress> bookieAddressList) {
+            List<String> m = new ArrayList<String>(bookieAddressList.size());
 
-            if (names.isEmpty()) {
+            if (bookieAddressList.isEmpty()) {
                 return m;
             }
 
@@ -166,7 +165,7 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
                 return null;
             }
 
-            String output = runResolveCommand(names);
+            String output = runResolveCommand(bookieAddressList);
             if (output != null) {
                 StringTokenizer allSwitchInfo = new StringTokenizer(output);
                 while (allSwitchInfo.hasMoreTokens()) {
@@ -174,10 +173,10 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
                     m.add(switchInfo);
                 }
 
-                if (m.size() != names.size()) {
+                if (m.size() != bookieAddressList.size()) {
                     // invalid number of entries returned by the script
                     LOG.error("Script " + scriptName + " returned " + Integer.toString(m.size()) + " values when "
-                            + Integer.toString(names.size()) + " were expected.");
+                            + Integer.toString(bookieAddressList.size()) + " were expected.");
                     return null;
                 }
             } else {
@@ -197,7 +196,7 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
          * @return null if the number of arguments is out of range,
          * or the output of the command.
          */
-        private String runResolveCommand(List<String> args) {
+        private String runResolveCommand(List<BookieSocketAddress> args) {
             int loopCount = 0;
             if (args.size() == 0) {
                 return null;
@@ -217,7 +216,7 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
                 for (numProcessed = start;
                      numProcessed < (start + maxArgs) && numProcessed < args.size();
                      numProcessed++) {
-                    cmdList.add(args.get(numProcessed));
+                    cmdList.add(args.get(numProcessed).getSocketAddress().getAddress().getHostAddress());
                 }
                 File dir = null;
                 String userDir;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicy.java
@@ -67,10 +67,15 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
     protected void setUp() throws Exception {
         super.setUp();
         StaticDNSResolver.reset();
-        StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostAddress(),
-                NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack("127.0.0.1", NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack("localhost", NetworkTopology.DEFAULT_REGION_AND_RACK);
+        BookieSocketAddress bookieAddress = new BookieSocketAddress(
+            InetAddress.getLocalHost().getHostAddress(), 0);
+        StaticDNSResolver.addNodeToRack(bookieAddress,
+            NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(new BookieSocketAddress("127.0.0.1", 0),
+            NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(new BookieSocketAddress("localhost", 0),
+            NetworkTopology.DEFAULT_REGION_AND_RACK);
+
         LOG.info("Set up static DNS Resolver.");
         conf.setProperty(REPP_DNS_RESOLVER_CLASS, StaticDNSResolver.class.getName());
         addr1 = new BookieSocketAddress("127.0.0.2", 3181);
@@ -78,10 +83,10 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION + "/rack1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), NetworkTopology.DEFAULT_REGION + "/rack2");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION + "/rack1");
+        StaticDNSResolver.addNodeToRack(addr2, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr3, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr4, NetworkTopology.DEFAULT_REGION + "/rack2");
         ensemble.add(addr1);
         ensemble.add(addr2);
         ensemble.add(addr3);
@@ -89,9 +94,9 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         writeSet = writeSetFromValues(0, 1, 2, 3);
 
         timer = new HashedWheelTimer(
-                new ThreadFactoryBuilder().setNameFormat("TestTimer-%d").build(),
-                conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
-                conf.getTimeoutTimerNumTicks());
+            new ThreadFactoryBuilder().setNameFormat("TestTimer-%d").build(),
+            conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
+            conf.getTimeoutTimerNumTicks());
 
         repp = new RackawareEnsemblePlacementPolicy();
         repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer, DISABLE_ALL, NullStatsLogger.INSTANCE);
@@ -124,10 +129,12 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
     }
 
     static void updateMyRack(String rack) throws Exception {
-        StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostAddress(), rack);
-        StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostName(), rack);
-        StaticDNSResolver.addNodeToRack("127.0.0.1", rack);
-        StaticDNSResolver.addNodeToRack("localhost", rack);
+        StaticDNSResolver.addNodeToRack(new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(), 0),
+            rack);
+        StaticDNSResolver.addNodeToRack(new BookieSocketAddress("127.0.0.1", 0),
+            rack);
+        StaticDNSResolver.addNodeToRack(new BookieSocketAddress("localhost", 0),
+            rack);
     }
 
     @Test
@@ -381,10 +388,11 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4, "/default-region/r3");
+
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -404,10 +412,11 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r4");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/default-region/r4");
+
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -431,10 +440,11 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r4");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/default-region/r4");
+
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -462,10 +472,10 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.3", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.4", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/r3");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/r2");
+        StaticDNSResolver.addNodeToRack(addr4, "/r3");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -515,10 +525,11 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.3", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.4", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4, "/default-region/r2");
+
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -549,14 +560,14 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr7 = new BookieSocketAddress("127.0.0.8", 3181);
         BookieSocketAddress addr8 = new BookieSocketAddress("127.0.0.9", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r4");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/default-region/r3");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/default-region/r4");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/default-region/r4");
+        StaticDNSResolver.addNodeToRack(addr5, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr6, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr7, "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr8, "/default-region/r4");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -588,10 +599,10 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4, "/default-region/r3");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -610,13 +621,13 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.3", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.4", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr1,
                 NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr2,
                 NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr3,
                 NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr4,
                 NetworkTopology.DEFAULT_REGION + "/r2");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
@@ -662,13 +673,13 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.4", 3181);
         // update dns mapping
         StaticDNSResolver.reset();
-        StaticDNSResolver.addNodeToRack(addr1.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr1,
                 NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr2,
                 NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr3,
                 NetworkTopology.DEFAULT_REGION + "/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr4,
                 NetworkTopology.DEFAULT_REGION + "/r4");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
@@ -734,23 +745,21 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr9 = new BookieSocketAddress("127.0.0.9", 3181);
 
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getSocketAddress().getAddress().getHostAddress(),
-                NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, NetworkTopology.DEFAULT_REGION + "/r2");
+        StaticDNSResolver.addNodeToRack(addr3,
                 NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr4,
                 NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr5,
                 NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr5.getSocketAddress().getAddress().getHostAddress(),
-                NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr6.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr6,
                 NetworkTopology.DEFAULT_REGION + "/r3");
-        StaticDNSResolver.addNodeToRack(addr7.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr7,
                 NetworkTopology.DEFAULT_REGION + "/r3");
-        StaticDNSResolver.addNodeToRack(addr8.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr8,
                 NetworkTopology.DEFAULT_REGION + "/r3");
-        StaticDNSResolver.addNodeToRack(addr9.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr9,
                 NetworkTopology.DEFAULT_REGION + "/r3");
 
         // Update cluster
@@ -824,16 +833,17 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr5 = new BookieSocketAddress("127.0.0.5", 3181);
 
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr1,
                 NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr2,
                 NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr3,
                 NetworkTopology.DEFAULT_REGION + "/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr4,
                 NetworkTopology.DEFAULT_REGION + "/r3");
-        StaticDNSResolver.addNodeToRack(addr5.getSocketAddress().getAddress().getHostAddress(),
+        StaticDNSResolver.addNodeToRack(addr5,
                 NetworkTopology.DEFAULT_REGION + "/r3");
+
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -886,7 +896,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
             for (int j = 0; j < writeQuorumSize; j++) {
                 int bookieIdx = (i + j) % ensembleSize;
                 BookieSocketAddress addr = ensemble.get(bookieIdx);
-                racks.add(StaticDNSResolver.getRack(addr.getHostName()));
+                racks.add(StaticDNSResolver.getRack(addr));
             }
             numCoveredWriteQuorums += (racks.size() > 1 ? 1 : 0);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -70,14 +70,13 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
     HashedWheelTimer timer;
 
     static void updateMyRack(String rack) throws Exception {
-        StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostAddress(), rack);
-        StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostName(), rack);
         BookieSocketAddress bookieAddress = new BookieSocketAddress(
             InetAddress.getLocalHost().getHostAddress(), 0);
-        StaticDNSResolver.addNodeToRack(bookieAddress.getSocketAddress().getHostName(), rack);
-        StaticDNSResolver.addNodeToRack(bookieAddress.getSocketAddress().getAddress().getHostAddress(), rack);
-        StaticDNSResolver.addNodeToRack("127.0.0.1", rack);
-        StaticDNSResolver.addNodeToRack("localhost", rack);
+        StaticDNSResolver.addNodeToRack(bookieAddress, rack);
+        StaticDNSResolver.addNodeToRack(new BookieSocketAddress("127.0.0.1", 0),
+            rack);
+        StaticDNSResolver.addNodeToRack(new BookieSocketAddress("localhost", 0),
+            rack);
     }
 
     @Override
@@ -93,10 +92,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/r1/rack1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/r1/rack2");
+        StaticDNSResolver.addNodeToRack(addr1, "/r1/rack1");
+        StaticDNSResolver.addNodeToRack(addr2, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr3, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr4, "/r1/rack2");
         ensemble.add(addr1);
         ensemble.add(addr2);
         ensemble.add(addr3);
@@ -411,10 +410,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r1");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r1");
+        StaticDNSResolver.addNodeToRack(addr3, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr4, "/default-region/r3");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -435,10 +434,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region2/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region3/r4");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region2/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region3/r4");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -463,10 +462,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region2/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region3/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region4/r4");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/region2/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region3/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region4/r4");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -490,10 +489,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region2/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region3/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region4/r4");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/region2/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region3/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region4/r4");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -524,10 +523,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr1, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr4, "/region1/r2");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -557,10 +556,10 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
         BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), NetworkTopology.DEFAULT_REGION_AND_RACK);
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr1, NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr4, "/region1/r2");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -598,14 +597,14 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr7 = new BookieSocketAddress("127.0.0.8", 3181);
         BookieSocketAddress addr8 = new BookieSocketAddress("127.0.0.9", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/default-region/default-rack1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region2/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region3/r4");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/default-region/default-rack2");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region1/r12");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/region2/r13");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/region3/r14");
+        StaticDNSResolver.addNodeToRack(addr1, "/default-region/default-rack1");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region2/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region3/r4");
+        StaticDNSResolver.addNodeToRack(addr5, "/default-region/default-rack2");
+        StaticDNSResolver.addNodeToRack(addr6, "/region1/r12");
+        StaticDNSResolver.addNodeToRack(addr7, "/region2/r13");
+        StaticDNSResolver.addNodeToRack(addr8, "/region3/r14");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -645,16 +644,16 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr9 = new BookieSocketAddress("127.0.0.10", 3181);
         BookieSocketAddress addr10 = new BookieSocketAddress("127.0.0.11", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region2/r1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region2/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region3/r4");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region1/r11");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region1/r12");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/region2/r13");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/region3/r14");
-        StaticDNSResolver.addNodeToRack(addr9.getHostName(), "/region2/r23");
-        StaticDNSResolver.addNodeToRack(addr10.getHostName(), "/region1/r24");
+        StaticDNSResolver.addNodeToRack(addr1, "/region2/r1");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region2/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region3/r4");
+        StaticDNSResolver.addNodeToRack(addr5, "/region1/r11");
+        StaticDNSResolver.addNodeToRack(addr6, "/region1/r12");
+        StaticDNSResolver.addNodeToRack(addr7, "/region2/r13");
+        StaticDNSResolver.addNodeToRack(addr8, "/region3/r14");
+        StaticDNSResolver.addNodeToRack(addr9, "/region2/r23");
+        StaticDNSResolver.addNodeToRack(addr10, "/region1/r24");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -713,16 +712,16 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr9 = new BookieSocketAddress("127.0.0.10", 3181);
         BookieSocketAddress addr10 = new BookieSocketAddress("127.0.0.11", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region2/r1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region2/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region3/r4");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region1/r11");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region1/r12");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/region2/r13");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/region3/r14");
-        StaticDNSResolver.addNodeToRack(addr9.getHostName(), "/region2/r23");
-        StaticDNSResolver.addNodeToRack(addr10.getHostName(), "/region1/r24");
+        StaticDNSResolver.addNodeToRack(addr1, "/region2/r1");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region2/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region3/r4");
+        StaticDNSResolver.addNodeToRack(addr5, "/region1/r11");
+        StaticDNSResolver.addNodeToRack(addr6, "/region1/r12");
+        StaticDNSResolver.addNodeToRack(addr7, "/region2/r13");
+        StaticDNSResolver.addNodeToRack(addr8, "/region3/r14");
+        StaticDNSResolver.addNodeToRack(addr9, "/region2/r23");
+        StaticDNSResolver.addNodeToRack(addr10, "/region1/r24");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -800,21 +799,21 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr14 = new BookieSocketAddress("127.1.0.15", 3181);
         BookieSocketAddress addr15 = new BookieSocketAddress("127.1.0.16", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region1/r1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region1/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region2/r4");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region2/r11");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region2/r12");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/region3/r13");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/region3/r14");
-        StaticDNSResolver.addNodeToRack(addr9.getHostName(), "/region3/r23");
-        StaticDNSResolver.addNodeToRack(addr10.getHostName(), "/region4/r24");
-        StaticDNSResolver.addNodeToRack(addr11.getHostName(), "/region4/r31");
-        StaticDNSResolver.addNodeToRack(addr12.getHostName(), "/region4/r32");
-        StaticDNSResolver.addNodeToRack(addr13.getHostName(), "/region5/r33");
-        StaticDNSResolver.addNodeToRack(addr14.getHostName(), "/region5/r34");
-        StaticDNSResolver.addNodeToRack(addr15.getHostName(), "/region5/r35");
+        StaticDNSResolver.addNodeToRack(addr1, "/region1/r1");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region1/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region2/r4");
+        StaticDNSResolver.addNodeToRack(addr5, "/region2/r11");
+        StaticDNSResolver.addNodeToRack(addr6, "/region2/r12");
+        StaticDNSResolver.addNodeToRack(addr7, "/region3/r13");
+        StaticDNSResolver.addNodeToRack(addr8, "/region3/r14");
+        StaticDNSResolver.addNodeToRack(addr9, "/region3/r23");
+        StaticDNSResolver.addNodeToRack(addr10, "/region4/r24");
+        StaticDNSResolver.addNodeToRack(addr11, "/region4/r31");
+        StaticDNSResolver.addNodeToRack(addr12, "/region4/r32");
+        StaticDNSResolver.addNodeToRack(addr13, "/region5/r33");
+        StaticDNSResolver.addNodeToRack(addr14, "/region5/r34");
+        StaticDNSResolver.addNodeToRack(addr15, "/region5/r35");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -901,15 +900,15 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr8 = new BookieSocketAddress("127.1.0.9", 3181);
         BookieSocketAddress addr9 = new BookieSocketAddress("127.1.0.10", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region1/r1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region1/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region2/r4");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region2/r11");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region2/r12");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/region3/r13");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/region3/r14");
-        StaticDNSResolver.addNodeToRack(addr9.getHostName(), "/region3/r23");
+        StaticDNSResolver.addNodeToRack(addr1, "/region1/r1");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region1/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region2/r4");
+        StaticDNSResolver.addNodeToRack(addr5, "/region2/r11");
+        StaticDNSResolver.addNodeToRack(addr6, "/region2/r12");
+        StaticDNSResolver.addNodeToRack(addr7, "/region3/r13");
+        StaticDNSResolver.addNodeToRack(addr8, "/region3/r14");
+        StaticDNSResolver.addNodeToRack(addr9, "/region3/r23");
 
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
@@ -1044,15 +1043,15 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr8 = new BookieSocketAddress("127.1.0.9", 3181);
         BookieSocketAddress addr9 = new BookieSocketAddress("127.1.0.10", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region1/r1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region1/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region1/r4");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region1/r11");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region1/r12");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/region1/r13");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/region1/r14");
-        StaticDNSResolver.addNodeToRack(addr9.getHostName(), "/region1/r23");
+        StaticDNSResolver.addNodeToRack(addr1, "/region1/r1");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region1/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region1/r4");
+        StaticDNSResolver.addNodeToRack(addr5, "/region1/r11");
+        StaticDNSResolver.addNodeToRack(addr6, "/region1/r12");
+        StaticDNSResolver.addNodeToRack(addr7, "/region1/r13");
+        StaticDNSResolver.addNodeToRack(addr8, "/region1/r14");
+        StaticDNSResolver.addNodeToRack(addr9, "/region1/r23");
 
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
@@ -1113,16 +1112,16 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr9 = new BookieSocketAddress("127.0.0.10", 3181);
         BookieSocketAddress addr10 = new BookieSocketAddress("127.0.0.11", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region1/r1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region2/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region2/r4");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region3/r11");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region3/r12");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/region4/r13");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/region4/r14");
-        StaticDNSResolver.addNodeToRack(addr9.getHostName(), "/region5/r23");
-        StaticDNSResolver.addNodeToRack(addr10.getHostName(), "/region5/r24");
+        StaticDNSResolver.addNodeToRack(addr1, "/region1/r1");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region2/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region2/r4");
+        StaticDNSResolver.addNodeToRack(addr5, "/region3/r11");
+        StaticDNSResolver.addNodeToRack(addr6, "/region3/r12");
+        StaticDNSResolver.addNodeToRack(addr7, "/region4/r13");
+        StaticDNSResolver.addNodeToRack(addr8, "/region4/r14");
+        StaticDNSResolver.addNodeToRack(addr9, "/region5/r23");
+        StaticDNSResolver.addNodeToRack(addr10, "/region5/r24");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -1166,15 +1165,15 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr8 = new BookieSocketAddress("127.0.0.9", 3181);
         BookieSocketAddress addr9 = new BookieSocketAddress("127.0.0.10", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region1/r1");
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region1/r3");
-        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region2/r1");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region2/r2");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region2/r3");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/region3/r1");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/region3/r2");
-        StaticDNSResolver.addNodeToRack(addr9.getHostName(), "/region3/r3");
+        StaticDNSResolver.addNodeToRack(addr1, "/region1/r1");
+        StaticDNSResolver.addNodeToRack(addr2, "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3, "/region1/r3");
+        StaticDNSResolver.addNodeToRack(addr4, "/region2/r1");
+        StaticDNSResolver.addNodeToRack(addr5, "/region2/r2");
+        StaticDNSResolver.addNodeToRack(addr6, "/region2/r3");
+        StaticDNSResolver.addNodeToRack(addr7, "/region3/r1");
+        StaticDNSResolver.addNodeToRack(addr8, "/region3/r2");
+        StaticDNSResolver.addNodeToRack(addr9, "/region3/r3");
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -1230,17 +1229,17 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             int k = 0;
             for (; k < RegionAwareEnsemblePlacementPolicy.REMOTE_NODE_IN_REORDER_SEQUENCE; k++) {
                 BookieSocketAddress address = ensemble.get(readSet.get(k));
-                assertEquals(myRegion, StaticDNSResolver.getRegion(address.getHostName()));
+                assertEquals(myRegion, StaticDNSResolver.getRegion(address));
             }
             BookieSocketAddress remoteAddress = ensemble.get(readSet.get(k));
-            assertFalse(myRegion.equals(StaticDNSResolver.getRegion(remoteAddress.getHostName())));
+            assertFalse(myRegion.equals(StaticDNSResolver.getRegion(remoteAddress)));
             k++;
             BookieSocketAddress localAddress = ensemble.get(readSet.get(k));
-            assertEquals(myRegion, StaticDNSResolver.getRegion(localAddress.getHostName()));
+            assertEquals(myRegion, StaticDNSResolver.getRegion(localAddress));
             k++;
             for (; k < ensembleSize; k++) {
                 BookieSocketAddress address = ensemble.get(readSet.get(k));
-                assertFalse(myRegion.equals(StaticDNSResolver.getRegion(address.getHostName())));
+                assertFalse(myRegion.equals(StaticDNSResolver.getRegion(address)));
             }
         }
     }
@@ -1299,7 +1298,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
     static Set<BookieSocketAddress> getBookiesForRegion(ArrayList<BookieSocketAddress> ensemble, String region) {
         Set<BookieSocketAddress> regionBookies = new HashSet<BookieSocketAddress>();
         for (BookieSocketAddress address : ensemble) {
-            String r = StaticDNSResolver.getRegion(address.getHostName());
+            String r = StaticDNSResolver.getRegion(address);
             if (r.equals(region)) {
                 regionBookies.add(address);
             }
@@ -1313,7 +1312,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
                                           List<Integer> finalSet) {
         for (int i = 0; i < writeSet.size(); i++) {
             int bi = writeSet.get(i);
-            String r = StaticDNSResolver.getRegion(ensemble.get(bi).getHostName());
+            String r = StaticDNSResolver.getRegion(ensemble.get(bi));
             if (r.equals(region)) {
                 finalSet.add(bi);
             }
@@ -1375,7 +1374,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
     private int getNumRegionsInEnsemble(ArrayList<BookieSocketAddress> ensemble) {
         Set<String> regions = new HashSet<String>();
         for (BookieSocketAddress addr: ensemble) {
-            regions.add(StaticDNSResolver.getRegion(addr.getHostName()));
+            regions.add(StaticDNSResolver.getRegion(addr));
         }
         return regions.size();
     }
@@ -1389,7 +1388,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             for (int j = 0; j < writeQuorumSize; j++) {
                 int bookieIdx = (i + j) % ensembleSize;
                 BookieSocketAddress addr = ensemble.get(bookieIdx);
-                regions.add(StaticDNSResolver.getRegion(addr.getHostName()));
+                regions.add(StaticDNSResolver.getRegion(addr));
             }
             numCoveredWriteQuorums += (regions.size() > 1 ? 1 : 0);
         }
@@ -1409,12 +1408,12 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieSocketAddress addr7 = new BookieSocketAddress("127.0.0.8", 3181);
         BookieSocketAddress addr8 = new BookieSocketAddress("127.0.0.9", 3181);
         // update dns mapping
-        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/r2/rack1");
-        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/r2/rack2");
-        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/r1/rack3");
-        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/r2/rack3");
-        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/r2/rack4");
-        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/r1/rack4");
+        StaticDNSResolver.addNodeToRack(addr2, "/r2/rack1");
+        StaticDNSResolver.addNodeToRack(addr3, "/r2/rack2");
+        StaticDNSResolver.addNodeToRack(addr5, "/r1/rack3");
+        StaticDNSResolver.addNodeToRack(addr6, "/r2/rack3");
+        StaticDNSResolver.addNodeToRack(addr7, "/r2/rack4");
+        StaticDNSResolver.addNodeToRack(addr8, "/r1/rack4");
         ensemble.add(addr5);
         ensemble.add(addr6);
         ensemble.add(addr7);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/StaticDNSResolver.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/StaticDNSResolver.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import org.apache.bookkeeper.net.AbstractDNSToSwitchMapping;
+import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.net.DNSToSwitchMapping;
 import org.apache.bookkeeper.net.NetworkTopology;
 import org.apache.bookkeeper.net.NodeBase;
@@ -36,25 +36,26 @@ public class StaticDNSResolver extends AbstractDNSToSwitchMapping {
 
     static final Logger LOG = LoggerFactory.getLogger(StaticDNSResolver.class);
 
-    private static final ConcurrentMap<String, String> name2Racks = new ConcurrentHashMap<String, String>();
+    private static final ConcurrentMap<BookieSocketAddress, String> name2Racks =
+        new ConcurrentHashMap<BookieSocketAddress, String>();
 
-    public static void addNodeToRack(String name, String rack) {
-        name2Racks.put(name, rack);
+    public static void addNodeToRack(BookieSocketAddress bookieAddress, String rack) {
+        name2Racks.put(bookieAddress, rack);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Add node {} to rack {}.", name, rack);
+            LOG.debug("Add node {} to rack {}.", bookieAddress, rack);
         }
     }
 
-    public static String getRack(String name) {
-        String rack = name2Racks.get(name);
+    public static String getRack(BookieSocketAddress bookieAddress) {
+        String rack = name2Racks.get(bookieAddress);
         if (null == rack) {
             rack = NetworkTopology.DEFAULT_REGION_AND_RACK;
         }
         return rack;
     }
 
-    public static String getRegion(String name) {
-        String[] parts = getRack(name).split(NodeBase.PATH_SEPARATOR_STR);
+    public static String getRegion(BookieSocketAddress bookieAddress) {
+        String[] parts = getRack(bookieAddress).split(NodeBase.PATH_SEPARATOR_STR);
         if (parts.length <= 1) {
             return NetworkTopology.DEFAULT_REGION;
         } else {
@@ -67,12 +68,12 @@ public class StaticDNSResolver extends AbstractDNSToSwitchMapping {
     }
 
     @Override
-    public List<String> resolve(List<String> names) {
+    public List<String> resolve(List<BookieSocketAddress> bookieAddressList) {
         List<String> racks = new ArrayList<String>();
-        for (String n : names) {
-            String rack = name2Racks.get(n);
+        for (BookieSocketAddress bookieAddress : bookieAddressList) {
+            String rack = name2Racks.get(bookieAddress);
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Resolve name {} to rack {}.", n, rack);
+                LOG.debug("Resolve name {} to rack {}.", bookieAddress, rack);
             }
             racks.add(rack);
         }


### PR DESCRIPTION

Descriptions of the changes in this PR:

use BookieSocketAddress in DNSToSwitchMapping.
Change-Id: Id74b6d31176f6e34f0cd148eae35adc7da2f3808
Here is original commit:
https://github.com/yahoo/bookkeeper/commit/569fff21
