### PR TITLE
Issue #1152: stats for durability violations in write/read path

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -111,17 +111,18 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     private OpStatsLogger deleteOpLogger;
     private OpStatsLogger recoverOpLogger;
     private OpStatsLogger readOpLogger;
-    private OpStatsLogger readOpDmLogger;
     private OpStatsLogger readLacAndEntryOpLogger;
     private OpStatsLogger readLacAndEntryRespLogger;
     private OpStatsLogger addOpLogger;
-    private OpStatsLogger addOpUrLogger;
     private OpStatsLogger writeLacOpLogger;
     private OpStatsLogger readLacOpLogger;
     private OpStatsLogger recoverAddEntriesStats;
     private OpStatsLogger recoverReadEntriesStats;
 
     private Counter speculativeReadCounter;
+    private Counter readOpDmCounter;
+    private Counter addOpUrCounter;
+
 
     // whether the event loop group is one we created, or is owned by whoever
     // instantiated us
@@ -1446,12 +1447,12 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         openOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.OPEN_OP);
         recoverOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.RECOVER_OP);
         readOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_OP);
-        readOpDmLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_OP_DM);
+        readOpDmCounter = stats.getCounter(BookKeeperClientStats.READ_OP_DM);
         readLacAndEntryOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY);
         readLacAndEntryRespLogger = stats.getOpStatsLogger(
                 BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE);
         addOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.ADD_OP);
-        addOpUrLogger = stats.getOpStatsLogger(BookKeeperClientStats.ADD_OP_UR);
+        addOpUrCounter = stats.getCounter(BookKeeperClientStats.ADD_OP_UR);
         writeLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.WRITE_LAC_OP);
         readLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAC_OP);
         recoverAddEntriesStats = stats.getOpStatsLogger(BookKeeperClientStats.LEDGER_RECOVER_ADD_ENTRIES);
@@ -1475,9 +1476,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     OpStatsLogger getReadOpLogger() {
         return readOpLogger;
     }
-    OpStatsLogger getReadOpDmLogger() {
-        return readOpDmLogger;
-    }
     OpStatsLogger getReadLacAndEntryOpLogger() {
         return readLacAndEntryOpLogger;
     }
@@ -1486,9 +1484,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     }
     OpStatsLogger getAddOpLogger() {
         return addOpLogger;
-    }
-    OpStatsLogger getAddOpUrLogger() {
-        return addOpUrLogger;
     }
     OpStatsLogger getWriteLacOpLogger() {
         return writeLacOpLogger;
@@ -1502,7 +1497,12 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     OpStatsLogger getRecoverReadCountLogger() {
         return recoverReadEntriesStats;
     }
-
+    Counter getReadOpDmCounter() {
+        return readOpDmCounter;
+    }
+    Counter getAddOpUrCounter() {
+        return addOpUrCounter;
+    }
     static EventLoopGroup getDefaultEventLoopGroup() {
         ThreadFactory threadFactory = new DefaultThreadFactory("bookkeeper-io");
         final int numThreads = Runtime.getRuntime().availableProcessors() * 2;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -111,9 +111,11 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     private OpStatsLogger deleteOpLogger;
     private OpStatsLogger recoverOpLogger;
     private OpStatsLogger readOpLogger;
+    private OpStatsLogger readOpDmLogger;
     private OpStatsLogger readLacAndEntryOpLogger;
     private OpStatsLogger readLacAndEntryRespLogger;
     private OpStatsLogger addOpLogger;
+    private OpStatsLogger addOpUrLogger;
     private OpStatsLogger writeLacOpLogger;
     private OpStatsLogger readLacOpLogger;
     private OpStatsLogger recoverAddEntriesStats;
@@ -1444,10 +1446,12 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         openOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.OPEN_OP);
         recoverOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.RECOVER_OP);
         readOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_OP);
+        readOpDmLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_OP_DM);
         readLacAndEntryOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY);
         readLacAndEntryRespLogger = stats.getOpStatsLogger(
                 BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE);
         addOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.ADD_OP);
+        addOpUrLogger = stats.getOpStatsLogger(BookKeeperClientStats.ADD_OP_UR);
         writeLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.WRITE_LAC_OP);
         readLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAC_OP);
         recoverAddEntriesStats = stats.getOpStatsLogger(BookKeeperClientStats.LEDGER_RECOVER_ADD_ENTRIES);
@@ -1471,6 +1475,9 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     OpStatsLogger getReadOpLogger() {
         return readOpLogger;
     }
+    OpStatsLogger getReadOpDmLogger() {
+        return readOpDmLogger;
+    }
     OpStatsLogger getReadLacAndEntryOpLogger() {
         return readLacAndEntryOpLogger;
     }
