### PR TITLE
Website fails to build due to a missing field at the yaml file

### DIFF
--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -71,6 +71,7 @@ groups:
     default: null
 
 - name: Worker thread settings
+  params:
   - param: numAddWorkerThreads
     description: The number of threads that handle write requests. if zero, writes are handled by [Netty threads](http://netty.io/wiki/thread-model.html) directly.
     default: 1


### PR DESCRIPTION

Descriptions of the changes in this PR:

The problem was introduced at apache/bookkeeper#898
