### PR TITLE
Refactored LAC cache in DbLedgerStorage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -52,6 +52,10 @@ public class ConcurrentLongHashMap<V> {
     private static final int DefaultExpectedItems = 256;
     private static final int DefaultConcurrencyLevel = 16;
 
+    public static interface LongObjectPredicate<V> {
+        boolean test(long key, V value);
+    }
+
     private final Section<V>[] sections;
 
     public ConcurrentLongHashMap() {
@@ -147,6 +151,17 @@ public class ConcurrentLongHashMap<V> {
         checkNotNull(value);
         long h = hash(key);
         return getSection(h).remove(key, value, (int) h) != null;
+    }
+
+    public int removeIf(LongObjectPredicate<V> predicate) {
+        checkNotNull(predicate);
+
+        int removedCount = 0;
+        for (Section<V> s : sections) {
+            removedCount += s.removeIf(predicate);
+        }
+
+        return removedCount;
     }
 
     private Section<V> getSection(long hash) {
@@ -370,6 +385,40 @@ public class ConcurrentLongHashMap<V> {
                     ++bucket;
                 }
 
+            } finally {
+                unlockWrite(stamp);
+            }
+        }
+
+        int removeIf(LongObjectPredicate<V> filter) {
+            long stamp = writeLock();
+
+            int removedCount = 0;
+            try {
+                // Go through all the buckets for this section
+                int capacity = this.capacity;
+                for (int bucket = 0; bucket < capacity; bucket++) {
+                    long storedKey = keys[bucket];
+                    V storedValue = values[bucket];
+
+                    if (storedValue != EmptyValue && storedValue != DeletedValue) {
+                        if (filter.test(storedKey, storedValue)) {
+                            // Removing item
+                            --size;
+                            ++removedCount;
+
+                            V nextValueInArray = values[signSafeMod(bucket + 1, capacity)];
+                            if (nextValueInArray == EmptyValue) {
+                                values[bucket] = (V) EmptyValue;
+                                --usedBuckets;
+                            } else {
+                                values[bucket] = (V) DeletedValue;
+                            }
+                        }
+                    }
+                }
+
+                return removedCount;
             } finally {
                 unlockWrite(stamp);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -57,7 +57,7 @@ public class ConcurrentLongHashMap<V> {
      *
      * @param <V>
      */
-    public static interface LongObjectPredicate<V> {
+    public interface LongObjectPredicate<V> {
         boolean test(long key, V value);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -52,6 +52,11 @@ public class ConcurrentLongHashMap<V> {
     private static final int DefaultExpectedItems = 256;
     private static final int DefaultConcurrencyLevel = 16;
 
+    /**
+     * Predicate specialization for (long, V) types.
+     *
+     * @param <V>
+     */
     public static interface LongObjectPredicate<V> {
         boolean test(long key, V value);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMapTest.java
@@ -117,6 +117,23 @@ public class ConcurrentLongHashMapTest {
     }
 
     @Test
+    public void testRemoveIf() {
+        ConcurrentLongHashMap<String> map = new ConcurrentLongHashMap<>(16, 1);
+
+        map.put(1L, "one");
+        map.put(2L, "two");
+        map.put(3L, "three");
+        map.put(4L, "four");
+
+        map.removeIf((k, v) -> k < 3);
+        assertFalse(map.containsKey(1L));
+        assertFalse(map.containsKey(2L));
+        assertTrue(map.containsKey(3L));
+        assertTrue(map.containsKey(4L));
+        assertEquals(2, map.size());
+    }
+
+    @Test
     public void testNegativeUsedBucketCount() {
         ConcurrentLongHashMap<String> map = new ConcurrentLongHashMap<>(16, 1);
 


### PR DESCRIPTION
The `TransientLedgerInfo` cache that holds the LAC (or explicit lac) for all ledgers has showed up in the profiler as a big contention point. 

### Modifications 

 * Only add an item in `TransientLedgerInfo` is someone has asked for LAC or has set explicity LAC. This will save lot of memory if many ledger are not requiring the LAC info.
 * Use `ConcurrentLongHashMap` to store the `TransientLedgerInfo`. There are few advantages: 
   - Key in the map is `long` and doesn't need boxing
   - The `get()` operation uses a stamped lock which is ideal in cases the number of `get()` is way bigger than `put()` operations, since it only needs a volatile variable read. In this case the map is only updated when new ledgers are added / removed, but we do a `get()` on each `addEntry()` operation.
  - Schedule periodical cleanup of the map for stale ledger info entries