### PR TITLE
Issue #1282: call to appendLedgersMap in flushCompactionLog

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -943,6 +943,7 @@ public class EntryLogger {
     void flushCompactionLog() throws IOException {
         synchronized (compactionLogLock) {
             if (compactionLogChannel != null) {
+                appendLedgersMap(compactionLogChannel);
                 compactionLogChannel.flushAndForceWrite(false);
                 LOG.info("Flushed compaction log file {} with logId.",
                     compactionLogChannel.getLogFile(),


### PR DESCRIPTION
Descriptions of the changes in this PR:

with this change https://github.com/apache/bookkeeper/commit/3392beee5c70abe36d36604723e14d97b7764be9 compactionlog was introduced. But for compactionlog call to appendLedgersMap (// Append ledgers map at the end of entry log) isn't made.

So for these logs, getEntryLogMetadata call has to call extractEntryLogMetadataByScanning for getting the metadata of entrylog. Which is a perf hit.

Master Issue: #1282 