### PR TITLE
Fixed buffer release in v2 BookieProtocol

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.ReferenceCountUtil;
 
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
 import org.apache.bookkeeper.util.ByteBufList;
@@ -275,10 +276,6 @@ public interface BookieProtocol {
             return (flags & FLAG_RECOVERY_ADD) == FLAG_RECOVERY_ADD;
         }
 
-        void release() {
-            data.release();
-        }
-
         private final Handle<AddRequest> recyclerHandle;
         private AddRequest(Handle<AddRequest> recyclerHandle) {
             this.recyclerHandle = recyclerHandle;
@@ -295,6 +292,7 @@ public interface BookieProtocol {
             ledgerId = -1;
             entryId = -1;
             masterKey = null;
+            ReferenceCountUtil.safeRelease(data);
             data = null;
             recyclerHandle.recycle(this);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1138,6 +1138,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         @Override
         public void safeRun() {
             completionValue.handleV2Response(ledgerId, entryId, status, response);
+            response.release();
             response.recycle();
             recycle();
         }


### PR DESCRIPTION
There was a buffers leak when using V2 bookie protocol. This was introduced with the refactoring and the merges from yahoo branch. 

Note: this was only happening when selecting  v2 protocol in client configuration.

The current code was missing a release in both the add and read entries path. I've been running it for some time and the ref-counting seems correct after the fix.