### PR TITLE
Improve FileInfoBackingCache

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
@@ -20,9 +20,9 @@
  */
 package org.apache.bookkeeper.bookie;
 
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.extern.slf4j.Slf4j;
@@ -112,15 +112,11 @@ class FileInfoBackingCache {
                 try {
                     fileInfo.close(false);
                 } catch (IOException e) {
-                    throw new UncheckedExecutionException(e);
+                    throw new UncheckedIOException(e);
                 }
             });
-        } catch (UncheckedExecutionException uee) {
-            if (uee.getCause() instanceof IOException) {
-                throw (IOException) uee.getCause();
-            } else {
-                throw new IOException("Unknown exception is thrown on closing all file infos", uee.getCause());
-            }
+        } catch (UncheckedIOException uioe) {
+            throw uioe.getCause();
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
@@ -20,24 +20,35 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.util.collections.ConcurrentLongHashMap;
 
 @Slf4j
 class FileInfoBackingCache {
     static final int DEAD_REF = -0xdead;
 
     final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    final ConcurrentHashMap<Long, CachedFileInfo> fileInfos = new ConcurrentHashMap<>();
+    final ConcurrentLongHashMap<CachedFileInfo> fileInfos = new ConcurrentLongHashMap<>();
     final FileLoader fileLoader;
 
     FileInfoBackingCache(FileLoader fileLoader) {
         this.fileLoader = fileLoader;
+    }
+
+    /**
+     * This method should be under `lock` of FileInfoBackingCache.
+     */
+    private static CachedFileInfo tryRetainFileInfo(CachedFileInfo fi) throws IOException {
+        boolean retained = fi.tryRetain();
+        if (!retained) {
+            throw new IOException("FileInfo " + fi + " is already marked dead");
+        }
+        return fi;
     }
 
     CachedFileInfo loadFileInfo(long ledgerId, byte[] masterKey) throws IOException {
@@ -52,25 +63,29 @@ class FileInfoBackingCache {
                 // have been able to get a reference to it here.
                 // The caller of loadFileInfo owns the refence, and is
                 // responsible for calling the corresponding #release().
-                boolean retained = fi.tryRetain();
-                assert(retained);
-                return fi;
+                return tryRetainFileInfo(fi);
             }
         } finally {
             lock.readLock().unlock();
         }
 
+        File backingFile = fileLoader.load(ledgerId, masterKey != null);
+        CachedFileInfo newFi = new CachedFileInfo(ledgerId, backingFile, masterKey);
+
         // else FileInfo not found, create it under write lock
         lock.writeLock().lock();
         try {
-            File backingFile = fileLoader.load(ledgerId, masterKey != null);
-            CachedFileInfo fi = new CachedFileInfo(ledgerId, backingFile, masterKey);
-            fileInfos.put(ledgerId, fi);
+            CachedFileInfo fi = fileInfos.get(ledgerId);
+            if (fi != null) {
+                // someone is already putting a fileinfo here, so use the existing one and recycle the new one
+                newFi.recycle();
+            } else {
+                fileInfos.put(ledgerId, newFi);
+                fi = newFi;
+            }
 
             // see comment above for why we assert
-            boolean retained = fi.tryRetain();
-            assert(retained);
-            return fi;
+            return tryRetainFileInfo(fi);
         } finally {
             lock.writeLock().unlock();
         }
@@ -92,8 +107,20 @@ class FileInfoBackingCache {
     }
 
     void closeAllWithoutFlushing() throws IOException {
-        for (Map.Entry<Long, CachedFileInfo> entry : fileInfos.entrySet()) {
-            entry.getValue().close(false);
+        try {
+            fileInfos.forEach((key, fileInfo) -> {
+                try {
+                    fileInfo.close(false);
+                } catch (IOException e) {
+                    throw new UncheckedExecutionException(e);
+                }
+            });
+        } catch (UncheckedExecutionException uee) {
+            if (uee.getCause() instanceof IOException) {
+                throw (IOException) uee.getCause();
+            } else {
+                throw new IOException("Unknown exception is thrown on closing all file infos", uee.getCause());
+            }
         }
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

There are a couple of issues noticed in FileInfoBackingCache:

1) There is a race condition in loadFileInfo between get-check and put. If concurrent loading happens, there might be a FileInfo loaded into the map after get-check. This can cause incorrect reference count on FileInfo.

2) FileLoader is doing I/O operation which happens under a giant write lock.

3) assert is typically not recommended since it is disabled at production runtime typically.

*Changes*

- Check whether fileinfo exists or not after getting write lock and before put
- Move any I/O operations out of write lock
- release the new FileInfo if concurrent puts happen
- remove the usage of assert

Beside that, switch to use ConcurrentLongHashMap to avoid boxing and unboxing.


Related Issues:

#913 #832 