### PR TITLE
Prune networks from previous runs before IT

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
@@ -39,6 +39,7 @@ freeStyleJob('bookkeeper_precommit_integrationtests') {
         shell('pwd')
         shell('df -h')
         shell('ps -eo euser,pid,ppid,pgid,start,pcpu,pmem,cmd')
+        shell('docker network prune -f') // clean up any dangling networks from previous runs
         shell('docker system events > docker.log & echo $! > docker-log.pid')
 
         shell('docker pull apachebookkeeper/bookkeeper-all-released-versions:latest')

--- a/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
@@ -39,7 +39,7 @@ freeStyleJob('bookkeeper_precommit_integrationtests') {
         shell('pwd')
         shell('df -h')
         shell('ps -eo euser,pid,ppid,pgid,start,pcpu,pmem,cmd')
-        shell('docker network prune -f') // clean up any dangling networks from previous runs
+        shell('docker network prune -f --filter name=testnetwork_*') // clean up any dangling networks from previous runs
         shell('docker system events > docker.log & echo $! > docker-log.pid')
 
         shell('docker pull apachebookkeeper/bookkeeper-all-released-versions:latest')


### PR DESCRIPTION
If a build fails, it can leave networks around. Run prune before the
integration tests to avoid this.
