### PR TITLE
V2 decoder marks the reads index of the payload on write

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -167,6 +167,9 @@ public class BookieProtoEncoding {
                 // Read ledger and entry id without advancing the reader index
                 ledgerId = packet.getLong(packet.readerIndex());
                 entryId = packet.getLong(packet.readerIndex() + 8);
+                // mark the reader index so that any resets will return to the
+                // start of the payload
+                packet.markReaderIndex();
                 return BookieProtocol.ParsedAddRequest.create(
                         version, ledgerId, entryId, flags,
                         masterKey, packet.retain());


### PR DESCRIPTION
This means that any storage implementation that receives that payload,
can reset the reader index, without jumping into bytes it knows
nothing about.

This was the source of an issue when using V2 protocol with
DbLedgerStorage where the data could not be successfully read back
from the ledger.
