### PR TITLE
Cleanup classloaders in backward-compat tests

### DIFF
--- a/tests/backward-compat/hierarchical-ledger-manager/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatHierarchicalLedgerManager.groovy
+++ b/tests/backward-compat/hierarchical-ledger-manager/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatHierarchicalLedgerManager.groovy
@@ -91,5 +91,8 @@ class TestCompatHierarchicalLedgerManager {
 
         v420BK.close()
         currentBK.close()
+
+        v420CL.close()
+        currentCL.close()
     }
 }

--- a/tests/backward-compat/hostname-bookieid/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeWithHostnameBookieId.groovy
+++ b/tests/backward-compat/hostname-bookieid/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeWithHostnameBookieId.groovy
@@ -126,8 +126,15 @@ class TestCompatUpgradeWithHostnameBookieId {
             ledger1.close()
 
             oldBK.close()
+            oldCL.close()
         }
         currentBK.close()
+        v420BK.close()
+        v410BK.close()
+
+        currentCL.close()
+        v420CL.close()
+        v410CL.close()
     }
 
 

--- a/tests/backward-compat/old-cookie-new-cluster/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeOldServerInClusterWithCookies.groovy
+++ b/tests/backward-compat/old-cookie-new-cluster/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeOldServerInClusterWithCookies.groovy
@@ -19,6 +19,8 @@ package org.apache.bookkeeper.tests.backwardcompat
 
 import com.github.dockerjava.api.DockerClient
 
+import lombok.Cleanup
+
 import org.apache.bookkeeper.tests.BookKeeperClusterUtils
 import org.apache.bookkeeper.tests.MavenClassLoader
 
@@ -49,8 +51,8 @@ class TestCompatUpgradeOldServerInClusterWithCookies {
         int numEntries = 10
 
         Assert.assertTrue(BookKeeperClusterUtils.startAllBookiesWithVersion(docker, "4.1.0"))
-        def v410CL = MavenClassLoader.forBookKeeperVersion("4.1.0")
-        def v410BK = v410CL.newBookKeeper(zookeeper)
+        @Cleanup def v410CL = MavenClassLoader.forBookKeeperVersion("4.1.0")
+        @Cleanup def v410BK = v410CL.newBookKeeper(zookeeper)
 
         def ledger0 = v410BK.createLedger(3, 2, v410CL.digestType("CRC32"), PASSWD)
         for (int i = 0; i < numEntries; i++) {
@@ -82,7 +84,5 @@ class TestCompatUpgradeOldServerInClusterWithCookies {
         } catch (Exception e) {
             // correct behaviour
         }
-
-        v410CL.close()
     }
 }

--- a/tests/backward-compat/old-cookie-new-cluster/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeOldServerInClusterWithCookies.groovy
+++ b/tests/backward-compat/old-cookie-new-cluster/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeOldServerInClusterWithCookies.groovy
@@ -82,5 +82,7 @@ class TestCompatUpgradeOldServerInClusterWithCookies {
         } catch (Exception e) {
             // correct behaviour
         }
+
+        v410CL.close()
     }
 }

--- a/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
+++ b/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
@@ -27,6 +27,8 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
+import lombok.Cleanup
+
 import org.apache.bookkeeper.client.BKException
 import org.apache.bookkeeper.client.BookKeeper
 import org.apache.bookkeeper.client.BookKeeperAdmin
@@ -156,7 +158,7 @@ class TestCompatRecoveryNoPassword {
         BookKeeperClusterUtils.legacyMetadataFormat(docker)
 
         // Create a 4.1.0 client, will update /ledgers/LAYOUT
-        def v410CL = MavenClassLoader.forBookKeeperVersion("4.1.0")
+        @Cleanup def v410CL = MavenClassLoader.forBookKeeperVersion("4.1.0")
         def v410Conf = v410CL.newInstance("org.apache.bookkeeper.conf.ClientConfiguration")
         v410Conf.setZkServers(zookeeper).setLedgerManagerType("hierarchical")
         def v410BK = v410CL.newInstance("org.apache.bookkeeper.client.BookKeeper", v410Conf)
@@ -247,7 +249,5 @@ class TestCompatRecoveryNoPassword {
         Assert.assertTrue("Should have recovered everything",
                           verifyFullyReplicated(bkCur, lh, numEntries))
         lh.close()
-
-        v410CL.close()
     }
 }

--- a/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
+++ b/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
@@ -247,5 +247,7 @@ class TestCompatRecoveryNoPassword {
         Assert.assertTrue("Should have recovered everything",
                           verifyFullyReplicated(bkCur, lh, numEntries))
         lh.close()
+
+        v410CL.close()
     }
 }

