### PR TITLE
AuditorLedgerCheckerTest: wait for ro transition to make more reliable

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -294,10 +295,12 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         int count = ledgerList.size();
         final CountDownLatch underReplicaLatch = registerUrLedgerWatcher(count);
 
-        ServerConfiguration bookieConf = bsConfs.get(2);
-        BookieServer bk = bs.get(2);
+        final int bkIndex = 2;
+        ServerConfiguration bookieConf = bsConfs.get(bkIndex);
+        BookieServer bk = bs.get(bkIndex);
         bookieConf.setReadOnlyModeEnabled(true);
         bk.getBookie().getStateManager().doTransitionToReadOnlyMode();
+        bkc.waitForReadOnlyBookie(Bookie.getBookieAddress(bsConfs.get(bkIndex))).get(30, TimeUnit.SECONDS);
 
         // grace period for publishing the bk-ledger
         LOG.debug("Waiting for Auditor to finish ledger check.");
@@ -324,6 +327,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         BookieServer bk = bs.get(bkIndex);
         bookieConf.setReadOnlyModeEnabled(true);
         bk.getBookie().getStateManager().doTransitionToReadOnlyMode();
+        bkc.waitForReadOnlyBookie(Bookie.getBookieAddress(bsConfs.get(bkIndex))).get(30, TimeUnit.SECONDS);
 
         // grace period for publishing the bk-ledger
         LOG.debug("Waiting for Auditor to finish ledger check.");


### PR DESCRIPTION
(@bug W-2999244@)
Signed-off-by: Andrey Yegorov <ayegorovsalesforce.com>
[Reworked for master]
Signed-off-by: Samuel Just <sjust@salesforce.com>