### PR TITLE
Test compatibility between old hierarchical ledger manager and current

### DIFF
--- a/tests/backward-compat-hierarchical-ledger-manager/pom.xml
+++ b/tests/backward-compat-hierarchical-ledger-manager/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+  http://maven.apache.org/POM/4.0.0
+  http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.bookkeeper.tests</groupId>
+    <artifactId>integration-tests-base-groovy</artifactId>
+    <version>4.7.0-SNAPSHOT</version>
+    <relativePath>../integration-tests-base-groovy</relativePath>
+  </parent>
+
+  <groupId>org.apache.bookkeeper.tests</groupId>
+  <artifactId>backward-compat-hierarchical-ledger-manager</artifactId>
+  <packaging>jar</packaging>
+  <name>Apache BookKeeper :: Tests :: Test compat between old version and new version of hierarchical ledger manager</name>
+
+</project>

--- a/tests/backward-compat-hierarchical-ledger-manager/src/test/groovy/org/apache/bookkeeper/tests/TestCompatHierarchicalLedgerManager.groovy
+++ b/tests/backward-compat-hierarchical-ledger-manager/src/test/groovy/org/apache/bookkeeper/tests/TestCompatHierarchicalLedgerManager.groovy
@@ -1,0 +1,92 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.bookkeeper.tests
+
+import com.github.dockerjava.api.DockerClient
+
+import org.jboss.arquillian.junit.Arquillian
+import org.jboss.arquillian.test.api.ArquillianResource
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@RunWith(Arquillian.class)
+class TestCompatHierarchicalLedgerManager {
+    private static final Logger LOG = LoggerFactory.getLogger(TestCompatHierarchicalLedgerManager.class)
+    private static byte[] PASSWD = "foobar".getBytes()
+
+    @ArquillianResource
+    DockerClient docker
+
+    /**
+     * Test compatability between version old version and the current version
+     * with respect to the HierarchicalLedgerManagers.
+     * - 4.2.0 server starts with HierarchicalLedgerManager.
+     * - Write ledgers with old and new clients
+     * - Read ledgers written by old clients.
+     */
+    @Test
+    public void testCompatHierarchicalLedgerManagerV420toCurrent() throws Exception {
+        String currentVersion = System.getProperty("currentVersion")
+        BookKeeperClusterUtils.legacyMetadataFormat(docker)
+
+        BookKeeperClusterUtils.updateAllBookieConf(docker, "4.2.0",
+                                                   "ledgerManagerFactoryClass",
+                                                   "org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory")
+        Assert.assertTrue(BookKeeperClusterUtils.startAllBookiesWithVersion(docker, "4.2.0"))
+
+        String zookeeper = BookKeeperClusterUtils.zookeeperConnectString(docker)
+        int numEntries = 10
+        def v420CL = MavenClassLoader.forBookKeeperVersion("4.2.0")
+        def v420BK = v420CL.newBookKeeper(zookeeper)
+
+        def ledger0 = v420BK.createLedger(3, 2, v420CL.digestType("CRC32"), PASSWD)
+        for (int i = 0; i < numEntries; i++) {
+            ledger0.addEntry(("foobar" + i).getBytes())
+        }
+        ledger0.close()
+
+        Assert.assertTrue(BookKeeperClusterUtils.stopAllBookies(docker))
+
+        BookKeeperClusterUtils.updateAllBookieConf(docker, currentVersion,
+                                                   "ledgerManagerFactoryClass",
+                                                   "org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory")
+        Assert.assertTrue(BookKeeperClusterUtils.startAllBookiesWithVersion(docker, currentVersion))
+
+        def currentCL = MavenClassLoader.forBookKeeperVersion(currentVersion)
+        def currentBK = currentCL.newBookKeeper(zookeeper)
+
+        def ledger1 = currentBK.openLedger(ledger0.getId(), currentCL.digestType("CRC32"), PASSWD)
+        Assert.assertEquals(numEntries, ledger1.getLastAddConfirmed() + 1 /* counts from 0 */)
+        def entries = ledger1.readEntries(0, ledger1.getLastAddConfirmed())
+        int j = 0
+        while (entries.hasMoreElements()) {
+            def e = entries.nextElement()
+            Assert.assertEquals(new String(e.getEntry()), "foobar"+ j)
+            j++
+        }
+        ledger1.close()
+
+        v420BK.close()
+        currentBK.close()
+    }
+}

