### PR TITLE
Refactored ReadResponse ref count handling

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -23,6 +23,7 @@ package org.apache.bookkeeper.client;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.netty.buffer.ByteBuf;
+
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashSet;
@@ -139,7 +140,6 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
             } catch (BKDigestMatchException e) {
                 readOpDmCounter.inc();
                 logErrorAndReattemptRead(bookieIndex, host, "Mac mismatch", BKException.Code.DigestMatchException);
-                buffer.release();
                 return false;
             }
 
@@ -154,7 +154,6 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
                 writeSet.recycle();
                 return true;
             } else {
-                buffer.release();
                 return false;
             }
         }
@@ -589,12 +588,15 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
         heardFromHosts.add(rctx.to);
         heardFromHostsBitSet.set(rctx.bookieIndex, true);
 
+        buffer.retain();
         if (entry.complete(rctx.bookieIndex, rctx.to, buffer)) {
             if (!isRecoveryRead) {
                 // do not advance LastAddConfirmed for recovery reads
                 lh.updateLastConfirmed(rctx.getLastAddConfirmed(), 0L);
             }
             submitCallback(BKException.Code.OK);
+        } else {
+            buffer.release();
         }
 
         if (numPendingEntries < 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -23,7 +23,6 @@ package org.apache.bookkeeper.client;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.netty.buffer.ByteBuf;
-
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashSet;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
@@ -18,7 +18,6 @@
 package org.apache.bookkeeper.client;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.ReferenceCountUtil;
 
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.proto.BookieProtocol;
@@ -100,8 +99,6 @@ class ReadLastConfirmedOp implements ReadEntryCallback {
                           + lh.metadata.currentEnsemble.get(bookieIndex));
             }
         }
