### PR TITLE
Fix ByteBuf leaking at Journal

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieJournalRollingTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieJournalRollingTest.java
@@ -160,6 +160,10 @@ public class BookieJournalRollingTest extends BookKeeperClusterTestCase {
                 end = start + read - 1;
             }
         }
+
+        for (LedgerHandle lh : lhs) {
+            lh.close();
+        }
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:

BufferLogChannel uses a pooled bytebuf for buffering writes. However Journal only closes the underlying log file channel, but it doesn't close buffer log channel, which can cause bytebuf leaking.

This problem get exposed at #1268 