@@ -1479,6 +1486,9 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     }
     OpStatsLogger getAddOpLogger() {
         return addOpLogger;
+    }
+    OpStatsLogger getAddOpUrLogger() {
+        return addOpUrLogger;
     }
     OpStatsLogger getWriteLacOpLogger() {
         return writeLacOpLogger;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -40,7 +40,10 @@ public interface BookKeeperClientStats {
     // Data Operations
 
     String ADD_OP = "ADD_ENTRY";
+    String ADD_OP_UR = "ADD_ENTRY_UR"; // Under Replicated during AddEntry.
     String READ_OP = "READ_ENTRY";
+    // Corrupted entry (Digest Mismatch/ Under Replication) detected during ReadEntry
+    String READ_OP_DM = "READ_ENTRY_DM";
     String WRITE_LAC_OP = "WRITE_LAC";
     String READ_LAC_OP = "READ_LAC";
     String READ_LAST_CONFIRMED_AND_ENTRY = "READ_LAST_CONFIRMED_AND_ENTRY";

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -1,4 +1,5 @@
 /**
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,19 +7,23 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
  */
 package org.apache.bookkeeper.client;
 
-import static org.apache.bookkeeper.client.BookKeeperClientStats.*;
+import static org.apache.bookkeeper.client.BookKeeperClientStats.ADD_OP;
+import static org.apache.bookkeeper.client.BookKeeperClientStats.ADD_OP_UR;
+import static org.apache.bookkeeper.client.BookKeeperClientStats.CLIENT_SCOPE;
+import static org.apache.bookkeeper.client.BookKeeperClientStats.READ_OP_DM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -58,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * Testing ledger write entry cases.
  */
 public class BookieWriteLedgerTest extends
-        BookKeeperClusterTestCase implements AddCallback {
+    BookKeeperClusterTestCase implements AddCallback {
 
     private static final Logger LOG = LoggerFactory
             .getLogger(BookieWriteLedgerTest.class);
@@ -216,9 +221,9 @@ public class BookieWriteLedgerTest extends
 
         assertTrue(
                 "Stats should have captured a new UnderReplication during write",
-                bkc.getTestStatsProvider().getOpStatsLogger(
+                bkc.getTestStatsProvider().getCounter(
                         CLIENT_SCOPE + "." + ADD_OP_UR)
-                        .getFailureCount() > 0);
+                        .get() > 0);
 
         sleepLatch1.countDown();
         sleepLatch2.countDown();
@@ -246,9 +251,9 @@ public class BookieWriteLedgerTest extends
         readEntries(lh, entries1);
         assertTrue(
                 "Stats should have captured DigestMismatch on Read",
-                bkc.getTestStatsProvider().getOpStatsLogger(
+                bkc.getTestStatsProvider().getCounter(
                         CLIENT_SCOPE + "." + READ_OP_DM)
-                        .getFailureCount() > 0);
+                        .get() > 0);
         lh.close();
     }
 
@@ -326,9 +331,9 @@ public class BookieWriteLedgerTest extends
         try {
             CompletableFuture<Object> done = new CompletableFuture<>();
             lh.asyncAddEntry(Unpooled.wrappedBuffer(entry.array()),
-                    (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
-                        SyncCallbackUtils.finish(rc, null, done);
-                    }, null);
+                (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
+                SyncCallbackUtils.finish(rc, null, done);
+            }, null);
             done.get();
         } catch (ExecutionException ee) {
             assertTrue(ee.getCause() instanceof BKException);
@@ -339,9 +344,9 @@ public class BookieWriteLedgerTest extends
         try {
             CompletableFuture<Object> done = new CompletableFuture<>();
             lh.asyncAddEntry(entry.array(),
-                    (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
-                        SyncCallbackUtils.finish(rc, null, done);
-                    }, null);
+                (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
+                SyncCallbackUtils.finish(rc, null, done);
+            }, null);
             done.get();
         } catch (ExecutionException ee) {
             assertTrue(ee.getCause() instanceof BKException);
@@ -352,9 +357,9 @@ public class BookieWriteLedgerTest extends
         try {
             CompletableFuture<Object> done = new CompletableFuture<>();
             lh.asyncAddEntry(entry.array(), 0, 4,
-                    (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
-                        SyncCallbackUtils.finish(rc, null, done);
-                    }, null);
+                (int rc, LedgerHandle lh1, long entryId, Object ctx) -> {
+                SyncCallbackUtils.finish(rc, null, done);
+            }, null);
             done.get();
         } catch (ExecutionException ee) {
             assertTrue(ee.getCause() instanceof BKException);
@@ -448,7 +453,7 @@ public class BookieWriteLedgerTest extends
             lh = bkc.openLedger(ledgerId, digestType, ledgerPassword);
             Map<String, byte[]> outputCustomMetadataMap = lh.getCustomMetadata();
             assertTrue("Can't retrieve proper Custom Data",
-                    LedgerMetadata.areByteArrayValMapsEqual(inputCustomMetadataMap, outputCustomMetadataMap));
+                       LedgerMetadata.areByteArrayValMapsEqual(inputCustomMetadataMap, outputCustomMetadataMap));
             lh.close();
             bkc.deleteLedger(ledgerId);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
-
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.OpStatsData;
@@ -148,10 +147,6 @@ public class TestStatsProvider implements StatsProvider {
         public synchronized long getSuccessCount() {
             return successCount;
         }
-
-        public synchronized long getFailureCount() {
-            return failureCount;
-        }
     }
 
     /**
@@ -198,8 +193,7 @@ public class TestStatsProvider implements StatsProvider {
         }
 
         @Override
-        public void removeScope(String name, StatsLogger statsLogger) {
-        }
+        public void removeScope(String name, StatsLogger statsLogger) {}
     }
 
     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
+
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.OpStatsData;
@@ -147,6 +148,10 @@ public class TestStatsProvider implements StatsProvider {
         public synchronized long getSuccessCount() {
             return successCount;
         }
+
+        public synchronized long getFailureCount() {
+            return failureCount;
+        }
     }
 
     /**
@@ -193,7 +198,8 @@ public class TestStatsProvider implements StatsProvider {
         }
 
         @Override
-        public void removeScope(String name, StatsLogger statsLogger) {}
+        public void removeScope(String name, StatsLogger statsLogger) {
+        }
     }
 
     @Override


### PR DESCRIPTION


Descriptions of the changes in this PR:

Durability contract demands that there are WQ copies spread
across fault zones as per the ensemble placement policy.
There are lots of areas where this contract is violated.

Add stats to track two areas that are well:
a. Write Path: if the write fails after satisfying AQ
b. Read Path: If the checksum error is detected on the read path

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>

Master Issue: #1152 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---