### PR TITLE
Allow derived implementations of RackawareEnsemblePlacementPolicy

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
@@ -37,11 +37,11 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
         implements ITopologyAwareEnsemblePlacementPolicy<TopologyAwareEnsemblePlacementPolicy.BookieNode> {
     RackawareEnsemblePlacementPolicyImpl slave = null;
 
-    RackawareEnsemblePlacementPolicy() {
+    public RackawareEnsemblePlacementPolicy() {
         super();
     }
 
-    RackawareEnsemblePlacementPolicy(boolean enforceDurability) {
+    public RackawareEnsemblePlacementPolicy(boolean enforceDurability) {
         super(enforceDurability);
     }
 


### PR DESCRIPTION
Leave public constructor so that it's possible to create a placement policy that derives from RackawareEnsemblePlacementPolicy.

For example, in Pulsar we have an isolation policy that works in conjunction with the rack-aware: https://github.com/apache/incubator-pulsar/blob/ac94698df6c66c4b84faa9f96db71f0019bf955e/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicy.java#L45