### PR TITLE
ISSUE #570: Entrylog per ledger

### DIFF
--- a/bookkeeper-server/conf/bk_server.conf
+++ b/bookkeeper-server/conf/bk_server.conf
@@ -620,3 +620,15 @@ zkEnableSecurity=false
 # dbStorage_rocksDB_numLevels=-1
 # dbStorage_rocksDB_numFilesInLevel0=4
 # dbStorage_rocksDB_maxSizeInLevel1MB=256
+
+# config enabling/disabling entrylog per ledger feature.
+# entryLogPerLedgerEnabled=false
+
+# in entryLogPerLedger feature, the time duration used for lastaccess eviction policy for cache
+# entrylogMapAccessExpiryTimeInSeconds=300
+
+# In the case of multipleentrylogs, multiple threads can be used to flush the memtable
+# numOfMemtableFlushThreads=4
+
+# memtableFlushTimeoutInSeconds specifies the amount of time main flushthread has to wait for the processor threads to complete the flush
+# memtableFlushTimeoutInSeconds=120

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -25,6 +25,10 @@ import static com.google.common.base.Charsets.UTF_8;
 import static org.apache.bookkeeper.bookie.TransactionalEntryLogCompactor.COMPACTING_SUFFIX;
 import static org.apache.bookkeeper.util.BookKeeperConstants.MAX_LOG_SIZE_LIMIT;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Sets;
 
