### PR TITLE
Cleanup client correctly in TestCompatOldClients#testFencingOldClient

### DIFF
--- a/tests/backward-compat/current-server-old-clients/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatOldClients.groovy
+++ b/tests/backward-compat/current-server-old-clients/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatOldClients.groovy
@@ -102,7 +102,8 @@ class TestCompatOldClients {
         } finally {
             oldBK.close()
             oldCL.close()
-            fencingCL.close()
+
+            fencingBK.close()
             fencingCL.close()
         }
     }


### PR DESCRIPTION
Previously we had been mistakenly cleaning up the classloader twice.