### PR TITLE
Fix flaky travis build on checking license header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,11 @@ before_install:
             echo "Enable testing distributedlog modules if this pull request modifies files under directory `stream/distributedlog`."
         fi
     fi
-    export BK_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate     -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)' 2> /dev/null`
 
 script:
   - travis_retry mvn --batch-mode clean apache-rat:check compile spotbugs:check install -DskipTests
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/all/target/bookkeeper-all-${BK_VERSION}-bin.tar.gz; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-${BK_VERSION}-bin.tar.gz; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/all/target/bookkeeper-all-*-bin.tar.gz; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-*-bin.tar.gz; fi
   - if [ "$DLOG_MODIFIED" == "true" ]; then cd stream/distributedlog && travis_wait 60 mvn --batch-mode clean package -Ddistributedlog; fi
 # Disabled the tests here. Since tests are running much slower on Travis than on Jenkins
 #  - ./dev/ticktoc.sh "mvn --batch-mode clean package"


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

In some environments, `BK_VERSION` is computed as `Downloading`, which is not a valid bookkeeper version. It fails the `dev/check-binary-license` script.

```
[0K$ if [ "$TRAVIS_OS_NAME" == "linux" ]; then dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-${BK_VERSION}-bin.tar.gz; fi
tar: ./bookkeeper-dist/server/target/bookkeeper-server-Downloading: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
tar: ./bookkeeper-dist/server/target/bookkeeper-server-Downloading: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
tar: ./bookkeeper-dist/server/target/bookkeeper-server-Downloading: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

*Solution*

Remove this `BK_VERSION` setting and use "*" in the file path.

