### PR TITLE
[Merge Yahoo repo] : 164, 165, 173,177, 205, 207, 209

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -2955,7 +2955,8 @@ public class BookieShell implements Tool {
         if (null == journals) {
             journals = Lists.newArrayListWithCapacity(bkConf.getJournalDirs().length);
             for (File journalDir : bkConf.getJournalDirs()) {
-                journals.add(new Journal(journalDir, bkConf, new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
+                journals.add(new Journal(new File(journalDir, BookKeeperConstants.CURRENT_DIR), bkConf,
+                    new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
                         new DiskChecker(bkConf.getDiskUsageThreshold(), bkConf.getDiskUsageWarnThreshold()))));
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -674,12 +674,26 @@ public class BookieShell implements Tool {
                 printUsage();
                 return -1;
             }
-            if (printMeta) {
-                // print meta
-                readLedgerMeta(ledgerId);
+
+            if (bkConf.getLedgerStorageClass().equals(DbLedgerStorage.class.getName())) {
+                // dump ledger info
+                try {
+                    DbLedgerStorage.readLedgerIndexEntries(ledgerId, bkConf,
+                            (currentEntry, entryLogId, position) -> System.out.println(
+                                    "entry " + currentEntry + "\t:\t(log: " + entryLogId + ", pos: " + position + ")"));
+                } catch (IOException e) {
+                    System.err.printf("ERROR: initializing dbLedgerStorage %s", e.getMessage());
+                    return -1;
+                }
+            } else {
+                if (printMeta) {
+                    // print meta
+                    readLedgerMeta(ledgerId);
+                }
+                // dump ledger info
+                readLedgerIndexEntries(ledgerId);
             }
-            // dump ledger info
-            readLedgerIndexEntries(ledgerId);
+
             return 0;
         }
 
@@ -3002,7 +3016,7 @@ public class BookieShell implements Tool {
     }
 
     /**
-     * Read ledger index entires.
+     * Read ledger index entries.
      *
      * @param ledgerId Ledger Id
      * @throws IOException

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -568,6 +568,8 @@ public class EntryLogger {
         } finally {
             serializedMap.release();
         }
+        //Flush the ledger's map out before we write the header.  Otherwise the header might point to something that is not fully written
+        entryLogChannel.flush(false);
 
         // Update the headers with the map offset and count of ledgers
         ByteBuffer mapInfo = ByteBuffer.allocate(8 + 4);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -568,7 +568,8 @@ public class EntryLogger {
         } finally {
             serializedMap.release();
         }
-        //Flush the ledger's map out before we write the header.  Otherwise the header might point to something that is not fully written
+        // Flush the ledger's map out before we write the header.
+        // Otherwise the header might point to something that is not fully written
         entryLogChannel.flush(false);
 
         // Update the headers with the map offset and count of ledgers

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1314,6 +1314,8 @@ public class EntryLogger {
                 // Move to next entry, if any
                 offset += ledgersMapSize + 4;
             }
+        } catch (IndexOutOfBoundsException e) {
+            throw new IOException(e);
         } finally {
             ledgersMap.release();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -21,14 +21,13 @@
 package org.apache.bookkeeper.bookie.storage.ldb;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.DefaultThreadFactory;
-
 import java.io.IOException;
 import java.util.SortedMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -40,7 +39,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.Bookie.NoEntryException;
 import org.apache.bookkeeper.bookie.BookieException;
@@ -56,11 +54,13 @@ import org.apache.bookkeeper.bookie.LedgerDirsManager;
 import org.apache.bookkeeper.bookie.StateManager;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorageDataFormats.LedgerData;
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorage.Batch;
+import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageFactory.DbConfigType;
 import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.stats.Gauge;
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
@@ -773,7 +773,6 @@ public class DbLedgerStorage implements CompactableLedgerStorage {
 
         return numberOfEntries.get();
     }
-
     @Override
     public void registerLedgerDeletionListener(LedgerDeletionListener listener) {
         ledgerDeletionListeners.add(listener);
@@ -789,6 +788,47 @@ public class DbLedgerStorage implements CompactableLedgerStorage {
 
     private void recordFailedEvent(OpStatsLogger logger, long startTimeNanos) {
         logger.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Reads ledger index entries to get list of entry-logger that contains given ledgerId
+     *
+     * @param ledgerId
+     * @param serverConf
+     * @param processor
+     * @throws IOException
+     */
+    public static void readLedgerIndexEntries(long ledgerId, ServerConfiguration serverConf,
+            LedgerLoggerProcessor processor) throws IOException {
+
+        checkNotNull(serverConf, "ServerConfiguration can't be null");
+        checkNotNull(processor, "LedgerLoggger info processor can't null");
+
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(serverConf, serverConf.getLedgerDirs());
+        String ledgerBasePath = ledgerDirsManager.getAllLedgerDirs().get(0).toString();
+
+        EntryLocationIndex entryLocationIndex = new EntryLocationIndex(serverConf,
+                (path, dbConfigType, conf1) -> new KeyValueStorageRocksDB(path, DbConfigType.Small, conf1, true),
+                ledgerBasePath, NullStatsLogger.INSTANCE);
+        try {
+            long lastEntryId = entryLocationIndex.getLastEntryInLedger(ledgerId);
+            for (long currentEntry = 0; currentEntry <= lastEntryId; currentEntry++) {
+                long offset = entryLocationIndex.getLocation(ledgerId, currentEntry);
+                if (offset <= 0) {
+                    // entry not found in this bookie
+                    continue;
+                }
+                long entryLogId = offset >> 32L;
+                long position = offset & 0xffffffffL;
+                processor.process(currentEntry, entryLogId, position);
+            }
+        } finally {
+            entryLocationIndex.close();
+        }
+    }
+
+    public interface LedgerLoggerProcessor {
+        void process(long entryId, long entryLogId, long position);
     }
 
     private static final Logger log = LoggerFactory.getLogger(DbLedgerStorage.class);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -63,6 +63,7 @@ import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.util.DiskChecker;
 import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -791,7 +792,7 @@ public class DbLedgerStorage implements CompactableLedgerStorage {
     }
 
     /**
-     * Reads ledger index entries to get list of entry-logger that contains given ledgerId
+     * Reads ledger index entries to get list of entry-logger that contains given ledgerId.
      *
      * @param ledgerId
      * @param serverConf
@@ -804,7 +805,8 @@ public class DbLedgerStorage implements CompactableLedgerStorage {
         checkNotNull(serverConf, "ServerConfiguration can't be null");
         checkNotNull(processor, "LedgerLoggger info processor can't null");
 
-        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(serverConf, serverConf.getLedgerDirs());
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(serverConf, serverConf.getLedgerDirs(),
+            new DiskChecker(serverConf.getDiskUsageThreshold(), serverConf.getDiskUsageWarnThreshold()));
         String ledgerBasePath = ledgerDirsManager.getAllLedgerDirs().get(0).toString();
 
         EntryLocationIndex entryLocationIndex = new EntryLocationIndex(serverConf,
@@ -827,6 +829,9 @@ public class DbLedgerStorage implements CompactableLedgerStorage {
         }
     }
 
+    /**
+     * Interface which process ledger logger.
+     */
     public interface LedgerLoggerProcessor {
         void process(long entryId, long entryLogId, long position);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -192,7 +192,8 @@ class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsemblePlacemen
     protected Cache<BookieSocketAddress, Long> slowBookies;
     protected BookieNode localNode;
     protected final ReentrantReadWriteLock rwLock;
-    protected ImmutableSet<BookieSocketAddress> readOnlyBookies = null;
+    // Initialize to empty set
+    protected ImmutableSet<BookieSocketAddress> readOnlyBookies = ImmutableSet.of();
     protected boolean reorderReadsRandom = false;
     protected boolean enforceDurability = false;
     protected int stabilizePeriodSeconds = 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -66,6 +66,7 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
                          ResponseBuilder.buildErrorResponse(BookieProtocol.EREADONLY, add),
                          requestProcessor.addRequestStats);
             add.release();
+            add.recycle();
             return;
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
@@ -20,10 +20,11 @@
  */
 package org.apache.bookkeeper.client;
 
+import static junit.framework.TestCase.assertEquals;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.bookkeeper.bookie.BookieShell;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
@@ -34,11 +35,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import junit.framework.Assert;
-
+/**
+ * A test for bookieshell ledger command.
+ */
 public class LedgerCmdTest extends BookKeeperClusterTestCase {
 
-    private final static Logger LOG = LoggerFactory.getLogger(LedgerCmdTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LedgerCmdTest.class);
     private DigestType digestType = DigestType.CRC32;
     private static final String PASSWORD = "testPasswd";
 
@@ -49,25 +51,25 @@ public class LedgerCmdTest extends BookKeeperClusterTestCase {
         baseConf.setFlushInterval(1);
     }
 
-    
+
     /**
-     * list of entry logger files that contains given ledgerId
+     * list of entry logger files that contains given ledgerId.
      */
     @Test
     public void testLedgerDbStorageCmd() throws Exception {
-        
+
         BookKeeper bk = new BookKeeper(baseClientConf, zkc);
         LOG.info("Create ledger and add entries to it");
         LedgerHandle lh1 = createLedgerWithEntries(bk, 10);
-        
+
         String[] argv = new String[] { "ledger", Long.toString(lh1.getId()) };
         final ServerConfiguration conf = bsConfs.get(0);
         conf.setUseHostNameAsBookieID(true);
 
         BookieShell bkShell = new BookieShell();
         bkShell.setConf(conf);
-        
-        Assert.assertEquals("Failed to return exit code!", 0, bkShell.run(argv));
+
+        assertEquals("Failed to return exit code!", 0, bkShell.run(argv));
 
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
@@ -1,0 +1,96 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.bookkeeper.bookie.BookieShell;
+import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
+import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import junit.framework.Assert;
+
+public class LedgerCmdTest extends BookKeeperClusterTestCase {
+
+    private final static Logger LOG = LoggerFactory.getLogger(LedgerCmdTest.class);
+    private DigestType digestType = DigestType.CRC32;
+    private static final String PASSWORD = "testPasswd";
+
+    public LedgerCmdTest() {
+        super(1);
+        baseConf.setLedgerStorageClass(DbLedgerStorage.class.getName());
+        baseConf.setGcWaitTime(60000);
+        baseConf.setFlushInterval(1);
+    }
+
+    
+    /**
+     * list of entry logger files that contains given ledgerId
+     */
+    @Test
+    public void testLedgerDbStorageCmd() throws Exception {
+        
+        BookKeeper bk = new BookKeeper(baseClientConf, zkc);
+        LOG.info("Create ledger and add entries to it");
+        LedgerHandle lh1 = createLedgerWithEntries(bk, 10);
+        
+        String[] argv = new String[] { "ledger", Long.toString(lh1.getId()) };
+        final ServerConfiguration conf = bsConfs.get(0);
+        conf.setUseHostNameAsBookieID(true);
+
+        BookieShell bkShell = new BookieShell();
+        bkShell.setConf(conf);
+        
+        Assert.assertEquals("Failed to return exit code!", 0, bkShell.run(argv));
+
+    }
+
+    private LedgerHandle createLedgerWithEntries(BookKeeper bk, int numOfEntries) throws Exception {
+        LedgerHandle lh = bk.createLedger(1, 1, digestType, PASSWORD.getBytes());
+        final AtomicInteger rc = new AtomicInteger(BKException.Code.OK);
+        final CountDownLatch latch = new CountDownLatch(numOfEntries);
+
+        final AddCallback cb = new AddCallback() {
+            public void addComplete(int rccb, LedgerHandle lh, long entryId, Object ctx) {
+                rc.compareAndSet(BKException.Code.OK, rccb);
+                latch.countDown();
+            }
+        };
+        for (int i = 0; i < numOfEntries; i++) {
+            lh.asyncAddEntry(("foobar" + i).getBytes(), cb, null);
+        }
+        if (!latch.await(30, TimeUnit.SECONDS)) {
+            throw new Exception("Entries took too long to add");
+        }
+        if (rc.get() != BKException.Code.OK) {
+            throw BKException.create(rc.get());
+        }
+        return lh;
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/PortManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/PortManager.java
@@ -20,9 +20,7 @@
  */
 package org.apache.bookkeeper.test;
 
-import java.io.IOException;
 import java.net.ServerSocket;
-
 /**
  * Port manager allows a base port to be specified on the commandline.
  * Tests will then use ports, counting up from this base port.
@@ -32,19 +30,18 @@ public class PortManager {
     private static int nextPort = getBasePort();
 
     public static synchronized int nextFreePort() {
+        int exceptionCount = 0;
         while (true) {
-            ServerSocket ss = null;
-            try {
-                int port = nextPort++;
-                ss = new ServerSocket(port);
-                ss.setReuseAddress(true);
+            int port = nextPort++;
+            try (ServerSocket ss = new ServerSocket(port)) {
+                ss.close();
+                //Give it some time to truly close the connection
+                Thread.sleep(100);
                 return port;
-            } catch (IOException ioe) {
-            } finally {
-                if (ss != null) {
-                    try {
-                        ss.close();
-                    } catch (IOException ioe) {}
+            } catch (Exception e) {
+                exceptionCount++;
+                if (exceptionCount > 5) {
+                    throw new RuntimeException(e);
                 }
             }
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:
This are cherry-picks from yahoo repo of branch yahoo-4.3.

This change includes following merge(164, 165, 173,177, 205, 207, 209):
- https://github.com/yahoo/bookkeeper/commit/2b7aacc5
CMS-2060: Catch IndexOutOfBoundsException when reading entry log index map
This need fix
- https://github.com/yahoo/bookkeeper/commit/270b69e4
Fixed NPE when accessing readonly bookie list
- https://github.com/yahoo/bookkeeper/commit/42bdc083
Release addEntry-Bytebuf on readOnlyBookie to prevent memory-leak 
- https://github.com/yahoo/bookkeeper/commit/fecdb751
YBK-14: Flush after writing out index
- https://github.com/yahoo/bookkeeper/commit//40196007
YBK-154: Addign sleep after finding free port so the OS has time to release it
- https://github.com/yahoo/bookkeeper/commit/c426efea
Fix bookie-shell readJournal by reading from correct journal-directory
- https://github.com/yahoo/bookkeeper/commit/384414b6
Support DbLedgerStorage in LedgerCmd to get list of logger files for a given ledgerId