--- a/tests/backward-compat/upgrade-direct/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeDirect.groovy
+++ b/tests/backward-compat/upgrade-direct/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeDirect.groovy
@@ -90,6 +90,9 @@ class TestCompatUpgradeDirect {
 
         v410BK.close()
         currentBK.close()
+
+        v410CL.close()
+        currentCL.close()
     }
 
     @Test
@@ -121,5 +124,8 @@ class TestCompatUpgradeDirect {
 
         currentBK.close()
         v410BK.close()
+
+        v410CL.close()
+        currentCL.close()
     }
 }

--- a/tests/backward-compat/upgrade-direct/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeDirect.groovy
+++ b/tests/backward-compat/upgrade-direct/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeDirect.groovy
@@ -19,6 +19,8 @@ package org.apache.bookkeeper.tests.backwardcompat
 
 import com.github.dockerjava.api.DockerClient
 
+import lombok.Cleanup
+
 import org.apache.bookkeeper.tests.BookKeeperClusterUtils
 import org.apache.bookkeeper.tests.MavenClassLoader
 
@@ -50,8 +52,8 @@ class TestCompatUpgradeDirect {
         int numEntries = 10
 
         Assert.assertTrue(BookKeeperClusterUtils.startAllBookiesWithVersion(docker, "4.1.0"))
-        def v410CL = MavenClassLoader.forBookKeeperVersion("4.1.0")
-        def v410BK = v410CL.newBookKeeper(zookeeper)
+        @Cleanup def v410CL = MavenClassLoader.forBookKeeperVersion("4.1.0")
+        @Cleanup def v410BK = v410CL.newBookKeeper(zookeeper)
 
         def ledger0 = v410BK.createLedger(3, 2,
                                           v410CL.digestType("CRC32"),
@@ -62,8 +64,8 @@ class TestCompatUpgradeDirect {
         ledger0.close()
 
         // Current client shouldn't be able to write to 4.1.0 server
-        def currentCL = MavenClassLoader.forBookKeeperVersion(currentVersion)
-        def currentBK = currentCL.newBookKeeper(zookeeper)
+        @Cleanup def currentCL = MavenClassLoader.forBookKeeperVersion(currentVersion)
+        @Cleanup def currentBK = currentCL.newBookKeeper(zookeeper)
         def ledger1 = currentBK.createLedger(3, 2, currentCL.digestType("CRC32"), PASSWD)
         try {
             ledger1.addEntry("foobar".getBytes())
@@ -87,12 +89,6 @@ class TestCompatUpgradeDirect {
             j++
         }
         ledger2.close()
-
-        v410BK.close()
-        currentBK.close()
-
-        v410CL.close()
-        currentCL.close()
     }
 
     @Test
@@ -100,8 +96,8 @@ class TestCompatUpgradeDirect {
         String currentVersion = System.getProperty("currentVersion")
         String zookeeper = BookKeeperClusterUtils.zookeeperConnectString(docker)
 
-        def currentCL = MavenClassLoader.forBookKeeperVersion(currentVersion)
-        def currentBK = currentCL.newBookKeeper(zookeeper)
+        @Cleanup def currentCL = MavenClassLoader.forBookKeeperVersion(currentVersion)
+        @Cleanup def currentBK = currentCL.newBookKeeper(zookeeper)
 
         def numEntries = 5
         def ledger0 = currentBK.createLedger(3, 2,
@@ -112,8 +108,8 @@ class TestCompatUpgradeDirect {
         }
         ledger0.close()
 
-        def v410CL = MavenClassLoader.forBookKeeperVersion("4.1.0")
-        def v410BK = v410CL.newBookKeeper(zookeeper)
+        @Cleanup def v410CL = MavenClassLoader.forBookKeeperVersion("4.1.0")
+        @Cleanup def v410BK = v410CL.newBookKeeper(zookeeper)
 
         try {
             def ledger1 = v410BK.openLedger(ledger0.getId(), v410CL.digestType("CRC32"), PASSWD)
@@ -121,11 +117,5 @@ class TestCompatUpgradeDirect {
         } catch (Exception e) {
             // correct behaviour
         }
-
-        currentBK.close()
-        v410BK.close()
-
-        v410CL.close()
-        currentCL.close()
     }
 }

--- a/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
+++ b/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
@@ -93,6 +93,9 @@ class TestCompatUpgrade {
 
         currentRunningBK.close()
         upgradedBK.close()
+
+        currentRunningCL.close()
+        upgradedCL.close()
     }
 
     @Test


### PR DESCRIPTION
The BC tests run in the maven process (for classloader reasons), so we
need to make sure we clean stuff up to avoid running out of memory, as
the classloaders will load a bunch of jars into memory.

Master Issue: #1030