### PR TITLE
Issue #570: Move logic of unpersistedbytes to bufferedchannel

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -41,20 +41,46 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
     // The buffer used to write operations.
     protected final ByteBuf writeBuffer;
     // The absolute position of the next write operation.
-    protected volatile long position;
+    protected final AtomicLong position;
+
+    /*
+     * if unpersistedBytesBound is non-zero value, then after writing to
+     * writeBuffer, it will check if the unpersistedBytes is greater than
+     * unpersistedBytesBound and then calls flush method if it is greater.
+     *
+     * It is a best-effort feature, since 'forceWrite' method is not
+     * synchronized and unpersistedBytes is reset in 'forceWrite' method before
+     * calling fileChannel.force
+     */
+    protected final long unpersistedBytesBound;
+
+    /*
+     * it tracks the number of bytes which are not persisted yet by force
+     * writing the FileChannel. The unpersisted bytes could be in writeBuffer or
+     * in fileChannel system cache.
+     */
+    protected final AtomicLong unpersistedBytes;
 
     // make constructor to be public for unit test
     public BufferedChannel(FileChannel fc, int capacity) throws IOException {
         // Use the same capacity for read and write buffers.
-        this(fc, capacity, capacity);
+        this(fc, capacity, 0L);
     }
 
-    public BufferedChannel(FileChannel fc, int writeCapacity, int readCapacity) throws IOException {
+    public BufferedChannel(FileChannel fc, int capacity, long unpersistedBytesBound) throws IOException {
+        // Use the same capacity for read and write buffers.
+        this(fc, capacity, capacity, unpersistedBytesBound);
+    }
+
+    public BufferedChannel(FileChannel fc, int writeCapacity, int readCapacity, long unpersistedBytesBound)
+            throws IOException {
         super(fc, readCapacity);
         this.writeCapacity = writeCapacity;
-        this.position = fc.position();
-        this.writeBufferStartPosition.set(position);
+        this.position = new AtomicLong(fc.position());
+        this.writeBufferStartPosition.set(position.get());
         this.writeBuffer = ByteBufAllocator.DEFAULT.directBuffer(writeCapacity);
+        this.unpersistedBytes = new AtomicLong(0);
+        this.unpersistedBytesBound = unpersistedBytesBound;
     }
 
     @Override
@@ -70,20 +96,34 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
      * @param src The source ByteBuffer which contains the data to be written.
      * @throws IOException if a write operation fails.
      */
-    public synchronized void write(ByteBuf src) throws IOException {
+    public void write(ByteBuf src) throws IOException {
         int copied = 0;
-        int len = src.readableBytes();
-        while (copied < len) {
-            int bytesToCopy = Math.min(src.readableBytes() - copied, writeBuffer.writableBytes());
-            writeBuffer.writeBytes(src, src.readerIndex() + copied, bytesToCopy);
-            copied += bytesToCopy;
+        boolean shouldForceWrite = false;
+        synchronized (this) {
+            int len = src.readableBytes();
+            while (copied < len) {
+                int bytesToCopy = Math.min(src.readableBytes() - copied, writeBuffer.writableBytes());
+                writeBuffer.writeBytes(src, src.readerIndex() + copied, bytesToCopy);
+                copied += bytesToCopy;
 
-            // if we have run out of buffer space, we should flush to the file
-            if (!writeBuffer.isWritable()) {
-                flushInternal();
+                // if we have run out of buffer space, we should flush to the
+                // file
+                if (!writeBuffer.isWritable()) {
+                    flushInternal();
+                }
+            }
+            position.addAndGet(copied);
+            unpersistedBytes.addAndGet(copied);
+            if (unpersistedBytesBound > 0) {
+                if (unpersistedBytes.get() >= unpersistedBytesBound) {
+                    flushInternal();
+                    shouldForceWrite = true;
+                }
             }
         }
-        position += copied;
+        if (shouldForceWrite) {
+            forceWrite(false);
+        }
     }
 
     /**
@@ -91,7 +131,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
      * @return
      */
     public long position() {
-        return position;
+        return position.get();
     }
 
     /**
@@ -110,11 +150,15 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
      * @throws IOException if the write or sync operation fails.
      */
     public void flush(boolean shouldForceWrite) throws IOException {
+        flush(shouldForceWrite, false);
+    }
+
+    public void flush(boolean shouldForceWrite, boolean forceMetadata) throws IOException {
         synchronized (this) {
             flushInternal();
         }
         if (shouldForceWrite) {
-            forceWrite(false);
+            forceWrite(forceMetadata);
         }
     }
 
@@ -138,6 +182,20 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
         // the force write, any flush that happens after this may or may
         // not be flushed
         long positionForceWrite = writeBufferStartPosition.get();
+        /*
+         * since forceWrite method is not called in synchronized block, to make
+         * sure we are not undercounting unpersistedBytes, setting
+         * unpersistedBytes to the current number of bytes in writeBuffer.
+         *
+         * since we are calling fileChannel.force, bytes which are written to
+         * filechannel (system filecache) will be persisted to the disk. So we
+         * dont need to consider those bytes for setting value to
+         * unpersistedBytes.
+         *
+         */
+        synchronized (this) {
+            unpersistedBytes.set(writeBuffer.readableBytes());
+        }
         fileChannel.force(forceMetadata);
         return positionForceWrite;
     }
@@ -187,5 +245,13 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
     public synchronized void clear() {
         super.clear();
         writeBuffer.clear();
+    }
+
+    public synchronized int getNumOfBytesInWriteBuffer() {
+        return writeBuffer.readableBytes();
+    }
+
+    long getUnpersistedBytes() {
+        return unpersistedBytes.get();
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -477,7 +477,7 @@ public class EntryLogger {
 
             // flush the internal buffer back to filesystem but not sync disk
             // so the readers could access the data from filesystem.
-            logChannel.flush(false);
+            logChannel.flush();
 
             // Append ledgers map at the end of entry log
             appendLedgersMap(logChannel);
@@ -566,7 +566,7 @@ public class EntryLogger {
         }
         // Flush the ledger's map out before we write the header.
         // Otherwise the header might point to something that is not fully written
-        entryLogChannel.flush(false);
+        entryLogChannel.flush();
 
         // Update the headers with the map offset and count of ledgers
         ByteBuffer mapInfo = ByteBuffer.allocate(8 + 4);
@@ -813,7 +813,7 @@ public class EntryLogger {
         while (chIter.hasNext()) {
             BufferedLogChannel channel = chIter.next();
             try {
-                channel.flush(true);
+                channel.flushAndForceWrite(false);
             } catch (IOException ioe) {
                 // rescue from flush exception, add unflushed channels back
                 synchronized (this) {
@@ -847,7 +847,7 @@ public class EntryLogger {
 
     synchronized void flushCurrentLog() throws IOException {
         if (logChannel != null) {
-            logChannel.flush(true);
+            logChannel.flushAndForceWrite(false);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Flush and sync current entry logger {}.", logChannel.getLogId());
             }
@@ -918,7 +918,7 @@ public class EntryLogger {
     void flushCompactionLog() throws IOException {
         synchronized (compactionLogLock) {
             if (compactionLogChannel != null) {
-                compactionLogChannel.flush(true);
+                compactionLogChannel.flushAndForceWrite(false);
                 LOG.info("Flushed compaction log file {} with logId.",
                     compactionLogChannel.getLogFile(),
                     compactionLogChannel.getLogId());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -92,8 +92,9 @@ public class EntryLogger {
                                   int writeCapacity,
                                   int readCapacity,
                                   long logId,
-                                  File logFile) throws IOException {
-            super(fc, writeCapacity, readCapacity);
+                                  File logFile,
+                                  long unpersistedBytesBound) throws IOException {
+            super(fc, writeCapacity, readCapacity, unpersistedBytesBound);
             this.logId = logId;
             this.entryLogMetadata = new EntryLogMetadata(logId);
             this.logFile = logFile;
@@ -197,9 +198,6 @@ public class EntryLogger {
     static final int MIN_SANE_ENTRY_SIZE = 8 + 8;
     static final long MB = 1024 * 1024;
 
-    private final long flushIntervalInBytes;
-    private final boolean doRegularFlushes;
-    private long bytesWrittenSinceLastFlush = 0;
     private final int maxSaneEntrySize;
 
     final ServerConfiguration conf;
@@ -287,8 +285,6 @@ public class EntryLogger {
         this.leastUnflushedLogId = logId + 1;
         this.entryLoggerAllocator = new EntryLoggerAllocator(logId);
         this.conf = conf;
-        flushIntervalInBytes = conf.getFlushIntervalInBytes();
-        doRegularFlushes = flushIntervalInBytes > 0;
 
         initialize();
     }
@@ -668,8 +664,8 @@ public class EntryLogger {
             } while (newLogFile == null);
 
             FileChannel channel = new RandomAccessFile(newLogFile, "rw").getChannel();
-            BufferedLogChannel logChannel = new BufferedLogChannel(channel,
-                    conf.getWriteBufferBytes(), conf.getReadBufferBytes(), preallocatedLogId, newLogFile);
+            BufferedLogChannel logChannel = new BufferedLogChannel(channel, conf.getWriteBufferBytes(),
+                    conf.getReadBufferBytes(), preallocatedLogId, newLogFile, conf.getFlushIntervalInBytes());
             logfileHeader.readerIndex(0);
             logChannel.write(logfileHeader);
 
@@ -852,7 +848,6 @@ public class EntryLogger {
     synchronized void flushCurrentLog() throws IOException {
         if (logChannel != null) {
             logChannel.flush(true);
-            bytesWrittenSinceLastFlush = 0;
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Flush and sync current entry logger {}.", logChannel.getLogId());
             }
@@ -881,9 +876,6 @@ public class EntryLogger {
         // Create new log if logSizeLimit reached or current disk is full
         boolean createNewLog = shouldCreateNewEntryLog.get();
         if (createNewLog || reachEntryLogLimit) {
-            if (doRegularFlushes) {
-                flushCurrentLog();
-            }
             createNewLog();
             // Reset the flag
             if (createNewLog) {
@@ -900,8 +892,6 @@ public class EntryLogger {
         long pos = logChannel.position();
         logChannel.write(entry);
         logChannel.registerWrittenEntry(ledger, entrySize);
-
-        incrementBytesWrittenAndMaybeFlush(4L + entrySize);
 
         return (logChannel.getLogId() << 32L) | pos;
     }
@@ -967,16 +957,6 @@ public class EntryLogger {
                 }
                 compactionLogChannel = null;
             }
-        }
-    }
-
-    private void incrementBytesWrittenAndMaybeFlush(long bytesWritten) throws IOException {
-        if (!doRegularFlushes) {
-            return;
-        }
-        bytesWrittenSinceLastFlush += bytesWritten;
-        if (bytesWrittenSinceLastFlush > flushIntervalInBytes) {
-            flushCurrentLog();
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -986,7 +986,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                                 writePaddingBytes(logFile, paddingBuff, journalAlignmentSize);
                             }
                             journalFlushWatcher.reset().start();
-                            bc.flush(false);
+                            bc.flush();
 
                             for (int i = 0; i < toFlush.size(); i++) {
                                 QueueEntry entry = toFlush.get(i);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
@@ -94,7 +94,7 @@ public interface LedgerManagerFactory extends AutoCloseable {
      * @param lm
      *            Layout manager
      */
-    void format(final AbstractConfiguration<?> conf, final LayoutManager lm)
+    void format(AbstractConfiguration<?> conf, LayoutManager lm)
             throws InterruptedException, KeeperException, IOException;
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -171,7 +171,7 @@ public class BookieJournalTest {
 
     private static void moveToPosition(JournalChannel jc, long pos) throws IOException {
         jc.fc.position(pos);
-        jc.bc.position = pos;
+        jc.bc.position.set(pos);
         jc.bc.writeBufferStartPosition.set(pos);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -211,7 +211,7 @@ public class BookieJournalTest {
             bc.write(packet);
             packet.release();
         }
-        bc.flush(true);
+        bc.flushAndForceWrite(false);
 
         updateJournalVersion(jc, JournalChannel.V2);
 
@@ -245,7 +245,7 @@ public class BookieJournalTest {
             bc.write(packet);
             packet.release();
         }
-        bc.flush(true);
+        bc.flushAndForceWrite(false);
 
         updateJournalVersion(jc, JournalChannel.V3);
 
@@ -284,7 +284,7 @@ public class BookieJournalTest {
         lenBuf.writeInt(packet.readableBytes());
         bc.write(lenBuf);
         bc.write(packet);
-        bc.flush(true);
+        bc.flushAndForceWrite(false);
         updateJournalVersion(jc, JournalChannel.V4);
         return jc;
     }
@@ -324,7 +324,7 @@ public class BookieJournalTest {
         bc.write(lenBuf);
         bc.write(packet);
         Journal.writePaddingBytes(jc, paddingBuff, JournalChannel.SECTOR_SIZE);
-        bc.flush(true);
+        bc.flushAndForceWrite(false);
         updateJournalVersion(jc, JournalChannel.V5);
         return jc;
     }
@@ -521,7 +521,7 @@ public class BookieJournalTest {
 
         JournalChannel jc = writeV2Journal(Bookie.getCurrentDirectory(journalDir), 0);
         jc.getBufferedChannel().write(Unpooled.wrappedBuffer("JunkJunkJunk".getBytes()));
-        jc.getBufferedChannel().flush(true);
+        jc.getBufferedChannel().flushAndForceWrite(false);
 
         writeIndexFileForLedger(ledgerDir, 1, "testPasswd".getBytes());
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BufferedChannelTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BufferedChannelTest.java
@@ -1,0 +1,112 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for BufferedChannel.
+ */
+public class BufferedChannelTest {
+
+    private static Random rand = new Random();
+
+    @Test
+    public void testBufferedChannelWithNoBoundOnUnpersistedBytes() throws Exception {
+        testBufferedChannel(5000, 30, 0, false, false);
+    }
+
+    @Test
+    public void testBufferedChannelWithBoundOnUnpersistedBytes() throws Exception {
+        testBufferedChannel(5000, 30, 5000 * 28, false, false);
+    }
+
+    @Test
+    public void testBufferedChannelWithBoundOnUnpersistedBytesAndFlush() throws Exception {
+        testBufferedChannel(5000, 30, 5000 * 28, true, false);
+    }
+
+    @Test
+    public void testBufferedChannelFlushNoForceWrite() throws Exception {
+        testBufferedChannel(5000, 30, 0, true, false);
+    }
+
+    @Test
+    public void testBufferedChannelFlushForceWrite() throws Exception {
+        testBufferedChannel(5000, 30, 0, true, true);
+    }
+
+    public void testBufferedChannel(int byteBufLength, int numOfWrites, int unpersistedBytesBound, boolean flush,
+            boolean shouldForceWrite) throws Exception {
+        File newLogFile = File.createTempFile("test", "log");
+        newLogFile.deleteOnExit();
+        FileChannel fileChannel = new RandomAccessFile(newLogFile, "rw").getChannel();
+
+        BufferedChannel logChannel = new BufferedChannel(fileChannel, 65536, 512, unpersistedBytesBound);
+
+        ByteBuf dataBuf = generateEntry(byteBufLength);
+        dataBuf.markReaderIndex();
+        dataBuf.markWriterIndex();
+
+        for (int i = 0; i < numOfWrites; i++) {
+            logChannel.write(dataBuf);
+            dataBuf.resetReaderIndex();
+            dataBuf.resetWriterIndex();
+        }
+
+        if (flush) {
+            logChannel.flush(shouldForceWrite);
+        }
+
+        int expectedNumOfUnpersistedBytes = 0;
+
+        if (flush && shouldForceWrite) {
+            /*
+             * if flush call is made with shouldForceWrite,
+             * then expectedNumOfUnpersistedBytes should be zero.
+             */
+            expectedNumOfUnpersistedBytes = 0;
+        } else {
+            expectedNumOfUnpersistedBytes = (byteBufLength * numOfWrites) - unpersistedBytesBound;
+        }
+
+        Assert.assertEquals("Unpersisted bytes", expectedNumOfUnpersistedBytes, logChannel.getUnpersistedBytes());
+        logChannel.close();
+        fileChannel.close();
+    }
+
+    private static ByteBuf generateEntry(int length) {
+        byte[] data = new byte[length];
+        ByteBuf bb = Unpooled.buffer(length);
+        rand.nextBytes(data);
+        bb.writeBytes(data);
+        return bb;
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
@@ -105,7 +105,7 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
             bc.write(packet);
             packet.release();
         }
-        bc.flush(true);
+        bc.flushAndForceWrite(false);
 
         return jc;
     }


### PR DESCRIPTION

Descriptions of the changes in this PR:

This is < sub-task2 > of Issue #570.

https://github.com/apache/bookkeeper/commit/26b09abb4202362ca37d6944ce75eb2a3309dc3c
introduced the flushEntrylogBytes factor. But it is structurally correct to have this
logic in BufferedChannel, rather than in EntryLogger, since it is paramter of BufferedChannel.

Master Issue: #570 
