### PR TITLE
Issue #1124: Lower memory usage in GarbageCollectionThread while extracting all ledger meta data

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -841,7 +841,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
      * Test extractMetaFromEntryLogs optimized method to avoid excess memory usage.
      */
     public void testExtractMetaFromEntryLogs() throws Exception {
-        // Always run this test with Throttle enabled. 
+        // Always run this test with Throttle enabled.
         baseConf.setIsThrottleByBytes(true);
         // restart bookies
         restartBookies(baseConf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -842,7 +842,6 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
      */
     @Test(timeout = 60000)
     public void testExtractMetaFromEntryLogs() throws Exception {
-        tearDown(); // I dont want the test infrastructure
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         File tmpDir = createTempDir("bkTest", ".dir");
         File curDir = Bookie.getCurrentDirectory(tmpDir);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -39,11 +39,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -852,7 +852,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
         final Set<Long> ledgers = Collections
             .newSetFromMap(new ConcurrentHashMap<Long, Boolean>());
-        
+
         LedgerManager manager = getLedgerManager(ledgers);
 
         CheckpointSource checkpointSource = new CheckpointSource() {
@@ -868,12 +868,12 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             }
         };
         InterleavedLedgerStorage storage = new InterleavedLedgerStorage();
-        storage.initialize(conf, manager, dirs, dirs, null, checkpointSource, Checkpointer.NULL, NullStatsLogger.INSTANCE);
-        final byte[] KEY = "foobar".getBytes();
+        storage.initialize(conf, manager, dirs, dirs, null, checkpointSource,
+            Checkpointer.NULL, NullStatsLogger.INSTANCE);
 
         for (long ledger = 0; ledger <= 10; ledger++) {
             ledgers.add(ledger);
-            for(int entry = 1; entry <= 50; entry++) {
+            for (int entry = 1; entry <= 50; entry++) {
                 try {
                     storage.addEntry(genEntry(ledger, entry, ENTRY_SIZE));
                 } catch (IOException e) {
@@ -886,14 +886,16 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         storage.shutdown();
 
         storage = new InterleavedLedgerStorage();
-        storage.initialize(conf, manager, dirs, dirs, null, checkpointSource, Checkpointer.NULL, NullStatsLogger.INSTANCE);
+        storage.initialize(conf, manager, dirs, dirs, null, checkpointSource,
+                           Checkpointer.NULL, NullStatsLogger.INSTANCE);
 
-        long startingEntriesCount = storage.gcThread.entryLogger.getLeastUnflushedLogId() - storage.gcThread.scannedLogId;
+        long startingEntriesCount = storage.gcThread.entryLogger.getLeastUnflushedLogId()
+            - storage.gcThread.scannedLogId;
         LOG.info("The old Log Entry count is: " + startingEntriesCount);
 
         Map<Long, EntryLogMetadata> entryLogMetaData = new HashMap<>();
-        Map<Long, EntryLogMetadata> finalEntryLogMetadataMap = storage.gcThread.extractMetaFromEntryLogs(entryLogMetaData);
-        long finalEntriesCount = storage.gcThread.entryLogger.getLeastUnflushedLogId() - storage.gcThread.scannedLogId;
+        long finalEntriesCount = storage.gcThread.entryLogger.getLeastUnflushedLogId()
+            - storage.gcThread.scannedLogId;
         LOG.info("The latest Log Entry count is: " + finalEntriesCount);
 
         assertTrue("The GC did not clean up entries...", startingEntriesCount != finalEntriesCount);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -840,8 +840,11 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
     /**
      * Test extractMetaFromEntryLogs optimized method to avoid excess memory usage.
      */
-    @Test(timeout = 60000)
     public void testExtractMetaFromEntryLogs() throws Exception {
+        // Always run this test with Throttle enabled. 
+        baseConf.setIsThrottleByBytes(true);
+        // restart bookies
+        restartBookies(baseConf);
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         File tmpDir = createTempDir("bkTest", ".dir");
         File curDir = Bookie.getCurrentDirectory(tmpDir);


### PR DESCRIPTION
Descriptions of the changes in this PR:

The PR contains the fix to cleanup non-existent ledger log entries from EntryLogMetadata while extracting all log entries.

Master Issue: #1124

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [X] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [X] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [X] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
