### PR TITLE
Issue #570: getting rid of unnecessary synchronization in InterleavedLedgerStorage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -76,7 +76,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     GarbageCollectorThread gcThread;
 
     // this indicates that a write has happened since the last flush
-    private AtomicBoolean somethingWritten = new AtomicBoolean(false);
+    private final AtomicBoolean somethingWritten = new AtomicBoolean(false);
 
     // Expose Stats
     private OpStatsLogger getOffsetStats;
@@ -362,10 +362,9 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
 
     @Override
     public synchronized void flush() throws IOException {
-        if (!somethingWritten.get()) {
+        if (!somethingWritten.compareAndSet(true, false)) {
             return;
         }
-        somethingWritten.set(false);
         flushOrCheckpoint(false);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
@@ -94,7 +94,7 @@ public interface LedgerManagerFactory extends AutoCloseable {
      * @param lm
      *            Layout manager
      */
-    void format(final AbstractConfiguration<?> conf, final LayoutManager lm)
+    void format(AbstractConfiguration<?> conf, LayoutManager lm)
             throws InterruptedException, KeeperException, IOException;
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -530,5 +530,7 @@ public class EntryLogTest {
             Assert.assertTrue("ReadEntry of ledgerId: " + ledgerId + " entryId: " + entryId
                     + " should have been completed successfully", future.get());
         }
+
+        executor.shutdownNow();
     }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

This is < sub-task1 > of Issue #570.

In InterleavedLedgerStorage, since the initial version of it, addEntry and processEntry methods are synchronized, but they are not required to be synchronized. 

Removal of unnecessary synchronization in InterleavedLedgerStorage methods, as described in http://mail-archives.apache.org/mod_mbox/bookkeeper-dev/201707.mbox/%3CCAO2yDyZ946fp2S_qR2iL178hPiXgrnFGb%3DpvkyK4ReSYAtNLBw%40mail.gmail.com%3E

Master Issue: #570
