### PR TITLE
Fix shutdown race which left ZK session open

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -219,7 +219,6 @@ public class Main {
             // the server is interrupted
             log.info("Bookie server is interrupted. Exiting ...");
         }
-        server.close();
         return ExitCode.OK;
     }
 


### PR DESCRIPTION
There was a race when shutting down a bookie, where both the main
thread and the shutdown hook thread would try to close the bookie
service. This would result in them racing to set the lifecycle state
and neither would end up cleaning up properly. Specifically, the
starter latch would be counted down, so the main thread would start to
close, then the shutdown hook would run, try to close, and get an
exception when it tried to change the state. Once the all shutdown
hooks end, the process exits, even if main hasn't completed. This
leaves the zookeeper session open.

I've removed the close from main(). The shutdown hook always runs
on a graceful shutdown, so that's the place to do the cleanup.
