### PR TITLE
Gather disk information before CI build

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -22,6 +22,11 @@ import common_job_properties
 mavenJob('bookkeeper_precommit_pullrequest_java8') {
   description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 8.')
 
+  // Temporary information gathering to see if full disks are causing the builds to flake
+  preBuildSteps {
+    shell("df -h")
+  }
+
   // Execute concurrent builds if necessary.
   concurrentBuild()
 

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -24,7 +24,9 @@ mavenJob('bookkeeper_precommit_pullrequest_java8') {
 
   // Temporary information gathering to see if full disks are causing the builds to flake
   preBuildSteps {
+    shell("pwd")
     shell("df -h")
+    shell("ps -ef")
   }
 
   // Execute concurrent builds if necessary.

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -28,7 +28,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java8') {
     shell("ulimit -a")
     shell("pwd")
     shell("df -h")
-    shell("ps -ef")
+    shell("ps aux")
   }
 
   // Execute concurrent builds if necessary.

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -24,6 +24,8 @@ mavenJob('bookkeeper_precommit_pullrequest_java8') {
 
   // Temporary information gathering to see if full disks are causing the builds to flake
   preBuildSteps {
+    shell("id")
+    shell("ulimit -a")
     shell("pwd")
     shell("df -h")
     shell("ps -ef")

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
@@ -28,7 +28,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
     shell("ulimit -a")
     shell("pwd")
     shell("df -h")
-    shell("ps -ef")
+    shell("ps aux")
   }
 
   // Execute concurrent builds if necessary.

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
@@ -22,6 +22,11 @@ import common_job_properties
 mavenJob('bookkeeper_precommit_pullrequest_java9') {
   description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 9.')
 
+  // Temporary information gathering to see if full disks are causing the builds to flake
+  preBuildSteps {
+    shell("df -h")
+  }
+
   // Execute concurrent builds if necessary.
   concurrentBuild()
 

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
@@ -24,6 +24,8 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
 
   // Temporary information gathering to see if full disks are causing the builds to flake
   preBuildSteps {
+    shell("id")
+    shell("ulimit -a")
     shell("pwd")
     shell("df -h")
     shell("ps -ef")

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
@@ -24,7 +24,9 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
 
   // Temporary information gathering to see if full disks are causing the builds to flake
   preBuildSteps {
+    shell("pwd")
     shell("df -h")
+    shell("ps -ef")
   }
 
   // Execute concurrent builds if necessary.


### PR DESCRIPTION
I suspect that we are getting quite a few flakes because of over-full
disks in the CI workers. I'd like to confirm this hypothesis and
gather some information before taking corrective action.
