### PR TITLE
Replaced synchronized with volatile read in BookieStatus

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStatus.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStatus.java
@@ -52,7 +52,7 @@ public class BookieStatus {
 
     private int layoutVersion;
     private long lastUpdateTime;
-    private BookieMode bookieMode;
+    private volatile BookieMode bookieMode;
 
 
     BookieStatus() {
@@ -61,11 +61,11 @@ public class BookieStatus {
         this.lastUpdateTime = INVALID_UPDATE_TIME;
     }
 
-    private synchronized BookieMode getBookieMode() {
+    private BookieMode getBookieMode() {
         return bookieMode;
     }
 
-    public synchronized boolean isInWritable() {
+    public boolean isInWritable() {
         return bookieMode.equals(BookieMode.READ_WRITE);
     }
 
@@ -78,7 +78,7 @@ public class BookieStatus {
         return false;
     }
 
-    synchronized boolean isInReadOnlyMode() {
+    boolean isInReadOnlyMode() {
         return bookieMode.equals(BookieMode.READ_ONLY);
     }
 


### PR DESCRIPTION
`BookieStatus.isInReadOnlyMode()` is being called from IO threads at each write request. 

Having `synchronized` method is a major source of contention between all these threads and caps the throughput and increases the latency. 

Replacing here with a `volatile` variable read. This will have the same exact behavior as today while removing the contention point. 

I think we could eventually even do a "dirty" read of that variable to further reduce the overhead of the volatile read.