### PR TITLE
Ensure we instantiate threads that extend Netty FastThreadLocalThread

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
@@ -22,13 +22,15 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -134,7 +136,7 @@ public class OrderedScheduler implements ScheduledExecutorService {
         @SuppressWarnings("unchecked")
         public T build() {
             if (null == threadFactory) {
-                threadFactory = Executors.defaultThreadFactory();
+                threadFactory = new DefaultThreadFactory(name);
             }
             return (T) new OrderedScheduler(
                 name,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieThread.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import io.netty.util.concurrent.FastThreadLocalThread;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * Any common handing that we require for all bookie threads
  * should be implemented here
  */
-public class BookieThread extends Thread implements
+public class BookieThread extends FastThreadLocalThread implements
         Thread.UncaughtExceptionHandler {
 
     private static final Logger LOG = LoggerFactory


### PR DESCRIPTION
Since we make heavy use of `Recycler` and other `FastThreadLocal` objects from Netty, we should make sure that all (critical) threads that we instantiate are inheriting from `FastThreadLocalThread`.

`FastThreadLocalThread` has an optimization that makes access to `FastThreadLocal` faster. It's a class that extends regular `Thread` and adds a field for the thread local access.

There are a couple of places where we're currently not using `FastThreadLocal`: 
 * `OrderedScheduler` builder
 * `BookieThread` (which is used in `Journal`, `ForceSyncThread`, etc..)
