### PR TITLE
Improve Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       dist: trusty
       env: CUSTOM_JDK="openjdk8"
 
-before_install:
+before_install: 
 - |
     echo "MAVEN_OPTS='-Xmx3072m -XX:MaxPermSize=512m'" > ~/.mavenrc
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -54,38 +54,18 @@ before_install:
     else
         if [ `git diff --name-only $TRAVIS_COMMIT_RANGE | grep "^stream\/distributedlog" | wc -l` -gt 0 ]; then
             export DLOG_MODIFIED="true"  
-            echo "Enable testing distributedlog modules if this pull request modifies files under directory `stream/distributedlog`."
+            echo "Enable testing distributedlog modules if this pull request modifies files under directory 'stream/distributedlog'."
         fi
         if [ `git diff --name-only $TRAVIS_COMMIT_RANGE | grep "^site\/" | wc -l` -gt 0 ]; then
             # building the website to ensure the changes don't break
             export WEBSITE_MODIFIED="true"
-            echo "Enable building website modules if this pull request modifies files under directory `site`."
+            echo "Enable building website modules if this pull request modifies files under directory 'site'."
         fi
     fi
 
-script:
-- |
-    set -e
-    mvn --batch-mode clean apache-rat:check compile spotbugs:check install -DskipTests
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-        dev/check-binary-license ./bookkeeper-dist/all/target/bookkeeper-all-*-bin.tar.gz;
-        dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-*-bin.tar.gz;
-    fi
-    if [ "$DLOG_MODIFIED" == "true" ]; then
-        cd stream/distributedlog
-        travis_wait 60 mvn --batch-mode clean package -Ddistributedlog
-        cd ../..
-    fi
-    if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$WEBSITE_MODIFIED" == "true" ]; then
-        cd site
-        make clean
-        # run the docker image to build the website
-        ./docker/ci.sh
-        cd ..
-    fi
+install: true
 
-# Disabled the tests here. Since tests are running much slower on Travis than on Jenkins
-#  - ./dev/ticktoc.sh "mvn --batch-mode clean package"
+script: .travis_scripts/build.sh
 
 cache:
   directories:

--- a/.travis_scripts/build.sh
+++ b/.travis_scripts/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -ev
+
+BINDIR=`dirname "$0"`
+BK_HOME=`cd $BINDIR/..;pwd`
+
+mvn --batch-mode clean apache-rat:check compile spotbugs:check install -DskipTests
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    $BK_HOME/dev/check-binary-license ./bookkeeper-dist/all/target/bookkeeper-all-*-bin.tar.gz;
+    $BK_HOME/dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-*-bin.tar.gz;
+fi
+if [ "$DLOG_MODIFIED" == "true" ]; then
+    cd $BK_HOME/stream/distributedlog
+    mvn --batch-mode clean package -Ddistributedlog
+fi
+if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$WEBSITE_MODIFIED" == "true" ]; then
+    cd $BK_HOME/site
+    make clean
+    # run the docker image to build the website
+    ./docker/ci.sh
+fi

--- a/site/README.md
+++ b/site/README.md
@@ -57,3 +57,4 @@ Here are a few steps to follow to stage your changes:
 6. Your changes will be live on `https://<your-github-id>.github.io/bookkeeper-staging-site`.
 
 If you have any ideas to improve the review process for website, please feel free to contact us at dev@bookkeeper.apache.org.
+

--- a/stream/distributedlog/core/bin/dlog
+++ b/stream/distributedlog/core/bin/dlog
@@ -70,3 +70,4 @@ case "${COMMAND}" in
     exec java $OPTS $COMMAND $@
     ;;
 esac
+


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

There are a couple of problem with current travis build

- apache/bookkeeper#1223 introduce `set -e` on script section, which it cause some weird early-exiting problem.
- we run two installs. one is the default install by travis, the other one is install with apache-rat/spotbug checks in script section, which make the build slow.
- travis_retry and travis_wait spread across different commands in the script section

*Solution*

- move build logic into a bash script file and invoke the script
- skip install section in travis

*Result*

This reduces travis build time by 10+ mins and make it stable


NOTES:

The changes under `site` and `stream/distributedlog` are used `empty commits` to trigger corresponding builds in travis.