### PR TITLE
Enable rerunning flakes twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,7 @@
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Enables a configuration in maven to rerun failed tests a second time.

Master issue: #1031
