### PR TITLE
Run checkstyle plugin at validate phase

### DIFF
--- a/tests/bookkeeper-server-shaded-artifact-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-artifact-test/pom.xml
@@ -85,7 +85,8 @@
         </configuration>
         <executions>
           <execution>
-            <phase>test-compile</phase>
+            <id>checkstyle</id>
+            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>

--- a/tests/bookkeeper-server-shaded-test/pom.xml
+++ b/tests/bookkeeper-server-shaded-test/pom.xml
@@ -84,7 +84,8 @@
         </configuration>
         <executions>
           <execution>
-            <phase>test-compile</phase>
+            <id>checkstyle</id>
+            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>

--- a/tests/bookkeeper-server-tests-shaded-test/pom.xml
+++ b/tests/bookkeeper-server-tests-shaded-test/pom.xml
@@ -104,7 +104,8 @@
         </configuration>
         <executions>
           <execution>
-            <phase>test-compile</phase>
+            <id>checkstyle</id>
+            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>


### PR DESCRIPTION


Descriptions of the changes in this PR:

Most of the modules run checkstyle plugin at validate phase. However a few modules are still running at `test-compile` phase.
Update the checkstyle plugins in those modules to run at validate phase. So the behavior is consistent across the project.
