### PR TITLE
Allow default methods in MavenClassloader callbacks

### DIFF
--- a/tests/integration-tests-base-groovy/pom.xml
+++ b/tests/integration-tests-base-groovy/pom.xml
@@ -35,7 +35,6 @@
   <name>Apache BookKeeper :: Tests :: Base module for Arquillian based integration tests using groovy</name>
 
   <properties>
-    <groovy.version>2.4.13</groovy.version>
     <groovy-eclipse-compiler.version>2.9.2-04</groovy-eclipse-compiler.version>
     <groovy-eclipse-batch.version>2.4.13-02</groovy-eclipse-batch.version>
   </properties>

--- a/tests/integration-tests-utils/pom.xml
+++ b/tests/integration-tests-utils/pom.xml
@@ -92,6 +92,12 @@
       <version>${arquillian-cube.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <version>${groovy.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/MavenClassLoader.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/MavenClassLoader.java
@@ -142,9 +142,7 @@ public class MavenClassLoader implements AutoCloseable {
     public Object createCallback(String interfaceName, Closure closure) throws Exception {
         final Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class.getDeclaredConstructor(
                 Class.class, int.class);
-        if (!constructor.isAccessible()) {
-            constructor.setAccessible(true);
-        }
+        constructor.setAccessible(true);
         return Proxy.newProxyInstance(classloader,
                                       new Class<?>[]{ Class.forName(interfaceName, true, classloader) },
                                       new InvocationHandler() {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -27,6 +27,11 @@
   <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>tests-parent</artifactId>
   <name>Apache BookKeeper :: Tests</name>
+
+  <properties>
+    <groovy.version>2.4.13</groovy.version>
+  </properties>
+
   <modules>
     <module>shaded</module>
     <module>docker-images</module>


### PR DESCRIPTION
AsyncCallback.AddCallback has recently acquired a default method,
which breaks the assumption that there is only one method on these
callbacks. However, if does have a default method that calls the one
method. This patch takes advantage of that to allow us to use
AddCallback in tests.