@@ -50,11 +54,16 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -63,13 +72,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.bookkeeper.bookie.LedgerDirsManager.LedgerDirsListener;
+import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap.BiConsumerLong;
+import org.apache.commons.lang.mutable.MutableInt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,18 +95,19 @@ import org.slf4j.LoggerFactory;
  */
 public class EntryLogger {
     private static final Logger LOG = LoggerFactory.getLogger(EntryLogger.class);
+    private static final Long INVALID_LEDGERID = new Long(-1);
+    // log file suffix
+    private static final String LOG_FILE_SUFFIX = ".log";
 
-    private static class BufferedLogChannel extends BufferedChannel {
+    class BufferedLogChannel extends BufferedChannel {
         private final long logId;
         private final EntryLogMetadata entryLogMetadata;
         private final File logFile;
+        private Long ledgerId = INVALID_LEDGERID;
 
-        public BufferedLogChannel(FileChannel fc,
-                                  int writeCapacity,
-                                  int readCapacity,
-                                  long logId,
-                                  File logFile) throws IOException {
-            super(fc, writeCapacity, readCapacity);
+        public BufferedLogChannel(FileChannel fc, int writeCapacity, int readCapacity, long logId, File logFile,
+                long unpersistedBytesBound) throws IOException {
+            super(fc, writeCapacity, readCapacity, unpersistedBytesBound);
             this.logId = logId;
             this.entryLogMetadata = new EntryLogMetadata(logId);
             this.logFile = logFile;
@@ -113,13 +127,25 @@ public class EntryLogger {
         public ConcurrentLongLongHashMap getLedgersMap() {
             return entryLogMetadata.getLedgersMap();
         }
+
+        public boolean isLedgerDirFull() {
+            return ledgerDirsManager.isDirFull(logFile.getParentFile());
+        }
+
+        public Long getLedgerId() {
+            return ledgerId;
+        }
+
+        public void setLedgerId(Long ledgerId) {
+            this.ledgerId = ledgerId;
+        }
+
     }
 
-    volatile File currentDir;
     private final LedgerDirsManager ledgerDirsManager;
-    private final AtomicBoolean shouldCreateNewEntryLog = new AtomicBoolean(false);
+    private final boolean entryLogPerLedgerEnabled;
 
-    private volatile long leastUnflushedLogId;
+    RecentEntryLogsStatus recentlyCreatedEntryLogsStatus;
 
     /**
      * locks for compaction log.
@@ -130,11 +156,10 @@ public class EntryLogger {
      * The maximum size of a entry logger file.
      */
     final long logSizeLimit;
-    private List<BufferedLogChannel> logChannelsToFlush;
-    private volatile BufferedLogChannel logChannel;
     private volatile BufferedLogChannel compactionLogChannel;
 
-    private final EntryLoggerAllocator entryLoggerAllocator;
+    final EntryLoggerAllocator entryLoggerAllocator;
+    final EntryLogManager entryLogManager;
     private final boolean entryLogPreAllocationEnabled;
     private final CopyOnWriteArrayList<EntryLogListener> listeners = new CopyOnWriteArrayList<EntryLogListener>();
 
@@ -199,7 +224,6 @@ public class EntryLogger {
 
     private final long flushIntervalInBytes;
     private final boolean doRegularFlushes;
-    private long bytesWrittenSinceLastFlush = 0;
     private final int maxSaneEntrySize;
 
     final ServerConfiguration conf;
@@ -256,6 +280,8 @@ public class EntryLogger {
         // but the protocol varies so an exact value is difficult to determine
         this.maxSaneEntrySize = conf.getNettyMaxFrameSizeBytes() - 500;
         this.ledgerDirsManager = ledgerDirsManager;
+        this.conf = conf;
+        entryLogPerLedgerEnabled = conf.isEntryLogPerLedgerEnabled();
         if (listener != null) {
             addListener(listener);
         }
@@ -284,13 +310,15 @@ public class EntryLogger {
                 logId = lastLogId;
             }
         }
-        this.leastUnflushedLogId = logId + 1;
+        this.recentlyCreatedEntryLogsStatus = new RecentEntryLogsStatus(logId + 1);
+        this.flushIntervalInBytes = conf.getFlushIntervalInBytes();
+        this.doRegularFlushes = flushIntervalInBytes > 0;
         this.entryLoggerAllocator = new EntryLoggerAllocator(logId);
-        this.conf = conf;
-        flushIntervalInBytes = conf.getFlushIntervalInBytes();
-        doRegularFlushes = flushIntervalInBytes > 0;
-
-        initialize();
+        if (entryLogPerLedgerEnabled) {
+            this.entryLogManager = new EntryLogManagerForEntryLogPerLedger(conf);
+        } else {
+            this.entryLogManager = new EntryLogManagerForSingleEntryLog();
+        }
     }
 
     void addListener(EntryLogListener listener) {
@@ -313,13 +341,11 @@ public class EntryLogger {
      */
     private int readFromLogChannel(long entryLogId, BufferedReadChannel channel, ByteBuf buff, long pos)
             throws IOException {
-        BufferedLogChannel bc = logChannel;
+        BufferedLogChannel bc = entryLogManager.getCurrentLogIfPresent(entryLogId);
         if (null != bc) {
-            if (entryLogId == bc.getLogId()) {
-                synchronized (bc) {
-                    if (pos + buff.writableBytes() >= bc.getFileChannelPosition()) {
-                        return bc.read(buff, pos);
-                    }
+            synchronized (bc) {
+                if (pos + buff.writableBytes() >= bc.getFileChannelPosition()) {
+                    return bc.read(buff, pos);
                 }
             }
         }
@@ -386,12 +412,37 @@ public class EntryLogger {
      *
      * @return least unflushed log id.
      */
-    synchronized long getLeastUnflushedLogId() {
-        return leastUnflushedLogId;
+    long getLeastUnflushedLogId() {
+        return recentlyCreatedEntryLogsStatus.getLeastUnflushedLogId();
     }
 
-    synchronized long getCurrentLogId() {
-        return logChannel.getLogId();
+    long getPreviousAllocatedEntryLogId() {
+        return entryLoggerAllocator.getPreallocatedLogId();
+    }
+
+    boolean rollLogsIfEntryLogLimitReached() throws IOException {
+        // for this add ledgerid to bufferedlogchannel, getcopyofcurrentlogs get
+        // ledgerid, lock it only if there is new data
+        // so that cache accesstime is not changed
+
+        boolean rolledLog = false;
+        Set<BufferedLogChannel> copyOfCurrentLogs = entryLogManager.getCopyOfCurrentLogs();
+        for (BufferedLogChannel currentLog : copyOfCurrentLogs) {
+            if (currentLog.position() > logSizeLimit) {
+                Long ledgerId = currentLog.getLedgerId();
+                entryLogManager.acquireLock(ledgerId);
+                try {
+                    if (reachEntryLogLimit(ledgerId, 0L)) {
+                        rolledLog = true;
+                        LOG.info("Rolling entry logger since it reached size limitation");
+                        createNewLog(ledgerId);
+                    }
+                } finally {
+                    entryLogManager.releaseLock(ledgerId);
+                }
+            }
+        }
+        return rolledLog;
     }
 
     /**
@@ -406,98 +457,39 @@ public class EntryLogger {
         }
     }
 
-    protected void initialize() throws IOException {
-        // Register listener for disk full notifications.
-        ledgerDirsManager.addLedgerDirsListener(getLedgerDirsListener());
-        // create a new log to write
-        createNewLog();
-    }
-
-    private LedgerDirsListener getLedgerDirsListener() {
-        return new LedgerDirsListener() {
-            @Override
-            public void diskFull(File disk) {
-                // If the current entry log disk is full, then create new entry
-                // log.
-                if (currentDir != null && currentDir.equals(disk)) {
-                    shouldCreateNewEntryLog.set(true);
-                }
-            }
-
-            @Override
-            public void diskAlmostFull(File disk) {
-                // If the current entry log disk is almost full, then create new entry
-                // log.
-                if (currentDir != null && currentDir.equals(disk)) {
-                    shouldCreateNewEntryLog.set(true);
-                }
-            }
-
-            @Override
-            public void diskFailed(File disk) {
-                // Nothing to handle here. Will be handled in Bookie
-            }
-
-            @Override
-            public void allDisksFull() {
-                // Nothing to handle here. Will be handled in Bookie
-            }
-
-            @Override
-            public void fatalError() {
-                // Nothing to handle here. Will be handled in Bookie
-            }
-
-            @Override
-            public void diskWritable(File disk) {
-                // Nothing to handle here. Will be handled in Bookie
-            }
-
-            @Override
-            public void diskJustWritable(File disk) {
-                // Nothing to handle here. Will be handled in Bookie
-            }
-        };
-    }
-
-    /**
-     * Rolling a new log file to write.
-     */
-    synchronized void rollLog() throws IOException {
-        createNewLog();
-    }
-
     /**
      * Creates a new log file.
      */
-    void createNewLog() throws IOException {
-        // first tried to create a new log channel. add current log channel to ToFlush list only when
-        // there is a new log channel. it would prevent that a log channel is referenced by both
-        // *logChannel* and *ToFlush* list.
-        if (null != logChannel) {
-            if (null == logChannelsToFlush) {
-                logChannelsToFlush = new LinkedList<BufferedLogChannel>();
+    void createNewLog(Long ledgerId) throws IOException {
+        entryLogManager.acquireLock(ledgerId);
+        try {
+            BufferedLogChannel logChannel = entryLogManager.getCurrentLogForLedger(ledgerId);
+            // first tried to create a new log channel. add current log channel to ToFlush list only when
+            // there is a new log channel. it would prevent that a log channel is referenced by both
+            // *logChannel* and *ToFlush* list.
+            if (null != logChannel) {
+
+                // flush the internal buffer back to filesystem but not sync disk
+                logChannel.flush(false);
+
+                // Append ledgers map at the end of entry log
+                appendLedgersMap(ledgerId);
+
+                BufferedLogChannel newLogChannel = entryLoggerAllocator.createNewLog();
+                entryLogManager.setCurrentLogForLedger(ledgerId, newLogChannel);
+                LOG.info("Flushing entry logger {} back to filesystem, pending for syncing entry loggers : {}.",
+                        logChannel.getLogId(), entryLogManager.getCopyOfRotatedLogChannels());
+                if (!entryLogPerLedgerEnabled) {
+                    for (EntryLogListener listener : listeners) {
+                        listener.onRotateEntryLog();
+                    }
+                }
+            } else {
+                entryLogManager.setCurrentLogForLedger(ledgerId, entryLoggerAllocator.createNewLog());
             }
-
-            // flush the internal buffer back to filesystem but not sync disk
-            // so the readers could access the data from filesystem.
-            logChannel.flush(false);
-
-            // Append ledgers map at the end of entry log
-            appendLedgersMap(logChannel);
-
-            BufferedLogChannel newLogChannel = entryLoggerAllocator.createNewLog();
-            logChannelsToFlush.add(logChannel);
-            LOG.info("Flushing entry logger {} back to filesystem, pending for syncing entry loggers : {}.",
-                    logChannel.getLogId(), logChannelsToFlush);
-            for (EntryLogListener listener : listeners) {
-                listener.onRotateEntryLog();
-            }
-            logChannel = newLogChannel;
-        } else {
-            logChannel = entryLoggerAllocator.createNewLog();
+        } finally {
+            entryLogManager.releaseLock(ledgerId);
         }
-        currentDir = logChannel.getLogFile().getParentFile();
     }
 
     /**
@@ -506,78 +498,86 @@ public class EntryLogger {
     EntryLoggerAllocator getEntryLoggerAllocator() {
         return entryLoggerAllocator;
     }
+
     /**
      * Append the ledger map at the end of the entry log.
      * Updates the entry log file header with the offset and size of the map.
      */
-    private void appendLedgersMap(BufferedLogChannel entryLogChannel) throws IOException {
-        long ledgerMapOffset = entryLogChannel.position();
-
-        ConcurrentLongLongHashMap ledgersMap = entryLogChannel.getLedgersMap();
-        int numberOfLedgers = (int) ledgersMap.size();
-
-        // Write the ledgers map into several batches
-
-        final int maxMapSize = LEDGERS_MAP_HEADER_SIZE + LEDGERS_MAP_ENTRY_SIZE * LEDGERS_MAP_MAX_BATCH_SIZE;
-        final ByteBuf serializedMap = ByteBufAllocator.DEFAULT.buffer(maxMapSize);
-
+    private void appendLedgersMap(Long ledgerId) throws IOException {
+        entryLogManager.acquireLock(ledgerId);
         try {
-            ledgersMap.forEach(new BiConsumerLong() {
-                int remainingLedgers = numberOfLedgers;
-                boolean startNewBatch = true;
-                int remainingInBatch = 0;
+            BufferedLogChannel entryLogChannel = entryLogManager.getCurrentLogForLedger(ledgerId);
+            long ledgerMapOffset = entryLogChannel.position();
 
-                @Override
-                public void accept(long ledgerId, long size) {
-                    if (startNewBatch) {
-                        int batchSize = Math.min(remainingLedgers, LEDGERS_MAP_MAX_BATCH_SIZE);
-                        int ledgerMapSize = LEDGERS_MAP_HEADER_SIZE + LEDGERS_MAP_ENTRY_SIZE * batchSize;
+            ConcurrentLongLongHashMap ledgersMap = entryLogChannel.getLedgersMap();
+            int numberOfLedgers = (int) ledgersMap.size();
 
-                        serializedMap.clear();
-                        serializedMap.writeInt(ledgerMapSize - 4);
-                        serializedMap.writeLong(INVALID_LID);
-                        serializedMap.writeLong(LEDGERS_MAP_ENTRY_ID);
-                        serializedMap.writeInt(batchSize);
+            // Write the ledgers map into several batches
 
-                        startNewBatch = false;
-                        remainingInBatch = batchSize;
-                    }
-                    // Dump the ledger in the current batch
-                    serializedMap.writeLong(ledgerId);
-                    serializedMap.writeLong(size);
-                    --remainingLedgers;
+            final int maxMapSize = LEDGERS_MAP_HEADER_SIZE + LEDGERS_MAP_ENTRY_SIZE * LEDGERS_MAP_MAX_BATCH_SIZE;
+            final ByteBuf serializedMap = ByteBufAllocator.DEFAULT.buffer(maxMapSize);
 
-                    if (--remainingInBatch == 0) {
-                        // Close current batch
-                        try {
-                            entryLogChannel.write(serializedMap);
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
+            try {
+                ledgersMap.forEach(new BiConsumerLong() {
+                    int remainingLedgers = numberOfLedgers;
+                    boolean startNewBatch = true;
+                    int remainingInBatch = 0;
+
+                    @Override
+                    public void accept(long ledgerId, long size) {
+                        if (startNewBatch) {
+                            int batchSize = Math.min(remainingLedgers, LEDGERS_MAP_MAX_BATCH_SIZE);
+                            int ledgerMapSize = LEDGERS_MAP_HEADER_SIZE + LEDGERS_MAP_ENTRY_SIZE * batchSize;
+
+                            serializedMap.clear();
+                            serializedMap.writeInt(ledgerMapSize - 4);
+                            serializedMap.writeLong(INVALID_LID);
+                            serializedMap.writeLong(LEDGERS_MAP_ENTRY_ID);
+                            serializedMap.writeInt(batchSize);
+
+                            startNewBatch = false;
+                            remainingInBatch = batchSize;
                         }
+                        // Dump the ledger in the current batch
+                        serializedMap.writeLong(ledgerId);
+                        serializedMap.writeLong(size);
+                        --remainingLedgers;
 
-                        startNewBatch = true;
+                        if (--remainingInBatch == 0) {
+                            // Close current batch
+                            try {
+                                entryLogChannel.write(serializedMap);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+
+                            startNewBatch = true;
+                        }
                     }
+                });
+            } catch (RuntimeException e) {
+                if (e.getCause() instanceof IOException) {
+                    throw (IOException) e.getCause();
+                } else {
+                    throw e;
                 }
-            });
-        } catch (RuntimeException e) {
-            if (e.getCause() instanceof IOException) {
-                throw (IOException) e.getCause();
-            } else {
-                throw e;
+            } finally {
+                serializedMap.release();
             }
-        } finally {
-            serializedMap.release();
-        }
-        // Flush the ledger's map out before we write the header.
-        // Otherwise the header might point to something that is not fully written
-        entryLogChannel.flush(false);
+            // Flush the ledger's map out before we write the header.
+            // Otherwise the header might point to something that is not fully
+            // written
+            entryLogChannel.flush(false);
 
-        // Update the headers with the map offset and count of ledgers
-        ByteBuffer mapInfo = ByteBuffer.allocate(8 + 4);
-        mapInfo.putLong(ledgerMapOffset);
-        mapInfo.putInt(numberOfLedgers);
-        mapInfo.flip();
-        entryLogChannel.fileChannel.write(mapInfo, LEDGERS_MAP_OFFSET_POSITION);
+            // Update the headers with the map offset and count of ledgers
+            ByteBuffer mapInfo = ByteBuffer.allocate(8 + 4);
+            mapInfo.putLong(ledgerMapOffset);
+            mapInfo.putInt(numberOfLedgers);
+            mapInfo.flip();
+            entryLogChannel.fileChannel.write(mapInfo, LEDGERS_MAP_OFFSET_POSITION);
+        } finally {
+            entryLogManager.releaseLock(ledgerId);
+        }
     }
 
     /**
@@ -588,92 +588,145 @@ public class EntryLogger {
         private long preallocatedLogId;
         private Future<BufferedLogChannel> preallocation = null;
         private ExecutorService allocatorExecutor;
-        private final Object createEntryLogLock = new Object();
-        private final Object createCompactionLogLock = new Object();
 
         EntryLoggerAllocator(long logId) {
             preallocatedLogId = logId;
             allocatorExecutor = Executors.newSingleThreadExecutor();
         }
 
-        BufferedLogChannel createNewLog() throws IOException {
-            synchronized (createEntryLogLock) {
-                BufferedLogChannel bc;
-                if (!entryLogPreAllocationEnabled){
-                    // create a new log directly
-                    bc = allocateNewLog();
-                    return bc;
-                } else {
-                    // allocate directly to response request
-                    if (null == preallocation){
-                        bc = allocateNewLog();
+        synchronized long getPreallocatedLogId(){
+            return preallocatedLogId;
+        }
+
+        synchronized BufferedLogChannel createNewLog() throws IOException {
+            BufferedLogChannel bc;
+            if (!entryLogPreAllocationEnabled || null == preallocation) {
+                // initialization time to create a new log
+                bc = allocateNewLog();
+            } else {
+                // has a preallocated entry log
+                try {
+                    /*
+                     * both createNewLog and allocateNewLog are synchronized on
+                     * EntryLoggerAllocator.this object. So it is possible that
+                     * a thread calling createNewLog would attain the lock on
+                     * this object and get to this point but preallocation
+                     * Future is starving for lock on EntryLoggerAllocator.this
+                     * to execute allocateNewLog. Here since we attained lock
+                     * for this it means preallocation future must have either
+                     * completed creating new log or still waiting for lock on
+                     * this object to execute allocateNewLog method. So we
+                     * should try to get result of the future without waiting.
+                     * If it fails with TimeoutException then call
+                     * allocateNewLog explicitly since we are holding the lock
+                     * on this anyhow.
+                     *
+                     */
+                    bc = preallocation.get(0, TimeUnit.MILLISECONDS);
+                } catch (ExecutionException ee) {
+                    if (ee.getCause() instanceof IOException) {
+                        throw (IOException) (ee.getCause());
                     } else {
-                        // has a preallocated entry log
-                        try {
-                            bc = preallocation.get();
-                        } catch (ExecutionException ee) {
-                            if (ee.getCause() instanceof IOException) {
-                                throw (IOException) (ee.getCause());
-                            } else {
-                                throw new IOException("Error to execute entry log allocation.", ee);
-                            }
-                        } catch (CancellationException ce) {
-                            throw new IOException("Task to allocate a new entry log is cancelled.", ce);
-                        } catch (InterruptedException ie) {
-                            throw new IOException("Intrrupted when waiting a new entry log to be allocated.", ie);
-                        }
+                        throw new IOException("Error to execute entry log allocation.", ee);
                     }
-                    // preallocate a new log in background upon every call
-                    preallocation = allocatorExecutor.submit(() -> allocateNewLog());
-                    return bc;
+                } catch (CancellationException ce) {
+                    throw new IOException("Task to allocate a new entry log is cancelled.", ce);
+                } catch (InterruptedException ie) {
+                    throw new IOException("Intrrupted when waiting a new entry log to be allocated.", ie);
+                } catch (TimeoutException e) {
+                    LOG.debug("Received TimeoutException while trying to get preallocation future result,"
+                            + " which means that Future is waiting for acquiring lock on EntryLoggerAllocator.this");
+                    bc = allocateNewLog();
                 }
             }
-        }
-
-        BufferedLogChannel createNewLogForCompaction() throws IOException {
-            synchronized (createCompactionLogLock) {
-                return allocateNewLog(COMPACTING_SUFFIX);
+            if (entryLogPreAllocationEnabled) {
+                /*
+                 * We should submit new callable / create new instance of future only if the previous preallocation is
+                 * null or if it is done. This is needed because previous preallocation has not completed its execution
+                 * since it is waiting for lock on EntryLoggerAllocator.this.
+                 */
+                if ((preallocation == null) || preallocation.isDone()) {
+                    preallocation = allocatorExecutor.submit(new Callable<BufferedLogChannel>() {
+                        @Override
+                        public BufferedLogChannel call() throws IOException {
+                            return allocateNewLog();
+                        }
+                    });
+                }
             }
+            LOG.info("Created new entry logger {}.", bc.getLogId());
+            return bc;
         }
 
-        private BufferedLogChannel allocateNewLog() throws IOException {
-            return allocateNewLog(".log");
+        synchronized BufferedLogChannel createNewLogForCompaction() throws IOException {
+                return allocateNewLog(COMPACTING_SUFFIX);
+        }
+
+        synchronized BufferedLogChannel allocateNewLog() throws IOException {
+            return allocateNewLog(LOG_FILE_SUFFIX);
         }
 
         /**
          * Allocate a new log file.
          */
-        private BufferedLogChannel allocateNewLog(String suffix) throws IOException {
-            List<File> list = ledgerDirsManager.getWritableLedgerDirsForNewLog();
-            Collections.shuffle(list);
-            // It would better not to overwrite existing entry log files
-            File newLogFile = null;
-            do {
+        synchronized BufferedLogChannel allocateNewLog(String suffix) throws IOException {
+            File dirForNextEntryLog;
+            List<File> list;
+
+            try {
+                list = ledgerDirsManager.getWritableLedgerDirs();
+            } catch (NoWritableLedgerDirException nwe) {
+                if (!ledgerDirsManager.hasWritableLedgerDirs()) {
+                    list = ledgerDirsManager.getWritableLedgerDirsForNewLog();
+                } else {
+                    LOG.error("All Disks are not full, but getWritableLedgerDirs threw exception ", nwe);
+                    throw nwe;
+                }
+            }
+
+            dirForNextEntryLog = entryLogManager.getDirForNextEntryLog(list);
+
+            List<File> ledgersDirs = ledgerDirsManager.getAllLedgerDirs();
+            String logFileName;
+            while (true) {
                 if (preallocatedLogId >= Integer.MAX_VALUE) {
                     preallocatedLogId = 0;
                 } else {
                     ++preallocatedLogId;
                 }
-                String logFileName = Long.toHexString(preallocatedLogId) + suffix;
-                for (File dir : list) {
-                    newLogFile = new File(dir, logFileName);
+                /*
+                 * make sure there is no entrylog which already has the same
+                 * logID. Have to check all the ledegerdirs. If already there is
+                 * an entrylog with that logid then move to next ID.
+                 */
+                logFileName = Long.toHexString(preallocatedLogId) + ".log";
+                boolean entryLogAlreadyExistsWithThisId = false;
+                for (File dir : ledgersDirs) {
+                    File newLogFile = new File(dir, logFileName);
                     if (newLogFile.exists()) {
                         LOG.warn("Found existed entry log " + newLogFile
                                + " when trying to create it as a new log.");
-                        newLogFile = null;
+                        entryLogAlreadyExistsWithThisId = true;
                         break;
                     }
                 }
-            } while (newLogFile == null);
+                if (!entryLogAlreadyExistsWithThisId) {
+                    break;
+                }
+            }
 
+            File newLogFile = new File(dirForNextEntryLog, logFileName);
             FileChannel channel = new RandomAccessFile(newLogFile, "rw").getChannel();
-            BufferedLogChannel logChannel = new BufferedLogChannel(channel,
-                    conf.getWriteBufferBytes(), conf.getReadBufferBytes(), preallocatedLogId, newLogFile);
+            BufferedLogChannel logChannel = new BufferedLogChannel(channel, conf.getWriteBufferBytes(),
+                    conf.getReadBufferBytes(), preallocatedLogId, newLogFile, conf.getFlushIntervalInBytes());
             logfileHeader.readerIndex(0);
             logChannel.write(logfileHeader);
 
-            for (File f : list) {
+            for (File f : ledgersDirs) {
                 setLastLogId(f, preallocatedLogId);
+            }
+            if (suffix.equals(LOG_FILE_SUFFIX)) {
+                recentlyCreatedEntryLogsStatus.createdEntryLog(preallocatedLogId);
             }
             LOG.info("Created new entry log file {} for logId {}.", newLogFile, preallocatedLogId);
             return logChannel;
@@ -794,6 +847,372 @@ public class EntryLogger {
         }
     }
 
+    interface EntryLogManager {
+        /*
+         * acquire lock for this ledger.
+         */
+        void acquireLock(Long ledgerId);
+
+        /*
+         * acquire lock for this ledger if it is not already available for this
+         * ledger then it will create a new one and then acquire lock.
+         */
+        void acquireLockByCreatingIfRequired(Long ledgerId);
+
+        /*
+         * release lock for this ledger
+         */
+        void releaseLock(Long ledgerId);
+
+        /*
+         * sets the logChannel for the given ledgerId. The previous one will be
+         * removed from replicaOfCurrentLogChannels. Previous logChannel will be
+         * added to rotatedLogChannels.
+         */
+        void setCurrentLogForLedger(Long ledgerId, BufferedLogChannel logChannel);
+
+        /*
+         * gets the logChannel for the given ledgerId.
+         */
+        BufferedLogChannel getCurrentLogForLedger(Long ledgerId);
+
+        /*
+         * gets the copy of rotatedLogChannels
+         */
+        Set<BufferedLogChannel> getCopyOfRotatedLogChannels();
+
+        /*
+         * gets the copy of replicaOfCurrentLogChannels
+         */
+        Set<BufferedLogChannel> getCopyOfCurrentLogs();
+
+        /*
+         * gets the active logChannel with the given entryLogId. null if it is
+         * not existing.
+         */
+        BufferedLogChannel getCurrentLogIfPresent(long entryLogId);
+
+        /*
+         * removes the logChannel from rotatedLogChannels collection
+         */
+        void removeFromRotatedLogChannels(BufferedLogChannel rotatedLogChannelToRemove);
+
+        /*
+         * Returns eligible writable ledger dir for the creation next entrylog
+         */
+        File getDirForNextEntryLog(List<File> writableLedgerDirs);
+    }
+
+    class EntryLogManagerForSingleEntryLog implements EntryLogManager {
+
+        private BufferedLogChannel activeLogChannel;
+        private Lock lockForActiveLogChannel;
+        private final Set<BufferedLogChannel> rotatedLogChannels;
+
+        EntryLogManagerForSingleEntryLog() {
+            rotatedLogChannels = ConcurrentHashMap.newKeySet();
+            lockForActiveLogChannel = new ReentrantLock();
+        }
+
+        /*
+         * since entryLogPerLedger is not enabled, it is just one lock for all
+         * ledgers.
+         */
+        @Override
+        public void acquireLock(Long ledgerId) {
+            lockForActiveLogChannel.lock();
+        }
+
+        @Override
+        public void acquireLockByCreatingIfRequired(Long ledgerId) {
+            acquireLock(ledgerId);
+        }
+
+        @Override
+        public void releaseLock(Long ledgerId) {
+            lockForActiveLogChannel.unlock();
+        }
+
+        @Override
+        public void setCurrentLogForLedger(Long ledgerId, BufferedLogChannel logChannel) {
+            acquireLock(ledgerId);
+            try {
+                BufferedLogChannel hasToRotateLogChannel = activeLogChannel;
+                activeLogChannel = logChannel;
+                if (hasToRotateLogChannel != null) {
+                    rotatedLogChannels.add(hasToRotateLogChannel);
+                }
+            } finally {
+                releaseLock(ledgerId);
+            }
+        }
+
+        @Override
+        public BufferedLogChannel getCurrentLogForLedger(Long ledgerId) {
+            return activeLogChannel;
+        }
+
+        @Override
+        public Set<BufferedLogChannel> getCopyOfRotatedLogChannels() {
+            return new HashSet<BufferedLogChannel>(rotatedLogChannels);
+        }
+
+        @Override
+        public Set<BufferedLogChannel> getCopyOfCurrentLogs() {
+            HashSet<BufferedLogChannel> copyOfCurrentLogs = new HashSet<BufferedLogChannel>();
+            copyOfCurrentLogs.add(activeLogChannel);
+            return copyOfCurrentLogs;
+        }
+
+        @Override
+        public BufferedLogChannel getCurrentLogIfPresent(long entryLogId) {
+            BufferedLogChannel activeLogChannelTemp = activeLogChannel;
+            if ((activeLogChannelTemp != null) && (activeLogChannelTemp.getLogId() == entryLogId)) {
+                return activeLogChannelTemp;
+            }
+            return null;
+        }
+
+        @Override
+        public void removeFromRotatedLogChannels(BufferedLogChannel rotatedLogChannelToRemove) {
+            rotatedLogChannels.remove(rotatedLogChannelToRemove);
+        }
+
+        @Override
+        public File getDirForNextEntryLog(List<File> writableLedgerDirs) {
+            Collections.shuffle(writableLedgerDirs);
+            return writableLedgerDirs.get(0);
+        }
+    }
+
+    class EntryLogManagerForEntryLogPerLedger implements EntryLogManager {
+
+        class EntryLogAndLockTuple {
+            private final Lock ledgerLock;
+            private BufferedLogChannel entryLog;
+
+            public EntryLogAndLockTuple() {
+                ledgerLock = new ReentrantLock();
+            }
+
+            public Lock getLedgerLock() {
+                return ledgerLock;
+            }
+
+            public BufferedLogChannel getEntryLog() {
+                return entryLog;
+            }
+
+            public void setEntryLog(BufferedLogChannel entryLog) {
+                this.entryLog = entryLog;
+            }
+        }
+
+        private Cache<Long, EntryLogAndLockTuple> ledgerIdEntryLogMap;
+        private final Set<BufferedLogChannel> rotatedLogChannels;
+        /*
+         * every time active logChannel is accessed from ledgerIdEntryLogMap
+         * cache, the accesstime of that entry is updated. But for certain
+         * operations we dont want to impact accessTime of the entries (like
+         * periodic flush of current active logChannels), and those operations
+         * can use this copy of references.
+         */
+        private final ConcurrentHashMap<Long, BufferedLogChannel> replicaOfCurrentLogChannels;
+        private final Callable<EntryLogAndLockTuple> entryLogAndLockTupleValueLoader;
+
+        EntryLogManagerForEntryLogPerLedger(ServerConfiguration conf) throws IOException {
+            rotatedLogChannels = ConcurrentHashMap.newKeySet();
+
+            replicaOfCurrentLogChannels = new ConcurrentHashMap<Long, BufferedLogChannel>();
+            int entrylogMapAccessExpiryTimeInSeconds = conf.getEntrylogMapAccessExpiryTimeInSeconds();
+            entryLogAndLockTupleValueLoader = new Callable<EntryLogAndLockTuple>() {
+                @Override
+                public EntryLogAndLockTuple call() throws Exception {
+                    return new EntryLogAndLockTuple();
+                }
+            };
+            /*
+             * Currently we are relying on access time based eviction policy for
+             * removal of EntryLogAndLockTuple, so if the EntryLogAndLockTuple of
+             * the ledger is not accessed in
+             * entrylogMapAccessExpiryTimeInSeconds period, it will be removed
+             * from the cache.
+             *
+             * We are going to introduce explicit advisory writeClose call, with
+             * that explicit call EntryLogAndLockTuple of the ledger will be
+             * removed from the cache. But still timebased eviciton policy is
+             * needed because it is not guaranteed that Bookie/EntryLogger would
+             * receive successfully write close call in all the cases.
+             */
+            ledgerIdEntryLogMap = CacheBuilder.newBuilder()
+                    .expireAfterAccess(entrylogMapAccessExpiryTimeInSeconds, TimeUnit.SECONDS)
+                    .removalListener(new RemovalListener<Long, EntryLogAndLockTuple>() {
+                        @Override
+                        public void onRemoval(
+                                RemovalNotification<Long, EntryLogAndLockTuple> expiredLedgerEntryLogMapEntry) {
+                            removalOnExpiry(expiredLedgerEntryLogMapEntry);
+                        }
+                    }).build();
+        }
+
+        /*
+         * This method is called when access time of that ledger has elapsed
+         * entrylogMapAccessExpiryTimeInSeconds period and the entry for that
+         * ledger is removed from cache. Since the entrylog of this ledger is
+         * not active anymore it has to be removed from
+         * replicaOfCurrentLogChannels and added to rotatedLogChannels.
+         *
+         * Because of performance/optimizations concerns the cleanup maintenance
+         * operations wont happen automatically, for more info on eviction
+         * cleanup maintenance tasks -
+         * https://google.github.io/guava/releases/19.0/api/docs/com/google/
+         * common/cache/CacheBuilder.html
+         *
+         */
+        private void removalOnExpiry(RemovalNotification<Long, EntryLogAndLockTuple> expiredLedgerEntryLogMapEntry) {
+            Long ledgerId = expiredLedgerEntryLogMapEntry.getKey();
+            LOG.debug("LedgerId {} is not accessed for entrylogMapAccessExpiryTimeInSeconds"
+                    + " period so it is being evicted from the cache map", ledgerId);
+            EntryLogAndLockTuple entryLogAndLockTuple = expiredLedgerEntryLogMapEntry.getValue();
+            Lock lock = entryLogAndLockTuple.ledgerLock;
+            BufferedLogChannel logChannel = entryLogAndLockTuple.entryLog;
+            lock.lock();
+            try {
+                replicaOfCurrentLogChannels.remove(logChannel.logId);
+                rotatedLogChannels.add(logChannel);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        @Override
+        public void acquireLock(Long ledgerId) {
+            ledgerIdEntryLogMap.getIfPresent(ledgerId).getLedgerLock().lock();
+        }
+
+        /*
+         * acquire lock for this ledger. In this method if EntryLogAndLockTuple
+         * is not already available for this ledger in the cache, then it will
+         * create a new EntryLogAndLockTuple, add it to cache and acquire lock.
+         *
+         */
+        @Override
+        public void acquireLockByCreatingIfRequired(Long ledgerId) {
+            try {
+                ledgerIdEntryLogMap.get(ledgerId, entryLogAndLockTupleValueLoader).getLedgerLock().lock();
+            } catch (ExecutionException e) {
+                throw new RuntimeException(
+                        "Got ExecutionException while trying to create EntryLogAndLockTuple for Ledger: " + ledgerId,
+                        e);
+            }
+        }
+
+        @Override
+        public void releaseLock(Long ledgerId) {
+            ledgerIdEntryLogMap.getIfPresent(ledgerId).getLedgerLock().unlock();
+        }
+
+        /*
+         * sets the logChannel for the given ledgerId. It will add the new
+         * logchannel to replicaOfCurrentLogChannels, and the previous one will
+         * be removed from replicaOfCurrentLogChannels. Previous logChannel will
+         * be added to rotatedLogChannels in both the cases.
+         */
+        @Override
+        public void setCurrentLogForLedger(Long ledgerId, BufferedLogChannel logChannel) {
+            acquireLock(ledgerId);
+            try {
+                BufferedLogChannel hasToRotateLogChannel = getCurrentLogForLedger(ledgerId);
+                logChannel.setLedgerId(ledgerId);
+                ledgerIdEntryLogMap.getIfPresent(ledgerId).setEntryLog(logChannel);
+                replicaOfCurrentLogChannels.put(logChannel.logId, logChannel);
+                if (hasToRotateLogChannel != null) {
+                    replicaOfCurrentLogChannels.remove(hasToRotateLogChannel.logId);
+                    rotatedLogChannels.add(hasToRotateLogChannel);
+                }
+            } finally {
+                releaseLock(ledgerId);
+            }
+        }
+
+        @Override
+        public BufferedLogChannel getCurrentLogForLedger(Long ledgerId) {
+            EntryLogAndLockTuple entryLogAndLockTuple = ledgerIdEntryLogMap.getIfPresent(ledgerId);
+            if (entryLogAndLockTuple == null) {
+                return null;
+            } else {
+                return entryLogAndLockTuple.getEntryLog();
+            }
+        }
+
+        @Override
+        public Set<BufferedLogChannel> getCopyOfRotatedLogChannels() {
+            return new HashSet<BufferedLogChannel>(rotatedLogChannels);
+        }
+
+        @Override
+        public Set<BufferedLogChannel> getCopyOfCurrentLogs() {
+            return new HashSet<BufferedLogChannel>(replicaOfCurrentLogChannels.values());
+        }
+
+        @Override
+        public BufferedLogChannel getCurrentLogIfPresent(long entryLogId) {
+            return replicaOfCurrentLogChannels.get(entryLogId);
+        }
+
+        @Override
+        public void removeFromRotatedLogChannels(BufferedLogChannel rotatedLogChannelToRemove) {
+            rotatedLogChannels.remove(rotatedLogChannelToRemove);
+        }
+
+        /*
+         * this is for testing purpose only. guava's cache doesnt cleanup
+         * completely (including calling expiry removal listener) automatically
+         * when access timeout elapses.
+         *
+         * https://google.github.io/guava/releases/19.0/api/docs/com/google/
+         * common/cache/CacheBuilder.html
+         *
+         * If expireAfterWrite or expireAfterAccess is requested entries may be
+         * evicted on each cache modification, on occasional cache accesses, or
+         * on calls to Cache.cleanUp(). Expired entries may be counted by
+         * Cache.size(), but will never be visible to read or write operations.
+         *
+         * Certain cache configurations will result in the accrual of periodic
+         * maintenance tasks which will be performed during write operations, or
+         * during occasional read operations in the absence of writes. The
+         * Cache.cleanUp() method of the returned cache will also perform
+         * maintenance, but calling it should not be necessary with a high
+         * throughput cache. Only caches built with removalListener,
+         * expireAfterWrite, expireAfterAccess, weakKeys, weakValues, or
+         * softValues perform periodic maintenance.
+         */
+        void doEntryLogMapCleanup() {
+            ledgerIdEntryLogMap.cleanUp();
+        }
+
+        /*
+         * Returns writable ledger dir with least number of current active
+         * entrylogs.
+         */
+        @Override
+        public File getDirForNextEntryLog(List<File> writableLedgerDirs) {
+            Map<File, MutableInt> writableLedgerDirFrequency = new HashMap<File, MutableInt>();
+            writableLedgerDirs.stream()
+                    .forEach((ledgerDir) -> writableLedgerDirFrequency.put(ledgerDir, new MutableInt()));
+            for (BufferedLogChannel logChannel : replicaOfCurrentLogChannels.values()) {
+                File parentDirOfCurrentLogChannel = logChannel.getLogFile().getParentFile();
+                if (writableLedgerDirFrequency.containsKey(parentDirOfCurrentLogChannel)) {
+                    writableLedgerDirFrequency.get(parentDirOfCurrentLogChannel).increment();
+                }
+            }
+            @SuppressWarnings("unchecked")
+            Optional<Entry<File, MutableInt>> ledgerDirWithLeastNumofCurrentLogs = writableLedgerDirFrequency.entrySet()
+                    .stream().min(Map.Entry.comparingByValue());
+            return ledgerDirWithLeastNumofCurrentLogs.get().getKey();
+        }
+    }
+
     /**
      * Flushes all rotated log channels. After log channels are flushed,
      * move leastUnflushedLogId ptr to current logId.
@@ -803,66 +1222,50 @@ public class EntryLogger {
     }
 
     void flushRotatedLogs() throws IOException {
-        List<BufferedLogChannel> channels = null;
-        long flushedLogId = INVALID_LID;
-        synchronized (this) {
-            channels = logChannelsToFlush;
-            logChannelsToFlush = null;
-        }
+        Set<BufferedLogChannel> channels = entryLogManager.getCopyOfRotatedLogChannels();
         if (null == channels) {
             return;
         }
-        Iterator<BufferedLogChannel> chIter = channels.iterator();
-        while (chIter.hasNext()) {
-            BufferedLogChannel channel = chIter.next();
-            try {
-                channel.flush(true);
-            } catch (IOException ioe) {
-                // rescue from flush exception, add unflushed channels back
-                synchronized (this) {
-                    if (null == logChannelsToFlush) {
-                        logChannelsToFlush = channels;
-                    } else {
-                        logChannelsToFlush.addAll(0, channels);
-                    }
-                }
-                throw ioe;
-            }
-            // remove the channel from the list after it is successfully flushed
-            chIter.remove();
+        for (BufferedLogChannel channel : channels) {
+            channel.flush(true);
             // since this channel is only used for writing, after flushing the channel,
             // we had to close the underlying file channel. Otherwise, we might end up
             // leaking fds which cause the disk spaces could not be reclaimed.
             closeFileChannel(channel);
-            if (channel.getLogId() > flushedLogId) {
-                flushedLogId = channel.getLogId();
-            }
+            recentlyCreatedEntryLogsStatus.flushRotatedEntryLog(channel.getLogId());
+            entryLogManager.removeFromRotatedLogChannels(channel);
             LOG.info("Synced entry logger {} to disk.", channel.getLogId());
         }
-        // move the leastUnflushedLogId ptr
-        leastUnflushedLogId = flushedLogId + 1;
     }
 
     public void flush() throws IOException {
+        flushCurrentLogs();
         flushRotatedLogs();
-        flushCurrentLog();
     }
 
-    synchronized void flushCurrentLog() throws IOException {
-        if (logChannel != null) {
-            logChannel.flush(true);
-            bytesWrittenSinceLastFlush = 0;
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Flush and sync current entry logger {}.", logChannel.getLogId());
-            }
+    void flushCurrentLogs() throws IOException {
+        Set<BufferedLogChannel> copyOfCurrentLogs = entryLogManager.getCopyOfCurrentLogs();
+        for (BufferedLogChannel logChannel : copyOfCurrentLogs) {
+            /**
+             * flushCurrentLogs method is called during checkpoint, so metadata
+             * of the file also should be force written.
+             */
+            flushCurrentLog(logChannel, true);
         }
     }
 
-    long addEntry(long ledger, ByteBuffer entry) throws IOException {
+    void flushCurrentLog(BufferedLogChannel logChannel, boolean forceMetadata) throws IOException {
+        if (logChannel != null) {
+            logChannel.flush(true, forceMetadata);
+            LOG.debug("Flush and sync current entry logger {}", logChannel.getLogId());
+        }
+    }
+
+    long addEntry(Long ledger, ByteBuffer entry) throws IOException {
         return addEntry(ledger, Unpooled.wrappedBuffer(entry), true);
     }
 
-    long addEntry(long ledger, ByteBuf entry) throws IOException {
+    long addEntry(Long ledger, ByteBuf entry) throws IOException {
         return addEntry(ledger, entry, true);
     }
 
@@ -873,36 +1276,44 @@ public class EntryLogger {
         }
     };
 
-    public synchronized long addEntry(long ledger, ByteBuf entry, boolean rollLog) throws IOException {
-        int entrySize = entry.readableBytes() + 4; // Adding 4 bytes to prepend the size
-        boolean reachEntryLogLimit =
-            rollLog ? reachEntryLogLimit(entrySize) : readEntryLogHardLimit(entrySize);
-        // Create new log if logSizeLimit reached or current disk is full
-        boolean createNewLog = shouldCreateNewEntryLog.get();
-        if (createNewLog || reachEntryLogLimit) {
-            if (doRegularFlushes) {
-                flushCurrentLog();
+    public long addEntry(Long ledger, ByteBuf entry, boolean rollLog) throws IOException {
+        entryLogManager.acquireLockByCreatingIfRequired(ledger);
+        try {
+            int entrySize = entry.readableBytes() + 4; // Adding 4 bytes to prepend the size
+            boolean reachEntryLogLimit = rollLog ? reachEntryLogLimit(ledger, entrySize)
+                    : readEntryLogHardLimit(ledger, entrySize);
+            BufferedLogChannel logChannel = entryLogManager.getCurrentLogForLedger(ledger);
+            // Create new log if logSizeLimit reached or current disk is full
+            boolean diskFull = (logChannel == null) ? false : logChannel.isLedgerDirFull();
+            boolean allDisksFull = !ledgerDirsManager.hasWritableLedgerDirs();
+
+            /**
+             * if disk of the logChannel is full or if the entrylog limit is
+             * reached of if the logchannel is not initialized, then
+             * createNewLog. If allDisks are full then proceed with the current
+             * logChannel, since Bookie must have turned to readonly mode and
+             * the addEntry traffic would be from GC and it is ok to proceed in
+             * this case.
+             */
+            if ((diskFull && (!allDisksFull)) || reachEntryLogLimit || (logChannel == null)) {
+                flushCurrentLog(logChannel, false);
+                createNewLog(ledger);
             }
-            createNewLog();
-            // Reset the flag
-            if (createNewLog) {
-                shouldCreateNewEntryLog.set(false);
-            }
+
+            logChannel = entryLogManager.getCurrentLogForLedger(ledger);
+            ByteBuf sizeBuffer = this.sizeBuffer.get();
+            sizeBuffer.clear();
+            sizeBuffer.writeInt(entry.readableBytes());
+            logChannel.write(sizeBuffer);
+
+            long pos = logChannel.position();
+            logChannel.write(entry);
+            logChannel.registerWrittenEntry(ledger, entrySize);
+
+            return (logChannel.getLogId() << 32L) | pos;
+        } finally {
+            entryLogManager.releaseLock(ledger);
         }
-
-        // Get a buffer from thread local to store the size
-        ByteBuf sizeBuffer = this.sizeBuffer.get();
-        sizeBuffer.clear();
-        sizeBuffer.writeInt(entry.readableBytes());
-        logChannel.write(sizeBuffer);
-
-        long pos = logChannel.position();
-        logChannel.write(entry);
-        logChannel.registerWrittenEntry(ledger, entrySize);
-
-        incrementBytesWrittenAndMaybeFlush(4L + entrySize);
-
-        return (logChannel.getLogId() << 32L) | pos;
     }
 
     long addEntryForCompaction(long ledgerId, ByteBuf entry) throws IOException {
@@ -969,26 +1380,34 @@ public class EntryLogger {
         }
     }
 
-    private void incrementBytesWrittenAndMaybeFlush(long bytesWritten) throws IOException {
-        if (!doRegularFlushes) {
-            return;
-        }
-        bytesWrittenSinceLastFlush += bytesWritten;
-        if (bytesWrittenSinceLastFlush > flushIntervalInBytes) {
-            flushCurrentLog();
-        }
-    }
-
     static long logIdForOffset(long offset) {
         return offset >> 32L;
     }
 
-    synchronized boolean reachEntryLogLimit(long size) {
-        return logChannel.position() + size > logSizeLimit;
+    boolean reachEntryLogLimit(Long ledger, long size) {
+        entryLogManager.acquireLock(ledger);
+        try {
+            BufferedLogChannel logChannel = entryLogManager.getCurrentLogForLedger(ledger);
+            if (logChannel == null) {
+                return false;
+            }
+            return logChannel.position() + size > logSizeLimit;
+        } finally {
+            entryLogManager.releaseLock(ledger);
+        }
     }
 
-    synchronized boolean readEntryLogHardLimit(long size) {
-        return logChannel.position() + size > Integer.MAX_VALUE;
+    boolean readEntryLogHardLimit(Long ledger, long size) {
+        entryLogManager.acquireLock(ledger);
+        try {
+            BufferedLogChannel logChannel = entryLogManager.getCurrentLogForLedger(ledger);
+            if (logChannel == null) {
+                return false;
+            }
+            return logChannel.position() + size > Integer.MAX_VALUE;
+        } finally {
+            entryLogManager.releaseLock(ledger);
+        }
     }
 
     public ByteBuf internalReadEntry(long ledgerId, long entryId, long location)
@@ -1360,6 +1779,7 @@ public class EntryLogger {
     public void shutdown() {
         // since logChannel is buffered channel, do flush when shutting down
         LOG.info("Stopping EntryLogger");
+        Set<BufferedLogChannel> copyOfCurrentLogs = entryLogManager.getCopyOfCurrentLogs();
         try {
             flush();
             for (FileChannel fc : logid2FileChannel.values()) {
@@ -1367,8 +1787,10 @@ public class EntryLogger {
             }
             // clear the mapping, so we don't need to go through the channels again in finally block in normal case.
             logid2FileChannel.clear();
-            // close current writing log file
-            closeFileChannel(logChannel);
+            for (BufferedLogChannel currentLog : copyOfCurrentLogs) {
+                // close current writing log file
+                closeFileChannel(currentLog);
+            }
             synchronized (compactionLogLock) {
                 closeFileChannel(compactionLogChannel);
                 compactionLogChannel = null;
@@ -1380,7 +1802,9 @@ public class EntryLogger {
             for (FileChannel fc : logid2FileChannel.values()) {
                 IOUtils.close(LOG, fc);
             }
-            forceCloseFileChannel(logChannel);
+            for (BufferedLogChannel currentLog : copyOfCurrentLogs) {
+                forceCloseFileChannel(currentLog);
+            }
             synchronized (compactionLogLock) {
                 forceCloseFileChannel(compactionLogChannel);
             }
@@ -1434,5 +1858,41 @@ public class EntryLogger {
      */
     static String logId2HexString(long logId) {
         return Long.toHexString(logId);
+    }
+
+    /**
+     * Datastructure which maintains the status of logchannels. When a
+     * logChannel is created entry of < entryLogId, false > will be made to this
+     * sortedmap and when logChannel is rotated and flushed then the entry is
+     * updated to < entryLogId, true > and all the lowest entries with
+     * < entryLogId, true > status will be removed from the sortedmap. So that way
+     * we could get least unflushed LogId.
+     *
+     */
+    class RecentEntryLogsStatus {
+        private SortedMap<Long, Boolean> entryLogsStatusMap;
+        private long leastUnflushedLogId;
+
+        RecentEntryLogsStatus(long leastUnflushedLogId) {
+            entryLogsStatusMap = new TreeMap<Long, Boolean>();
+            this.leastUnflushedLogId = leastUnflushedLogId;
+        }
+
+        synchronized void createdEntryLog(Long entryLogId) {
+            entryLogsStatusMap.put(entryLogId, false);
+        }
+
+        synchronized void flushRotatedEntryLog(Long entryLogId) {
+            entryLogsStatusMap.replace(entryLogId, true);
+            while ((!entryLogsStatusMap.isEmpty()) && (entryLogsStatusMap.get(entryLogsStatusMap.firstKey()))) {
+                long leastFlushedLogId = entryLogsStatusMap.firstKey();
+                entryLogsStatusMap.remove(leastFlushedLogId);
+                leastUnflushedLogId = leastFlushedLogId + 1;
+            }
+        }
+
+        synchronized long getLeastUnflushedLogId() {
+            return leastUnflushedLogId;
+        }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyEntryLogger.java
@@ -38,12 +38,7 @@ public class ReadOnlyEntryLogger extends EntryLogger {
     }
 
     @Override
-    protected void initialize() throws IOException {
-        // do nothing for read only entry logger
-    }
-
-    @Override
-    void createNewLog() throws IOException {
+    void createNewLog(Long ledgerId) throws IOException {
         throw new IOException("Can't create new entry log using a readonly entry logger.");
     }
 
@@ -54,7 +49,7 @@ public class ReadOnlyEntryLogger extends EntryLogger {
     }
 
     @Override
-    public synchronized long addEntry(long ledger, ByteBuffer entry) throws IOException {
+    public synchronized long addEntry(Long ledgerId, ByteBuffer entry) throws IOException {
         throw new IOException("Can't add entry to a readonly entry logger.");
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -119,6 +119,12 @@ class SyncThread implements Checkpointer {
         });
     }
 
+    void start() {
+        executor.scheduleAtFixedRate(() -> {
+            startCheckpoint(checkpointSource.newCheckpoint());
+        }, flushInterval, flushInterval, TimeUnit.MILLISECONDS);
+    }
+
     private void flush() {
         Checkpoint checkpoint = checkpointSource.newCheckpoint();
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -177,6 +177,23 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     // Stats
     protected static final String ENABLE_TASK_EXECUTION_STATS = "enableTaskExecutionStats";
 
+    /*
+     * config specifying if the entrylog per ledger is enabled or not.
+     */
+    protected static final String ENTRY_LOG_PERLEDGER_ENABLED = "entryLogPerLedgerEnabled";
+
+    // In the case of multipleentrylogs, multiple threads can be used to flush the memtable parallelly.
+    protected static final String NUMBER_OF_MEMTABLE_FLUSH_THREADS = "numOfMemtableFlushThreads";
+
+    /*
+     * In the case of multiple entrylogs, memtableFlushTimeoutInSeconds specifies the amount of time main flushthread
+     * has to wait for the processor threads to complete the flush
+     */
+    protected static final String MEMTABLE_FLUSH_TIMEOUT_INSECONDS = "memtableFlushTimeoutInSeconds";
+
+
+    protected static final String ENTRYLOGMAP_ACCESS_EXPIRYTIME_INSECONDS = "entrylogMapAccessExpiryTimeInSeconds";
+
     /**
      * Construct a default configuration object.
      */
@@ -2584,6 +2601,81 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
 
     @Override
     protected ServerConfiguration getThis() {
+        return this;
+    }
+
+
+    /*
+     * specifies if entryLog per ledger is enabled. If it is enabled, then there
+     * would be a active entrylog for each ledger
+     */
+    public boolean isEntryLogPerLedgerEnabled() {
+        return this.getBoolean(ENTRY_LOG_PERLEDGER_ENABLED, false);
+    }
+
+    /*
+     * enables/disables entrylog per ledger feature.
+     *
+     */
+    public ServerConfiguration setEntryLogPerLedgerEnabled(boolean entryLogPerLedgerEnabled) {
+        this.setProperty(ENTRY_LOG_PERLEDGER_ENABLED, Boolean.toString(entryLogPerLedgerEnabled));
+        return this;
+    }
+
+    /*
+     * in entryLogPerLedger feature, this specifies the time, once this duration
+     * has elapsed after the entry's last access, that entry should be
+     * automatically removed from the cache
+     */
+    public int getEntrylogMapAccessExpiryTimeInSeconds() {
+        return this.getInt(ENTRYLOGMAP_ACCESS_EXPIRYTIME_INSECONDS, 5 * 60);
+    }
+
+    /*
+     * sets the time duration for entrylogMapAccessExpiryTimeInSeconds, which will be used for cache eviction
+     * policy, in entrylogperledger feature.
+     *
+     */
+    public ServerConfiguration setEntrylogMapAccessExpiryTimeInSeconds(int entrylogMapAccessExpiryTimeInSeconds) {
+        this.setProperty(ENTRYLOGMAP_ACCESS_EXPIRYTIME_INSECONDS,
+                Integer.toString(entrylogMapAccessExpiryTimeInSeconds));
+        return this;
+    }
+
+    /*
+     * In the case of multipleentrylogs, multiple threads can be used to flush the memtable.
+     *
+     * Gets the number of threads used to flush entrymemtable
+     */
+    public int getNumOfMemtableFlushThreads() {
+        return this.getInt(NUMBER_OF_MEMTABLE_FLUSH_THREADS, 4);
+    }
+
+    /*
+     * Sets the number of threads used to flush entrymemtable, in the case of multiple entrylogs
+     *
+     */
+    public ServerConfiguration setNumOfMemtableFlushThreads(int numOfMemtableFlushThreads) {
+        this.setProperty(NUMBER_OF_MEMTABLE_FLUSH_THREADS, Integer.toString(numOfMemtableFlushThreads));
+        return this;
+    }
+
+    /*
+     * In the case of multiple entrylogs, memtableFlushTimeoutInSeconds specifies the amount of time main flushthread.
+     * has to wait for the processor threads to complete the flush.
+     *
+     * Gets the amount of time to wait for the flush to be completed.
+     */
+    public int getMemtableFlushTimeoutInSeconds() {
+        return this.getInt(MEMTABLE_FLUSH_TIMEOUT_INSECONDS, 120);
+    }
+
+    /*
+     * Sets the amount of time to wait for the flush to be completed.
+     *
+     */
+    public ServerConfiguration setMemtableFlushTimeoutInSeconds(int memtableFlushTimeoutInSeconds) {
+        this.setProperty(MEMTABLE_FLUSH_TIMEOUT_INSECONDS, Integer.toString(memtableFlushTimeoutInSeconds));
         return this;
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -171,7 +171,7 @@ public class BookieJournalTest {
 
     private static void moveToPosition(JournalChannel jc, long pos) throws IOException {
         jc.fc.position(pos);
-        jc.bc.position = pos;
+        jc.bc.position.set(pos);
         jc.bc.writeBufferStartPosition.set(pos);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
@@ -100,9 +100,9 @@ public class CreateNewLogTest {
         EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
         // Calls createNewLog, and with the number of directories we
         // are using, if it picks one at random it will fail.
-        el.createNewLog();
-        LOG.info("This is the current log id: " + el.getCurrentLogId());
-        assertTrue("Wrong log id", el.getCurrentLogId() > 1);
+        el.createNewLog(0L);
+        LOG.info("This is the current log id: " + el.getPreviousAllocatedEntryLogId());
+        assertTrue("Wrong log id", el.getPreviousAllocatedEntryLogId() > 1);
     }
 
     @Test
@@ -131,9 +131,9 @@ public class CreateNewLogTest {
         EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
         // Calls createNewLog, and with the number of directories we
         // are using, if it picks one at random it will fail.
-        el.createNewLog();
-        LOG.info("This is the current log id: " + el.getCurrentLogId());
-        assertTrue("Wrong log id", el.getCurrentLogId() > 1);
+        el.createNewLog(0L);
+        LOG.info("This is the current log id: " + el.getPreviousAllocatedEntryLogId());
+        assertTrue("Wrong log id", el.getPreviousAllocatedEntryLogId() > 1);
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -489,7 +489,7 @@ public class LedgerCacheTest {
                 checkpointSource,
                 checkpointer,
                 statsLogger);
-            this.memTable = new EntryMemTable(conf, checkpointSource, statsLogger) {
+            this.memTable = new EntryMemTable(conf, checkpointSource, null, statsLogger) {
                 @Override
                 boolean isSizeLimitReached() {
                     return (injectMemTableSizeLimitReached.get() || super.isSizeLimitReached());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -207,9 +207,9 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
         });
 
         // simulate entry log is rotated (due to compaction)
-        storage.entryLogger.rollLog();
+        storage.entryLogger.createNewLog(EntryLogger.INVALID_LID);
         long leastUnflushedLogId = storage.entryLogger.getLeastUnflushedLogId();
-        long currentLogId = storage.entryLogger.getCurrentLogId();
+        long currentLogId = storage.entryLogger.getPreviousAllocatedEntryLogId();
         log.info("Least unflushed entry log : current = {}, leastUnflushed = {}", currentLogId, leastUnflushedLogId);
 
         readyLatch.countDown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestEntryMemTable.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestEntryMemTable.java
@@ -59,7 +59,7 @@ public class TestEntryMemTable implements CacheCallback, SkipListFlusher, Checkp
     @Before
     public void setUp() throws Exception {
         this.memTable = new EntryMemTable(TestBKConfiguration.newServerConfiguration(),
-                this, NullStatsLogger.INSTANCE);
+                this, null, NullStatsLogger.INSTANCE);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -215,7 +215,7 @@ public class DbLedgerStorageTest {
         newEntry3.writeLong(4); // ledger id
         newEntry3.writeLong(3); // entry id
         newEntry3.writeBytes("new-entry-3".getBytes());
-        long location = entryLogger.addEntry(4, newEntry3, false);
+        long location = entryLogger.addEntry(4L, newEntry3, false);
 
         List<EntryLocation> locations = Lists.newArrayList(new EntryLocation(4, 3, location));
         storage.updateEntriesLocations(locations);


### PR DESCRIPTION
Descriptions of the changes in this PR:

Current bookkeeper is tuned for rotational HDDs. It has one active entrylog,
and all the ledger/entries go to the same entrylog until it is rotated out.
This is perfect for HDDs as seeks and moving head allover the disk platter
is very expensive. But this is very inefficient for SSDs, as each SSD
can handle multiple parallel writers, also this method is extremely
inefficient for compaction as it causes write amplification
and inefficient disk space usage.

Our proposal is to have configurable feature to have entrylog per ledger
and also to have parallel EntryMemTable flusher for SortedLedgerStorage.

Implementation Details

- created Interface and corresponding implementations for EntryLogManager
- changed logic of EntryMemTable flush parallely to have just one Runnable per ledger
- moved the complete logic of flushIntervalInBytes from EntryLogger to BufferedChannel

Master Issue: #570 

