### PR TITLE
ISSUE #1075: Add a noop digest implentation

### DIFF
--- a/bookkeeper-proto/src/main/proto/DataFormats.proto
+++ b/bookkeeper-proto/src/main/proto/DataFormats.proto
@@ -46,6 +46,7 @@ message LedgerMetadataFormat {
         CRC32 = 1;
         HMAC = 2;
         CRC32C = 3;
+        DUMMY = 4;
     }
     optional DigestType digestType = 7;
     optional bytes password = 8;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -658,9 +658,12 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      * The CRC32C, which use SSE processor instruction, has better performance than CRC32.
      * Legacy DigestType for backward compatibility. If we want to add new DigestType,
      * we should add it in here, client.api.DigestType and DigestType in DataFormats.proto.
+     * If the digest type is set/passed in as DUMMY, a dummy digest is added/checked.
+     * This DUMMY digest is mostly for test purposes or in situations/use-cases
+     * where digest is considered a overhead.
      */
     public enum DigestType {
-        MAC, CRC32, CRC32C;
+        MAC, CRC32, CRC32C, DUMMY;
 
         public static DigestType fromApiDigestType(org.apache.bookkeeper.client.api.DigestType digestType) {
             switch (digestType) {
@@ -670,6 +673,8 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                     return DigestType.CRC32;
                 case CRC32C:
                     return DigestType.CRC32C;
+                case DUMMY:
+                    return DigestType.DUMMY;
                 default:
                     throw new IllegalArgumentException("Unable to convert digest type " + digestType);
             }
@@ -682,6 +687,8 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                     return DataFormats.LedgerMetadataFormat.DigestType.CRC32;
                 case CRC32C:
                     return DataFormats.LedgerMetadataFormat.DigestType.CRC32C;
+                case DUMMY:
+                    return DataFormats.LedgerMetadataFormat.DigestType.DUMMY;
                 default:
                     throw new IllegalArgumentException("Unable to convert digest type " + digestType);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -237,6 +237,8 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
                 return DigestType.CRC32;
             case CRC32C:
                 return DigestType.CRC32C;
+            case DUMMY:
+                return DigestType.DUMMY;
             default:
                 throw new IllegalArgumentException("Unable to convert digest type " + digestType);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -72,6 +72,8 @@ public abstract class DigestManager {
             return new CRC32DigestManager(ledgerId);
         case CRC32C:
             return new CRC32CDigestManager(ledgerId);
+        case DUMMY:
+            return new DummyDigestManager(ledgerId);
         default:
             throw new GeneralSecurityException("Unknown checksum type: " + digestType);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DummyDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DummyDigestManager.java
@@ -18,34 +18,27 @@
  * under the License.
  *
  */
-package org.apache.bookkeeper.client.api;
+package org.apache.bookkeeper.proto.checksum;
 
-import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
-import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
+import io.netty.buffer.ByteBuf;
+
 
 /**
- * Digest type.
- *
- * @since 4.6
+ * This class provides a noop digest implementation.
  */
-@Public
-@Unstable
-public enum DigestType {
+public class DummyDigestManager extends DigestManager {
+    public DummyDigestManager(long ledgerId) {
+        super(ledgerId);
+    }
 
-    /**
-     * Entries are verified by applied CRC32 algorithm.
-     */
-    CRC32,
-    /**
-     * Entries are verified by applied MAC algorithm.
-     */
-    MAC,
-    /**
-     * Entries are verified by applied CRC32C algorithm.
-     */
-    CRC32C,
-    /**
-     * Entries are not verified.
-     */
-    DUMMY,
+    @Override
+    int getMacCodeLength() {
+        return 0;
+    }
+
+    @Override
+    void update(ByteBuf buffer) {}
+
+    @Override
+    void populateValueAndReset(ByteBuf buffer) {}
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -150,6 +150,34 @@ public class BookieWriteLedgerTest extends
     }
 
     /**
+     * Verify the functionality Ledgers with different digests.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLedgerDigestTest() throws Exception {
+        for (DigestType type: DigestType.values()) {
+            lh = bkc.createLedger(5, 3, 2, type, ledgerPassword);
+
+            for (int i = 0; i < numEntriesToWrite; i++) {
+                ByteBuffer entry = ByteBuffer.allocate(4);
+                entry.putInt(rng.nextInt(maxInt));
+                entry.position(0);
+
+                entries1.add(entry.array());
+                lh.addEntry(entry.array());
+            }
+
+            readEntries(lh, entries1);
+
+            long lid = lh.getId();
+            lh.close();
+            bkc.deleteLedger(lid);
+            entries1.clear();
+        }
+    }
+
+    /**
      * Verify the functionality of Advanced Ledger which returns
      * LedgerHandleAdv. LedgerHandleAdv takes entryId for addEntry, and let
      * user manage entryId allocation.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -50,7 +50,6 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
-import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType;
 import org.apache.bookkeeper.proto.checksum.DigestManager;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
@@ -160,6 +159,16 @@ public abstract class MockBookKeeperTestCase {
         when(bk.getRecoverAddCountLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
         when(bk.getRecoverReadCountLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
         return nullStatsLogger;
+    }
+
+    private DigestManager getDigestType(long ledgerId) throws GeneralSecurityException {
+        LedgerMetadata metadata = mockLedgerMetadataRegistry.get(ledgerId);
+        return DigestManager.instantiate(
+                ledgerId,
+                metadata.getPassword(),
+                org.apache.bookkeeper.client.BookKeeper.DigestType.toProtoDigestType(
+                        org.apache.bookkeeper.client.BookKeeper.DigestType.fromApiDigestType(
+                                metadata.getDigestType())));
     }
 
     @After
@@ -338,7 +347,7 @@ public abstract class MockBookKeeperTestCase {
             executor.submitOrdered(ledgerId, () -> {
                 DigestManager macManager = null;
                 try {
-                    macManager = DigestManager.instantiate(ledgerId, new byte[2], DigestType.CRC32);
+                    macManager = getDigestType(ledgerId);
                 } catch (GeneralSecurityException gse){
                     LOG.error("Initialize macManager fail", gse);
                 }
@@ -373,7 +382,7 @@ public abstract class MockBookKeeperTestCase {
             executor.submitOrdered(ledgerId, () -> {
                 DigestManager macManager = null;
                 try {
-                    macManager = DigestManager.instantiate(ledgerId, new byte[2], DigestType.CRC32);
+                    macManager = getDigestType(ledgerId);
                 } catch (GeneralSecurityException gse){
                     LOG.error("Initialize macManager fail", gse);
                 }
@@ -396,13 +405,13 @@ public abstract class MockBookKeeperTestCase {
             any(BookkeeperInternalCallbacks.ReadEntryCallback.class), any());
     }
 
-    private static byte[] extractEntryPayload(long ledgerId, long entryId, ByteBuf toSend)
+    private byte[] extractEntryPayload(long ledgerId, long entryId, ByteBuf toSend)
             throws BKException.BKDigestMatchException {
         ByteBuf toSendCopy = Unpooled.copiedBuffer(toSend);
         toSendCopy.resetReaderIndex();
         DigestManager macManager = null;
         try {
-            macManager = DigestManager.instantiate(ledgerId, new byte[2], DigestType.CRC32);
+            macManager = getDigestType(ledgerId);
         } catch (GeneralSecurityException gse){
             LOG.error("Initialize macManager fail", gse);
         }


### PR DESCRIPTION
This digest will add a predefined digest key without actually computing
it. This can be used for testing or in situations/use-cases where digest
is considered overhead.

(@bug W-3245776@)
Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>
[Adapted to current patch]
Signed-off-by: Samuel Just <sjust@salesforce.com>