### PR TITLE
Fixing validation in BookieShell.scanEntryLogForSpecificEntry

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -3157,15 +3157,16 @@ public class BookieShell implements Tool {
         final MutableBoolean entryFound = new MutableBoolean(false);
         scanEntryLog(logId, new EntryLogScanner() {
             @Override
-            public boolean accept(long ledgerId) {
-                return (((!entryFound.booleanValue()) || (entryId == -1)));
+            public boolean accept(long candidateLedgerId) {
+                return ((candidateLedgerId == ledgerId) && ((!entryFound.booleanValue()) || (entryId == -1)));
             }
 
             @Override
-            public void process(long ledgerId, long startPos, ByteBuf entry) {
+            public void process(long candidateLedgerId, long startPos, ByteBuf entry) {
                 long entrysLedgerId = entry.getLong(entry.readerIndex());
                 long entrysEntryId = entry.getLong(entry.readerIndex() + 8);
-                if ((ledgerId == entrysLedgerId) && ((entrysEntryId == entryId)) || (entryId == -1)) {
+                if ((candidateLedgerId == entrysLedgerId) && (candidateLedgerId == ledgerId)
+                        && ((entrysEntryId == entryId) || (entryId == -1))) {
                     entryFound.setValue(true);
                     formatEntry(startPos, entry, printMsg);
                 }


### PR DESCRIPTION

Descriptions of the changes in this PR:

https://github.com/apache/bookkeeper/commit/086537beda9427c057a286ad6c4614659da6ed7f
has messed up conditional checks in BookieShell.scanEntryLogForSpecificEntry.
Reverting those changes.