### PR TITLE
BP-26 (task 4): run dlog tests when pull requests modify dlog modules

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_postcommit_master_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_postcommit_master_java8.groovy
@@ -42,5 +42,5 @@ mavenJob('bookkeeper_postcommit_master_java8') {
   common_job_properties.setMavenConfig(delegate)
 
   // Maven build project.
-  goals('clean apache-rat:check package spotbugs:check')
+  goals('clean apache-rat:check package spotbugs:check -Ddistributedlog')
 }

--- a/.test-infra/jenkins/job_bookkeeper_postcommit_master_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_postcommit_master_java9.groovy
@@ -42,5 +42,5 @@ mavenJob('bookkeeper_postcommit_master_java9') {
   common_job_properties.setMavenConfig(delegate)
 
   // Maven build project.
-  goals('clean apache-rat:check package spotbugs:check')
+  goals('clean apache-rat:check package spotbugs:check -Ddistributedlog')
 }

--- a/.test-infra/jenkins/job_bookkeeper_release_nightly_snapshot.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_release_nightly_snapshot.groovy
@@ -41,5 +41,5 @@ mavenJob('bookkeeper_release_nightly_snapshot') {
   common_job_properties.setMavenConfig(delegate)
 
   // Maven build project.
-  goals('clean apache-rat:check package spotbugs:check -Dmaven.test.failure.ignore=true deploy')
+  goals('clean apache-rat:check package spotbugs:check -Dmaven.test.failure.ignore=true deploy -Ddistributedlog')
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,29 @@ matrix:
       env: CUSTOM_JDK="openjdk8"
 
 before_install:
-  - echo "MAVEN_OPTS='-Xmx3072m -XX:MaxPermSize=512m'" > ~/.mavenrc
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "$CUSTOM_JDK"; fi
+- |
+    echo "MAVEN_OPTS='-Xmx3072m -XX:MaxPermSize=512m'" > ~/.mavenrc
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        export JAVA_HOME=$(/usr/libexec/java_home);
+    fi
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+        jdk_switcher use "$CUSTOM_JDK";
+    fi
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+        export DLOG_MODIFIED="true"  
+        echo "Enable testing distributedlog modules since if they are not pull requests."
+    else
+        if [ `git diff --name-only $TRAVIS_COMMIT_RANGE | grep "^stream\/distributedlog" | wc -l` -gt 0 ]; then
+            export DLOG_MODIFIED="true"  
+            echo "Enable testing distributedlog modules since if they are not pull requests."
+        fi
+    fi
 
 script:
-  - travis_retry mvn --batch-mode clean apache-rat:check compile spotbugs:check package -DskipTests
+  - travis_retry mvn --batch-mode clean apache-rat:check compile spotbugs:check install -DskipTests
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/all/target/bookkeeper-all-4.7.0-SNAPSHOT-bin.tar.gz; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-4.7.0-SNAPSHOT-bin.tar.gz; fi
+  - if [ "$DLOG_MODIFIED" == "true" ]; then cd stream/distributedlog && mvn --batch-mode clean package -Ddistributedlog; fi
 # Disabled the tests here. Since tests are running much slower on Travis than on Jenkins
 #  - ./dev/ticktoc.sh "mvn --batch-mode clean package"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,11 @@ before_install:
     fi
     if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         export DLOG_MODIFIED="true"  
-        echo "Enable testing distributedlog modules since if they are not pull requests."
+        echo "Enable testing distributedlog modules since they are not pull requests."
     else
         if [ `git diff --name-only $TRAVIS_COMMIT_RANGE | grep "^stream\/distributedlog" | wc -l` -gt 0 ]; then
             export DLOG_MODIFIED="true"  
-            echo "Enable testing distributedlog modules since if they are not pull requests."
+            echo "Enable testing distributedlog modules if this pull request modifies files under directory `stream/distributedlog`."
         fi
     fi
 

--- a/stream/distributedlog/pom.xml
+++ b/stream/distributedlog/pom.xml
@@ -239,4 +239,5 @@
       </build>
     </profile>
   </profiles>
+
 </project>


### PR DESCRIPTION
Descriptions of the changes in this PR:

- enable dlog tests on all post commit CI jobs
- for pull requests, only run dlog tests on travis CI and only when the pull requests modify dlog modules. 

Master Issue: #1024 
