### PR TITLE
Improve `BookKeeperAdmin#format` to avoid constructing redundant resources

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -21,6 +21,7 @@
 package org.apache.bookkeeper.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithMetadataBookieDriver;
 import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithRegistrationManager;
 
 import com.google.common.collect.Lists;
@@ -1133,9 +1134,9 @@ public class BookKeeperAdmin implements AutoCloseable {
      */
     public static boolean format(ServerConfiguration conf,
             boolean isInteractive, boolean force) throws Exception {
-        return runFunctionWithRegistrationManager(conf, rm -> {
+        return runFunctionWithMetadataBookieDriver(conf, driver -> {
             try {
-                boolean ledgerRootExists = rm.prepareFormat();
+                boolean ledgerRootExists = driver.getRegistrationManager().prepareFormat();
 
                 // If old data was there then confirm with admin.
                 boolean doFormat = true;
@@ -1160,11 +1161,11 @@ public class BookKeeperAdmin implements AutoCloseable {
                     return false;
                 }
 
-                try (BookKeeper bkc = new BookKeeper(new ClientConfiguration(conf))) {
-                    bkc.ledgerManagerFactory.format(conf, bkc.getMetadataClientDriver().getLayoutManager());
-                }
+                driver.getLedgerManagerFactory().format(
+                    conf,
+                    driver.getLayoutManager());
 
-                return rm.format();
+                return driver.getRegistrationManager().format();
             } catch (Exception e) {
                 throw new UncheckedExecutionException(e.getMessage(), e);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MetadataBookieDriver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MetadataBookieDriver.java
@@ -64,6 +64,13 @@ public interface MetadataBookieDriver extends AutoCloseable {
     LedgerManagerFactory getLedgerManagerFactory()
         throws MetadataException;
 
+    /**
+     * Return the layout manager.
+     *
+     * @return the layout manager.
+     */
+    LayoutManager getLayoutManager();
+
     @Override
     void close();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/MetadataDriversTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/MetadataDriversTest.java
@@ -51,7 +51,7 @@ import org.junit.Test;
  */
 public class MetadataDriversTest {
 
-    static class ClientDriver1 implements MetadataClientDriver {
+    abstract static class TestClientDriver implements MetadataClientDriver {
 
         @Override
         public MetadataClientDriver initialize(ClientConfiguration conf,
@@ -59,11 +59,6 @@ public class MetadataDriversTest {
                                                StatsLogger statsLogger,
                                                Optional<Object> ctx) throws MetadataException {
             return this;
-        }
-
-        @Override
-        public String getScheme() {
-            return "driver1";
         }
 
         @Override
@@ -86,24 +81,35 @@ public class MetadataDriversTest {
         }
     }
 
-    static class ClientDriver2 implements MetadataClientDriver {
+    static class ClientDriver1 extends TestClientDriver {
 
         @Override
-        public MetadataClientDriver initialize(ClientConfiguration conf,
-                                               ScheduledExecutorService scheduler,
-                                               StatsLogger statsLogger,
-                                               Optional<Object> ctx) throws MetadataException {
-            return this;
+        public String getScheme() {
+            return "driver1";
         }
+
+    }
+
+    static class ClientDriver2 extends TestClientDriver {
 
         @Override
         public String getScheme() {
             return "driver2";
         }
 
+    }
+
+    abstract static class TestBookieDriver implements MetadataBookieDriver {
         @Override
-        public RegistrationClient getRegistrationClient() {
-            return mock(RegistrationClient.class);
+        public MetadataBookieDriver initialize(ServerConfiguration conf,
+                                               RegistrationListener listener,
+                                               StatsLogger statsLogger) throws MetadataException {
+            return this;
+        }
+
+        @Override
+        public RegistrationManager getRegistrationManager() {
+            return mock(RegistrationManager.class);
         }
 
         @Override
@@ -118,65 +124,26 @@ public class MetadataDriversTest {
 
         @Override
         public void close() {
+
         }
     }
 
-    static class BookieDriver1 implements MetadataBookieDriver {
-
-        @Override
-        public MetadataBookieDriver initialize(ServerConfiguration conf,
-                                               RegistrationListener listener,
-                                               StatsLogger statsLogger) throws MetadataException {
-            return this;
-        }
+    static class BookieDriver1 extends TestBookieDriver {
 
         @Override
         public String getScheme() {
             return "driver1";
         }
 
-        @Override
-        public RegistrationManager getRegistrationManager() {
-            return mock(RegistrationManager.class);
-        }
-
-        @Override
-        public LedgerManagerFactory getLedgerManagerFactory() throws MetadataException {
-            return mock(LedgerManagerFactory.class);
-        }
-
-        @Override
-        public void close() {
-        }
     }
 
-    static class BookieDriver2 implements MetadataBookieDriver {
-
-        @Override
-        public MetadataBookieDriver initialize(ServerConfiguration conf,
-                                               RegistrationListener listener,
-                                               StatsLogger statsLogger) throws MetadataException {
-            return this;
-        }
+    static class BookieDriver2 extends TestBookieDriver {
 
         @Override
         public String getScheme() {
             return "driver2";
         }
 
-        @Override
-        public RegistrationManager getRegistrationManager() {
-            return mock(RegistrationManager.class);
-        }
-
-        @Override
-        public LedgerManagerFactory getLedgerManagerFactory() throws MetadataException {
-            return mock(LedgerManagerFactory.class);
-        }
-
-        @Override
-        public void close() {
-        }
     }
 
     private Map<String, MetadataClientDriverInfo> savedClientDrivers;


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Problem*

After metadata service uri change, all the metadata managers can be retrieved via metadata drivers.
So there is no need to construct another bookkeeper client to get ledger manager factory for formatting ledger metadata.

*Solution*

- remove constructing bookkeeper client and use the metadata driver to get ledger manager factory to format ledger metadata
- expose layout manager in bookie driver as well
- since we are adding `getLayoutManager` in bookie driver, we need to update `MetadataDriversTest`. cleanup the test drivers in `MetadataDriversTest`.

Related Issue: #1269 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
