### PR TITLE
Issue #570: Introducing EntryLogManager.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -53,6 +53,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
      * calling fileChannel.force
      */
     protected final long unpersistedBytesBound;
+    private final boolean doRegularFlushes;
 
     /*
      * it tracks the number of bytes which are not persisted yet by force
@@ -81,6 +82,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
         this.writeBuffer = ByteBufAllocator.DEFAULT.directBuffer(writeCapacity);
         this.unpersistedBytes = new AtomicLong(0);
         this.unpersistedBytesBound = unpersistedBytesBound;
+        this.doRegularFlushes = unpersistedBytesBound > 0;
     }
 
     @Override
@@ -114,7 +116,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
             }
             position.addAndGet(copied);
             unpersistedBytes.addAndGet(copied);
-            if (unpersistedBytesBound > 0) {
+            if (doRegularFlushes) {
                 if (unpersistedBytes.get() >= unpersistedBytesBound) {
                     flush();
                     shouldForceWrite = true;
@@ -154,6 +156,22 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
     public void flushAndForceWrite(boolean forceMetadata) throws IOException {
         flush();
         forceWrite(forceMetadata);
+    }
+
+    /**
+     * calls both flush and forceWrite methods if regular flush is enabled.
+     *
+     * @param forceMetadata
+     *            - If true then this method is required to force changes to
+     *            both the file's content and metadata to be written to storage;
+     *            otherwise, it need only force content changes to be written
+     * @throws IOException
+     */
+    public void flushAndForceWriteIfRegularFlush(boolean forceMetadata) throws IOException {
+        if (doRegularFlushes) {
+            flush();
+            forceWrite(forceMetadata);
+        }
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -169,8 +169,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
      */
     public void flushAndForceWriteIfRegularFlush(boolean forceMetadata) throws IOException {
         if (doRegularFlushes) {
-            flush();
-            forceWrite(forceMetadata);
+            flushAndForceWrite(forceMetadata);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1186,15 +1186,15 @@ public class EntryLogger {
         entryLogManager.flush();
     }
 
-    long addEntry(Long ledger, ByteBuffer entry) throws IOException {
+    long addEntry(long ledger, ByteBuffer entry) throws IOException {
         return entryLogManager.addEntry(ledger, Unpooled.wrappedBuffer(entry), true);
     }
 
-    long addEntry(Long ledger, ByteBuf entry) throws IOException {
+    long addEntry(long ledger, ByteBuf entry) throws IOException {
         return entryLogManager.addEntry(ledger, entry, true);
     }
 
-    public long addEntry(Long ledger, ByteBuf entry, boolean rollLog) throws IOException {
+    public long addEntry(long ledger, ByteBuf entry, boolean rollLog) throws IOException {
         return entryLogManager.addEntry(ledger, entry, true);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyEntryLogger.java
@@ -38,23 +38,13 @@ public class ReadOnlyEntryLogger extends EntryLogger {
     }
 
     @Override
-    protected void initialize() throws IOException {
-        // do nothing for read only entry logger
-    }
-
-    @Override
-    void createNewLog() throws IOException {
-        throw new IOException("Can't create new entry log using a readonly entry logger.");
-    }
-
-    @Override
     protected boolean removeEntryLog(long entryLogId) {
         // can't remove entry log in readonly mode
         return false;
     }
 
     @Override
-    public synchronized long addEntry(long ledger, ByteBuffer entry) throws IOException {
+    public synchronized long addEntry(Long ledgerId, ByteBuffer entry) throws IOException {
         throw new IOException("Can't add entry to a readonly entry logger.");
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyEntryLogger.java
@@ -44,7 +44,7 @@ public class ReadOnlyEntryLogger extends EntryLogger {
     }
 
     @Override
-    public synchronized long addEntry(Long ledgerId, ByteBuffer entry) throws IOException {
+    public synchronized long addEntry(long ledgerId, ByteBuffer entry) throws IOException {
         throw new IOException("Can't add entry to a readonly entry logger.");
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -2262,6 +2262,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
         if (0 == getBookiePort() && !getAllowEphemeralPorts()) {
             throw new ConfigurationException("Invalid port specified, using ephemeral ports accidentally?");
         }
+        if (isEntryLogPerLedgerEnabled() && getUseTransactionalCompaction()) {
+            throw new ConfigurationException(
+                    "When entryLogPerLedger is enabled , it is unnecessary to use transactional compaction");
+        }
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
@@ -226,7 +226,7 @@ public class CreateNewLogTest {
                 el.getPreviousAllocatedEntryLogId());
 
         // Extracted from createNewLog()
-        logFileName = Long.toHexString(3) + TransactionalEntryLogCompactor.COMPACTING_SUFFIX;
+        logFileName = Long.toHexString(3) + ".log";
         dir = ledgerDirsManager.pickRandomWritableDir();
         LOG.info("Picked this directory: {}", dir);
         newLogFile = new File(dir, logFileName);
@@ -250,14 +250,6 @@ public class CreateNewLogTest {
         EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
         AtomicBoolean receivedException = new AtomicBoolean(false);
 
-        // create a gap
-        // Extracted from createNewLog()
-        String logFileName = Long.toHexString(2) + TransactionalEntryLogCompactor.COMPACTED_SUFFIX;
-        File dir = ledgerDirsManager.pickRandomWritableDir();
-        LOG.info("Picked this directory: {}", dir);
-        File newLogFile = new File(dir, logFileName);
-        newLogFile.createNewFile();
-
         IntStream.range(0, 2).parallel().forEach((i) -> {
             try {
                 if (i % 2 == 0) {
@@ -275,7 +267,7 @@ public class CreateNewLogTest {
 
         Assert.assertFalse("There shouldn't be any exceptions while creating newlog", receivedException.get());
         Assert.assertEquals(
-                "previousAllocatedEntryLogId after 2 times createNewLog is called and entrylogid 2 is already taken", 3,
+                "previousAllocatedEntryLogId after 2 times createNewLog is called", 2,
                 el.getPreviousAllocatedEntryLogId());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
@@ -21,12 +21,17 @@ package org.apache.bookkeeper.bookie;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
+import org.apache.bookkeeper.bookie.EntryLogger.EntryLogManagerBase;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.util.DiskChecker;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -93,16 +98,16 @@ public class CreateNewLogTest {
         // Extracted from createNewLog()
         String logFileName = Long.toHexString(1) + ".log";
         File dir = ledgerDirsManager.pickRandomWritableDir();
-        LOG.info("Picked this directory: " + dir);
+        LOG.info("Picked this directory: {}", dir);
         File newLogFile = new File(dir, logFileName);
         newLogFile.createNewFile();
 
         EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
         // Calls createNewLog, and with the number of directories we
         // are using, if it picks one at random it will fail.
-        el.createNewLog();
-        LOG.info("This is the current log id: " + el.getCurrentLogId());
-        assertTrue("Wrong log id", el.getCurrentLogId() > 1);
+        ((EntryLogManagerBase) el.entryLogManager).createNewLog(0L);
+        LOG.info("This is the current log id: {}", el.getPreviousAllocatedEntryLogId());
+        assertTrue("Wrong log id", el.getPreviousAllocatedEntryLogId() > 1);
     }
 
     @Test
@@ -118,7 +123,7 @@ public class CreateNewLogTest {
         // Extracted from createNewLog()
         String logFileName = Long.toHexString(1) + ".log";
         File dir = ledgerDirsManager.pickRandomWritableDir();
-        LOG.info("Picked this directory: " + dir);
+        LOG.info("Picked this directory: {}", dir);
         File newLogFile = new File(dir, logFileName);
         newLogFile.createNewFile();
 
@@ -131,9 +136,142 @@ public class CreateNewLogTest {
         EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
         // Calls createNewLog, and with the number of directories we
         // are using, if it picks one at random it will fail.
-        el.createNewLog();
-        LOG.info("This is the current log id: " + el.getCurrentLogId());
-        assertTrue("Wrong log id", el.getCurrentLogId() > 1);
+        ((EntryLogManagerBase) el.entryLogManager).createNewLog(0L);
+        LOG.info("This is the current log id: {}", el.getPreviousAllocatedEntryLogId());
+        assertTrue("Wrong log id", el.getPreviousAllocatedEntryLogId() > 1);
     }
 
+    @Test
+    public void testConcurrentCreateNewLogWithEntryLogFilePreAllocationEnabled() throws Exception {
+        testConcurrentCreateNewLog(true);
+    }
+
+    @Test
+    public void testConcurrentCreateNewLogWithEntryLogFilePreAllocationDisabled() throws Exception {
+        testConcurrentCreateNewLog(false);
+    }
+
+    public void testConcurrentCreateNewLog(boolean entryLogFilePreAllocationEnabled) throws Exception {
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+
+        // Creating a new configuration with a number of
+        // ledger directories.
+        conf.setLedgerDirNames(ledgerDirs);
+        conf.setEntryLogFilePreAllocationEnabled(entryLogFilePreAllocationEnabled);
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
+
+        EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
+        Assert.assertEquals("previousAllocatedEntryLogId after initialization", -1,
+                el.getPreviousAllocatedEntryLogId());
+        Assert.assertEquals("leastUnflushedLogId after initialization", 0, el.getLeastUnflushedLogId());
+        int createNewLogNumOfTimes = 10;
+        AtomicBoolean receivedException = new AtomicBoolean(false);
+
+        IntStream.range(0, createNewLogNumOfTimes).parallel().forEach((i) -> {
+            try {
+                ((EntryLogManagerBase) el.entryLogManager).createNewLog((long) i);
+            } catch (IOException e) {
+                LOG.error("Received exception while creating newLog", e);
+                receivedException.set(true);
+            }
+        });
+        // wait for the pre-allocation to complete
+        Thread.sleep(1000);
+
+        Assert.assertFalse("There shouldn't be any exceptions while creating newlog", receivedException.get());
+        int expectedPreviousAllocatedEntryLogId = createNewLogNumOfTimes - 1;
+        if (entryLogFilePreAllocationEnabled) {
+            expectedPreviousAllocatedEntryLogId = createNewLogNumOfTimes;
+        }
+
+        Assert.assertEquals(
+                "previousAllocatedEntryLogId after " + createNewLogNumOfTimes
+                        + " number of times createNewLog is called",
+                expectedPreviousAllocatedEntryLogId, el.getPreviousAllocatedEntryLogId());
+        Assert.assertEquals("Number of RotatedLogChannels", createNewLogNumOfTimes - 1,
+                ((EntryLogManagerBase) el.entryLogManager).getCopyOfRotatedLogChannels().size());
+    }
+
+    @Test
+    public void testCreateNewLogWithGaps() throws Exception {
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+
+        // Creating a new configuration with a number of
+        // ledger directories.
+        conf.setLedgerDirNames(ledgerDirs);
+        conf.setEntryLogFilePreAllocationEnabled(false);
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
+
+        EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
+        EntryLogManagerBase entryLogManagerBase = (EntryLogManagerBase) el.entryLogManager;
+        entryLogManagerBase.createNewLog(0L);
+
+        Assert.assertEquals("previousAllocatedEntryLogId after initialization", 0, el.getPreviousAllocatedEntryLogId());
+
+        // Extracted from createNewLog()
+        String logFileName = Long.toHexString(1) + ".log";
+        File dir = ledgerDirsManager.pickRandomWritableDir();
+        LOG.info("Picked this directory: {}", dir);
+        File newLogFile = new File(dir, logFileName);
+        newLogFile.createNewFile();
+
+        entryLogManagerBase.createNewLog(0L);
+        Assert.assertEquals("previousAllocatedEntryLogId since entrylogid 1 is already taken", 2,
+                el.getPreviousAllocatedEntryLogId());
+
+        // Extracted from createNewLog()
+        logFileName = Long.toHexString(3) + TransactionalEntryLogCompactor.COMPACTING_SUFFIX;
+        dir = ledgerDirsManager.pickRandomWritableDir();
+        LOG.info("Picked this directory: {}", dir);
+        newLogFile = new File(dir, logFileName);
+        newLogFile.createNewFile();
+
+        entryLogManagerBase.createNewLog(0L);
+        Assert.assertEquals("previousAllocatedEntryLogId since entrylogid 3 is already taken", 4,
+                el.getPreviousAllocatedEntryLogId());
+    }
+
+    @Test
+    public void testCreateNewLogAndCompactionLog() throws Exception {
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+
+        // Creating a new configuration with a number of
+        // ledger directories.
+        conf.setLedgerDirNames(ledgerDirs);
+        conf.setEntryLogFilePreAllocationEnabled(true);
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
+        EntryLogger el = new EntryLogger(conf, ledgerDirsManager);
+        AtomicBoolean receivedException = new AtomicBoolean(false);
+
+        // create a gap
+        // Extracted from createNewLog()
+        String logFileName = Long.toHexString(2) + TransactionalEntryLogCompactor.COMPACTED_SUFFIX;
+        File dir = ledgerDirsManager.pickRandomWritableDir();
+        LOG.info("Picked this directory: {}", dir);
+        File newLogFile = new File(dir, logFileName);
+        newLogFile.createNewFile();
+
+        IntStream.range(0, 2).parallel().forEach((i) -> {
+            try {
+                if (i % 2 == 0) {
+                    ((EntryLogManagerBase) el.entryLogManager).createNewLog((long) i);
+                } else {
+                    el.createNewCompactionLog();
+                }
+            } catch (IOException e) {
+                LOG.error("Received exception while creating newLog", e);
+                receivedException.set(true);
+            }
+        });
+        // wait for the pre-allocation to complete
+        Thread.sleep(1000);
+
+        Assert.assertFalse("There shouldn't be any exceptions while creating newlog", receivedException.get());
+        Assert.assertEquals(
+                "previousAllocatedEntryLogId after 2 times createNewLog is called and entrylogid 2 is already taken", 3,
+                el.getPreviousAllocatedEntryLogId());
+    }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -44,6 +44,9 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.bookkeeper.bookie.EntryLogger.EntryLogManager;
+import org.apache.bookkeeper.bookie.EntryLogger.EntryLogManagerBase;
+import org.apache.bookkeeper.bookie.EntryLogger.EntryLogManagerForSingleEntryLog;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
@@ -64,6 +67,7 @@ public class EntryLogTest {
     private static final Logger LOG = LoggerFactory.getLogger(EntryLogTest.class);
 
     final List<File> tempDirs = new ArrayList<File>();
+    final Random rand = new Random();
 
     File createTempDir(String prefix, String suffix) throws IOException {
         File dir = IOUtils.createTempDir(prefix, suffix);
@@ -119,11 +123,13 @@ public class EntryLogTest {
         this.dirsMgr.addToFilledDirs(curDir);
 
         entryLogger = new EntryLogger(conf, dirsMgr);
-        assertEquals(EntryLogger.UNINITIALIZED_LOG_ID, entryLogger.getCurrentLogId());
+        EntryLogManagerForSingleEntryLog entryLogManager =
+                (EntryLogManagerForSingleEntryLog) entryLogger.entryLogManager;
+        assertEquals(EntryLogger.UNINITIALIZED_LOG_ID, entryLogManager.getCurrentLogId());
 
         // add the first entry will trigger file creation
-        entryLogger.addEntry(1, generateEntry(1, 1).nioBuffer());
-        assertEquals(2L, entryLogger.getCurrentLogId());
+        entryLogger.addEntry(1L, generateEntry(1, 1).nioBuffer());
+        assertEquals(0L, entryLogManager.getCurrentLogId());
     }
 
     @Test
@@ -141,23 +147,25 @@ public class EntryLogTest {
         this.dirsMgr.addToFilledDirs(curDir);
 
         entryLogger = new EntryLogger(conf, dirsMgr);
-        assertEquals(EntryLogger.UNINITIALIZED_LOG_ID, entryLogger.getCurrentLogId());
+        EntryLogManagerForSingleEntryLog entryLogManager =
+                (EntryLogManagerForSingleEntryLog) entryLogger.entryLogManager;
+        assertEquals(EntryLogger.UNINITIALIZED_LOG_ID, entryLogManager.getCurrentLogId());
 
         // add the first entry will trigger file creation
         try {
-            entryLogger.addEntry(1, generateEntry(1, 1).nioBuffer());
+            entryLogger.addEntry(1L, generateEntry(1, 1).nioBuffer());
             fail("Should fail to append entry if there is no enough reserved space left");
         } catch (NoWritableLedgerDirException e) {
-            assertEquals(EntryLogger.UNINITIALIZED_LOG_ID, entryLogger.getCurrentLogId());
+            assertEquals(EntryLogger.UNINITIALIZED_LOG_ID, entryLogManager.getCurrentLogId());
         }
     }
 
     @Test
     public void testCorruptEntryLog() throws Exception {
         // create some entries
-        entryLogger.addEntry(1, generateEntry(1, 1).nioBuffer());
-        entryLogger.addEntry(3, generateEntry(3, 1).nioBuffer());
-        entryLogger.addEntry(2, generateEntry(2, 1).nioBuffer());
+        entryLogger.addEntry(1L, generateEntry(1, 1).nioBuffer());
+        entryLogger.addEntry(3L, generateEntry(3, 1).nioBuffer());
+        entryLogger.addEntry(2L, generateEntry(2, 1).nioBuffer());
         entryLogger.flush();
         entryLogger.shutdown();
         // now lets truncate the file to corrupt the last entry, which simulates a partial write
@@ -184,6 +192,16 @@ public class EntryLogTest {
         return bb;
     }
 
+    private ByteBuf generateEntry(long ledger, long entry, int length) {
+        ByteBuf bb = Unpooled.buffer(length);
+        bb.writeLong(ledger);
+        bb.writeLong(entry);
+        byte[] randbyteArray = new byte[length - 8 - 8];
+        rand.nextBytes(randbyteArray);
+        bb.writeBytes(randbyteArray);
+        return bb;
+    }
+
     private static String generateDataString(long ledger, long entry) {
         return ("ledger-" + ledger + "-" + entry);
     }
@@ -199,7 +217,7 @@ public class EntryLogTest {
 
             EntryLogger logger = new EntryLogger(conf, dirsMgr);
             for (int j = 0; j < numEntries; j++) {
-                positions[i][j] = logger.addEntry(i, generateEntry(i, j).nioBuffer());
+                positions[i][j] = logger.addEntry((long) i, generateEntry(i, j).nioBuffer());
             }
             logger.flush();
             logger.shutdown();
@@ -214,7 +232,7 @@ public class EntryLogTest {
 
             EntryLogger logger = new EntryLogger(conf, dirsMgr);
             for (int j = 0; j < numEntries; j++) {
-                positions[i][j] = logger.addEntry(i, generateEntry(i, j).nioBuffer());
+                positions[i][j] = logger.addEntry((long) i, generateEntry(i, j).nioBuffer());
             }
             logger.flush();
             logger.shutdown();
@@ -271,6 +289,7 @@ public class EntryLogTest {
         File ledgerDir1 = createTempDir("bkTest", ".dir");
         File ledgerDir2 = createTempDir("bkTest", ".dir");
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setLedgerStorageClass(InterleavedLedgerStorage.class.getName());
         conf.setJournalDirName(ledgerDir1.toString());
         conf.setLedgerDirNames(new String[] { ledgerDir1.getAbsolutePath(),
                 ledgerDir2.getAbsolutePath() });
@@ -287,7 +306,8 @@ public class EntryLogTest {
         ledgerStorage.addEntry(generateEntry(1, 1));
         ledgerStorage.addEntry(generateEntry(2, 1));
         // Add entry with disk full failure simulation
-        bookie.getLedgerDirsManager().addToFilledDirs(entryLogger.currentDir);
+        bookie.getLedgerDirsManager().addToFilledDirs(((EntryLogManagerBase) entryLogger.entryLogManager)
+                .getCurrentLogForLedger(EntryLogger.UNASSIGNED_LEDGERID).getLogFile().getParentFile());
         ledgerStorage.addEntry(generateEntry(3, 1));
         // Verify written entries
         Assert.assertTrue(0 == generateEntry(1, 1).compareTo(ledgerStorage.getEntry(1, 1)));
@@ -301,12 +321,12 @@ public class EntryLogTest {
     @Test
     public void testRecoverFromLedgersMap() throws Exception {
         // create some entries
-        entryLogger.addEntry(1, generateEntry(1, 1).nioBuffer());
-        entryLogger.addEntry(3, generateEntry(3, 1).nioBuffer());
-        entryLogger.addEntry(2, generateEntry(2, 1).nioBuffer());
-        entryLogger.addEntry(1, generateEntry(1, 2).nioBuffer());
-        entryLogger.rollLog();
-        entryLogger.flushRotatedLogs();
+        entryLogger.addEntry(1L, generateEntry(1, 1).nioBuffer());
+        entryLogger.addEntry(3L, generateEntry(3, 1).nioBuffer());
+        entryLogger.addEntry(2L, generateEntry(2, 1).nioBuffer());
+        entryLogger.addEntry(1L, generateEntry(1, 2).nioBuffer());
+        ((EntryLogManagerBase) entryLogger.entryLogManager).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
+        entryLogger.entryLogManager.flushRotatedLogs();
 
         EntryLogMetadata meta = entryLogger.extractEntryLogMetadataFromIndex(0L);
         LOG.info("Extracted Meta From Entry Log {}", meta);
@@ -324,11 +344,11 @@ public class EntryLogTest {
     @Test
     public void testRecoverFromLedgersMapOnV0EntryLog() throws Exception {
         // create some entries
-        entryLogger.addEntry(1, generateEntry(1, 1).nioBuffer());
-        entryLogger.addEntry(3, generateEntry(3, 1).nioBuffer());
-        entryLogger.addEntry(2, generateEntry(2, 1).nioBuffer());
-        entryLogger.addEntry(1, generateEntry(1, 2).nioBuffer());
-        entryLogger.rollLog();
+        entryLogger.addEntry(1L, generateEntry(1, 1).nioBuffer());
+        entryLogger.addEntry(3L, generateEntry(3, 1).nioBuffer());
+        entryLogger.addEntry(2L, generateEntry(2, 1).nioBuffer());
+        entryLogger.addEntry(1L, generateEntry(1, 2).nioBuffer());
+        ((EntryLogManagerBase) entryLogger.entryLogManager).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
         entryLogger.shutdown();
 
         // Rewrite the entry log header to be on V0 format
@@ -373,9 +393,10 @@ public class EntryLogTest {
 
         entryLogger = new EntryLogger(conf, dirsMgr);
         // create a logger whose initialization phase allocating a new entry log
+        ((EntryLogManagerBase) entryLogger.entryLogManager).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
         assertNotNull(entryLogger.getEntryLoggerAllocator().getPreallocationFuture());
 
-        entryLogger.addEntry(1, generateEntry(1, 1).nioBuffer());
+        entryLogger.addEntry(1L, generateEntry(1, 1).nioBuffer());
         // the Future<BufferedLogChannel> is not null all the time
         assertNotNull(entryLogger.getEntryLoggerAllocator().getPreallocationFuture());
         entryLogger.shutdown();
@@ -386,7 +407,7 @@ public class EntryLogTest {
         entryLogger = new EntryLogger(conf, dirsMgr);
         assertNull(entryLogger.getEntryLoggerAllocator().getPreallocationFuture());
 
-        entryLogger.addEntry(2, generateEntry(1, 1).nioBuffer());
+        entryLogger.addEntry(2L, generateEntry(1, 1).nioBuffer());
 
         // the Future<BufferedLogChannel> is null all the time
         assertNull(entryLogger.getEntryLoggerAllocator().getPreallocationFuture());
@@ -398,17 +419,18 @@ public class EntryLogTest {
     @Test
     public void testGetEntryLogsSet() throws Exception {
         // create some entries
+        EntryLogManagerBase entryLogManagerBase = ((EntryLogManagerBase) entryLogger.entryLogManager);
+        assertEquals(Sets.newHashSet(), entryLogger.getEntryLogsSet());
+
+        entryLogManagerBase.createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
+        entryLogManagerBase.flushRotatedLogs();
+
         assertEquals(Sets.newHashSet(0L, 1L), entryLogger.getEntryLogsSet());
 
-        entryLogger.rollLog();
-        entryLogger.flushRotatedLogs();
+        entryLogManagerBase.createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
+        entryLogManagerBase.flushRotatedLogs();
 
         assertEquals(Sets.newHashSet(0L, 1L, 2L), entryLogger.getEntryLogsSet());
-
-        entryLogger.rollLog();
-        entryLogger.flushRotatedLogs();
-
-        assertEquals(Sets.newHashSet(0L, 1L, 2L, 3L), entryLogger.getEntryLogsSet());
     }
 
     static class LedgerStorageWriteTask implements Callable<Boolean> {
@@ -565,5 +587,122 @@ public class EntryLogTest {
         });
 
         executor.shutdownNow();
+    }
+
+    /**
+     * Test to verify the leastUnflushedLogId logic in EntryLogsStatus.
+     */
+    @Test
+    public void testEntryLoggersRecentEntryLogsStatus() throws Exception {
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setLedgerDirNames(createAndGetLedgerDirs(2));
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
+
+        EntryLogger entryLogger = new EntryLogger(conf, ledgerDirsManager);
+        EntryLogger.RecentEntryLogsStatus recentlyCreatedLogsStatus = entryLogger.recentlyCreatedEntryLogsStatus;
+
+        recentlyCreatedLogsStatus.createdEntryLog(0L);
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 0L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.flushRotatedEntryLog(0L);
+        // since we marked entrylog - 0 as rotated, LeastUnflushedLogId would be previous rotatedlog+1
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 1L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.createdEntryLog(1L);
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 1L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.createdEntryLog(2L);
+        recentlyCreatedLogsStatus.createdEntryLog(3L);
+        recentlyCreatedLogsStatus.createdEntryLog(4L);
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 1L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.flushRotatedEntryLog(1L);
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 2L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.flushRotatedEntryLog(3L);
+        // here though we rotated entrylog-3, entrylog-2 is not yet rotated so
+        // LeastUnflushedLogId should be still 2
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 2L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.flushRotatedEntryLog(2L);
+        // entrylog-3 is already rotated, so leastUnflushedLogId should be 4
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 4L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.flushRotatedEntryLog(4L);
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 5L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.createdEntryLog(5L);
+        recentlyCreatedLogsStatus.createdEntryLog(7L);
+        recentlyCreatedLogsStatus.createdEntryLog(9L);
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 5L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.flushRotatedEntryLog(5L);
+        // since we marked entrylog-5 as rotated, LeastUnflushedLogId would be previous rotatedlog+1
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 6L, entryLogger.getLeastUnflushedLogId());
+        recentlyCreatedLogsStatus.flushRotatedEntryLog(7L);
+        Assert.assertEquals("entryLogger's leastUnflushedLogId ", 8L, entryLogger.getLeastUnflushedLogId());
+    }
+
+    String[] createAndGetLedgerDirs(int numOfLedgerDirs) throws IOException {
+        File ledgerDir;
+        File curDir;
+        String[] ledgerDirsPath = new String[numOfLedgerDirs];
+        for (int i = 0; i < numOfLedgerDirs; i++) {
+            ledgerDir = createTempDir("bkTest", ".dir");
+            curDir = Bookie.getCurrentDirectory(ledgerDir);
+            Bookie.checkDirectoryStructure(curDir);
+            ledgerDirsPath[i] = ledgerDir.getAbsolutePath();
+        }
+        return ledgerDirsPath;
+    }
+
+    /*
+     * test for validating if the EntryLog/BufferedChannel flushes/forcewrite if the bytes written to it are more than
+     * flushIntervalInBytes
+     */
+    @Test(timeout = 60000)
+    public void testFlushIntervalInBytes() throws Exception {
+        long flushIntervalInBytes = 5000;
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setEntryLogPerLedgerEnabled(true);
+        conf.setFlushIntervalInBytes(flushIntervalInBytes);
+        conf.setLedgerDirNames(createAndGetLedgerDirs(2));
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
+        EntryLogger entryLogger = new EntryLogger(conf, ledgerDirsManager);
+        EntryLogManagerBase entryLogManagerBase = ((EntryLogManagerBase) entryLogger.entryLogManager);
+
+        /*
+         * when entryLogger is created Header of length EntryLogger.LOGFILE_HEADER_SIZE is created
+         */
+        long ledgerId = 0L;
+        int firstEntrySize = 1000;
+        long entry0Position = entryLogger.addEntry(0L, generateEntry(ledgerId, 0L, firstEntrySize));
+        // entrylogger writes length of the entry (4 bytes) before writing entry
+        long expectedUnpersistedBytes = EntryLogger.LOGFILE_HEADER_SIZE + firstEntrySize + 4;
+        Assert.assertEquals("Unpersisted Bytes of entrylog", expectedUnpersistedBytes,
+                entryLogManagerBase.getCurrentLogForLedger(ledgerId).getUnpersistedBytes());
+
+        /*
+         * 'flushIntervalInBytes' number of bytes are flushed so BufferedChannel should be forcewritten
+         */
+        int secondEntrySize = (int) (flushIntervalInBytes - expectedUnpersistedBytes);
+        long entry1Position = entryLogger.addEntry(0L, generateEntry(ledgerId, 1L, secondEntrySize));
+        Assert.assertEquals("Unpersisted Bytes of entrylog", 0,
+                entryLogManagerBase.getCurrentLogForLedger(ledgerId).getUnpersistedBytes());
+
+        /*
+         * since entrylog/Bufferedchannel is persisted (forcewritten), we should be able to read the entrylog using
+         * newEntryLogger
+         */
+        conf.setEntryLogPerLedgerEnabled(false);
+        EntryLogger newEntryLogger = new EntryLogger(conf, ledgerDirsManager);
+        EntryLogManager newEntryLogManager = newEntryLogger.entryLogManager;
+        Assert.assertEquals("EntryLogManager class type", EntryLogger.EntryLogManagerForSingleEntryLog.class,
+                newEntryLogManager.getClass());
+
+        ByteBuf buf = newEntryLogger.readEntry(ledgerId, 0L, entry0Position);
+        long readLedgerId = buf.readLong();
+        long readEntryId = buf.readLong();
+        Assert.assertEquals("LedgerId", ledgerId, readLedgerId);
+        Assert.assertEquals("EntryId", 0L, readEntryId);
+
+        buf = newEntryLogger.readEntry(ledgerId, 1L, entry1Position);
+        readLedgerId = buf.readLong();
+        readEntryId = buf.readLong();
+        Assert.assertEquals("LedgerId", ledgerId, readLedgerId);
+        Assert.assertEquals("EntryId", 1L, readEntryId);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -124,7 +124,7 @@ public class EntryLogTest {
 
         entryLogger = new EntryLogger(conf, dirsMgr);
         EntryLogManagerForSingleEntryLog entryLogManager =
-                (EntryLogManagerForSingleEntryLog) entryLogger.entryLogManager;
+                (EntryLogManagerForSingleEntryLog) entryLogger.getEntryLogManager();
         assertEquals(EntryLogger.UNINITIALIZED_LOG_ID, entryLogManager.getCurrentLogId());
 
         // add the first entry will trigger file creation
@@ -148,7 +148,7 @@ public class EntryLogTest {
 
         entryLogger = new EntryLogger(conf, dirsMgr);
         EntryLogManagerForSingleEntryLog entryLogManager =
-                (EntryLogManagerForSingleEntryLog) entryLogger.entryLogManager;
+                (EntryLogManagerForSingleEntryLog) entryLogger.getEntryLogManager();
         assertEquals(EntryLogger.UNINITIALIZED_LOG_ID, entryLogManager.getCurrentLogId());
 
         // add the first entry will trigger file creation
@@ -306,7 +306,7 @@ public class EntryLogTest {
         ledgerStorage.addEntry(generateEntry(1, 1));
         ledgerStorage.addEntry(generateEntry(2, 1));
         // Add entry with disk full failure simulation
-        bookie.getLedgerDirsManager().addToFilledDirs(((EntryLogManagerBase) entryLogger.entryLogManager)
+        bookie.getLedgerDirsManager().addToFilledDirs(((EntryLogManagerBase) entryLogger.getEntryLogManager())
                 .getCurrentLogForLedger(EntryLogger.UNASSIGNED_LEDGERID).getLogFile().getParentFile());
         ledgerStorage.addEntry(generateEntry(3, 1));
         // Verify written entries
@@ -325,8 +325,10 @@ public class EntryLogTest {
         entryLogger.addEntry(3L, generateEntry(3, 1).nioBuffer());
         entryLogger.addEntry(2L, generateEntry(2, 1).nioBuffer());
         entryLogger.addEntry(1L, generateEntry(1, 2).nioBuffer());
-        ((EntryLogManagerBase) entryLogger.entryLogManager).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
-        entryLogger.entryLogManager.flushRotatedLogs();
+
+        EntryLogManagerBase entryLogManager = (EntryLogManagerBase) entryLogger.getEntryLogManager();
+        entryLogManager.createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
+        entryLogManager.flushRotatedLogs();
 
         EntryLogMetadata meta = entryLogger.extractEntryLogMetadataFromIndex(0L);
         LOG.info("Extracted Meta From Entry Log {}", meta);
@@ -348,7 +350,7 @@ public class EntryLogTest {
         entryLogger.addEntry(3L, generateEntry(3, 1).nioBuffer());
         entryLogger.addEntry(2L, generateEntry(2, 1).nioBuffer());
         entryLogger.addEntry(1L, generateEntry(1, 2).nioBuffer());
-        ((EntryLogManagerBase) entryLogger.entryLogManager).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
+        ((EntryLogManagerBase) entryLogger.getEntryLogManager()).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
         entryLogger.shutdown();
 
         // Rewrite the entry log header to be on V0 format
@@ -393,7 +395,7 @@ public class EntryLogTest {
 
         entryLogger = new EntryLogger(conf, dirsMgr);
         // create a logger whose initialization phase allocating a new entry log
-        ((EntryLogManagerBase) entryLogger.entryLogManager).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
+        ((EntryLogManagerBase) entryLogger.getEntryLogManager()).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
         assertNotNull(entryLogger.getEntryLoggerAllocator().getPreallocationFuture());
 
         entryLogger.addEntry(1L, generateEntry(1, 1).nioBuffer());
@@ -419,7 +421,7 @@ public class EntryLogTest {
     @Test
     public void testGetEntryLogsSet() throws Exception {
         // create some entries
-        EntryLogManagerBase entryLogManagerBase = ((EntryLogManagerBase) entryLogger.entryLogManager);
+        EntryLogManagerBase entryLogManagerBase = ((EntryLogManagerBase) entryLogger.getEntryLogManager());
         assertEquals(Sets.newHashSet(), entryLogger.getEntryLogsSet());
 
         entryLogManagerBase.createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
@@ -662,7 +664,7 @@ public class EntryLogTest {
         LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
         EntryLogger entryLogger = new EntryLogger(conf, ledgerDirsManager);
-        EntryLogManagerBase entryLogManagerBase = ((EntryLogManagerBase) entryLogger.entryLogManager);
+        EntryLogManagerBase entryLogManagerBase = ((EntryLogManagerBase) entryLogger.getEntryLogManager());
 
         /*
          * when entryLogger is created Header of length EntryLogger.LOGFILE_HEADER_SIZE is created
@@ -689,7 +691,7 @@ public class EntryLogTest {
          */
         conf.setEntryLogPerLedgerEnabled(false);
         EntryLogger newEntryLogger = new EntryLogger(conf, ledgerDirsManager);
-        EntryLogManager newEntryLogManager = newEntryLogger.entryLogManager;
+        EntryLogManager newEntryLogManager = newEntryLogger.getEntryLogManager();
         Assert.assertEquals("EntryLogManager class type", EntryLogger.EntryLogManagerForSingleEntryLog.class,
                 newEntryLogManager.getClass());
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
@@ -364,7 +364,7 @@ public class LedgerStorageCheckpointTest {
         }
         handle.close();
         // simulate rolling entrylog
-        ((EntryLogManagerBase) ledgerStorage.entryLogger.entryLogManager).createNewLog(ledgerId);
+        ((EntryLogManagerBase) ledgerStorage.getEntryLogger().getEntryLogManager()).createNewLog(ledgerId);
         // sleep for a bit for checkpoint to do its task
         executorController.advance(Duration.ofMillis(500));
 
@@ -496,7 +496,7 @@ public class LedgerStorageCheckpointTest {
         BookKeeper bkClient = new BookKeeper(clientConf);
         InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) server.getBookie().ledgerStorage;
         EntryLogger entryLogger = ledgerStorage.entryLogger;
-        EntryLogManagerBase entryLogManagerBase = (EntryLogManagerBase) entryLogger.entryLogManager;
+        EntryLogManagerBase entryLogManagerBase = (EntryLogManagerBase) entryLogger.getEntryLogManager();
 
         int numOfEntries = 5;
         byte[] dataBytes = "data".getBytes();
@@ -533,7 +533,7 @@ public class LedgerStorageCheckpointTest {
                     currentLog.getUnpersistedBytes());
         }
         Assert.assertNotEquals("There should be logChannelsToFlush", 0,
-                entryLogManagerBase.getCopyOfRotatedLogChannels().size());
+                entryLogManagerBase.getRotatedLogChannels().size());
 
         /*
          * wait for atleast flushInterval period, so that checkpoint can happen.
@@ -544,7 +544,7 @@ public class LedgerStorageCheckpointTest {
          * since checkpoint happenend, there shouldn't be any logChannelsToFlush
          * and bytesWrittenSinceLastFlush should be zero.
          */
-        Set<BufferedLogChannel> copyOfRotatedLogChannels = entryLogManagerBase.getCopyOfRotatedLogChannels();
+        List<BufferedLogChannel> copyOfRotatedLogChannels = entryLogManagerBase.getRotatedLogChannels();
         Assert.assertTrue("There shouldn't be logChannelsToFlush",
                 ((copyOfRotatedLogChannels == null) || (copyOfRotatedLogChannels.size() == 0)));
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
@@ -28,10 +28,13 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
+import org.apache.bookkeeper.bookie.EntryLogger.BufferedLogChannel;
+import org.apache.bookkeeper.bookie.EntryLogger.EntryLogManagerBase;
 import org.apache.bookkeeper.bookie.Journal.LastLogMark;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -359,7 +364,7 @@ public class LedgerStorageCheckpointTest {
         }
         handle.close();
         // simulate rolling entrylog
-        ledgerStorage.entryLogger.rollLog();
+        ((EntryLogManagerBase) ledgerStorage.entryLogger.entryLogManager).createNewLog(ledgerId);
         // sleep for a bit for checkpoint to do its task
         executorController.advance(Duration.ofMillis(500));
 
@@ -491,6 +496,7 @@ public class LedgerStorageCheckpointTest {
         BookKeeper bkClient = new BookKeeper(clientConf);
         InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) server.getBookie().ledgerStorage;
         EntryLogger entryLogger = ledgerStorage.entryLogger;
+        EntryLogManagerBase entryLogManagerBase = (EntryLogManagerBase) entryLogger.entryLogManager;
 
         int numOfEntries = 5;
         byte[] dataBytes = "data".getBytes();
@@ -502,7 +508,7 @@ public class LedgerStorageCheckpointTest {
         }
         handle.close();
         // simulate rolling entrylog
-        ledgerStorage.entryLogger.rollLog();
+        entryLogManagerBase.createNewLog(ledgerId);
 
         ledgerId = 20;
         handle = bkClient.createLedgerAdv(ledgerId, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(), null);
@@ -511,7 +517,7 @@ public class LedgerStorageCheckpointTest {
         }
         handle.close();
         // simulate rolling entrylog
-        ledgerStorage.entryLogger.rollLog();
+        entryLogManagerBase.createNewLog(ledgerId);
 
         ledgerId = 30;
         handle = bkClient.createLedgerAdv(ledgerId, 1, 1, 1, DigestType.CRC32, "passwd".getBytes(), null);
@@ -520,9 +526,14 @@ public class LedgerStorageCheckpointTest {
         }
         handle.close();
 
-        Assert.assertNotEquals("bytesWrittenSinceLastFlush shouldn't be zero", 0,
-                entryLogger.logChannel.getUnpersistedBytes());
-        Assert.assertNotEquals("There should be logChannelsToFlush", 0, entryLogger.logChannelsToFlush.size());
+        Set<BufferedLogChannel> copyOfCurrentLogs = new HashSet<BufferedLogChannel>(
+                Arrays.asList(entryLogManagerBase.getCurrentLogForLedger(EntryLogger.UNASSIGNED_LEDGERID)));
+        for (BufferedLogChannel currentLog : copyOfCurrentLogs) {
+            Assert.assertNotEquals("bytesWrittenSinceLastFlush shouldn't be zero", 0,
+                    currentLog.getUnpersistedBytes());
+        }
+        Assert.assertNotEquals("There should be logChannelsToFlush", 0,
+                entryLogManagerBase.getCopyOfRotatedLogChannels().size());
 
         /*
          * wait for atleast flushInterval period, so that checkpoint can happen.
@@ -533,11 +544,16 @@ public class LedgerStorageCheckpointTest {
          * since checkpoint happenend, there shouldn't be any logChannelsToFlush
          * and bytesWrittenSinceLastFlush should be zero.
          */
+        Set<BufferedLogChannel> copyOfRotatedLogChannels = entryLogManagerBase.getCopyOfRotatedLogChannels();
         Assert.assertTrue("There shouldn't be logChannelsToFlush",
-                ((entryLogger.logChannelsToFlush == null) || (entryLogger.logChannelsToFlush.size() == 0)));
+                ((copyOfRotatedLogChannels == null) || (copyOfRotatedLogChannels.size() == 0)));
 
-        Assert.assertEquals("bytesWrittenSinceLastFlush should be zero", 0,
-                entryLogger.logChannel.getUnpersistedBytes());
+        copyOfCurrentLogs = new HashSet<BufferedLogChannel>(
+                Arrays.asList(entryLogManagerBase.getCurrentLogForLedger(EntryLogger.UNASSIGNED_LEDGERID)));
+        for (BufferedLogChannel currentLog : copyOfCurrentLogs) {
+            Assert.assertEquals("bytesWrittenSinceLastFlush should be zero", 0,
+                    currentLog.getUnpersistedBytes());
+        }
     }
 
     static class MockInterleavedLedgerStorage extends InterleavedLedgerStorage {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -36,7 +36,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
-import org.apache.bookkeeper.bookie.EntryLogger.EntryLogManagerBase;
+import org.apache.bookkeeper.bookie.EntryLogger.EntryLogManagerForSingleEntryLog;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.After;
@@ -223,9 +223,11 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
         });
 
         // simulate entry log is rotated (due to compaction)
-        ((EntryLogManagerBase) storage.entryLogger.entryLogManager).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
+        EntryLogManagerForSingleEntryLog entryLogManager = (EntryLogManagerForSingleEntryLog) storage.getEntryLogger()
+                .getEntryLogManager();
+        entryLogManager.createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
         long leastUnflushedLogId = storage.entryLogger.getLeastUnflushedLogId();
-        long currentLogId = storage.entryLogger.getPreviousAllocatedEntryLogId();
+        long currentLogId = entryLogManager.getCurrentLogId();
         log.info("Least unflushed entry log : current = {}, leastUnflushed = {}", currentLogId, leastUnflushedLogId);
 
         readyLatch.countDown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -36,9 +36,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
+import org.apache.bookkeeper.bookie.EntryLogger.EntryLogManagerBase;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -99,6 +101,7 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
     public SortedLedgerStorageCheckpointTest() {
         super();
         conf.setEntryLogSizeLimit(1);
+        conf.setEntryLogFilePreAllocationEnabled(false);
         this.checkpoints = new LinkedBlockingQueue<>();
     }
 
@@ -182,6 +185,7 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
         assertEquals(new TestCheckpoint(0), memtableCp);
 
         // trigger a memtable flush
+        Assert.assertNotNull("snapshot shouldn't have returned null", storage.memTable.snapshot());
         storage.onSizeLimitReached(checkpointSrc.newCheckpoint());
         // wait for checkpoint to complete
         checkpoints.poll(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
@@ -219,9 +223,9 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
         });
 
         // simulate entry log is rotated (due to compaction)
-        storage.entryLogger.rollLog();
+        ((EntryLogManagerBase) storage.entryLogger.entryLogManager).createNewLog(EntryLogger.UNASSIGNED_LEDGERID);
         long leastUnflushedLogId = storage.entryLogger.getLeastUnflushedLogId();
-        long currentLogId = storage.entryLogger.getCurrentLogId();
+        long currentLogId = storage.entryLogger.getPreviousAllocatedEntryLogId();
         log.info("Least unflushed entry log : current = {}, leastUnflushed = {}", currentLogId, leastUnflushedLogId);
 
         readyLatch.countDown();
@@ -230,6 +234,7 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
         assertEquals(20, storage.memTable.kvmap.size());
 
         // trigger a memtable flush
+        Assert.assertNotNull("snapshot shouldn't have returned null", storage.memTable.snapshot());
         storage.onSizeLimitReached(checkpointSrc.newCheckpoint());
         assertEquals(new TestCheckpoint(100), checkpoints.poll(Long.MAX_VALUE, TimeUnit.MILLISECONDS));
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -227,7 +227,7 @@ public class DbLedgerStorageTest {
         newEntry3.writeLong(4); // ledger id
         newEntry3.writeLong(3); // entry id
         newEntry3.writeBytes("new-entry-3".getBytes());
-        long location = entryLogger.addEntry(4, newEntry3, false);
+        long location = entryLogger.addEntry(4L, newEntry3, false);
 
         List<EntryLocation> locations = Lists.newArrayList(new EntryLocation(4, 3, location));
         singleDirStorage.updateEntriesLocations(locations);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
+import org.apache.bookkeeper.bookie.LedgerDirsManager.LedgerDirsListener;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -71,8 +72,12 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
             ledger.addEntry("data".getBytes());
         }
 
-        // Now add the current ledger dir to filled dirs list
-        ledgerDirsManager.addToFilledDirs(new File(ledgerDirs[0], "current"));
+        // simulate allDisksFull
+        for (LedgerDirsListener ledgerDirsListener : ledgerDirsManager.getListeners()){
+            ledgerDirsListener.allDisksFull(true);
+        }
+        // sleep for transition to RO complete
+        Thread.sleep(1000);
 
         try {
             ledger.addEntry("data".getBytes());
@@ -116,8 +121,12 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
 
         File testDir = new File(ledgerDirs[0], "current");
 
-        // Now add the current ledger dir to filled dirs list
-        ledgerDirsManager.addToFilledDirs(testDir);
+        // simulate allDisksFull
+        for (LedgerDirsListener ledgerDirsListener : ledgerDirsManager.getListeners()){
+            ledgerDirsListener.allDisksFull(true);
+        }
+        // sleep for transition to RO complete
+        Thread.sleep(1000);
 
         try {
             ledger.addEntry("data".getBytes());
@@ -142,7 +151,9 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         }
 
         // Now add the current ledger dir back to writable dirs list
-        ledgerDirsManager.addToWritableDirs(testDir, true);
+        for (LedgerDirsListener ledgerDirsListener : ledgerDirsManager.getListeners()){
+            ledgerDirsListener.diskWritable(testDir);
+        }
 
         bkc.waitForWritableBookie(Bookie.getBookieAddress(bsConfs.get(1)))
             .get(30, TimeUnit.SECONDS);
@@ -183,8 +194,12 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
             ledger.addEntry("data".getBytes());
         }
 
-        // Now add the current ledger dir to filled dirs list
-        ledgerDirsManager.addToFilledDirs(new File(ledgerDirs[0], "current"));
+        // simulate allDisksFull
+        for (LedgerDirsListener ledgerDirsListener : ledgerDirsManager.getListeners()){
+            ledgerDirsListener.allDisksFull(true);
+        }
+        // sleep for transition to RO complete
+        Thread.sleep(1000);
 
         try {
             ledger.addEntry("data".getBytes());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
-import org.apache.bookkeeper.bookie.LedgerDirsManager.LedgerDirsListener;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -72,12 +71,8 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
             ledger.addEntry("data".getBytes());
         }
 
-        // simulate allDisksFull
-        for (LedgerDirsListener ledgerDirsListener : ledgerDirsManager.getListeners()){
-            ledgerDirsListener.allDisksFull(true);
-        }
-        // sleep for transition to RO complete
-        Thread.sleep(1000);
+        // Now add the current ledger dir to filled dirs list
+        ledgerDirsManager.addToFilledDirs(new File(ledgerDirs[0], "current"));
 
         try {
             ledger.addEntry("data".getBytes());
@@ -121,12 +116,8 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
 
         File testDir = new File(ledgerDirs[0], "current");
 
-        // simulate allDisksFull
-        for (LedgerDirsListener ledgerDirsListener : ledgerDirsManager.getListeners()){
-            ledgerDirsListener.allDisksFull(true);
-        }
-        // sleep for transition to RO complete
-        Thread.sleep(1000);
+        // Now add the current ledger dir to filled dirs list
+        ledgerDirsManager.addToFilledDirs(testDir);
 
         try {
             ledger.addEntry("data".getBytes());
@@ -151,9 +142,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         }
 
         // Now add the current ledger dir back to writable dirs list
-        for (LedgerDirsListener ledgerDirsListener : ledgerDirsManager.getListeners()){
-            ledgerDirsListener.diskWritable(testDir);
-        }
+        ledgerDirsManager.addToWritableDirs(testDir, true);
 
         bkc.waitForWritableBookie(Bookie.getBookieAddress(bsConfs.get(1)))
             .get(30, TimeUnit.SECONDS);
@@ -194,12 +183,8 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
             ledger.addEntry("data".getBytes());
         }
 
-        // simulate allDisksFull
-        for (LedgerDirsListener ledgerDirsListener : ledgerDirsManager.getListeners()){
-            ledgerDirsListener.allDisksFull(true);
-        }
-        // sleep for transition to RO complete
-        Thread.sleep(1000);
+        // Now add the current ledger dir to filled dirs list
+        ledgerDirsManager.addToFilledDirs(new File(ledgerDirs[0], "current"));
 
         try {
             ledger.addEntry("data".getBytes());


### PR DESCRIPTION
Descriptions of the changes in this PR:

Introducing EntryLogManager interface, which abstracts out current activeLogChannel,
rotatedLogChannels and corresponding lock for activeLogChannel. The current logic of
handling logs is moved to EntryLogManagerForSingleEntryLog class, in the
next sub-task EntryLogManagerForEntryLogPerLedger will be introduced. Also there
are minor changes to createNewLog logic and leastUnflushedLogId logic.

This is < sub-task5  > of Issue #570

Master Issue: #570 
