### PR TITLE
Close bookkeeper client used in format

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1160,8 +1160,9 @@ public class BookKeeperAdmin implements AutoCloseable {
                     return false;
                 }
 
-                BookKeeper bkc = new BookKeeper(new ClientConfiguration(conf));
-                bkc.ledgerManagerFactory.format(conf, bkc.getMetadataClientDriver().getLayoutManager());
+                try (BookKeeper bkc = new BookKeeper(new ClientConfiguration(conf))) {
+                    bkc.ledgerManagerFactory.format(conf, bkc.getMetadataClientDriver().getLayoutManager());
+                }
 
                 return rm.format();
             } catch (Exception e) {


### PR DESCRIPTION
Otherwise, the executors threads could keep the process calling it
alive. This isn't a problem for BookieShell, since it does a System.exit,
but it currently is for pulsar metadata cluster format.
