### PR TITLE
Fix test regression due to change in default ledger manager

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
@@ -83,6 +83,7 @@ public class BenchReadThroughputLatency {
         LedgerHandle lh = null;
         try {
             bk = new BookKeeper(conf);
+
             while (true) {
                 lh = bk.openLedgerNoRecovery(ledgerId, BookKeeper.DigestType.CRC32,
                                              passwd);
@@ -116,8 +117,13 @@ public class BenchReadThroughputLatency {
                 long endtime = System.nanoTime();
                 time += endtime - starttime;
 
-                lh.close();
+                boolean wasClosed = lh.isClosed();
+                lh.close(); // close the handle
                 lh = null;
+
+                if (wasClosed) {
+                    break;
+                }
                 Thread.sleep(1000);
             }
         } catch (InterruptedException ie) {

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
@@ -83,7 +83,6 @@ public class BenchReadThroughputLatency {
         LedgerHandle lh = null;
         try {
             bk = new BookKeeper(conf);
-
             while (true) {
                 lh = bk.openLedgerNoRecovery(ledgerId, BookKeeper.DigestType.CRC32,
                                              passwd);
@@ -117,13 +116,8 @@ public class BenchReadThroughputLatency {
                 long endtime = System.nanoTime();
                 time += endtime - starttime;
 
-                boolean wasClosed = lh.isClosed();
-                lh.close(); // close the handle
+                lh.close();
                 lh = null;
-
-                if (wasClosed) {
-                    break;
-                }
                 Thread.sleep(1000);
             }
         } catch (InterruptedException ie) {

--- a/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
+++ b/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
@@ -19,13 +19,6 @@
  */
 package org.apache.bookkeeper.benchmark;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
-import java.util.concurrent.Executors;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -81,20 +74,27 @@ public class TestBenchmark extends BookKeeperClusterTestCase {
 
     @Test
     public void testReadThroughputLatency() throws Exception {
-        ExecutorService executor = Executors.newSingleThreadExecutor(
-                new ThreadFactoryBuilder().setNameFormat("read-throughput-latency-test").build());
-        Future<Integer> f = executor.submit(() -> {
-                BenchReadThroughputLatency.main(new String[] {
-                        "--zookeeper", zkUtil.getZooKeeperConnectString(),
-                        "--listen", "10"});
-                return 0;
-            });
+        final AtomicBoolean threwException = new AtomicBoolean(false);
+        Thread t = new Thread() {
+                public void run() {
+                    try {
+                        BenchReadThroughputLatency.main(new String[] {
+                                "--zookeeper", zkUtil.getZooKeeperConnectString(),
+                                "--listen", "10"});
+                    } catch (Throwable t) {
+                        LOG.error("Error reading", t);
+                        threwException.set(true);
+                    }
+                }
+            };
+        t.start();
 
-        Thread.sleep(2000);
+        Thread.sleep(10000);
         byte data[] = new byte[1024];
         Arrays.fill(data, (byte)'x');
 
         long lastLedgerId = 0;
+        Assert.assertTrue("Thread should be running", t.isAlive());
         for (int i = 0; i < 10; i++) {
             BookKeeper bk = new BookKeeper(zkUtil.getZooKeeperConnectString());
             LedgerHandle lh = bk.createLedger(BookKeeper.DigestType.CRC32, "benchPasswd".getBytes());
@@ -108,7 +108,14 @@ public class TestBenchmark extends BookKeeperClusterTestCase {
                 bk.close();
             }
         }
-        Assert.assertEquals(Integer.valueOf(0), f.get());
+        for (int i = 0; i < 60; i++) {
+            if (!t.isAlive()) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+
+        Assert.assertFalse("Thread should be finished", t.isAlive());
 
         BenchReadThroughputLatency.main(new String[] {
                 "--zookeeper", zkUtil.getZooKeeperConnectString(),

--- a/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
+++ b/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
@@ -108,7 +108,7 @@ public class TestBenchmark extends BookKeeperClusterTestCase {
                 bk.close();
             }
         }
-        Assert.assertEquals(Integer.valueOf(0), f.get(30, TimeUnit.SECONDS));
+        Assert.assertEquals(Integer.valueOf(0), f.get());
 
         BenchReadThroughputLatency.main(new String[] {
                 "--zookeeper", zkUtil.getZooKeeperConnectString(),


### PR DESCRIPTION
TestBenchmark#testReadThroughputLatency() regressed due to the change
in 3ddc5db, where the default ledger manager was changed from flat to
hierarchical.

The fix is to use flat for this test. I've also cleaned up the test a
little, and added some code to the benchmark to make the test run
faster.