### PR TITLE
Propogate exception when bookie shutdown fails

### DIFF
--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/component/TestComponentStarter.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/component/TestComponentStarter.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.common.component.ComponentStarter.ComponentShutdownHook;
 import org.junit.Test;
 
@@ -34,21 +34,20 @@ public class TestComponentStarter {
   @Test
   public void testStartComponent() {
     LifecycleComponent component = mock(LifecycleComponent.class);
-    CountDownLatch latch = new CountDownLatch(1);
     when(component.getName()).thenReturn("test-start-component");
-    ComponentStarter.startComponent(component, latch);
+    ComponentStarter.startComponent(component);
     verify(component).start();
   }
 
   @Test
   public void testComponentShutdownHook() throws Exception {
     LifecycleComponent component = mock(LifecycleComponent.class);
-    CountDownLatch latch = new CountDownLatch(1);
     when(component.getName()).thenReturn("test-shutdown-hook");
-    ComponentShutdownHook shutdownHook = new ComponentShutdownHook(component, latch);
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    ComponentShutdownHook shutdownHook = new ComponentShutdownHook(component, future);
     shutdownHook.run();
     verify(component).close();
-    latch.await();
+    future.get();
   }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -217,7 +217,7 @@ public class Main {
             // the server is interrupted
             log.info("Bookie server is interrupted. Exiting ...");
         } catch (ExecutionException ee) {
-            log.error("Error in bookie shutdown", ee);
+            log.error("Error in bookie shutdown", ee.getCause());
             return ExitCode.SERVER_EXCEPTION;
         }
         return ExitCode.OK;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -25,7 +25,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.ExitCode;
 import org.apache.bookkeeper.common.component.ComponentStarter;
@@ -211,13 +211,14 @@ public class Main {
         }
 
         // 2. start the server
-        CountDownLatch aliveLatch = new CountDownLatch(1);
-        ComponentStarter.startComponent(server, aliveLatch);
         try {
-            aliveLatch.await();
+            ComponentStarter.startComponent(server).get();
         } catch (InterruptedException ie) {
             // the server is interrupted
             log.info("Bookie server is interrupted. Exiting ...");
+        } catch (ExecutionException ee) {
+            log.error("Error in bookie shutdown", ee);
+            return ExitCode.SERVER_EXCEPTION;
         }
         return ExitCode.OK;
     }


### PR DESCRIPTION
When a bookie fails to shutdown cleanly, we should propogate the
exception that caused the problem to the main thread.
