### PR TITLE
Entry count parameters for BenchBookie

### DIFF
--- a/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
+++ b/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
@@ -57,7 +57,10 @@ public class TestBenchmark extends BookKeeperClusterTestCase {
         BenchBookie.main(new String[] {
                 "--host", bookie.getSocketAddress().getHostName(),
                 "--port", String.valueOf(bookie.getPort()),
-                "--zookeeper", zkUtil.getZooKeeperConnectString()
+                "--zookeeper", zkUtil.getZooKeeperConnectString(),
+                "--warmupCount", "10",
+                "--latencyCount", "100",
+                "--throughputCount", "100"
                 });
     }
 


### PR DESCRIPTION
So that they can be added in the test, to make the test run faster and
not timeout in CI and ruin an otherwise good test run.