-
-        ReferenceCountUtil.release(buffer);
 
         if (rc == BKException.Code.NoSuchLedgerExistsException || rc == BKException.Code.NoSuchEntryException) {
             // this still counts as a valid response, e.g., if the client crashed without writing any entry

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -292,12 +292,8 @@ public class BookieProtoEncoding {
                 ledgerId = buffer.readLong();
                 entryId = buffer.readLong();
 
-                if (rc == BookieProtocol.EOK) {
-                    return new BookieProtocol.ReadResponse(version, rc,
-                                                           ledgerId, entryId, buffer.retainedSlice());
-                } else {
-                    return new BookieProtocol.ReadResponse(version, rc, ledgerId, entryId);
-                }
+                return new BookieProtocol.ReadResponse(
+                        version, rc, ledgerId, entryId, buffer.retainedSlice());
             case BookieProtocol.AUTH:
                 ByteBufInputStream bufStream = new ByteBufInputStream(buffer);
                 BookkeeperProtocol.AuthMessage.Builder builder = BookkeeperProtocol.AuthMessage.newBuilder();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -428,7 +428,14 @@ public interface BookieProtocol {
                                  opCode, ledgerId, entryId, errorCode);
         }
 
-        abstract void recycle();
+        void retain() {
+        }
+
+        void release() {
+        }
+
+        void recycle() {
+        }
     }
 
     /**
@@ -438,8 +445,7 @@ public interface BookieProtocol {
         final ByteBuf data;
 
         ReadResponse(byte protocolVersion, int errorCode, long ledgerId, long entryId) {
-            init(protocolVersion, READENTRY, errorCode, ledgerId, entryId);
-            this.data = Unpooled.EMPTY_BUFFER;
+            this(protocolVersion, errorCode, ledgerId, entryId, Unpooled.EMPTY_BUFFER);
         }
 
         ReadResponse(byte protocolVersion, int errorCode, long ledgerId, long entryId, ByteBuf data) {
@@ -455,7 +461,14 @@ public interface BookieProtocol {
             return data;
         }
 
-        void recycle() {
+        @Override
+        public void retain() {
+            data.retain();
+        }
+
+        @Override
+        public void release() {
+            data.release();
         }
     }
 
@@ -480,6 +493,7 @@ public interface BookieProtocol {
             }
         };
 
+        @Override
         public void recycle() {
             recyclerHandle.recycle(this);
         }
@@ -492,9 +506,6 @@ public interface BookieProtocol {
         ErrorResponse(byte protocolVersion, byte opCode, int errorCode,
                       long ledgerId, long entryId) {
             init(protocolVersion, opCode, errorCode, ledgerId, entryId);
-        }
-
-        void recycle() {
         }
     }
 
@@ -511,9 +522,6 @@ public interface BookieProtocol {
 
         AuthMessage getAuthMessage() {
             return authMessage;
-        }
-
-        void recycle() {
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1105,6 +1105,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                 LOG.debug("Unexpected response received from bookie : " + addr + " for type : " + operationType
                         + " and ledger:entry : " + response.ledgerId + ":" + response.entryId);
             }
+            response.release();
         } else {
             long orderingKey = completionValue.ledgerId;
             executor.submitOrdered(orderingKey,
@@ -1582,11 +1583,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                 return;
             }
             BookieProtocol.ReadResponse readResponse = (BookieProtocol.ReadResponse) response;
-            ByteBuf data = null;
-            if (readResponse.hasData()) {
-                data = readResponse.getData();
-            }
-            handleReadResponse(ledgerId, entryId, status, data,
+            handleReadResponse(ledgerId, entryId, status, readResponse.getData(),
                                INVALID_ENTRY_ID, -1L);
         }
 
@@ -1619,23 +1616,20 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                                         ByteBuf buffer,
                                         long maxLAC, // max known lac piggy-back from bookies
                                         long lacUpdateTimestamp) { // the timestamp when the lac is updated.
-            int readableBytes = buffer == null ? 0 : buffer.readableBytes();
+            int readableBytes = buffer.readableBytes();
             int rc = logAndConvertStatus(status,
                                          BKException.Code.ReadException,
                                          "ledger", ledgerId,
                                          "entry", entryId,
                                          "entryLength", readableBytes);
 
-            if (buffer != null) {
-                buffer = buffer.slice();
-            }
             if (maxLAC > INVALID_ENTRY_ID && (ctx instanceof ReadEntryCallbackCtx)) {
                 ((ReadEntryCallbackCtx) ctx).setLastAddConfirmed(maxLAC);
             }
             if (lacUpdateTimestamp > -1L && (ctx instanceof ReadLastConfirmedAndEntryContext)) {
                 ((ReadLastConfirmedAndEntryContext) ctx).setLacUpdateTimestamp(lacUpdateTimestamp);
             }
-            cb.readEntryComplete(rc, ledgerId, entryId, buffer, ctx);
+            cb.readEntryComplete(rc, ledgerId, entryId, buffer.slice(), ctx);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1608,6 +1608,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             handleReadResponse(readResponse.getLedgerId(),
                                readResponse.getEntryId(),
                                status, buffer, maxLAC, lacUpdateTimestamp);
+            buffer.release(); // meaningless using unpooled, but client may expect to hold the last reference
         }
 
         private void handleReadResponse(long ledgerId,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -84,8 +84,6 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
                     if (null == fenced || !fenced) {
                         // if failed to fence, fail the read request to make it retry.
                         errorCode = BookieProtocol.EIO;
-                        data.release();
-                        data = null;
                     } else {
                         errorCode = BookieProtocol.EOK;
                     }
@@ -93,18 +91,12 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
                     Thread.currentThread().interrupt();
                     LOG.error("Interrupting fence read entry {}", request, ie);
                     errorCode = BookieProtocol.EIO;
-                    data.release();
-                    data = null;
                 } catch (ExecutionException ee) {
                     LOG.error("Failed to fence read entry {}", request, ee);
                     errorCode = BookieProtocol.EIO;
-                    data.release();
-                    data = null;
                 } catch (TimeoutException te) {
                     LOG.error("Timeout to fence read entry {}", request, te);
                     errorCode = BookieProtocol.EIO;
-                    data.release();
-                    data = null;
                 }
             } else {
                 errorCode = BookieProtocol.EOK;
@@ -141,7 +133,6 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
                     TimeUnit.NANOSECONDS);
             sendResponse(errorCode, ResponseBuilder.buildReadResponse(data, request),
                          requestProcessor.readRequestStats);
-
         } else {
             ReferenceCountUtil.release(data);
 


### PR DESCRIPTION
This contains a number of changes.

- V2 bookie protocol
  - Add retain and release methods to all responses. For read response
    it handles the data buffer.
  - ReadResponses always have a buffer now, even if empty.

- Server side
  - In the v2 read handler, releasing of the buffer in the case of
    error is left to the very end.

- Client side
  - Per channel bookie clients own the buffer for read responses.
    If a ReadCallback want it to live past the lifetime of the call
    it must call retain.

This change was originally e8643140 in the yahoo-4.3 branch.
