### PR TITLE
BP-30: BookKeeper Table Service

### DIFF
--- a/site/community/bookkeeper_proposals.md
+++ b/site/community/bookkeeper_proposals.md
@@ -100,7 +100,7 @@ Proposal | State
 [BP-26: Move distributedlog library as part of bookkeeper](../../bps/BP-26-move-distributedlog-core-library) | Accepted
 [BP-27: New BookKeeper CLI](../../bps/BP-27-new-bookkeeper-cli) | Draft
 [BP-29: Metadata API module](../../bps/BP-29-metadata-store-api-module) | Draft
-[BP-30: BookKeeper Table Service](https://docs.google.com/document/d/155xAwWv5IdOitHh1NVMEwCMGgB28M3FyMiQSxEpjE-Y/edit#heading=h.56rbh52koe3f) | Draft
+[BP-30: BookKeeper Table Service](https://docs.google.com/document/d/155xAwWv5IdOitHh1NVMEwCMGgB28M3FyMiQSxEpjE-Y/edit#heading=h.56rbh52koe3f) | Accepted
 
 ### Adopted
 

--- a/site/community/bookkeeper_proposals.md
+++ b/site/community/bookkeeper_proposals.md
@@ -85,7 +85,7 @@ using Google Doc.
 
 This section lists all the _bookkeeper proposals_ made to BookKeeper.
 
-*Next Proposal Number: 30*
+*Next Proposal Number: 32*
 
 ### Inprogress
 
@@ -100,6 +100,7 @@ Proposal | State
 [BP-26: Move distributedlog library as part of bookkeeper](../../bps/BP-26-move-distributedlog-core-library) | Accepted
 [BP-27: New BookKeeper CLI](../../bps/BP-27-new-bookkeeper-cli) | Draft
 [BP-29: Metadata API module](../../bps/BP-29-metadata-store-api-module) | Draft
+[BP-30: BookKeeper Table Service](https://docs.google.com/document/d/155xAwWv5IdOitHh1NVMEwCMGgB28M3FyMiQSxEpjE-Y/edit#heading=h.56rbh52koe3f) | Draft
 
 ### Adopted
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

This BP is proposing adding a table (aka key/value) service component as a contrib module to the bookkeeper, which can later be used for metadata storage. This BP together with other BPs forms the ideas of  improving metadata management in bookkeeper.

BP Details: https://docs.google.com/document/d/155xAwWv5IdOitHh1NVMEwCMGgB28M3FyMiQSxEpjE-Y/edit#heading=h.56rbh52koe3f

Related BPs:

- BP-29: Metadata API Module #1123
- BP-28: Etcd Metadata Store #1113  

