### PR TITLE
Issue 1162 - Test for unsetSuccessAndSendWriteRequest with LedgerHandleAdv

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -188,8 +188,10 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
             return;
         }
 
-        LOG.info("Unsetting success for ledger: " + lh.ledgerId + " entry: " + entryId + " bookie index: "
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Unsetting success for ledger: " + lh.ledgerId + " entry: " + entryId + " bookie index: "
                       + bookieIndex);
+        }
 
         // if we had already heard a success from this array index, need to
         // increment our number of responses that are pending, since we are

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -188,10 +188,8 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
             return;
         }
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Unsetting success for ledger: " + lh.ledgerId + " entry: " + entryId + " bookie index: "
+        LOG.info("Unsetting success for ledger: " + lh.ledgerId + " entry: " + entryId + " bookie index: "
                       + bookieIndex);
-        }
 
         // if we had already heard a success from this array index, need to
         // increment our number of responses that are pending, since we are


### PR DESCRIPTION
Descriptions of the changes in this PR:

Add a test case to verify unsetSuccessAndSendWriteRequest with
LedgerHandleAdv out of order writers which forces ensemble change.

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>

Master Issue: #1162 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
