### PR TITLE
Make it possible to build site on ubuntu and debian

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.4.1'
+ruby '>=2.3.1'
 
 gem 'jekyll', '3.7.0'
 gem 'nokogiri'

--- a/site/Makefile
+++ b/site/Makefile
@@ -10,7 +10,7 @@ clean:
 	rm -rf _site local-generated generated_site
 
 setup:
-	gem install bundler \
+	gem install --user-install bundler \
 		--no-rdoc \
 		--no-ri
 	NOKOGIRI_USE_SYSTEM_LIBRARIES=true $(BUNDLE) install \

--- a/site/README.md
+++ b/site/README.md
@@ -12,7 +12,7 @@ The site is built using Jekyll and Sass.
 
 In order to run the site locally, you need to have the following installed:
 
-* Ruby 2.4.1 and Rubygems
+* Ruby 2.3.1 and Rubygems
 * The Javadoc CLI tool
 
 ## Setup


### PR DESCRIPTION
Xenial ships with ruby 2.3.1. Debian Stretch ships 2.3.3. The current
Gemfile asks for 2.4.1. This patch drops the requirement to >=2.3.1.

It also make it possible to test the site without sudo.
