### PR TITLE
Include yahoo custom version in all versions image

### DIFF
--- a/tests/docker-all-versions-image/all-released-image/scripts/install-pulsar-tarball.sh
+++ b/tests/docker-all-versions-image/all-released-image/scripts/install-pulsar-tarball.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+set -e
+
+gpg --import KEYS.pulsar
+
+TARBALL=$(ls apache-pulsar-*-incubating-bin.tar.gz | tail -1)
+
+gpg --verify $TARBALL.asc
+
+VERSION="4.3-yahoo"
+
+tar -zxf $TARBALL
+rm $TARBALL
+mv apache-pulsar-*-incubating /opt/bookkeeper/$VERSION
+
+cat > /etc/supervisord/conf.d/bookkeeper-$VERSION.conf <<EOF
+[program:bookkeeper-$VERSION]
+autostart=false
+redirect_stderr=true
+stdout_logfile=/var/log/bookkeeper/stdout-$VERSION.log
+directory=/opt/bookkeeper/$VERSION
+command=/opt/bookkeeper/$VERSION/bin/pulsar bookie
+EOF

--- a/tests/docker-images/all-released-versions-image/Dockerfile
+++ b/tests/docker-images/all-released-versions-image/Dockerfile
@@ -46,14 +46,17 @@ RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.5.0/bookkee
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.5.1/bookkeeper-server-4.5.1-bin.tar.gz{,.sha1,.md5,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.6.0/bookkeeper-server-4.6.0-bin.tar.gz{,.sha1,.md5,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.6.1/bookkeeper-server-4.6.1-bin.tar.gz{,.sha1,.md5,.asc}
+RUN wget -nv https://archive.apache.org/dist/incubator/pulsar/pulsar-1.21.0-incubating/apache-pulsar-1.21.0-incubating-bin.tar.gz{,.asc}
 RUN wget -nv https://dist.apache.org/repos/dist/release/bookkeeper/KEYS
 RUN wget -nv http://svn.apache.org/repos/asf/zookeeper/bookkeeper/dist/KEYS?p=1620552 -O KEYS.old
+RUN wget -nv https://archive.apache.org/dist/incubator/pulsar/KEYS -O KEYS.pulsar
 
 RUN mkdir -p /etc/supervisord/conf.d && mkdir -p /var/run/supervisor && mkdir -p /var/log/bookkeeper
 ADD conf/supervisord.conf /etc/supervisord.conf
 ADD scripts/install-all-tarballs.sh /install-all-tarballs.sh
 ADD scripts/install-tarball.sh /install-tarball.sh
-RUN bash /install-all-tarballs.sh && rm -rf /tarballs
+ADD scripts/install-pulsar-tarball.sh /install-pulsar-tarball.sh
+RUN bash /install-all-tarballs.sh && bash /install-pulsar-tarball.sh && rm -rf /tarballs
 
 WORKDIR /
 ADD scripts/update-conf-and-boot.sh /update-conf-and-boot.sh

--- a/tests/docker-images/all-released-versions-image/scripts/update-conf-and-boot.sh
+++ b/tests/docker-images/all-released-versions-image/scripts/update-conf-and-boot.sh
@@ -20,9 +20,9 @@
 
 mkdir -p $BK_JOURNALDIR $BK_LEDGERDIR
 
-sed -i "s|journalDirectory=.*|journalDirectory=$BK_JOURNALDIR|" /opt/bookkeeper/*/conf/bk_server.conf
-sed -i "s|ledgerDirectories=.*|ledgerDirectories=$BK_LEDGERDIR|" /opt/bookkeeper/*/conf/bk_server.conf
-sed -i "s|zkServers=.*|zkServers=$BK_ZKCONNECTSTRING|" /opt/bookkeeper/*/conf/bk_server.conf
+sed -i "s|journalDirectory=.*|journalDirectory=$BK_JOURNALDIR|" /opt/bookkeeper/*/conf/{bk_server,bookkeeper}.conf
+sed -i "s|ledgerDirectories=.*|ledgerDirectories=$BK_LEDGERDIR|" /opt/bookkeeper/*/conf/{bk_server,bookkeeper}.conf
+sed -i "s|zkServers=.*|zkServers=$BK_ZKCONNECTSTRING|" /opt/bookkeeper/*/conf/{bk_server,bookkeeper}.conf
 
 # 4.3.1 & 4.3.2 shipped with a broken confs
 sed -i "s|\(# \)\?logSizeLimit=.*|logSizeLimit=1073741824|" /opt/bookkeeper/4.3.1/conf/bk_server.conf


### PR DESCRIPTION
To ensure compatibility between versions during the merge, we need the
yahoo custom version of bookkeeper.

The most straightforward way to get this version is through
pulsar. It's distributed as part of the pulsar distribution, with
scripts to start it and all.
