### PR TITLE
Improve write rejection in DbLedgerStorage 

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
@@ -82,6 +82,7 @@ public abstract class BookieException extends Exception {
         int CookieNotFoundException = -105;
         int MetadataStoreException = -106;
         int UnknownBookieIdException = -107;
+        int OperationRejectedException = -108;
     }
 
     public void setCode(int code) {
@@ -121,6 +122,9 @@ public abstract class BookieException extends Exception {
             break;
         case Code.UnknownBookieIdException:
             err = "Unknown bookie id";
+            break;
+        case Code.OperationRejectedException:
+            err = "Operation rejected";
             break;
         default:
             err = "Invalid operation";
@@ -171,6 +175,22 @@ public abstract class BookieException extends Exception {
     public static class LedgerFencedException extends BookieException {
         public LedgerFencedException() {
             super(Code.LedgerFencedException);
+        }
+    }
+
+    /**
+     * Signals that a ledger has been fenced in a bookie. No more entries can be appended to that ledger.
+     */
+    public static class OperationRejectedException extends BookieException {
+        public OperationRejectedException() {
+            super(Code.OperationRejectedException);
+        }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            // Since this exception is a way to signal a specific condition and it's triggered and very specific points,
+            // we can disable stack traces.
+            return null;
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
@@ -73,7 +73,7 @@ public abstract class LedgerDescriptor {
      */
     abstract SettableFuture<Boolean> fenceAndLogInJournal(Journal journal) throws IOException;
 
-    abstract long addEntry(ByteBuf entry) throws IOException;
+    abstract long addEntry(ByteBuf entry) throws IOException, BookieException;
     abstract ByteBuf readEntry(long entryId) throws IOException;
 
     abstract long getLastAddConfirmed() throws IOException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -138,7 +138,7 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
     }
 
     @Override
-    long addEntry(ByteBuf entry) throws IOException {
+    long addEntry(ByteBuf entry) throws IOException, BookieException {
         long ledgerId = entry.getLong(entry.readerIndex());
 
         if (ledgerId != this.ledgerId) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -100,7 +100,7 @@ public interface LedgerStorage {
      *
      * @return the entry id of the entry added
      */
-    long addEntry(ByteBuf entry) throws IOException;
+    long addEntry(ByteBuf entry) throws IOException, BookieException;
 
     /**
      * Read an entry from storage.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -413,7 +413,7 @@ public class EntryLogTest {
         }
 
         @Override
-        public Boolean call() throws IOException {
+        public Boolean call() throws IOException, BookieException {
             try {
                 ledgerStorage.addEntry(generateEntry(ledgerId, entryId));
             } catch (IOException e) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.bookie.BookieException.OperationRejectedException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.junit.After;
@@ -85,6 +86,7 @@ public class DbLedgerStorageWriteCacheTest {
         conf.setGcWaitTime(gcWaitTime);
         conf.setLedgerStorageClass(MockedDbLedgerStorage.class.getName());
         conf.setProperty(DbLedgerStorage.WRITE_CACHE_MAX_SIZE_MB, 1);
+        conf.setProperty(DbLedgerStorage.MAX_THROTTLE_TIME_MILLIS, 1000);
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
         Bookie bookie = new Bookie(conf);
 
@@ -131,7 +133,7 @@ public class DbLedgerStorageWriteCacheTest {
         try {
             storage.addEntry(entry);
             fail("Should have thrown exception");
-        } catch (IOException e) {
+        } catch (OperationRejectedException e) {
             // Expected
         }
     }


### PR DESCRIPTION
This PR contain 2 changes that are much related to each other. 

1. Changed DbLedgerStorage write cache read-write lock into a `StampedLock`
   Main reason for using `StampedLock` is that this lock is always taken as a "read" lock, when putting entries in the the cache. It is protecting for the swapping of the write cache when the flush is triggered. Most of the time, we have many threads acquiring the read-lock. `StampedLock` is better in this scenario because there isn't any contention in the optimistic path (just a double volatile read).

2. Have a configurable throttle timing when the write cache is really full. 
    If we try to write faster than we can put data in the storage device, eventually both write caches will get full and we have to throttle writes. Added here a setting to configure the amount of time to block the thread (who's calling `Bookie.addEntry()`, it could be IO thread or a addEntryWorker depending on configuration).
   After the timeout, if we still weren't able to flush the write cache and insert the current entry, bookie will reject the write operation, without logging but rather using a counter to keep track of it.