### PR TITLE
Issue 1063: Write keeps refCnt longer

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -208,7 +208,6 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
      * Initiate the add operation.
      */
     public void safeRun() {
-        hasRun = true;
         if (callbackTriggered) {
             // this should only be true if the request was failed due
             // to another request ahead in the pending queue,
@@ -232,6 +231,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
                 sendWriteRequest(writeSet.get(i));
             }
         } finally {
+            hasRun = true;
             writeSet.recycle();
         }
     }
@@ -383,29 +383,40 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         this.recyclerHandle = recyclerHandle;
     }
 
+
     private void maybeRecycle() {
-        // The reference to PendingAddOp can be held in 3 places
-        // - LedgerHandle#pendingAddOp
-        //   This reference is released when the callback is run
-        // - The executor
-        //   Released after safeRun finishes
-        // - BookieClient
-        //   Holds a reference from the point the addEntry requests are
-        //   sent.
-        // The object can only be recycled after all references are
-        // released, otherwise we could end up recycling twice and all
-        // joy that goes along with that.
-        if (hasRun && callbackTriggered && pendingWriteRequests == 0) {
-            recycle();
+        /**
+         * We have opportunity to recycle two objects here.
+         * PendingAddOp#toSend and LedgerHandle#pendingAddOp
+         *
+         * A. LedgerHandle#pendingAddOp: This can be released after all 3 conditions are met.
+         *    - After the callback is run
+         *    - After safeRun finished by the executor
+         *    - Write responses are returned from all bookies
+         *      as BookieClient Holds a reference from the point the addEntry requests are sent.
+         *
+         * B. ByteBuf can be released after 2 of the conditions are met.
+         *    - After the callback is run as we will not retry the write after callback
+         *    - After safeRun finished by the executor
+         * BookieClient takes and releases on this buffer immediately after sending the data.
+         *
+         * The object can only be recycled after the above conditions are met
+         * otherwise we could end up recycling twice and all
+         * joy that goes along with that.
+         */
+        if (hasRun && callbackTriggered) {
+            ReferenceCountUtil.release(toSend);
+            toSend = null;
+        }
+        if (toSend == null && pendingWriteRequests == 0) {
+            recyclePendAddOpObject();
         }
     }
 
-    private void recycle() {
+    private void recyclePendAddOpObject() {
         entryId = LedgerHandle.INVALID_ENTRY_ID;
         currentLedgerLength = -1;
-        ReferenceCountUtil.release(toSend);
         payload = null;
-        toSend = null;
         cb = null;
         ctx = null;
         ackSet.recycle();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -208,6 +208,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
      * Initiate the add operation.
      */
     public void safeRun() {
+        hasRun = true;
         if (callbackTriggered) {
             // this should only be true if the request was failed due
             // to another request ahead in the pending queue,
@@ -231,7 +232,6 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
                 sendWriteRequest(writeSet.get(i));
             }
         } finally {
-            hasRun = true;
             writeSet.recycle();
         }
     }


### PR DESCRIPTION

Descriptions of the changes in this PR:

Current code keeps the toSend buffers until client receives
resonses from all wq bookies. From the senders perspective,
It is not required to keep the refcount on it at the PendingAddOp
level, as the ref is taken at bookie client level.

Keeping these buffers longer will increase the memory pressure
on the client.

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>


Master Issue: #1091 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue # or BOOKKEEPER-#>: Description of pull request`
>     `e.g. Issue 123: Description ...`
>     `e.g. BOOKKEEPER-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue # or BOOKKEEPER-#>` in the title with the actual Issue/JIRA number.
> 
> ---
