### PR TITLE
Use BookieServer#getLocalAddress as the identifier in the test

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.fail;
 import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -307,20 +306,18 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        int initialPort = bsConfs.get(0).getBookiePort();
+        BookieSocketAddress bookieSrc = bs.get(0).getLocalAddress();
         bs.get(0).shutdown();
         bs.remove(0);
 
         // Startup a new bookie server
-        int newBookiePort = startNewBookie();
+        startNewBookie();
 
         // Write some more entries for the ledgers so a new ensemble will be
         // created for them.
         writeEntriestoLedgers(numMsgs, 10, lhs);
 
         // Call the async recover bookie method.
-        BookieSocketAddress bookieSrc = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
-          initialPort);
         // Initiate the sync object
         sync.value = false;
         bkAdmin.asyncRecoverBookieData(bookieSrc, bookieRecoverCb, sync);
@@ -359,7 +356,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        int initialPort = bsConfs.get(0).getBookiePort();
+        BookieSocketAddress bookieSrc = bs.get(0).getLocalAddress();
         bs.get(0).shutdown();
         bs.remove(0);
 
@@ -373,8 +370,6 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         writeEntriestoLedgers(numMsgs, 10, lhs);
 
         // Call the async recover bookie method.
-        BookieSocketAddress bookieSrc = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
-          initialPort);
         LOG.info("Now recover the data on the killed bookie (" + bookieSrc
           + ") and replicate it to a random available one");
         // Initiate the sync object
@@ -414,7 +409,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        int initialPort = bsConfs.get(0).getBookiePort();
+        BookieSocketAddress bookieSrc = bs.get(0).getLocalAddress();
         bs.get(0).shutdown();
         bs.remove(0);
 
@@ -426,12 +421,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         writeEntriestoLedgers(numMsgs, 10, lhs);
 
         // Call the sync recover bookie method.
-        BookieSocketAddress bookieSrc = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
-          initialPort);
-        BookieSocketAddress bookieDest = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
-          newBookiePort);
-        LOG.info("Now recover the data on the killed bookie (" + bookieSrc + ") and replicate it to the new one ("
-          + bookieDest + ")");
+        LOG.info("Now recover the data on the killed bookie (" + bookieSrc + ") and replicate it to other bookies");
         bkAdmin.recoverBookieData(bookieSrc);
 
         // Verify the recovered ledger entries are okay.
@@ -460,7 +450,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        int initialPort = bsConfs.get(0).getBookiePort();
+        BookieSocketAddress bookieSrc = bs.get(0).getLocalAddress();
         bs.get(0).shutdown();
         bs.remove(0);
 
@@ -474,8 +464,6 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         writeEntriestoLedgers(numMsgs, 10, lhs);
 
         // Call the sync recover bookie method.
-        BookieSocketAddress bookieSrc = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
-          initialPort);
         LOG.info("Now recover the data on the killed bookie (" + bookieSrc
           + ") and replicate it to a random available one");
         bkAdmin.recoverBookieData(bookieSrc);
@@ -757,13 +745,11 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        int initialPort = bsConfs.get(0).getBookiePort();
+        BookieSocketAddress bookieSrc = bs.get(0).getLocalAddress();
         bs.get(0).shutdown();
         bs.remove(0);
 
         // Call the async recover bookie method.
-        BookieSocketAddress bookieSrc = new BookieSocketAddress(InetAddress.getLocalHost().getHostAddress(),
-          initialPort);
         LOG.info("Now recover the data on the killed bookie (" + bookieSrc
           + ") and replicate it to a random available one");
         // Initiate the sync object

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.Sets;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Enumeration;
@@ -95,14 +94,13 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
 
-        int startNewBookie = startNewBookie();
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr);
+
         for (int i = 0; i < 10; i++) {
             lh.addEntry(data);
         }
 
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie);
-        LOG.info("New Bookie addr :" + newBkAddr);
         Set<LedgerFragment> result = getFragmentsToReplicate(lh);
 
         BookKeeperAdmin admin = new BookKeeperAdmin(baseClientConf);
@@ -161,13 +159,12 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         BookieSocketAddress replicaToKill2 = lh.getLedgerMetadata()
                 .getEnsembles().get(0L).get(1);
 
-        int startNewBookie2 = startNewBookie();
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr);
+
         LOG.info("Killing Bookie", replicaToKill2);
         killBookie(replicaToKill2);
 
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie2);
-        LOG.info("New Bookie addr :" + newBkAddr);
         Set<LedgerFragment> result = getFragmentsToReplicate(lh);
 
         BookKeeperAdmin admin = new BookKeeperAdmin(baseClientConf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
@@ -23,7 +23,6 @@ package org.apache.bookkeeper.replication;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Map.Entry;
@@ -71,9 +70,7 @@ public class TestAutoRecoveryAlongWithBookieServers extends
 
         killBookie(replicaToKill);
 
-        int startNewBookie = startNewBookie();
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie);
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
 
         while (ReplicationTestUtil.isLedgerInUnderReplication(zkc, lh.getId(),
                 basePath)) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Map.Entry;
