### PR TITLE
Utilities for bookies running in test containers

### DIFF
--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/BookKeeperClusterUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/BookKeeperClusterUtils.java
@@ -175,7 +175,7 @@ public class BookKeeperClusterUtils {
             LOG.error("Exception stopping bookie", e);
             return false;
         }
-        return waitBookieDown(docker, containerId, 10, TimeUnit.SECONDS);
+        return waitBookieDown(docker, containerId, 5, TimeUnit.SECONDS);
     }
 
     public static boolean stopAllBookies(DockerClient docker) {


### PR DESCRIPTION
The changes include:
- Updating configuration in bk_server.conf for one or all bookies
- Run commands on all or one bookie
- Wait for all bookies in the test are up

There are also improvements to DockerUtils#runCommand:
- Better logging
- Catches RunTime exceptions, as Docker-java throws them and it could
  fail the test
- Throw an exception is the command exits with anything but 0

Master Issue: #903
