### PR TITLE
 Fix AbstractLedgerManagerFactory on handling both shaded class and original class co-exists case

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
@@ -199,11 +199,11 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
                     throw new IOException("Wrong ledger manager factory " + layout.getManagerFactoryClass());
                 }
                 factoryClass = theCls.asSubclass(LedgerManagerFactory.class);
-            } catch (ClassNotFoundException cnfe) {
+            } catch (ClassNotFoundException | IOException e) {
                 factoryClass = attemptToResolveShadedLedgerManagerFactory(
                     conf,
                     layout.getManagerFactoryClass(),
-                    cnfe);
+                    e);
             }
         }
         // instantiate a factory

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogWriter.java
@@ -92,6 +92,7 @@ class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWriter {
         public void onFailure(Throwable cause) {
             promise.completeExceptionally(cause);
             encounteredError = true;
+            LOG.info("Fail the pending log record {}", record, cause);
         }
     }
 
@@ -380,6 +381,7 @@ class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWriter {
 
     @VisibleForTesting
     void errorOutPendingRequests(Throwable cause, boolean errorOutWriter) {
+        LOG.info("Error out pending requests : ", cause);
         final List<PendingLogRecord> pendingRequestsSnapshot;
         synchronized (this) {
             pendingRequestsSnapshot = pendingRequests;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogWriter.java
@@ -92,7 +92,6 @@ class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWriter {
         public void onFailure(Throwable cause) {
             promise.completeExceptionally(cause);
             encounteredError = true;
-            LOG.info("Fail the pending log record {}", record, cause);
         }
     }
 
@@ -381,7 +380,6 @@ class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWriter {
 
     @VisibleForTesting
     void errorOutPendingRequests(Throwable cause, boolean errorOutWriter) {
-        LOG.info("Error out pending requests : ", cause);
         final List<PendingLogRecord> pendingRequestsSnapshot;
         synchronized (this) {
             pendingRequestsSnapshot = pendingRequests;


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

#1217 addresses the issue when using a shaded class accessing a bookkeeper cluster.  However the assumption was made when the classpath only has shaded classes. However, it didn't address the case when shaded class and original class can co-exist. because IOException is thrown instead of ClassNotFoundException at following code:

```
                Class<?> theCls = Class.forName(layout.getManagerFactoryClass());
                if (!LedgerManagerFactory.class.isAssignableFrom(theCls)) {
                    throw new IOException("Wrong ledger manager factory " + layout.getManagerFactoryClass());
                }
```

*Solution*

This change fixes the issue.