### PR TITLE
Implement `toString` method for CheckpointList and BufferedLogChannel

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/CheckpointSource.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/CheckpointSource.java
@@ -27,7 +27,7 @@ public interface CheckpointSource {
     /**
      * A checkpoint presented a time point. All entries added before this checkpoint are already persisted.
      */
-    public interface Checkpoint extends Comparable<Checkpoint> {
+    interface Checkpoint extends Comparable<Checkpoint> {
 
         Checkpoint MAX = new Checkpoint() {
 
@@ -44,6 +44,11 @@ public interface CheckpointSource {
                 return this == o;
             }
 
+            @Override
+            public String toString() {
+                return "MAX";
+            }
+
         };
 
         Checkpoint MIN = new Checkpoint() {
@@ -58,6 +63,11 @@ public interface CheckpointSource {
             @Override
             public boolean equals(Object o) {
                 return this == o;
+            }
+
+            @Override
+            public String toString() {
+                return "MIN";
             }
         };
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/CheckpointSourceList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/CheckpointSourceList.java
@@ -19,6 +19,7 @@ package org.apache.bookkeeper.bookie;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -107,6 +108,13 @@ public class CheckpointSourceList implements CheckpointSource {
             }
 
             return 0;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(CheckpointList.class)
+                .add("checkpoints", checkpoints)
+                .toString();
         }
 
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -25,6 +25,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static org.apache.bookkeeper.bookie.TransactionalEntryLogCompactor.COMPACTING_SUFFIX;
 import static org.apache.bookkeeper.util.BookKeeperConstants.MAX_LOG_SIZE_LIMIT;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Sets;
 
@@ -113,6 +114,14 @@ public class EntryLogger {
 
         public ConcurrentLongLongHashMap getLedgersMap() {
             return entryLogMetadata.getLedgersMap();
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(BufferedChannel.class)
+                .add("logId", logId)
+                .add("logFile", logFile)
+                .toString();
         }
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

```
Flushing entry logger 102 back to filesystem, pending for syncing entry loggers : [org.apache.bookkeeper.bookie.EntryLogger$BufferedLogChannel@7d98c184].

org.apache.bookkeeper.bookie.SortedLedgerStorage - Reached size org.apache.bookkeeper.bookie.CheckpointSourceList$CheckpointList@d2c00ea5
```

`CheckpointList` and `BufferedLogChannel` is missing `toString` implementation. 