### PR TITLE
[Merge Yahoo repo] CMS-2060: Catch IndexOutOfBoundsException when reading entry log index map

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1314,6 +1314,8 @@ public class EntryLogger {
                 // Move to next entry, if any
                 offset += ledgersMapSize + 4;
             }
+        } catch (IndexOutOfBoundsException e) {
+            throw new IOException(e);
         } finally {
             ledgersMap.release();
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:
This is cherry-pick from yahoo repo of branch yahoo-4.3.

original commit is:
https://github.com/yahoo/bookkeeper/commit/2b7aacc5
CMS-2060: Catch IndexOutOfBoundsException when reading entry log index map