### PR TITLE
Fixed Journal stats names

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -685,7 +685,7 @@ public class Bookie extends BookieCriticalThread {
         journals = Lists.newArrayList();
         for (int i = 0; i < journalDirectories.size(); i++) {
             journals.add(new Journal(journalDirectories.get(i),
-                         conf, ledgerDirsManager, statsLogger.scope(JOURNAL_SCOPE + "_" + i)));
+                         conf, ledgerDirsManager, statsLogger.scope(JOURNAL_SCOPE)));
         }
 
         CheckpointSource checkpointSource = new CheckpointSourceList(journals);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
@@ -114,9 +114,9 @@ public class OpStatTest extends BookKeeperClusterTestCase {
             assertTrue(average <= elapsed);
         });
         validateNonMonotonicCounterGauges(stats, new String[]{
-                BOOKIE_SCOPE + "." + JOURNAL_SCOPE + "_0." + JOURNAL_CB_QUEUE_SIZE,
-                BOOKIE_SCOPE + "." + JOURNAL_SCOPE + "_0." + JOURNAL_FORCE_WRITE_QUEUE_SIZE,
-                BOOKIE_SCOPE + "." + JOURNAL_SCOPE + "_0." + JOURNAL_QUEUE_SIZE
+                BOOKIE_SCOPE + "." + JOURNAL_SCOPE + "." + JOURNAL_CB_QUEUE_SIZE,
+                BOOKIE_SCOPE + "." + JOURNAL_SCOPE + "." + JOURNAL_FORCE_WRITE_QUEUE_SIZE,
+                BOOKIE_SCOPE + "." + JOURNAL_SCOPE + "." + JOURNAL_QUEUE_SIZE
         }, (value, max) -> {
             assertTrue(max > 0);
         });


### PR DESCRIPTION
In `BOOKKEEPER-1009: Use multiple journals in bookie` 123eccd435a4a96a9147ed4a24efbe9025fe79ba there was a change in the metrics name that would be affecting also user not running with multiple journal.

It is a bit inconvenient to aggregate the stats in the metrics collector (how to aggregate 99pct latency for example). 

I think the best option is to have a single metric even when using multiple journal threads.