### PR TITLE
Pull as many reviewers as possible when merging

### DIFF
--- a/dev/bk-merge-pr.py
+++ b/dev/bk-merge-pr.py
@@ -453,7 +453,7 @@ def get_reviewers(pr_num):
                 reviewers_ids.add(comment['user']['login'])
 
     approval_review_states = ['approved']
-    pr_reviews = get_json('{0}/pulls/{1}/reviews'.format(GITHUB_API_BASE, pr_num), True)
+    pr_reviews = get_json('{0}/pulls/{1}/reviews?per_page=100'.format(GITHUB_API_BASE, pr_num), True)
     for review in pr_reviews:
         for approval_state in approval_review_states:
             if approval_state in review['state'].lower():


### PR DESCRIPTION
Github uses pagination on some apis. This means that if there are a
lot of comments on a issue, it may not pick up approvals by
default. This patch increases the number of review comments to pull,
from a default of 30 to 100. A proper fix would be to enable
pagination using the Link header, but that's a much bigger change, for
little return.
