### PR TITLE
 Issue 1229: PendingAddOp can get recycled before it gets executed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -43,6 +43,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.CreateCallback;
 import org.apache.bookkeeper.client.AsyncCallback.DeleteCallback;
 import org.apache.bookkeeper.client.AsyncCallback.IsClosedCallback;
@@ -158,6 +160,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     final int explicitLacInterval;
     final boolean delayEnsembleChange;
     final boolean reorderReadSequence;
+    @Getter(AccessLevel.PACKAGE)
     final long addEntryQuorumTimeoutNanos;
 
     final Optional<SpeculativeRequestExecutionPolicy> readSpeculativeRequestPolicy;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -43,8 +43,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import lombok.AccessLevel;
-import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.CreateCallback;
 import org.apache.bookkeeper.client.AsyncCallback.DeleteCallback;
 import org.apache.bookkeeper.client.AsyncCallback.IsClosedCallback;
@@ -160,7 +158,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     final int explicitLacInterval;
     final boolean delayEnsembleChange;
     final boolean reorderReadSequence;
-    @Getter(AccessLevel.PACKAGE)
     final long addEntryQuorumTimeoutNanos;
 
     final Optional<SpeculativeRequestExecutionPolicy> readSpeculativeRequestPolicy;
@@ -574,6 +571,10 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         bookieInfoScheduler = null;
         bookieClient = null;
         addEntryQuorumTimeoutNanos = 0;
+    }
+
+    long getAddEntryQuorumTimeoutNanos() {
+        return addEntryQuorumTimeoutNanos;
     }
 
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -51,8 +51,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.AccessLevel;
-import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallbackWithLatency;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
@@ -100,7 +98,6 @@ public class LedgerHandle implements WriteHandle {
 
     final byte[] ledgerKey;
     LedgerMetadata metadata;
-    @Getter(AccessLevel.PACKAGE)
     final BookKeeper bk;
     final long ledgerId;
     long lastAddPushed;
@@ -108,7 +105,6 @@ public class LedgerHandle implements WriteHandle {
 
     long length;
     final DigestManager macManager;
-    @Getter(AccessLevel.PACKAGE)
     final DistributionSchedule distributionSchedule;
     final RateLimiter throttler;
     final LoadingCache<BookieSocketAddress, Long> bookieFailureHistory;
@@ -225,6 +221,10 @@ public class LedgerHandle implements WriteHandle {
                                                                   bk.getConf().getTimeoutMonitorIntervalSec(),
                                                                   TimeUnit.SECONDS);
         }
+    }
+
+    BookKeeper getBk() {
+        return bk;
     }
 
     protected void initializeExplicitLacFlushPolicy() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -51,6 +51,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallbackWithLatency;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
