### PR TITLE
WIP - Use ByteBufOutputStream to serialize ProtoBuf messages

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -20,7 +20,6 @@
  */
 package org.apache.bookkeeper.proto;
 
-import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
@@ -356,7 +355,7 @@ public class BookieProtoEncoding {
         ByteBuf buf = allocator.heapBuffer(size, size);
 
         try {
-            msg.writeTo(CodedOutputStream.newInstance(buf.array(), buf.arrayOffset() + buf.writerIndex(), size));
+            msg.writeTo(new ByteBufOutputStream(buf));
         } catch (IOException e) {
             // This is in-memory serialization, should not fail
             throw new RuntimeException(e);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -361,8 +361,6 @@ public class BookieProtoEncoding {
             throw new RuntimeException(e);
         }
 
-        // Advance writer idx
-        buf.writerIndex(buf.capacity());
         return buf;
     }
 


### PR DESCRIPTION
This patch fixes an issue found on a staging environment running on Java 9.

Responses and requests encoded using direct access to the underlying ByteBuf#array() result as corrupted packets on the receiving peer.