### PR TITLE
Use travis_wait on running mvn test on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - travis_retry mvn --batch-mode clean apache-rat:check compile spotbugs:check install -DskipTests
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/all/target/bookkeeper-all-${BK_VERSION}-bin.tar.gz; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-${BK_VERSION}-bin.tar.gz; fi
-  - if [ "$DLOG_MODIFIED" == "true" ]; then cd stream/distributedlog && mvn --batch-mode clean package -Ddistributedlog; fi
+  - if [ "$DLOG_MODIFIED" == "true" ]; then cd stream/distributedlog && travis_wait 60 mvn --batch-mode clean package -Ddistributedlog; fi
 # Disabled the tests here. Since tests are running much slower on Travis than on Jenkins
 #  - ./dev/ticktoc.sh "mvn --batch-mode clean package"
 


### PR DESCRIPTION
Descriptions of the changes in this PR:


*Problem*

The travis build can take more than 30 minutes, which exceeds the default limit. so the travis builds on master usually fail

*Solution*

Configure the travis build to use `travis_wait` and configure a higher timeout value.

This was set in dlog travis build : https://github.com/apache/distributedlog/blob/master/.travis.yml#L41
