### PR TITLE
Use final variables in BoundedScheduledExecutorService

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/BoundedScheduledExecutorService.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/BoundedScheduledExecutorService.java
@@ -42,9 +42,9 @@ import java.util.concurrent.TimeoutException;
  */
 public class BoundedScheduledExecutorService extends ForwardingListeningExecutorService
         implements ListeningScheduledExecutorService {
-    BlockingQueue<Runnable> queue;
-    ListeningScheduledExecutorService thread;
-    int maxTasksInQueue;
+    private final BlockingQueue<Runnable> queue;
+    private final ListeningScheduledExecutorService thread;
+    private final int maxTasksInQueue;
 
     public BoundedScheduledExecutorService(ScheduledThreadPoolExecutor thread, int maxTasksInQueue) {
         this.queue = thread.getQueue();


### PR DESCRIPTION
Make the fields final so that the optimizer can easily remove the `if (maxTasksInQueue > 0) {}` branch when the limit on the executor is disabled.