### PR TITLE
Cleanup registration client interface

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationClient.java
@@ -30,7 +30,6 @@ import org.apache.bookkeeper.meta.LayoutManager;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.versioning.Versioned;
-import org.apache.zookeeper.ZooKeeper;
 
 /**
  * A registration client, which the bookkeeper client will use to interact with registration service.
@@ -55,13 +54,13 @@ public interface RegistrationClient extends AutoCloseable {
      *
      * @param conf client configuration
      * @param statsLogger stats logger
-     * @param zkOptional a supplier to supply zookeeper client.
+     * @param optionalCtx optional context is passed for initialization.
      * @return
      */
     RegistrationClient initialize(ClientConfiguration conf,
                                   ScheduledExecutorService scheduler,
                                   StatsLogger statsLogger,
-                                  Optional<ZooKeeper> zkOptional)
+                                  Optional<Object> optionalCtx)
         throws BKException;
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -197,7 +197,7 @@ public class ZKRegistrationClient implements RegistrationClient {
     public RegistrationClient initialize(ClientConfiguration conf,
                                          ScheduledExecutorService scheduler,
                                          StatsLogger statsLogger,
-                                         Optional<ZooKeeper> zkOptional)
+                                         Optional<Object> zkOptional)
             throws BKException {
         this.conf = conf;
         this.scheduler = scheduler;
@@ -208,8 +208,10 @@ public class ZKRegistrationClient implements RegistrationClient {
         this.acls = ZkUtils.getACLs(conf);
 
         // construct the zookeeper
-        if (zkOptional.isPresent()) {
-            this.zk = zkOptional.get();
+        if (zkOptional.isPresent()
+            && zkOptional.get() instanceof ZooKeeper) {
+            // if an external zookeeper is added, use the zookeeper instance
+            this.zk = (ZooKeeper) (zkOptional.get());
             this.ownZKHandle = false;
         } else {
             try {


### PR DESCRIPTION
Descriptions of the changes in this PR:

This change is mainly to remove `zookeeper` reference from metadata interface. The existence of `Optional<ZooKeeper>` is to allow passing an external zookeeper client to bookkeeper, so bookkeeper can reuse that client instance. That is useful for services like pulsar broker, which they can only instantiate a zookeeper client and pass the zookeeper client around to construct bookkeeper client. However, this pollutes the registration client interface, change the method to `Optional<Object>` as an optional context object and let the implementation interpret it.