### PR TITLE
Set `ENABLE_DIGEST_TYPE_AUTODETECTION` to true as default value

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -239,10 +239,12 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
      * <p>Ignores provided digestType, if enabled and uses one from ledger metadata instead.
      * Incompatible with ledger created by bookie versions < 4.2
      *
+     * <p>It is turned on by default since 4.7.
+     *
      * @return flag to enable/disable autodetection of digest type.
      */
     public boolean getEnableDigestTypeAutodetection() {
-        return getBoolean(ENABLE_DIGEST_TYPE_AUTODETECTION, false);
+        return getBoolean(ENABLE_DIGEST_TYPE_AUTODETECTION, true);
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

We have recorded digest type in the ledger metadata since BK 4.5. it would be great to let client automatically detect the digest type
on opening ledger. So turn on the autodetection feature by default.

*Result*

digest type autodetection is on by default.