--- a/tests/backward-compat-hierarchical-ledger-manager/src/test/resources/arquillian.xml
+++ b/tests/backward-compat-hierarchical-ledger-manager/src/test/resources/arquillian.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+                                http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <extension qualifier="docker">
+    <property name="definitionFormat">CUBE</property>
+    <property name="dockerContainersResource">cube-definitions/3-node-all-version-unstarted.yaml</property>
+  </extension>
+
+</arquillian>

--- a/tests/backward/src/test/java/org/apache/bookkeeper/tests/backward/TestBackwardCompat.java
+++ b/tests/backward/src/test/java/org/apache/bookkeeper/tests/backward/TestBackwardCompat.java
@@ -659,46 +659,4 @@ public class TestBackwardCompat {
         oldledger.close();
         scur.stop();
     }
-
-    /**
-     * Test compatability between version old version and the current version
-     * with respect to the HierarchicalLedgerManagers.
-     * - 4.2.0 server starts with HierarchicalLedgerManager.
-     * - Write ledgers with old and new clients
-     * - Read ledgers written by old clients.
-     */
-    @Test
-    public void testCompatHierarchicalLedgerManager() throws Exception {
-        File journalDir = createTempDir("bookie", "journal");
-        File ledgerDir = createTempDir("bookie", "ledger");
-
-        int port = PortManager.nextFreePort();
-        // start server, upgrade
-        Server420 s420 = new Server420(journalDir, ledgerDir, port);
-        s420.getConf().setLedgerManagerFactoryClassName(
-                "org.apache.bk_v4_2_0.bookkeeper.meta.HierarchicalLedgerManagerFactory");
-        s420.start();
-
-        Ledger420 l420 = Ledger420.newLedger();
-        l420.write100();
-        long oldLedgerId = l420.getId();
-        l420.close();
-        s420.stop();
-
-        // Start the current server
-        ServerCurrent scur = new ServerCurrent(journalDir, ledgerDir, port, false);
-        scur.getConf().setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory");
-        scur.getConf().setProperty(AbstractConfiguration.LEDGER_MANAGER_FACTORY_DISABLE_CLASS_CHECK, true);
-        scur.start();
-
-        // Munge the conf so we can test.
-        ClientConfiguration conf = new ClientConfiguration();
-        conf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory");
-        conf.setProperty(AbstractConfiguration.LEDGER_MANAGER_FACTORY_DISABLE_CLASS_CHECK, true);
-
-        // check that new client can read old ledgers on new server
-        LedgerCurrent oldledger = LedgerCurrent.openLedger(oldLedgerId, conf);
-        assertEquals("Failed to read entries!", 100, oldledger.readAll());
-        oldledger.close();
-    }
 }

--- a/tests/backward/src/test/java/org/apache/bookkeeper/tests/backward/TestBackwardCompat.java
+++ b/tests/backward/src/test/java/org/apache/bookkeeper/tests/backward/TestBackwardCompat.java
@@ -34,7 +34,6 @@ import java.util.List;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
-import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.test.PortManager;

--- a/tests/integration-tests-base-groovy/pom.xml
+++ b/tests/integration-tests-base-groovy/pom.xml
@@ -36,8 +36,8 @@
 
   <properties>
     <groovy.version>2.4.13</groovy.version>
-    <groovy-eclipse-compiler.version>2.9.2-01</groovy-eclipse-compiler.version>
-    <groovy-eclipse-batch.version>2.4.3-01</groovy-eclipse-batch.version>
+    <groovy-eclipse-compiler.version>2.9.2-04</groovy-eclipse-compiler.version>
+    <groovy-eclipse-batch.version>2.4.13-02</groovy-eclipse-batch.version>
   </properties>
 
   <build>
@@ -105,4 +105,14 @@
       <version>${groovy.version}</version>
     </dependency>
   </dependencies>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>bintray</id>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <name>groovy-bintray-plugins</name>
+      <url>https://dl.bintray.com/groovy/maven</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -40,6 +40,7 @@
     <module>integration-tests-base-groovy</module>
     <module>integration-tests-utils</module>
     <module>integration-tests-topologies</module>
+    <module>backward-compat-hierarchical-ledger-manager</module>
   </modules>
   <build>
     <plugins>


### PR DESCRIPTION
Ensures that the current client and server can handle ledgers created by the
hierarchical ledger manager from 4.2.0.

Replaces TestBackwardCompat#testCompatHierarchicalLedgerManager from old tests

Master Issue: #903
