### PR TITLE
Issue #570: make changes to SyncThread/checkpoint logic.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -847,7 +847,7 @@ public class Bookie extends BookieCriticalThread {
          * again if bookie restarted again before finished journal replays.
          */
         if (entryLogPerLedgerEnabled) {
-            syncThread.start();
+            syncThread.scheduleCheckpointAtFixedRate(conf.getFlushInterval());
         }
 
         // start bookie thread

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -2494,6 +2494,11 @@ public class BookieShell implements Tool {
                 public void startCheckpoint(Checkpoint checkpoint) {
                     // No-op
                 }
+
+                @Override
+                public void start() {
+                    // no-op
+                }
             };
 
             interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager,
@@ -2583,6 +2588,11 @@ public class BookieShell implements Tool {
                 @Override
                 public void startCheckpoint(Checkpoint checkpoint) {
                     // No-op
+                }
+
+                @Override
+                public void start() {
+                    // no-op
                 }
             };
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Checkpointer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Checkpointer.java
@@ -26,8 +26,16 @@ import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
  */
 public interface Checkpointer {
 
-    Checkpointer NULL = checkpoint -> {
-        // do nothing;
+    Checkpointer NULL = new Checkpointer(){
+        @Override
+        public void startCheckpoint(Checkpoint checkpoint) {
+            // no-op
+        }
+
+        @Override
+        public void start() {
+            // no-op
+        }
     };
 
     /**
@@ -37,4 +45,5 @@ public interface Checkpointer {
      */
     void startCheckpoint(Checkpoint checkpoint);
 
+    void start();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -131,7 +131,7 @@ public class EntryLogger {
      * The maximum size of a entry logger file.
      */
     final long logSizeLimit;
-    private List<BufferedLogChannel> logChannelsToFlush;
+    List<BufferedLogChannel> logChannelsToFlush;
     private volatile BufferedLogChannel logChannel;
     private volatile BufferedLogChannel compactionLogChannel;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -82,6 +82,8 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     private OpStatsLogger getOffsetStats;
     private OpStatsLogger getEntryStats;
 
+    protected boolean entryLogPerLedgerEnabled;
+
     @VisibleForTesting
     public InterleavedLedgerStorage() {
         activeLedgers = new SnapshotMap<Long, Boolean>();
@@ -99,7 +101,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
             throws IOException {
         checkNotNull(checkpointSource, "invalid null checkpoint source");
         checkNotNull(checkpointer, "invalid null checkpointer");
-
+        this.entryLogPerLedgerEnabled = conf.isEntryLogPerLedgerEnabled();
         this.checkpointSource = checkpointSource;
         this.checkpointer = checkpointer;
         entryLogger = new EntryLogger(conf, ledgerDirsManager, this);
@@ -333,9 +335,16 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         }
 
         try {
-            // if it is just a checkpoint flush, we just flush rotated entry log files
-            // in entry logger.
-            if (isCheckpointFlush) {
+            /*
+             * if it is just a checkpoint flush and if entryLogPerLedger is not
+             * enabled, then we just flush rotated entry log files in entry
+             * logger.
+             *
+             * In the case of entryLogPerLedgerEnabled we need to flush both
+             * rotatedlogs and currentlogs. Hence we call entryLogger.flush in
+             * the case of entrylogperledgerenabled.
+             */
+            if (isCheckpointFlush && !entryLogPerLedgerEnabled) {
                 entryLogger.checkpoint();
             } else {
                 entryLogger.flush();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -82,8 +82,6 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     private OpStatsLogger getOffsetStats;
     private OpStatsLogger getEntryStats;
 
-    protected boolean entryLogPerLedgerEnabled;
-
     @VisibleForTesting
     public InterleavedLedgerStorage() {
         activeLedgers = new SnapshotMap<Long, Boolean>();
@@ -101,7 +99,6 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
             throws IOException {
         checkNotNull(checkpointSource, "invalid null checkpoint source");
         checkNotNull(checkpointer, "invalid null checkpointer");
-        this.entryLogPerLedgerEnabled = conf.isEntryLogPerLedgerEnabled();
         this.checkpointSource = checkpointSource;
         this.checkpointer = checkpointer;
         entryLogger = new EntryLogger(conf, ledgerDirsManager, this);
@@ -335,16 +332,9 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         }
 
         try {
-            /*
-             * if it is just a checkpoint flush and if entryLogPerLedger is not
-             * enabled, then we just flush rotated entry log files in entry
-             * logger.
-             *
-             * In the case of entryLogPerLedgerEnabled we need to flush both
-             * rotatedlogs and currentlogs. Hence we call entryLogger.flush in
-             * the case of entrylogperledgerenabled.
-             */
-            if (isCheckpointFlush && !entryLogPerLedgerEnabled) {
+            // if it is just a checkpoint flush, we just flush rotated entry log files
+            // in entry logger.
+            if (isCheckpointFlush) {
                 entryLogger.checkpoint();
             } else {
                 entryLogger.flush();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -82,7 +82,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
      * @param filter journal id filter
      * @return list of filtered ids
      */
-    private static List<Long> listJournalIds(File journalDir, JournalIdFilter filter) {
+    static List<Long> listJournalIds(File journalDir, JournalIdFilter filter) {
         File logFiles[] = journalDir.listFiles();
         if (logFiles == null || logFiles.length == 0) {
             return Collections.emptyList();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -119,6 +119,12 @@ class SyncThread implements Checkpointer {
         });
     }
 
+    void start() {
+        executor.scheduleWithFixedDelay(() -> {
+            startCheckpoint(checkpointSource.newCheckpoint());
+        }, flushInterval, flushInterval, TimeUnit.MILLISECONDS);
+    }
+
     private void flush() {
         Checkpoint checkpoint = checkpointSource.newCheckpoint();
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -61,7 +61,6 @@ import org.apache.bookkeeper.util.MathUtils;
 class SyncThread implements Checkpointer {
 
     final ScheduledExecutorService executor;
-    final int flushInterval;
     final LedgerStorage ledgerStorage;
     final LedgerDirsListener dirsListener;
     final CheckpointSource checkpointSource;
@@ -78,10 +77,6 @@ class SyncThread implements Checkpointer {
         this.ledgerStorage = ledgerStorage;
         this.checkpointSource = checkpointSource;
         this.executor = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("SyncThread"));
-        flushInterval = conf.getFlushInterval();
-        if (log.isDebugEnabled()) {
-            log.debug("Flush Interval : {}", flushInterval);
-        }
     }
 
     @Override
@@ -119,7 +114,7 @@ class SyncThread implements Checkpointer {
         });
     }
 
-    void start() {
+    void scheduleCheckpointAtFixedRate(int flushInterval) {
         executor.scheduleWithFixedDelay(() -> {
             startCheckpoint(checkpointSource.newCheckpoint());
         }, flushInterval, flushInterval, TimeUnit.MILLISECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -22,9 +22,7 @@
 package org.apache.bookkeeper.bookie;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import io.netty.util.concurrent.DefaultThreadFactory;
-
 import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -32,13 +30,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.LedgerDirsListener;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.util.MathUtils;
-
 
 /**
  * SyncThread is a background thread which help checkpointing ledger storage
@@ -81,6 +77,10 @@ class SyncThread implements Checkpointer {
 
     @Override
     public void startCheckpoint(Checkpoint checkpoint) {
+        doCheckpoint(checkpoint);
+    }
+
+    protected void doCheckpoint(Checkpoint checkpoint) {
         executor.submit(() -> {
             try {
                 synchronized (suspensionLock) {
@@ -103,21 +103,14 @@ class SyncThread implements Checkpointer {
         });
     }
 
-    public Future<Void> requestFlush() {
+    public Future requestFlush() {
         return executor.submit(() -> {
             try {
                 flush();
             } catch (Throwable t) {
                 log.error("Exception flushing ledgers ", t);
             }
-            return null;
         });
-    }
-
-    void scheduleCheckpointAtFixedRate(int flushInterval) {
-        executor.scheduleWithFixedDelay(() -> {
-            startCheckpoint(checkpointSource.newCheckpoint());
-        }, flushInterval, flushInterval, TimeUnit.MILLISECONDS);
     }
 
     private void flush() {
@@ -172,6 +165,11 @@ class SyncThread implements Checkpointer {
         }
     }
 
+    @Override
+    public void start() {
+        // no-op
+    }
+
     /**
      * Suspend sync thread. (for testing)
      */
@@ -202,6 +200,7 @@ class SyncThread implements Checkpointer {
     void shutdown() throws InterruptedException {
         log.info("Shutting down SyncThread");
         requestFlush();
+
         executor.shutdown();
         long start = MathUtils.now();
         while (!executor.awaitTermination(5, TimeUnit.MINUTES)) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -182,7 +182,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     /*
      * config specifying if the entrylog per ledger is enabled or not.
      */
-    protected static final String ENTRY_LOG_PERLEDGER_ENABLED = "entryLogPerLedgerEnabled";
+    protected static final String ENTRY_LOG_PER_LEDGER_ENABLED = "entryLogPerLedgerEnabled";
 
     /**
      * Construct a default configuration object.
@@ -2644,7 +2644,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * would be a active entrylog for each ledger
      */
     public boolean isEntryLogPerLedgerEnabled() {
-        return this.getBoolean(ENTRY_LOG_PERLEDGER_ENABLED, false);
+        return this.getBoolean(ENTRY_LOG_PER_LEDGER_ENABLED, false);
     }
 
     /*
@@ -2652,7 +2652,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      *
      */
     public ServerConfiguration setEntryLogPerLedgerEnabled(boolean entryLogPerLedgerEnabled) {
-        this.setProperty(ENTRY_LOG_PERLEDGER_ENABLED, Boolean.toString(entryLogPerLedgerEnabled));
+        this.setProperty(ENTRY_LOG_PER_LEDGER_ENABLED, Boolean.toString(entryLogPerLedgerEnabled));
         return this;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -179,6 +179,11 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     // Stats
     protected static final String ENABLE_TASK_EXECUTION_STATS = "enableTaskExecutionStats";
 
+    /*
+     * config specifying if the entrylog per ledger is enabled or not.
+     */
+    protected static final String ENTRY_LOG_PERLEDGER_ENABLED = "entryLogPerLedgerEnabled";
+
     /**
      * Construct a default configuration object.
      */
@@ -2631,6 +2636,23 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
 
     @Override
     protected ServerConfiguration getThis() {
+        return this;
+    }
+
+    /*
+     * specifies if entryLog per ledger is enabled. If it is enabled, then there
+     * would be a active entrylog for each ledger
+     */
+    public boolean isEntryLogPerLedgerEnabled() {
+        return this.getBoolean(ENTRY_LOG_PERLEDGER_ENABLED, false);
+    }
+
+    /*
+     * enables/disables entrylog per ledger feature.
+     *
+     */
+    public ServerConfiguration setEntryLogPerLedgerEnabled(boolean entryLogPerLedgerEnabled) {
+        this.setProperty(ENTRY_LOG_PERLEDGER_ENABLED, Boolean.toString(entryLogPerLedgerEnabled));
         return this;
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
@@ -1,0 +1,573 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.bookkeeper.bookie.Journal.LastLogMark;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.test.PortManager;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * LedgerStorageCheckpointTest.
+ *
+ */
+public class LedgerStorageCheckpointTest extends BookKeeperClusterTestCase {
+    private static final Logger LOG = LoggerFactory
+            .getLogger(LedgerStorageCheckpointTest.class);
+
+    @Rule
+    public final TestName runtime = new TestName();
+
+    public LedgerStorageCheckpointTest() {
+        super(0);
+    }
+
+    private LogMark readLastMarkFile(File lastMarkFile) throws IOException {
+        byte buff[] = new byte[16];
+        ByteBuffer bb = ByteBuffer.wrap(buff);
+        LogMark rolledLogMark = new LogMark();
+        FileInputStream fis = new FileInputStream(lastMarkFile);
+        int bytesRead = fis.read(buff);
+        fis.close();
+        if (bytesRead != 16) {
+            throw new IOException("Couldn't read enough bytes from lastMark." + " Wanted " + 16 + ", got " + bytesRead);
+        }
+        bb.clear();
+        rolledLogMark.readLogMark(bb);
+        return rolledLogMark;
+    }
+
+    /*
+     * In this testcase, InterleavedLedgerStorage is used and validate if the
+     * checkpoint is called for every flushinterval period.
+     */
+    @Test
+    public void testPeriodicCheckpointForInterleavedLedgerStorage() throws Exception {
+        testPeriodicCheckpointForLedgerStorage(InterleavedLedgerStorage.class.getName());
+    }
+
+    /*
+     * In this testcase, SortedLedgerStorage is used and validate if the
+     * checkpoint is called for every flushinterval period.
+     */
+    @Test
+    public void testPeriodicCheckpointForSortedLedgerStorage() throws Exception {
+        testPeriodicCheckpointForLedgerStorage(SortedLedgerStorage.class.getName());
+    }
+
+    public void testPeriodicCheckpointForLedgerStorage(String ledgerStorageClassName) throws Exception {
+        File tmpDir = createTempDir("DiskCheck", "test");
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setZkTimeout(5000)
+                .setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setAutoRecoveryDaemonEnabled(false)
+                .setFlushInterval(2000)
+                .setBookiePort(PortManager.nextFreePort())
+                // entrylog per ledger is enabled
+                .setEntryLogPerLedgerEnabled(true)
+                .setLedgerStorageClass(ledgerStorageClassName);
+        Assert.assertEquals("Number of JournalDirs", 1, conf.getJournalDirs().length);
+        // we know there is only one ledgerDir
+        File ledgerDir = Bookie.getCurrentDirectories(conf.getLedgerDirs())[0];
+        BookieServer server = new BookieServer(conf);
+        server.start();
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        BookKeeper bkClient = new BookKeeper(clientConf);
+
+        int numOfLedgers = 2;
+        int numOfEntries = 5;
+        byte[] dataBytes = "data".getBytes();
+
+        for (int i = 0; i < numOfLedgers; i++) {
+            int ledgerIndex = i;
+            LedgerHandle handle = bkClient.createLedgerAdv((long) i, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(),
+                    null);
+            for (int j = 0; j < numOfEntries; j++) {
+                handle.addEntry(j, dataBytes);
+            }
+            handle.close();
+        }
+
+        LastLogMark lastLogMarkAfterFirstSetOfAdds = server.getBookie().journals.get(0).getLastLogMark();
+        LogMark curMarkAfterFirstSetOfAdds = lastLogMarkAfterFirstSetOfAdds.getCurMark();
+
+        File lastMarkFile = new File(ledgerDir, "lastMark");
+        // lastMark file should be zero, because checkpoint hasn't happenend
+        LogMark logMarkFileBeforeCheckpoint = readLastMarkFile(lastMarkFile);
+        Assert.assertEquals("lastMarkFile before checkpoint should be zero", 0,
+                logMarkFileBeforeCheckpoint.compare(new LogMark()));
+
+        // wait for flushInterval for SyncThread to do next iteration of checkpoint
+        Thread.sleep(conf.getFlushInterval() + 500);
+        /*
+         * since we have waited for more than flushInterval SyncThread should
+         * have checkpointed. if entrylogperledger is not enabled, then we
+         * checkpoint only when currentLog in EntryLogger is rotated. but if
+         * entrylogperledger is enabled, then we checkpoint for every
+         * flushInterval period
+         */
+        Assert.assertTrue("lastMark file must be existing, because checkpoint should have happened",
+                lastMarkFile.exists());
+
+        LastLogMark lastLogMarkAfterCheckpoint = server.getBookie().journals.get(0).getLastLogMark();
+        LogMark curMarkAfterCheckpoint = lastLogMarkAfterCheckpoint.getCurMark();
+
+        LogMark rolledLogMark = readLastMarkFile(lastMarkFile);
+        Assert.assertNotEquals("rolledLogMark should not be zero, since checkpoint has happenend", 0,
+                rolledLogMark.compare(new LogMark()));
+        /*
+         * Curmark should be equal before and after checkpoint, because we didnt
+         * add new entries during this period
+         */
+        Assert.assertTrue("Curmark should be equal before and after checkpoint",
+                curMarkAfterCheckpoint.compare(curMarkAfterFirstSetOfAdds) == 0);
+        /*
+         * Curmark after checkpoint should be equal to rolled logmark, because
+         * we checkpointed
+         */
+        Assert.assertTrue("Curmark after first set of adds should be equal to rolled logmark",
+                curMarkAfterCheckpoint.compare(rolledLogMark) == 0);
+
+        // add more ledger/entries
+        for (int i = numOfLedgers; i < 2 * numOfLedgers; i++) {
+            int ledgerIndex = i;
+            LedgerHandle handle = bkClient.createLedgerAdv((long) i, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(),
+                    null);
+            for (int j = 0; j < numOfEntries; j++) {
+                handle.addEntry(j, dataBytes);
+            }
+            handle.close();
+        }
+
+        // wait for flushInterval for SyncThread to do next iteration of checkpoint
+        Thread.sleep(conf.getFlushInterval() + 500);
+
+        LastLogMark lastLogMarkAfterSecondSetOfAdds = server.getBookie().journals.get(0).getLastLogMark();
+        LogMark curMarkAfterSecondSetOfAdds = lastLogMarkAfterSecondSetOfAdds.getCurMark();
+
+        rolledLogMark = readLastMarkFile(lastMarkFile);
+        /*
+         * Curmark after checkpoint should be equal to rolled logmark, because
+         * we checkpointed
+         */
+        Assert.assertTrue("Curmark after second set of adds should be equal to rolled logmark",
+                curMarkAfterSecondSetOfAdds.compare(rolledLogMark) == 0);
+
+        server.shutdown();
+        bkClient.close();
+    }
+
+    /*
+     * In this testcase, InterleavedLedgerStorage is used, entrylogperledger is
+     * enabled and validate that when entrylog is rotated it doesn't do
+     * checkpoint.
+     */
+    @Test
+    public void testCheckpointOfILSEntryLogIsRotatedWithELPLEnabled() throws Exception {
+        testCheckpointofILSWhenEntryLogIsRotated(true);
+    }
+
+    /*
+     * In this testcase, InterleavedLedgerStorage is used, entrylogperledger is
+     * not enabled and validate that when entrylog is rotated it does
+     * checkpoint.
+     */
+    @Test
+    public void testCheckpointOfILSEntryLogIsRotatedWithELPLDisabled() throws Exception {
+        testCheckpointofILSWhenEntryLogIsRotated(false);
+    }
+
+    public void testCheckpointofILSWhenEntryLogIsRotated(boolean entryLogPerLedgerEnabled) throws Exception {
+        File tmpDir = createTempDir("DiskCheck", "test");
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setZkTimeout(5000)
+                .setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setAutoRecoveryDaemonEnabled(false)
+                //set very high period for flushInterval
+                .setFlushInterval(30000)
+                .setBookiePort(PortManager.nextFreePort())
+                // entrylog per ledger is enabled
+                .setEntryLogPerLedgerEnabled(entryLogPerLedgerEnabled)
+                .setLedgerStorageClass(InterleavedLedgerStorage.class.getName());
+
+        Assert.assertEquals("Number of JournalDirs", 1, conf.getJournalDirs().length);
+        // we know there is only one ledgerDir
+        File ledgerDir = Bookie.getCurrentDirectories(conf.getLedgerDirs())[0];
+        BookieServer server = new BookieServer(conf);
+        server.start();
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        BookKeeper bkClient = new BookKeeper(clientConf);
+        InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) server.getBookie().ledgerStorage;
+
+        int numOfEntries = 5;
+        byte[] dataBytes = "data".getBytes();
+
+        long ledgerId = 10;
+        LedgerHandle handle = bkClient.createLedgerAdv(ledgerId, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(), null);
+        for (int j = 0; j < numOfEntries; j++) {
+            handle.addEntry(j, dataBytes);
+        }
+        handle.close();
+        // simulate rolling entrylog
+        ledgerStorage.entryLogger.rollLog();
+        // sleep for a bit for checkpoint to do its task
+        Thread.sleep(1000);
+
+        File lastMarkFile = new File(ledgerDir, "lastMark");
+        LogMark rolledLogMark = readLastMarkFile(lastMarkFile);
+        if (entryLogPerLedgerEnabled) {
+            Assert.assertEquals(
+                    "rolledLogMark should be zero, since checkpoint"
+                            + "shouldn't have happened when entryLog is rotated",
+                    0, rolledLogMark.compare(new LogMark()));
+        } else {
+            Assert.assertNotEquals("rolledLogMark shouldn't be zero, since checkpoint"
+                    + "should have happened when entryLog is rotated", 0, rolledLogMark.compare(new LogMark()));
+        }
+        bkClient.close();
+        server.shutdown();
+    }
+
+    /*
+     * In this testcase, SortedLedgerStorage is used, entrylogperledger is
+     * enabled and validate that when entrylog is rotated it doesn't do
+     * checkpoint.
+     */
+    @Test
+    public void testCheckpointOfSLSEntryLogIsRotatedWithELPLEnabled() throws Exception {
+        testCheckpointOfSLSWhenEntryLogIsRotated(true);
+    }
+
+    /*
+     * In this testcase, SortedLedgerStorage is used, entrylogperledger is
+     * not enabled and validate that when entrylog is rotated it does
+     * checkpoint.
+     */
+    @Test
+    public void testCheckpointOfSLSEntryLogIsRotatedWithELPLDisabled() throws Exception {
+        testCheckpointOfSLSWhenEntryLogIsRotated(false);
+    }
+
+    public void testCheckpointOfSLSWhenEntryLogIsRotated(boolean entryLogPerLedgerEnabled) throws Exception {
+        File tmpDir = createTempDir("DiskCheck", "test");
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setZkTimeout(5000)
+                .setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setAutoRecoveryDaemonEnabled(false)
+                //set very high period for flushInterval
+                .setFlushInterval(30000)
+                .setBookiePort(PortManager.nextFreePort())
+                // entrylog per ledger is enabled
+                .setEntryLogPerLedgerEnabled(entryLogPerLedgerEnabled)
+                .setLedgerStorageClass(SortedLedgerStorage.class.getName())
+                // set very low skipListSizeLimit and entryLogSizeLimit to simulate log file rotation
+                .setSkipListSizeLimit(1 * 1000 * 1000)
+                .setEntryLogSizeLimit(2 * 1000 * 1000);
+
+        Assert.assertEquals("Number of JournalDirs", 1, conf.getJournalDirs().length);
+        // we know there is only one ledgerDir
+        File ledgerDir = Bookie.getCurrentDirectories(conf.getLedgerDirs())[0];
+        BookieServer server = new BookieServer(conf);
+        server.start();
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        BookKeeper bkClient = new BookKeeper(clientConf);
+        InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) server.getBookie().ledgerStorage;
+
+        Random rand = new Random();
+        byte[] dataBytes = new byte[10 * 1000];
+        rand.nextBytes(dataBytes);
+        int numOfEntries = ((int) conf.getEntryLogSizeLimit() + (100 * 1000)) / dataBytes.length;
+
+        LedgerHandle handle = bkClient.createLedgerAdv(10, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(), null);
+        for (int j = 0; j < numOfEntries; j++) {
+            handle.addEntry(j, dataBytes);
+        }
+        handle.close();
+
+        // sleep for a bit for checkpoint to do its task
+        Thread.sleep(1000);
+
+        File lastMarkFile = new File(ledgerDir, "lastMark");
+        LogMark rolledLogMark = readLastMarkFile(lastMarkFile);
+        if (entryLogPerLedgerEnabled) {
+            Assert.assertEquals(
+                    "rolledLogMark should be zero, since checkpoint"
+                            + "shouldn't have happened when entryLog is rotated",
+                    0, rolledLogMark.compare(new LogMark()));
+        } else {
+            Assert.assertNotEquals("rolledLogMark shouldn't be zero, since checkpoint"
+                    + "should have happened when entryLog is rotated", 0, rolledLogMark.compare(new LogMark()));
+        }
+        bkClient.close();
+        server.shutdown();
+    }
+
+    /*
+     * in this method it checks if entryLogPerLedger is enabled, then
+     * InterLeavedLedgerStorage.checkpoint flushes current activelog and flushes
+     * all rotatedlogs and closes them.
+     *
+     */
+    @Test
+    public void testIfEntryLogPerLedgerEnabledCheckpointFlushesAllLogs() throws Exception {
+        File tmpDir = createTempDir("DiskCheck", "test");
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setZkTimeout(5000)
+                .setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setAutoRecoveryDaemonEnabled(false)
+                //set very high period for flushInterval
+                .setFlushInterval(30000)
+                .setBookiePort(PortManager.nextFreePort())
+                // entrylog per ledger is enabled
+                .setEntryLogPerLedgerEnabled(true)
+                .setLedgerStorageClass(InterleavedLedgerStorage.class.getName())
+                // set flushInterval to some very high number
+                .setFlushIntervalInBytes(10000000);
+
+        Assert.assertEquals("Number of JournalDirs", 1, conf.getJournalDirs().length);
+        // we know there is only one ledgerDir
+        File ledgerDir = Bookie.getCurrentDirectories(conf.getLedgerDirs())[0];
+        BookieServer server = new BookieServer(conf);
+        server.start();
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        BookKeeper bkClient = new BookKeeper(clientConf);
+        InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) server.getBookie().ledgerStorage;
+        EntryLogger entryLogger = ledgerStorage.entryLogger;
+
+        int numOfEntries = 5;
+        byte[] dataBytes = "data".getBytes();
+
+        long ledgerId = 10;
+        LedgerHandle handle = bkClient.createLedgerAdv(ledgerId, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(), null);
+        for (int j = 0; j < numOfEntries; j++) {
+            handle.addEntry(j, dataBytes);
+        }
+        handle.close();
+        // simulate rolling entrylog
+        ledgerStorage.entryLogger.rollLog();
+
+        ledgerId = 20;
+        handle = bkClient.createLedgerAdv(ledgerId, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(), null);
+        for (int j = 0; j < numOfEntries; j++) {
+            handle.addEntry(j, dataBytes);
+        }
+        handle.close();
+        // simulate rolling entrylog
+        ledgerStorage.entryLogger.rollLog();
+
+        ledgerId = 30;
+        handle = bkClient.createLedgerAdv(ledgerId, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(), null);
+        for (int j = 0; j < numOfEntries; j++) {
+            handle.addEntry(j, dataBytes);
+        }
+        handle.close();
+
+        Assert.assertNotEquals("bytesWrittenSinceLastFlush shouldn't be zero", 0,
+                entryLogger.bytesWrittenSinceLastFlush);
+        Assert.assertNotEquals("There should be logChannelsToFlush", 0, entryLogger.logChannelsToFlush.size());
+
+        ledgerStorage.checkpoint(ledgerStorage.checkpointSource.newCheckpoint());
+
+        Assert.assertTrue("There shouldn't be logChannelsToFlush",
+                ((entryLogger.logChannelsToFlush == null) || (entryLogger.logChannelsToFlush.size() == 0)));
+
+        Assert.assertEquals("bytesWrittenSinceLastFlush should be zero", 0, entryLogger.bytesWrittenSinceLastFlush);
+    }
+
+    static class MockInterleavedLedgerStorage extends InterleavedLedgerStorage {
+        @Override
+        public void shutdown() {
+            // During BookieServer shutdown this method will be called
+            // and we want it to be noop.
+            // do nothing
+        }
+
+        @Override
+        public synchronized void flush() throws IOException {
+            // this method will be called by SyncThread.shutdown.
+            // During BookieServer shutdown we want this method to be noop
+            // do nothing
+        }
+    }
+
+    /*
+     * This is complete end-to-end scenario.
+     *
+     * 1) This testcase uses MockInterleavedLedgerStorage, which extends
+     * InterleavedLedgerStorage but doesn't do anything when Bookie is shutdown.
+     * This is needed to simulate Bookie crash.
+     * 2) entryLogPerLedger is enabled
+     * 3) ledgers are created and entries are added.
+     * 4) wait for flushInterval period for checkpoint to complete
+     * 6) delete the journal files and lastmark file
+     * 7) Now restart the Bookie
+     * 8) validate that the entries which were written can be read successfully.
+     */
+    @Test
+    public void testCheckPointForEntryLoggerWithMultipleActiveEntryLogs() throws Exception {
+        File tmpDir = createTempDir("DiskCheck", "test");
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setZkTimeout(5000)
+                .setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setAutoRecoveryDaemonEnabled(false)
+                .setFlushInterval(3000)
+                .setBookiePort(PortManager.nextFreePort())
+                // entrylog per ledger is enabled
+                .setEntryLogPerLedgerEnabled(true)
+                .setLedgerStorageClass(MockInterleavedLedgerStorage.class.getName());
+        Assert.assertEquals("Number of JournalDirs", 1, conf.getJournalDirs().length);
+        // we know there is only one ledgerDir
+        File ledgerDir = Bookie.getCurrentDirectories(conf.getLedgerDirs())[0];
+        BookieServer server = new BookieServer(conf);
+        server.start();
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        BookKeeper bkClient = new BookKeeper(clientConf);
+
+        ExecutorService threadPool = Executors.newFixedThreadPool(30);
+        int numOfLedgers = 12;
+        int numOfEntries = 100;
+        byte[] dataBytes = "data".getBytes();
+        LedgerHandle[] handles = new LedgerHandle[numOfLedgers];
+        AtomicBoolean receivedExceptionForAdd = new AtomicBoolean(false);
+        CountDownLatch countDownLatch = new CountDownLatch(numOfLedgers * numOfEntries);
+        for (int i = 0; i < numOfLedgers; i++) {
+            int ledgerIndex = i;
+            handles[i] = bkClient.createLedgerAdv((long) i, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(), null);
+            for (int j = 0; j < numOfEntries; j++) {
+                int entryIndex = j;
+                threadPool.submit(() -> {
+                    try {
+                        handles[ledgerIndex].addEntry(entryIndex, dataBytes);
+                    } catch (Exception e) {
+                        LOG.error("Got Exception while trying to addEntry for ledgerId: " + ledgerIndex + " entry: "
+                                + entryIndex, e);
+                        receivedExceptionForAdd.set(true);
+                    } finally {
+                        countDownLatch.countDown();
+                    }
+                });
+            }
+        }
+        Assert.assertTrue("It is expected add requests are supposed to be completed in 20000 secs",
+                countDownLatch.await(20000, TimeUnit.MILLISECONDS));
+        Assert.assertFalse("there shouldn't be any exceptions for addentry requests", receivedExceptionForAdd.get());
+        for (int i = 0; i < numOfLedgers; i++) {
+            handles[i].close();
+        }
+        threadPool.shutdown();
+
+        LastLogMark lastLogMarkBeforeCheckpoint = server.getBookie().journals.get(0).getLastLogMark();
+        LogMark curMarkBeforeCheckpoint = lastLogMarkBeforeCheckpoint.getCurMark();
+
+        Thread.sleep(conf.getFlushInterval() + 1000);
+        // since we have waited for more than flushInterval SyncThread should have checkpointed.
+        // if entrylogperledger is not enabled, then we checkpoint only when currentLog in EntryLogger
+        // is rotated. but if entrylogperledger is enabled, then we checkpoint for every flushInterval period
+        File lastMarkFile = new File(ledgerDir, "lastMark");
+        Assert.assertTrue("lastMark file must be existing, because checkpoint should have happened",
+                lastMarkFile.exists());
+
+        bkClient.close();
+        // here we are calling shutdown, but MockInterleavedLedgerStorage shudown/flush
+        // methods are noop, so entrylogger is not flushed as part of this shutdown
+        // here we are trying to simulate Bookie crash, but there is no way to
+        // simulate bookie abrupt crash
+        server.shutdown();
+
+        // delete journal files and lastMark, to make sure that we are not reading from
+        // Journal file
+        File journalDirectory = Bookie.getCurrentDirectory(conf.getJournalDirs()[0]);
+        List<Long> journalLogsId = Journal.listJournalIds(journalDirectory, null);
+        for (long journalId : journalLogsId) {
+            File journalFile = new File(journalDirectory, Long.toHexString(journalId) + ".txn");
+            journalFile.delete();
+        }
+
+        // we know there is only one ledgerDir
+        lastMarkFile = new File(ledgerDir, "lastMark");
+        lastMarkFile.delete();
+
+        // now we are restarting BookieServer
+        server = new BookieServer(conf);
+        server.start();
+        bkClient = new BookKeeper(clientConf);
+        // since Bookie checkpointed successfully before shutdown/crash,
+        // we should be able to read from entryLogs though journal is deleted
+        for (int i = 0; i < numOfLedgers; i++) {
+            LedgerHandle lh = bkClient.openLedger(i, DigestType.CRC32, "passwd".getBytes());
+            Enumeration<LedgerEntry> entries = lh.readEntries(0, numOfEntries - 1);
+            while (entries.hasMoreElements()) {
+                LedgerEntry entry = entries.nextElement();
+                byte[] readData = entry.getEntry();
+                Assert.assertEquals("Ledger Entry Data should match", new String("data".getBytes()),
+                        new String(readData));
+            }
+        }
+        bkClient.close();
+        server.shutdown();
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
@@ -374,13 +374,13 @@ public class LedgerStorageCheckpointTest extends BookKeeperClusterTestCase {
                 .setJournalDirName(tmpDir.getPath())
                 .setLedgerDirNames(new String[] { tmpDir.getPath() })
                 .setAutoRecoveryDaemonEnabled(false)
-                //set very high period for flushInterval
-                .setFlushInterval(30000)
+                //set flushInterval
+                .setFlushInterval(3000)
                 .setBookiePort(PortManager.nextFreePort())
                 // entrylog per ledger is enabled
                 .setEntryLogPerLedgerEnabled(true)
                 .setLedgerStorageClass(InterleavedLedgerStorage.class.getName())
-                // set flushInterval to some very high number
+                // set setFlushIntervalInBytes to some very high number
                 .setFlushIntervalInBytes(10000000);
 
         Assert.assertEquals("Number of JournalDirs", 1, conf.getJournalDirs().length);
@@ -426,8 +426,15 @@ public class LedgerStorageCheckpointTest extends BookKeeperClusterTestCase {
                 entryLogger.bytesWrittenSinceLastFlush);
         Assert.assertNotEquals("There should be logChannelsToFlush", 0, entryLogger.logChannelsToFlush.size());
 
-        ledgerStorage.checkpoint(ledgerStorage.checkpointSource.newCheckpoint());
+        /*
+         * wait for atleast flushInterval period, so that checkpoint can happen.
+         */
+        Thread.sleep(conf.getFlushInterval() + 500);
 
+        /*
+         * since checkpoint happenend, there shouldn't be any logChannelsToFlush
+         * and bytesWrittenSinceLastFlush should be zero.
+         */
         Assert.assertTrue("There shouldn't be logChannelsToFlush",
                 ((entryLogger.logChannelsToFlush == null) || (entryLogger.logChannelsToFlush.size() == 0)));
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -110,15 +110,27 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
         // initial checkpoint
 
         this.storage = new SortedLedgerStorage();
-        this.checkpointer = checkpoint -> storage.getScheduler().submit(() -> {
-            log.info("Checkpoint the storage at {}", checkpoint);
-            try {
-                storage.checkpoint(checkpoint);
-                checkpoints.add(checkpoint);
-            } catch (IOException e) {
-                log.error("Failed to checkpoint at {}", checkpoint, e);
+        this.checkpointer = new Checkpointer() {
+            @Override
+            public void startCheckpoint(Checkpoint checkpoint) {
+                // TODO Auto-generated method stub
+                storage.getScheduler().submit(() -> {
+                    log.info("Checkpoint the storage at {}", checkpoint);
+                    try {
+                        storage.checkpoint(checkpoint);
+                        checkpoints.add(checkpoint);
+                    } catch (IOException e) {
+                        log.error("Failed to checkpoint at {}", checkpoint, e);
+                    }
+                });
             }
-        });
+
+            @Override
+            public void start() {
+                // no-op
+            }
+        };
+
         // if the SortedLedgerStorage need not to change bookie's state, pass StateManager==null is ok
         this.storage.initialize(
             conf,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -113,7 +113,6 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
         this.checkpointer = new Checkpointer() {
             @Override
             public void startCheckpoint(Checkpoint checkpoint) {
-                // TODO Auto-generated method stub
                 storage.getScheduler().submit(() -> {
                     log.info("Checkpoint the storage at {}", checkpoint);
                     try {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionRollbackTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionRollbackTest.java
@@ -70,6 +70,11 @@ public class ConversionRollbackTest {
         public void startCheckpoint(Checkpoint checkpoint) {
             // No-op
         }
+
+        @Override
+        public void start() {
+            // no-op
+        }
     };
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionTest.java
@@ -67,6 +67,11 @@ public class ConversionTest {
         public void startCheckpoint(Checkpoint checkpoint) {
             // No-op
         }
+
+        @Override
+        public void start() {
+            // no-op
+        }
     };
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildTest.java
@@ -67,6 +67,11 @@ public class LocationsIndexRebuildTest {
         public void startCheckpoint(Checkpoint checkpoint) {
             // No-op
         }
+
+        @Override
+        public void start() {
+            // no-op
+        }
     };
 
     @Test

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -75,15 +75,20 @@ journalDirectory=/tmp/bk-txn
 # Interval to watch whether bookie is dead or not, in milliseconds
 # bookieDeathWatchInterval=1000
 
-# How long the interval to flush ledger index pages to disk, in milliseconds
-# Flushing index files will introduce much random disk I/O.
+# When entryLogPerLedgerEnabled is enabled, checkpoint doesn't happens
+# when a new active entrylog is created / previous one is rolled over.
+# Instead SyncThread checkpoints periodically with 'flushInterval' delay
+# (in milliseconds) in between executions. Checkpoint flushes both ledger 
+# entryLogs and ledger index pages to disk. 
+# Flushing entrylog and index files will introduce much random disk I/O.
 # If separating journal dir and ledger dirs each on different devices,
 # flushing would not affect performance. But if putting journal dir
 # and ledger dirs on same device, performance degrade significantly
 # on too frequent flushing. You can consider increment flush interval
 # to get better performance, but you need to pay more time on bookie
 # server restart after failure.
-# flushInterval=100
+# This config is used only when entryLogPerLedgerEnabled is enabled.
+# flushInterval=10000
 
 # Allow the expansion of bookie storage capacity. Newly added ledger
 # and index dirs must be empty.
@@ -434,6 +439,12 @@ ledgerManagerFactoryClass=org.apache.bookkeeper.meta.HierarchicalLedgerManagerFa
 
 # The number of bytes used as capacity for the write buffer. Default is 64KB.
 # writeBufferSizeBytes=65536
+
+# Specifies if entryLog per ledger is enabled/disabled. If it is enabled, then there would be a 
+# active entrylog for each ledger. It would be ideal to enable this feature if the underlying 
+# storage device has multiple DiskPartitions or SSD and if in a given moment, entries of fewer 
+# number of active ledgers are written to a bookie.
+# entryLogPerLedgerEnabled=false
 
 #############################################################################
 ## Entry log compaction settings

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -43,8 +43,8 @@ groups:
     description: Interval to watch whether bookie is dead or not, in milliseconds.
     default: 1000
   - param: flushInterval
-    description: How long the interval to flush ledger index pages to disk, in milliseconds. Flushing index files will introduce much random disk I/O. If separating journal dir and ledger dirs each on different devices, flushing would not affect performance. But if putting journal dir and ledger dirs on same device, performance degrade significantly on too frequent flushing. You can consider increment flush interval to get better performance, but you need to pay more time on bookie server restart after failure.
-    default: 100
+    description: When entryLogPerLedgerEnabled is enabled, checkpoint doesn't happens when a new active entrylog is created / previous one is rolled over. Instead SyncThread checkpoints periodically with 'flushInterval' delay (in milliseconds) in between executions. Checkpoint flushes both ledger entryLogs and ledger index pages to disk.  Flushing entrylog and index files will introduce much random disk I/O. If separating journal dir and ledger dirs each on different devices, flushing would not affect performance. But if putting journal dir and ledger dirs on same device, performance degrade significantly on too frequent flushing. You can consider increment flush interval to get better performance, but you need to pay more time on bookie server restart after failure. This config is used only when entryLogPerLedgerEnabled is enabled.
+    default: 10000
   - param: allowStorageExpansion
     description: Allow the expansion of bookie storage capacity. Newly added ledger and index directories must be empty.
     default: 'false'
@@ -300,6 +300,9 @@ groups:
   - param: writeBufferSizeBytes
     description: The number of bytes used as capacity for the write buffer.
     default: 65536
+  - param: entryLogPerLedgerEnabled
+    description: Specifies if entryLog per ledger is enabled/disabled. If it is enabled, then there would be a active entrylog for each ledger. It would be ideal to enable this feature if the underlying storage device has multiple DiskPartitions or SSD and if in a given moment, entries of fewer number of active ledgers are written to the bookie.
+    default: false
 
 - name: Entry log compaction settings
   params:


### PR DESCRIPTION
Descriptions of the changes in this PR:

make changes to SyncThread/checkpoint logic, so that incase of
entrylogperledger, checkpoint happens for every flushInterval
but not when active entrylog is created/rolled over.

This is < sub-task3  > of Issue #570

Master Issue: #570 
