### PR TITLE
Upgrade JaCoCo and Upgrade Coveralls.io configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,9 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.3.0</version>
+                <configuration>
+                    <sourceDirectories>circe-checksum/target/nar/nar-generated</sourceDirectories>
+                </configuration>
               </plugin>
               <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -400,12 +403,14 @@
 	          <redirectTestOutputToFile>true</redirectTestOutputToFile>
 	          <reuseForks>false</reuseForks>
 	          <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
+                  <!-- we want build to complete even in case of failures -->
+                  <testFailureIgnore>true</testFailureIgnore>
                 </configuration>
              </plugin>
              <plugin>
                <groupId>org.jacoco</groupId>
                <artifactId>jacoco-maven-plugin</artifactId>
-               <version>0.7.9</version>
+               <version>0.8.0</version>
                <executions>
                  <execution>
                    <goals>


### PR DESCRIPTION
- Upgrade JaCoCo to version 0.8.0 which supports Java 9
- Update Coveralls.io configuration in order to handle NAR-plugin files
- Update surefire configuration in order to not fail the build while using -Pcode-coverage