### PR TITLE
Issue #1164: TestTruncate#testPurgeLogs is flaky

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAbstractLogWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAbstractLogWriter.java
@@ -76,6 +76,11 @@ abstract class BKAbstractLogWriter implements Closeable, AsyncCloseable, Abortab
                 TimeUnit.MILLISECONDS.convert(dynConf.getRetentionPeriodHours(), TimeUnit.HOURS));
     }
 
+    @VisibleForTesting
+    CompletableFuture<List<LogSegmentMetadata>> getLastTruncationAttempt() {
+        return lastTruncationAttempt;
+    }
+
     // manage write handler
 
     protected synchronized BKLogWriteHandler getCachedWriteHandler() {


### PR DESCRIPTION

Descriptions of the changes in this PR:

*Problem*

log segments are truncated in the background after TTL. the truncation is done asynchronously.
so when we finish writing all the log records, the truncation might still not complete yet.

*Solution*

Improve the test case to wait until the last truncation attempt is completed before asserting the log segments


Master Issue: #1164 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
