### PR TITLE
Make shading rule consistent between bookkeeper-server-shaded and bookkeeper-server-tests-shaded

### DIFF
--- a/shaded/bookkeeper-server-tests-shaded/pom.xml
+++ b/shaded/bookkeeper-server-tests-shaded/pom.xml
@@ -32,31 +32,10 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
-      <artifactId>bookkeeper-server-shaded</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <type>test-jar</type>
       <version>${project.version}</version>
       <exclusions>
-        <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
-          <artifactId>bookkeeper-common</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
-          <artifactId>bookkeeper-proto</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
-          <artifactId>bookkeeper-server</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.bookkeeper.stats</groupId>
-          <artifactId>bookkeeper-stats-api</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
@@ -86,10 +65,18 @@
               <minimizeJar>false</minimizeJar>
               <artifactSet>
                 <includes>
+                  <include>com.google.guava:guava</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+                  <include>org.apache.bookkeeper:bookkeeper-common</include>
+                  <include>org.apache.bookkeeper:bookkeeper-proto</include>
+                  <include>org.apache.bookkeeper:bookkeeper-server</include>
                   <include>org.apache.bookkeeper:bookkeeper-server:test-jar:tests</include>
+                  <include>org.apache.bookkeeper:circe-checksum</include>
+                  <include>org.apache.bookkeeper.stats:bookkeeper-stats-api</include>
                 </includes>
               </artifactSet>
               <relocations>
+                <!-- make the relocation rules consistent with `bookkeeper-server-shaded` -->
                 <relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>org.apache.bookkeeper.shaded.com.google</shadedPattern>

--- a/shaded/bookkeeper-server-tests-shaded/pom.xml
+++ b/shaded/bookkeeper-server-tests-shaded/pom.xml
@@ -44,6 +44,26 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>bookkeeper-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>bookkeeper-proto</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>bookkeeper-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>circe-checksum</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.bookkeeper.stats</groupId>
+          <artifactId>bookkeeper-stats-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>
@@ -67,12 +87,7 @@
                 <includes>
                   <include>com.google.guava:guava</include>
                   <include>com.google.protobuf:protobuf-java</include>
-                  <include>org.apache.bookkeeper:bookkeeper-common</include>
-                  <include>org.apache.bookkeeper:bookkeeper-proto</include>
-                  <include>org.apache.bookkeeper:bookkeeper-server</include>
                   <include>org.apache.bookkeeper:bookkeeper-server:test-jar:tests</include>
-                  <include>org.apache.bookkeeper:circe-checksum</include>
-                  <include>org.apache.bookkeeper.stats:bookkeeper-stats-api</include>
                 </includes>
               </artifactSet>
               <relocations>


### PR DESCRIPTION

Descriptions of the changes in this PR:

`bookkeeper-server:test-jar` is working with `bookkeeper-server`. we should make `bookkeeper-server-tests-shaded` work with `bookkeeper-server-shaded`.  so this change is to make they have consistent shading rule.

```
<dependency>
      <groupId>org.apache.bookkeeper</groupId>
      <artifactId>bookkeeper-server-shaded</artifactId>
      <version>${bookkeeper.version}</version>
      <scope>test</scope>
    </dependency>
<dependency>
      <groupId>org.apache.bookkeeper</groupId>
      <artifactId>bookkeeper-server-tests-shaded</artifactId>
      <version>${bookkeeper.version}</version>
      <scope>test</scope>
    </dependency>
```