### PR TITLE
proto/*Processor: clean up logging, include exception stack

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -93,17 +93,17 @@ class ReadEntryProcessor extends PacketProcessorBase {
                         errorCode = BookieProtocol.EOK;
                     }
                 } catch (InterruptedException ie) {
-                    LOG.error("Interrupting fence read entry " + read, ie);
+                    LOG.error("Interrupting fence read entry {}", read, ie);
                     errorCode = BookieProtocol.EIO;
                     data.release();
                     data = null;
                 } catch (ExecutionException ee) {
-                    LOG.error("Failed to fence read entry " + read, ee);
+                    LOG.error("Failed to fence read entry {}", read, ee);
                     errorCode = BookieProtocol.EIO;
                     data.release();
                     data = null;
                 } catch (TimeoutException te) {
-                    LOG.error("Timeout to fence read entry " + read, te);
+                    LOG.error("Timeout to fence read entry {}", read, te);
                     errorCode = BookieProtocol.EIO;
                     data.release();
                     data = null;
@@ -112,22 +112,20 @@ class ReadEntryProcessor extends PacketProcessorBase {
                 errorCode = BookieProtocol.EOK;
             }
         } catch (Bookie.NoLedgerException e) {
-            if (LOG.isTraceEnabled()) {
-                LOG.error("Error reading " + read, e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error reading {}", read, e);
             }
             errorCode = BookieProtocol.ENOLEDGER;
         } catch (Bookie.NoEntryException e) {
-            if (LOG.isTraceEnabled()) {
-                LOG.error("Error reading " + read, e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error reading {}", read, e);
             }
             errorCode = BookieProtocol.ENOENTRY;
         } catch (IOException e) {
-            if (LOG.isTraceEnabled()) {
-                LOG.error("Error reading " + read, e);
-            }
+            LOG.error("Error reading {}", read, e);
             errorCode = BookieProtocol.EIO;
         } catch (BookieException e) {
-            LOG.error("Unauthorized access to ledger " + read.getLedgerId(), e);
+            LOG.error("Unauthorized access to ledger {}", read.getLedgerId(), e);
             errorCode = BookieProtocol.EUA;
         } catch (Throwable t) {
             LOG.error("Unexpected exception reading at {}:{} : {}", read.getLedgerId(), read.getEntryId(),
@@ -136,7 +134,7 @@ class ReadEntryProcessor extends PacketProcessorBase {
         }
 
         if (LOG.isTraceEnabled()) {
-            LOG.trace("Read entry rc = {} for {}", new Object[] { errorCode, read });
+            LOG.trace("Read entry rc = {} for {}", errorCode, read);
         }
         if (errorCode == BookieProtocol.EOK) {
             requestProcessor.readEntryStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
@@ -78,7 +78,7 @@ class ReadLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             }
         } catch (Bookie.NoLedgerException e) {
             status = StatusCode.ENOLEDGER;
-            logger.error("No ledger found while performing readLac from ledger: {}", ledgerId);
+            logger.error("No ledger found while performing readLac from ledger: {}", ledgerId, e);
         } catch (IOException e) {
             status = StatusCode.EIO;
             logger.error("IOException while performing readLac from ledger: {}", ledgerId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
@@ -116,12 +116,12 @@ class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
                     entryId, ledgerId, e);
             status = StatusCode.EIO;
         } catch (BookieException.LedgerFencedException e) {
-            logger.debug("Ledger fenced while writing entry:{} to ledger:{}",
-                         entryId, ledgerId);
+            logger.error("Ledger fenced while writing entry:{} to ledger:{}",
+                    entryId, ledgerId, e);
             status = StatusCode.EFENCED;
         } catch (BookieException e) {
             logger.error("Unauthorized access to ledger:{} while writing entry:{}",
-                         ledgerId, entryId);
+                    ledgerId, entryId, e);
             status = StatusCode.EUA;
         } catch (Throwable t) {
             logger.error("Unexpected exception while writing {}@{} : ",

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -73,16 +73,16 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             requestProcessor.bookie.setExplicitLac(Unpooled.wrappedBuffer(lacToAdd), channel, masterKey);
             status = StatusCode.EOK;
         } catch (IOException e) {
-            logger.error("Error saving lac for ledger:{}",
+            logger.error("Error saving lac {} for ledger:{}",
                     lac, ledgerId, e);
             status = StatusCode.EIO;
         } catch (BookieException e) {
             logger.error("Unauthorized access to ledger:{} while adding lac:{}",
-                                                  ledgerId, lac);
+                    ledgerId, lac, e);
             status = StatusCode.EUA;
         } catch (Throwable t) {
-            logger.error("Unexpected exception while writing {}@{} : ",
-                    new Object[] { lac, t });
+            logger.error("Unexpected exception while writing lac {} for ledger:{}",
+                    lac, ledgerId, t);
             // some bad request which cause unexpected exception
             status = StatusCode.EBADREQ;
         }


### PR DESCRIPTION
For WriteEntryProcessorV3, log fence exception at error in order to help
with debugging the cause of a fenced ledger.

(@bug W-3299246@)
(@bug W-3158835@)
Signed-off-by: Andrey Yegorov <ayegorovsalesforce.com>
Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>
[Minor formatting fixes]
Signed-off-by: Samuel Just <sjust@salesforce.com>