### PR TITLE
Issue #605: bk_server.conf wrong default logSizeLimit

### DIFF
--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -415,7 +415,7 @@ ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFa
 
 # Max file size of entry logger, in bytes
 # A new entry log file will be created when the old one reaches the file size limitation
-# logSizeLimit=2147483648
+# logSizeLimit=1073741824
 
 # Enable/Disable entry logger preallocation
 # entryLogFilePreallocationEnabled=true


### PR DESCRIPTION
It's commented out, but the value is invalid. This patch changes it to
match the default in ServerConfiguration.
