### PR TITLE
Arquillian topologies module

### DIFF
--- a/tests/integration-tests-base/pom.xml
+++ b/tests/integration-tests-base/pom.xml
@@ -42,6 +42,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.bookkeeper.tests</groupId>
+      <artifactId>integration-tests-topologies</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-standalone</artifactId>
       <version>1.1.14.Final</version>

--- a/tests/integration-tests-topologies/pom.xml
+++ b/tests/integration-tests-topologies/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+  http://maven.apache.org/POM/4.0.0
+  http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.bookkeeper.tests</groupId>
+    <artifactId>tests-parent</artifactId>
+    <version>4.7.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.apache.bookkeeper.tests</groupId>
+  <artifactId>integration-tests-topologies</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Apache BookKeeper :: Tests :: Common topologies for Arquillian based integration tests</name>
+
+</project>

--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/3-node-all-version-unstarted.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/3-node-all-version-unstarted.yaml
@@ -1,0 +1,64 @@
+#/**
+# * Copyright 2007 The Apache Software Foundation
+# *
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+networks:
+  testnetwork*:
+    driver: bridge
+
+zookeeper*:
+  image: jplock/zookeeper
+  await:
+    strategy: org.apache.bookkeeper.tests.ZooKeeperAwaitStrategy
+  aliases:
+    - zookeeper
+  beforeStop:
+    - customBeforeStopAction:
+        strategy: org.apache.bookkeeper.tests.LogToTargetDirStopAction
+  networkMode: testnetwork*
+
+bookkeeper1*:
+  image: apachebookkeeper/bookkeeper-all-versions
+  await:
+    strategy: org.apache.bookkeeper.tests.NoopAwaitStrategy
+  env: [BK_ZKCONNECTSTRING=zookeeper]
+  beforeStop:
+    - customBeforeStopAction:
+        strategy: org.apache.bookkeeper.tests.BookKeeperLogsToTargetDirStopAction
+  networkMode: testnetwork*
+
+bookkeeper2*:
+  image: apachebookkeeper/bookkeeper-all-versions
+  await:
+    strategy: org.apache.bookkeeper.tests.NoopAwaitStrategy
+  env: [BK_ZKCONNECTSTRING=zookeeper]
+  beforeStop:
+    - customBeforeStopAction:
+        strategy: org.apache.bookkeeper.tests.BookKeeperLogsToTargetDirStopAction
+  networkMode: testnetwork*
+
+bookkeeper3*:
+  image: apachebookkeeper/bookkeeper-all-versions
+  await:
+    strategy: org.apache.bookkeeper.tests.NoopAwaitStrategy
+  env: [BK_ZKCONNECTSTRING=zookeeper]
+  beforeStop:
+    - customBeforeStopAction:
+        strategy: org.apache.bookkeeper.tests.BookKeeperLogsToTargetDirStopAction
+  networkMode: testnetwork*
+

--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/3-node-all-version-unstarted.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/3-node-all-version-unstarted.yaml
@@ -22,7 +22,7 @@ networks:
     driver: bridge
 
 zookeeper*:
-  image: jplock/zookeeper
+  image: zookeeper:3.4.11
   await:
     strategy: org.apache.bookkeeper.tests.ZooKeeperAwaitStrategy
   aliases:

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -39,6 +39,7 @@
     <module>integration-tests-base</module>
     <module>integration-tests-base-groovy</module>
     <module>integration-tests-utils</module>
+    <module>integration-tests-topologies</module>
   </modules>
   <build>
     <plugins>


### PR DESCRIPTION
Will allow topologies to be shared among modules, which is important
as arquillian builds and pulls down the containers on a per
module/suite basis.

Currently contains a single topology, which is 3 BK nodes and 1 ZK
nodes. The BK nodes contain all released versions, with no version
started by default.

Master Issue: #903