### PR TITLE
ISSUE #1067: PendingReadOp: recovery, return NoSuchEntry on wQ-aQ+1 errors

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
@@ -360,7 +360,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                 // read
 
                 // Do it a bit pessimistically, only when finished trying all replicas
-                // to check whether we received more missed reads than maxMissedReadsAllowed
+                // to check whether we received more missed reads than requiredBookiesMissingEntryForRecovery
                 if (BKException.Code.BookieHandleNotAvailableException == firstError
                         && numMissedEntryReads > maxMissedReadsAllowed) {
                     firstError = BKException.Code.NoSuchEntryException;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
@@ -139,7 +139,7 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
     }
 
     @Test
-    public void testFailParallelReadMissingEntryImmediately() throws Exception {
+    public void testFailParallelRecoveryReadMissingEntryImmediately() throws Exception {
         int numEntries = 1;
 
         long id = getLedgerToRead(5, 5, 3, numEntries);
@@ -160,7 +160,7 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
         sleepBookie(ensemble.get(1), latch2);
 
         PendingReadOp readOp =
-                new PendingReadOp(lh, lh.bk.scheduler, 10, 10);
+                new PendingReadOp(lh, lh.bk.scheduler, 10, 10, true);
         readOp.parallelRead(true).submit();
         // would fail immediately if found missing entries don't cover ack quorum
         expectFail(readOp.future(), Code.NoSuchEntryException);


### PR DESCRIPTION
In the case of a recovery read, we rely on a NoSuchEntry response on the
first missing entry to determine the final LAC.  As such, we need to
consider an entry to be gone once we see wQ-aQ+1 NoSuchEntry/Ledger
responses from bookies.  Otherwise, a zombie bookie can prevent ledger
recovery from suceeding indefinitely (it'll hit the timeout each time).

There was some preexisting logic from
https://issues.apache.org/jira/browse/BOOKKEEPER-365
b6c1a8bbd7c2d44c2edb59d9938fa073f6f478de,
but it seems to have been too conservative in that it waited for all
responses and required that there were no other errors present.  It
seems now to be unnecessary, and so has been removed.

TestParallelRead.testFailParallelReadMissingEntryImmediately seemed to
rely on the previous logic working outside of recovery, but I believe it
was really meant to test the recovery case, so it has been adjusted.

(@bug W-4651456@)
Signed-off-by: Samuel Just <sjust@salesforce.com>