### PR TITLE
Create a forked JVM for each bc test

### DIFF
--- a/tests/integration-tests-base-groovy/pom.xml
+++ b/tests/integration-tests-base-groovy/pom.xml
@@ -84,10 +84,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- DO NOT CHANGE VERSION
+             Versions newer than 2.8.1 do not respect useSystemClassLoader=false
+             https://issues.apache.org/jira/browse/SUREFIRE-1476 //-->
+        <version>2.8.1</version>
         <configuration>
-          <!-- forkCount=0 forces groovy tests to run in isolated classloaders
-               which is required if want to test BC without test deps interfering //-->
-          <forkCount>0</forkCount>
+          <forkCount>1</forkCount>
+          <useSystemClassLoader>false</useSystemClassLoader>
           <systemPropertyVariables>
             <!-- only takes effect in later simpleLogger versions (1.7+) //-->
             <org.slf4j.simpleLogger.logFile>System.out</org.slf4j.simpleLogger.logFile>

--- a/tests/integration-tests-base-groovy/pom.xml
+++ b/tests/integration-tests-base-groovy/pom.xml
@@ -89,6 +89,7 @@
              https://issues.apache.org/jira/browse/SUREFIRE-1476 //-->
         <version>2.8.1</version>
         <configuration>
+          <argLine>-Xmx4G -Djava.net.preferIPv4Stack=true</argLine>
           <forkCount>1</forkCount>
           <useSystemClassLoader>false</useSystemClassLoader>
           <systemPropertyVariables>

--- a/tests/integration-tests-utils/pom.xml
+++ b/tests/integration-tests-utils/pom.xml
@@ -99,11 +99,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- DO NOT CHANGE VERSION
+             Versions newer than 2.8.1 do not respect useSystemClassLoader=false
+             https://issues.apache.org/jira/browse/SUREFIRE-1476 //-->
+        <version>2.8.1</version>
         <configuration>
-          <!-- forkCount=0 forces tests to run in isolated classloaders
-               which is required if want to test maven classloader without
-               test deps interfering //-->
-          <forkCount>0</forkCount>
+          <forkCount>1</forkCount>
+          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Until now, BC tests have been running in the maven processes because
they do funny stuff with the classloader which didn't seem to work
with later versions of the surefire plugin. However, using a version
of surefire less than or equal to 2.8.1, we can use
useSystemClassLoader to the same effect, and therefore fork a JVM for
each test. This is desirable to isolate the tests from each other.
