### PR TITLE
Register jvm_memory_direct_bytes_used metric so that it's reported on Prometheus

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -125,7 +125,7 @@ public class PrometheusMetricsProvider implements StatsProvider {
             public double get() {
                 return directMemoryUsage != null ? directMemoryUsage.longValue() : Double.NaN;
             }
-        }).register(CollectorRegistry.defaultRegistry);
+        }).register(registry);
 
         Gauge.build("jvm_memory_direct_bytes_max", "-").create().setChild(new Child() {
             @Override


### PR DESCRIPTION
The `jvm_memory_direct_bytes_used` metric is being registered on the default Prometheus static registry, though we're only exporting the stats that were added into the local registry instance.