### PR TITLE
Enforce zkAcls on initNewCluster

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationManager.java
@@ -73,7 +73,6 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZKUtil;
-import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
@@ -485,10 +484,10 @@ public class ZKRegistrationManager implements RegistrationManager {
         }
 
         // Create ledgers root node
-        zk.create(zkLedgersRootPath, "".getBytes(UTF_8), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        zk.create(zkLedgersRootPath, "".getBytes(UTF_8), zkAcls, CreateMode.PERSISTENT);
 
         // create available bookies node
-        zk.create(zkAvailableBookiesPath, "".getBytes(UTF_8), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        zk.create(zkAvailableBookiesPath, "".getBytes(UTF_8), zkAcls, CreateMode.PERSISTENT);
 
         // creates the new layout and stores in zookeeper
         LedgerManagerFactory.newLedgerManagerFactory(conf, layoutManager);
@@ -496,7 +495,7 @@ public class ZKRegistrationManager implements RegistrationManager {
         // create INSTANCEID
         String instanceId = UUID.randomUUID().toString();
         zk.create(conf.getZkLedgersRootPath() + "/" + BookKeeperConstants.INSTANCEID, instanceId.getBytes(UTF_8),
-                Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                zkAcls, CreateMode.PERSISTENT);
 
         log.info("Successfully initiated cluster. ZKServers: {} ledger root path: {} instanceId: {}", zkServers,
                 zkLedgersRootPath, instanceId);


### PR DESCRIPTION
Descriptions of the changes in this PR:

initNewCluster was introduced #979. The new command doesn't honor to zookeeper acls settings. This change is to change those zookeeper calls to use `zkAcls`.