### PR TITLE
Only run integration tests with -DintegrationTests

### DIFF
--- a/tests/docker-all-versions-image/pom.xml
+++ b/tests/docker-all-versions-image/pom.xml
@@ -40,6 +40,11 @@
   <profiles>
     <profile>
       <id>docker</id>
+      <activation>
+        <property>
+          <name>integrationTests</name>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/tests/integration-tests-base/pom.xml
+++ b/tests/integration-tests-base/pom.xml
@@ -63,6 +63,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!-- only run tests when -DintegrationTests is specified //-->
+          <skipTests>true</skipTests>
           <systemPropertyVariables>
             <currentVersion>${project.version}</currentVersion>
             <maven.buildDirectory>${project.build.directory}</maven.buildDirectory>
@@ -72,4 +74,25 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>integrationTests</id>
+      <activation>
+        <property>
+          <name>integrationTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>false</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Integration tests have a higher system requirement than normal unit
tests, and take longer to run, so they should be explicitly enabled.

Master Issue: #903
