### PR TITLE
Dont shade netty at distributedlog-core-shaded

### DIFF
--- a/shaded/distributedlog-core-shaded/pom.xml
+++ b/shaded/distributedlog-core-shaded/pom.xml
@@ -44,6 +44,14 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-buffer</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>
@@ -75,11 +83,8 @@
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.protobuf:protobuf-java</include>
+                  <!-- netty 3 (included from zookeeper) -->
                   <include>io.netty:netty</include>
-                  <include>io.netty:netty-all</include>
-                  <include>io.netty:netty-buffer</include>
-                  <include>io.netty:netty-common</include>
-                  <include>io.netty:netty-tcnative-boringssl-static</include>
                   <include>net.java.dev.jna:jna</include>
                   <include>net.jpountz.lz4:lz4</include>
                   <include>org.apache.bookkeeper:bookkeeper-common</include>
@@ -169,10 +174,6 @@
                   <shadedPattern>dlshade.com.google</shadedPattern>
                 </relocation>
                 <!-- netty -->
-                <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>dlshade.io.netty</shadedPattern>
-                </relocation>
                 <relocation>
                   <pattern>org.jboss.netty</pattern>
                   <shadedPattern>dlshade.org.jboss.netty</shadedPattern>


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

JVM crashed when `distributedlog-core-shaded` (where netty was shaded) is used in a project where netty isn't shaded
and epoll is enabled. The conflict happens on loading the native epoll transport because shaded netty doesn't actually
shade the native jni library. so signature mismatch when both version of netty try to resolve jni library.

*Solution*

Dont shade netty at all. Let the application resolve which netty version to use.

