### PR TITLE
Fixed Journal static empty array list recycling

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/RecyclableArrayList.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/RecyclableArrayList.java
@@ -45,6 +45,14 @@ public final class RecyclableArrayList<T> extends ArrayList<T> {
 
     private final Handle<RecyclableArrayList<T>> handle;
 
+    /**
+     * Default non-pooled instance.
+     */
+    public RecyclableArrayList() {
+        super();
+        this.handle = null;
+    }
+
     private RecyclableArrayList(Handle<RecyclableArrayList<T>> handle, int initialCapacity) {
         super(initialCapacity);
         this.handle = handle;
@@ -52,6 +60,8 @@ public final class RecyclableArrayList<T> extends ArrayList<T> {
 
     public void recycle() {
         clear();
-        handle.recycle(this);
+        if (handle != null) {
+            handle.recycle(this);
+        }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -66,7 +66,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
     private static final RecyclableArrayList.Recycler<QueueEntry> entryListRecycler =
         new RecyclableArrayList.Recycler<QueueEntry>();
-    private static final RecyclableArrayList<QueueEntry> EMPTY_ARRAY_LIST = entryListRecycler.newInstance();
+    private static final RecyclableArrayList<QueueEntry> EMPTY_ARRAY_LIST = new RecyclableArrayList<>();
 
     /**
      * Filter to pickup journals.


### PR DESCRIPTION
When `journalSyncData=false`, we passing `EMPTY_ARRAY_LIST` to the `ForceWriteThread` when the journal is rolled over. 


I have seen this exception:

```
18:39:52.285 [ForceWriteThread] ERROR org.apache.bookkeeper.bookie.BookieCriticalThread - Uncaught exception in thread ForceWriteThread and is exiting!
java.lang.NullPointerException: null
	at io.netty.util.Recycler$DefaultHandle.recycle(Recycler.java:219) ~[io.netty-netty-all-4.1.21.Final.jar:4.1.21.Final]
	at org.apache.bookkeeper.common.collections.RecyclableArrayList.recycle(RecyclableArrayList.java:55) ~[org.apache.bookkeeper-bookkeeper-server-shaded-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at org.apache.bookkeeper.bookie.Journal$ForceWriteRequest.recycle(Journal.java:402) ~[org.apache.bookkeeper-bookkeeper-server-shaded-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at org.apache.bookkeeper.bookie.Journal$ForceWriteRequest.access$1(Journal.java:399) ~[org.apache.bookkeeper-bookkeeper-server-shaded-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at org.apache.bookkeeper.bookie.Journal$ForceWriteThread.run(Journal.java:506) ~[org.apache.bookkeeper-bookkeeper-server-shaded-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
```

This is due to calling `recycle()` twice on the same `EMPTY_ARRAY_LIST`  instance. The solution is that `EMPTY_ARRAY_LIST` should not be a pooled instance and we should check that before recycling.