### PR TITLE
[Merge Yahoo repo] Fix bookie-shell readJournal by reading from correct journal-directory

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -2955,7 +2955,8 @@ public class BookieShell implements Tool {
         if (null == journals) {
             journals = Lists.newArrayListWithCapacity(bkConf.getJournalDirs().length);
             for (File journalDir : bkConf.getJournalDirs()) {
-                journals.add(new Journal(journalDir, bkConf, new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
+                journals.add(new Journal(new File(journalDir, BookKeeperConstants.CURRENT_DIR), bkConf,
+                    new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
                         new DiskChecker(bkConf.getDiskUsageThreshold(), bkConf.getDiskUsageWarnThreshold()))));
             }
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:
This is cherry-pick from yahoo repo of branch yahoo-4.3.

original change is:
https://github.com/yahoo/bookkeeper/commit/c426efea
Fix bookie-shell readJournal by reading from correct journal-directory