### PR TITLE
Issue #1169 Upgrade Surefire plugin to 2.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
     <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
-    <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>2.20.1</maven-surefire-plugin.version>
     <maven-assembly-plugin.version>2.2.1</maven-assembly-plugin.version>
   </properties>
 


### PR DESCRIPTION
**Context**

We at Salesforce have been experiencing a series of hard to nail down test failures related to some of our changes causing Bookkeeper tests occasionally hanging up until they were terminated by Maven / Surefire. What's been making it harder to figure out was that the issue was only reproducing on Jenkins, not locally, and the lack of thread dumps along with Surefire failing to produce reports for these tests, making them next to invisible in Jenkins output.

**Related**

Issue #463 / PR #481 changes help terminate tests hanging in `@Before` or `@After` by changing `@Test` based "local" timeouts to `@Rule` based "global" ones.

**Proposed changes**

Upgrade Surefire plugin to 2.20.1 which has a few related [fixes and improvements since 2.19.1](https://issues.apache.org/jira/browse/SUREFIRE-1413?jql=project%20%3D%20SUREFIRE%20AND%20fixVersion%20in%20(2.20%2C%202.20.1)): 
* [SUREFIRE-1322](https://issues.apache.org/jira/browse/SUREFIRE-1322) Surefire and Failsafe should dump critical errors in dump file and console
* [SUREFIRE-1435](https://issues.apache.org/jira/browse/SUREFIRE-1435) Improve Thread Dump
etc

(@bug W-4700391@)