@@ -98,6 +100,7 @@ public class LedgerHandle implements WriteHandle {
 
     final byte[] ledgerKey;
     LedgerMetadata metadata;
+    @Getter(AccessLevel.PACKAGE)
     final BookKeeper bk;
     final long ledgerId;
     long lastAddPushed;
@@ -105,6 +108,7 @@ public class LedgerHandle implements WriteHandle {
 
     long length;
     final DigestManager macManager;
+    @Getter(AccessLevel.PACKAGE)
     final DistributionSchedule distributionSchedule;
     final RateLimiter throttler;
     final LoadingCache<BookieSocketAddress, Long> bookieFailureHistory;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -92,10 +92,10 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         op.entryLength = payload.readableBytes();
 
         op.completed = false;
-        op.ackSet = lh.distributionSchedule.getAckSet();
-        op.addOpLogger = lh.bk.getAddOpLogger();
-        op.addOpUrCounter = lh.bk.getAddOpUrCounter();
-        op.timeoutNanos = lh.bk.addEntryQuorumTimeoutNanos;
+        op.ackSet = lh.getDistributionSchedule().getAckSet();
+        op.addOpLogger = lh.getBk().getAddOpLogger();
+        op.addOpUrCounter = lh.getBk().getAddOpUrCounter();
+        op.timeoutNanos = lh.getBk().getAddEntryQuorumTimeoutNanos();
         op.pendingWriteRequests = 0;
         op.callbackTriggered = false;
         op.hasRun = false;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -397,29 +397,40 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         this.recyclerHandle = recyclerHandle;
     }
 
+
     private void maybeRecycle() {
-        // The reference to PendingAddOp can be held in 3 places
-        // - LedgerHandle#pendingAddOp
-        //   This reference is released when the callback is run
-        // - The executor
-        //   Released after safeRun finishes
-        // - BookieClient
-        //   Holds a reference from the point the addEntry requests are
-        //   sent.
-        // The object can only be recycled after all references are
-        // released, otherwise we could end up recycling twice and all
-        // joy that goes along with that.
-        if (hasRun && callbackTriggered && pendingWriteRequests == 0) {
-            recycle();
+        /**
+         * We have opportunity to recycle two objects here.
+         * PendingAddOp#toSend and LedgerHandle#pendingAddOp
+         *
+         * A. LedgerHandle#pendingAddOp: This can be released after all 3 conditions are met.
+         *    - After the callback is run
+         *    - After safeRun finished by the executor
+         *    - Write responses are returned from all bookies
+         *      as BookieClient Holds a reference from the point the addEntry requests are sent.
+         *
+         * B. ByteBuf can be released after 2 of the conditions are met.
+         *    - After the callback is run as we will not retry the write after callback
+         *    - After safeRun finished by the executor
+         * BookieClient takes and releases on this buffer immediately after sending the data.
+         *
+         * The object can only be recycled after the above conditions are met
+         * otherwise we could end up recycling twice and all
+         * joy that goes along with that.
+         */
+        if (hasRun && callbackTriggered) {
+            ReferenceCountUtil.release(toSend);
+            toSend = null;
+        }
+        if (toSend == null && pendingWriteRequests == 0) {
+            recyclePendAddOpObject();
         }
     }
 
-    private void recycle() {
+    private void recyclePendAddOpObject() {
         entryId = LedgerHandle.INVALID_ENTRY_ID;
         currentLedgerLength = -1;
-        ReferenceCountUtil.release(toSend);
         payload = null;
-        toSend = null;
         cb = null;
         ctx = null;
         ackSet.recycle();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -422,6 +422,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
             ReferenceCountUtil.release(toSend);
             toSend = null;
         }
+        // only recycle a pending add op after it has been run.
         if (hasRun && toSend == null && pendingWriteRequests == 0) {
             recyclePendAddOpObject();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -422,7 +422,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
             ReferenceCountUtil.release(toSend);
             toSend = null;
         }
-        if (toSend == null && pendingWriteRequests == 0) {
+        if (hasRun && toSend == null && pendingWriteRequests == 0) {
             recyclePendAddOpObject();
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -397,40 +397,29 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         this.recyclerHandle = recyclerHandle;
     }
 
-
     private void maybeRecycle() {
-        /**
-         * We have opportunity to recycle two objects here.
-         * PendingAddOp#toSend and LedgerHandle#pendingAddOp
-         *
-         * A. LedgerHandle#pendingAddOp: This can be released after all 3 conditions are met.
-         *    - After the callback is run
-         *    - After safeRun finished by the executor
-         *    - Write responses are returned from all bookies
-         *      as BookieClient Holds a reference from the point the addEntry requests are sent.
-         *
-         * B. ByteBuf can be released after 2 of the conditions are met.
-         *    - After the callback is run as we will not retry the write after callback
-         *    - After safeRun finished by the executor
-         * BookieClient takes and releases on this buffer immediately after sending the data.
-         *
-         * The object can only be recycled after the above conditions are met
-         * otherwise we could end up recycling twice and all
-         * joy that goes along with that.
-         */
-        if (hasRun && callbackTriggered) {
-            ReferenceCountUtil.release(toSend);
-            toSend = null;
-        }
-        if (toSend == null && pendingWriteRequests == 0) {
-            recyclePendAddOpObject();
+        // The reference to PendingAddOp can be held in 3 places
+        // - LedgerHandle#pendingAddOp
+        //   This reference is released when the callback is run
+        // - The executor
+        //   Released after safeRun finishes
+        // - BookieClient
+        //   Holds a reference from the point the addEntry requests are
+        //   sent.
+        // The object can only be recycled after all references are
+        // released, otherwise we could end up recycling twice and all
+        // joy that goes along with that.
+        if (hasRun && callbackTriggered && pendingWriteRequests == 0) {
+            recycle();
         }
     }
 
-    private void recyclePendAddOpObject() {
+    private void recycle() {
         entryId = LedgerHandle.INVALID_ENTRY_ID;
         currentLedgerLength = -1;
+        ReferenceCountUtil.release(toSend);
         payload = null;
+        toSend = null;
         cb = null;
         ctx = null;
         ackSet.recycle();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingAddOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingAddOpTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.client;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.bookkeeper.client.BKException.Code;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test of {@link PendingAddOp}.
+ */
+public class PendingAddOpTest {
+
+    private BookKeeper bk;
+    private LedgerHandle lh;
+    private ByteBuf payload;
+
+    @Before
+    public void setup() {
+        bk = mock(BookKeeper.class);
+        when(bk.getAddEntryQuorumTimeoutNanos()).thenReturn(1000L);
+        when(bk.getAddOpLogger()).thenReturn(NullStatsLogger.INSTANCE.getOpStatsLogger("test"));
+        when(bk.getAddOpUrCounter()).thenReturn(NullStatsLogger.INSTANCE.getCounter("test"));
+        lh = mock(LedgerHandle.class);
+        when(lh.getBk()).thenReturn(bk);
+        when(lh.getDistributionSchedule())
+            .thenReturn(new RoundRobinDistributionSchedule(3, 3, 2));
+        byte[] data = "test-pending-add-op".getBytes(UTF_8);
+        payload = Unpooled.wrappedBuffer(data);
+        payload.writerIndex(data.length);
+    }
+
+    @Test
+    public void testExecuteAfterCancelled() {
+        AtomicInteger rcHolder = new AtomicInteger(-0xdead);
+        CountDownLatch latch = new CountDownLatch(1);
+        PendingAddOp op = PendingAddOp.create(
+            lh, payload, (rc, handle, entryId, qwcLatency, ctx) -> {
+                rcHolder.set(rc);
+                latch.countDown();
+            }, null);
+        assertSame(lh, op.lh);
+
+        // cancel the op.
+        op.submitCallback(Code.NotEnoughBookiesException);
+        // if a op is cancelled, it is not recycled until it has been run.
+        assertSame(lh, op.lh);
+
+        op.run();
+        // after the op is run, the object is recycled.
+        assertNull(op.lh);
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
@@ -213,5 +213,4 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
         checklatch.await();
         assertEquals("There should be no missing fragments", 0, numFragments.get());
     }
-
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
@@ -23,7 +23,6 @@ package org.apache.bookkeeper.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
@@ -215,61 +214,4 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
         assertEquals("There should be no missing fragments", 0, numFragments.get());
     }
 
-    @Test
-    public void testBookieFailure() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
-        conf.setReadTimeout(5)
-            .setAddEntryQuorumTimeout(5)
-            .setAddEntryQuorumTimeout(10)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
-
-        BookKeeper bkc = new BookKeeper(conf);
-
-        byte[] pwd = new byte[] {};
-        final LedgerHandle lh = bkc.createLedger(4, 4, 3, BookKeeper.DigestType.CRC32, pwd);
-        final AtomicBoolean finished = new AtomicBoolean(false);
-        final AtomicBoolean failTest = new AtomicBoolean(false);
-        final byte[] entry = "Test Entry".getBytes();
-
-        Thread t = new Thread(() -> {
-            while (!finished.get()) {
-                lh.asyncAddEntry(entry, (rc, lh1, entryId, ctx) -> {
-                    if (rc != BKException.Code.OK) {
-                        failTest.set(true);
-                        finished.set(true);
-                    }
-                }, null);
-            }
-        });
-
-        killBookie(0);
-
-        t.start();
-
-        Thread.sleep(2_000);
-
-        finished.set(true);
-        t.join();
-
-        assertTrue(failTest.get());
-
-        lh.close();
-
-        LedgerHandle lh2 = bkc.openLedger(lh.getId(), BookKeeper.DigestType.CRC32, pwd);
-        LedgerChecker lc = new LedgerChecker(bkc);
-        final CountDownLatch checklatch = new CountDownLatch(1);
-        final AtomicInteger numFragments = new AtomicInteger(-1);
-        lc.checkLedger(lh2, new GenericCallback<Set<LedgerFragment>>() {
-            public void operationComplete(int rc, Set<LedgerFragment> fragments) {
-                LOG.debug("Checked ledgers returned {} {}", rc, fragments);
-                if (rc == BKException.Code.OK) {
-                    numFragments.set(fragments.size());
-                    LOG.error("Checked ledgers returned {} {}", rc, fragments);
-                }
-                checklatch.countDown();
-            }
-        });
-        checklatch.await();
-        assertEquals("There should be no missing fragments", 0, numFragments.get());
-    }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:
*Problem*

The PendingAddOp can be recycled when it is cancelled before it is executed. so it will hit NPE when it is actually executed. This is a bug introduced by #1091

*Solution*

Only recycle PendingAddOp after it has been run.

Master Issue: #1229 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
