### PR TITLE
[Merge Yahoo repo]: Release addEntry-Bytebuf on readOnlyBookie to prevent memory-leak

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -66,6 +66,7 @@ class WriteEntryProcessor extends PacketProcessorBase implements WriteCallback {
                          ResponseBuilder.buildErrorResponse(BookieProtocol.EREADONLY, add),
                          requestProcessor.addRequestStats);
             add.release();
+            add.recycle();
             return;
         }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:
This is cherry-pick from yahoo repo of branch yahoo-4.3.

original commit is:
https://github.com/yahoo/bookkeeper/commit/42bdc083
Release addEntry-Bytebuf on readOnlyBookie to prevent memory-leak