### PR TITLE
Issue 881: use initialize insteadof format in docker image

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -72,7 +72,7 @@ run-bk:
 			$(BK_LOCAL_CONTAINER_DATA_DIR)/journal \
 			$(BK_LOCAL_CONTAINER_DATA_DIR)/ledger \
 			$(BK_LOCAL_CONTAINER_DATA_DIR)/index
-	
+
 	-docker rm -f $(CONTAINER_NAME)
 	docker run -it\
 		--network $(DOCKER_NETWORK) \
@@ -88,15 +88,28 @@ run-bk:
 
 # -------------------------------- #
 
-# Create run and destroy a container that will format zookeeper metadata
-#   make run-format
+# Create run and destroy a container that will
+# intializes new bookkeeper cluster by creating required znodes for the cluster
+#   make run-init
 
-run-format:
+run-init:
 	docker run -it --rm \
 		--network $(DOCKER_NETWORK) \
 		--env BK_zkServers=$(ZK_CONTAINER_NAME):2181 \
 		$(IMAGE) \
-		bookkeeper shell metaformat $(FORMAT_OPTS)
+		bookkeeper shell initnewcluster
+
+# -------------------------------- #
+
+# Create run and destroy a container that will nuke bookkeeper metadata of existing cluster in zookeeper
+#   make run-nuke
+
+run-nuke:
+	docker run -it --rm \
+		--network $(DOCKER_NETWORK) \
+		--env BK_zkServers=$(ZK_CONTAINER_NAME):2181 \
+		$(IMAGE) \
+		bookkeeper shell nukeexistingcluster -zkledgersrootpath $(BK_zkLedgersRootPath) -f
 
 # -------------------------------- #
 
@@ -176,7 +189,7 @@ root-shell root-exec:
 # -------------------------------- #
 
 info ip:
-	@echo 
+	@echo
 	@echo "Image: $(IMAGE)"
 	@echo "Container name: $(CONTAINER_NAME)"
 	@echo

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -47,7 +47,9 @@ mkdir -p "${BK_journalDirectory}" "${BK_ledgerDirectories}" "${BK_indexDirectori
 # -------------- #
 # Allow the container to be started with `--user`
 if [ "$1" = '/opt/bookkeeper/bin/bookkeeper' -a "$(id -u)" = '0' ]; then
+    echo "This is root, will use user $BK_USER to run it"
     chown -R "$BK_USER:$BK_USER" "/opt/bookkeeper/" "${BK_journalDirectory}" "${BK_ledgerDirectories}" "${BK_indexDirectories}"
+    chmod -R +x "/opt/bookkeeper/"
     sudo -s -E -u "$BK_USER" /bin/bash "$0" "$@"
     exit
 fi
@@ -61,11 +63,50 @@ until /opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server 
 echo "create the zk root dir for bookkeeper"
 /opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server ${BK_zkServers} create ${BK_CLUSTER_ROOT_PATH}
 
-echo "format zk metadata"
-echo "please ignore the failure, if it has already been formatted, "
 export BOOKIE_CONF=/opt/bookkeeper/conf/bk_server.conf
 export SERVICE_PORT=$PORT0
-/opt/bookkeeper/bin/bookkeeper shell metaformat -n || true
+
+# Init the cluster if required znodes not exist in Zookeeper.
+# Use ephemeral zk node as lock to keep initialize atomic.
+/opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server ${BK_zkServers} stat ${BK_zkLedgersRootPath}/available/readonly
+if [ $? -eq 0 ]; then
+    echo "Metadata of cluster already exists, no need format"
+else
+    # create ephemeral zk node bkInitLock, initiator who this node, then do init; other initiators will wait.
+    /opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server ${BK_zkServers} create -e ${BK_CLUSTER_ROOT_PATH}/bkInitLock
+    if [ $? -eq 0 ]; then
+        # bkInitLock created success, this is the successor to do znode init
+        echo "Bookkeeper znodes not exist in Zookeeper, do the init to create them."
+        /opt/bookkeeper/bin/bookkeeper shell initnewcluster
+        if [ $? -eq 0 ]; then
+            echo "Bookkeeper znodes init success."
+        else
+            echo "Bookkeeper znodes init failed. please check the reason."
+            exit
+        fi
+    else
+        echo "Other docker instance is doing initialize at the same time, will wait in this instance."
+        tenSeconds=1
+        while [ ${tenSeconds} -lt 10 ]
+        do
+            sleep 10
+            /opt/bookkeeper/bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server ${BK_zkServers} stat ${BK_zkLedgersRootPath}/available/readonly
+            if [ $? -eq 0 ]; then
+                echo "Waited $tenSeconds * 10 seconds, bookkeeper inited"
+                break
+            else
+                echo "Waited $tenSeconds * 10 seconds, still not init"
+                (( tenSeconds++ ))
+                continue
+            fi
+        done
+
+        if [ ${tenSeconds} -eq 10 ]; then
+            echo "Waited 100 seconds for bookkeeper cluster init, something wrong, please check"
+            exit
+        fi
+    fi
+fi
 
 echo "run command by exec"
 exec "$@"


### PR DESCRIPTION
Descriptions of the changes in this PR:

Currently docker image uses format during startup to initialize the cluster. It would be good to separate initialize from format. The initialize command should only create znodes for brand new environment. It should not involve any logic on reformatting.

- use initialize insteadof format in docker image.
- make initialize an atomic operation.
- add initialize and nuke command in makefile.
- fix error for non root user running.

This PR tested by local build, since 4.7 is not released, will bump bk version in Dockerfile once 4.7 released.

Master Issue: #881