@@ -125,14 +124,12 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
 
-        int startNewBookie = startNewBookie();
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr);
+
         for (int i = 0; i < 10; i++) {
             lh.addEntry(data);
         }
-
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie);
-        LOG.info("New Bookie addr :" + newBkAddr);
 
         ReplicationWorker rw = new ReplicationWorker(zkc, baseConf);
 
@@ -175,9 +172,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         LOG.info("Killing Bookie", replicaToKill);
         ServerConfiguration killedBookieConfig = killBookie(replicaToKill);
 
-        int startNewBookie = startNewBookie();
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie);
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
         LOG.info("New Bookie addr :" + newBkAddr);
 
         killAllBookies(lh, newBkAddr);
@@ -229,17 +224,13 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
 
         killAllBookies(lh, null);
         // Starte RW1
-        int startNewBookie1 = startNewBookie();
-        BookieSocketAddress newBkAddr1 = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie1);
-        LOG.info("New Bookie addr :" + newBkAddr1);
+        BookieSocketAddress newBkAddr1 = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr1);
         ReplicationWorker rw1 = new ReplicationWorker(zkc, baseConf);
 
         // Starte RW2
-        int startNewBookie2 = startNewBookie();
-        BookieSocketAddress newBkAddr2 = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie2);
-        LOG.info("New Bookie addr :" + newBkAddr2);
+        BookieSocketAddress newBkAddr2 = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr2);
         ZooKeeper zkc1 = ZooKeeperClient.newBuilder()
                 .connectString(zkUtil.getZooKeeperConnectString())
                 .sessionTimeoutMs(10000)
@@ -293,10 +284,8 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
 
-        int startNewBookie = startNewBookie();
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie);
-        LOG.info("New Bookie addr :" + newBkAddr);
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr);
         ReplicationWorker rw = new ReplicationWorker(zkc, baseConf);
         rw.start();
 
@@ -349,11 +338,8 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         killBookie(replicaToKillFromFirstLedger);
         lh2.close();
 
-        int startNewBookie = startNewBookie();
-
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie);
-        LOG.info("New Bookie addr :" + newBkAddr);
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr);
 
         ReplicationWorker rw = new ReplicationWorker(zkc, baseConf);
 
@@ -406,11 +392,8 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
 
-        int startNewBookie = startNewBookie();
-
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie);
-        LOG.info("New Bookie addr :" + newBkAddr);
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr);
 
         // set to 3s instead of default 30s
         baseConf.setOpenLedgerRereplicationGracePeriod("3000");
@@ -468,17 +451,14 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
 
-        int startNewBookie = startNewBookie();
+        BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
+        LOG.info("New Bookie addr : {}", newBkAddr);
 
         // Reform ensemble...Making sure that last fragment is not in
         // under-replication
         for (int i = 0; i < 10; i++) {
             lh.addEntry(data);
         }
-
-        BookieSocketAddress newBkAddr = new BookieSocketAddress(InetAddress
-                .getLocalHost().getHostAddress(), startNewBookie);
-        LOG.info("New Bookie addr :" + newBkAddr);
 
         ReplicationWorker rw = new ReplicationWorker(zkc, baseConf);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -584,12 +584,18 @@ public abstract class BookKeeperClusterTestCase {
      */
     public int startNewBookie()
             throws Exception {
+        return startNewBookieAndReturnAddress().getPort();
+    }
+
+    public BookieSocketAddress startNewBookieAndReturnAddress()
+            throws Exception {
         ServerConfiguration conf = newServerConfiguration();
         bsConfs.add(conf);
         LOG.info("Starting new bookie on port: {}", conf.getBookiePort());
-        bs.add(startBookie(conf));
+        BookieServer server = startBookie(conf);
+        bs.add(server);
 
-        return conf.getBookiePort();
+        return server.getLocalAddress();
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

Issue #1097 introduced using `loopback` nic as the bookie server identifier. However a few test cases construct the bookie socket address using `InetAddress.getLocalHost()` and the bookie port. This bookie socket address can be different from the actual socket address that a bookie is advertising to zookeeper. It will cause test cases fail with certain network settings.

*Solution*

This change use `BookieServer#getLocalAddress()` to retrieve the actual bookie socket address. so it would respect to the server configuration and use the right socket address in the test.
