### PR TITLE
Implement directly ChannelOutboundHandlerAdapter in BookieProtoEncoding#ResponseEncoder

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -413,7 +413,7 @@ public class BookieProtoEncoding {
             usingV3Protocol = true;
         }
 
-         @Override
+        @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Received request {} from channel {} to decode.", msg, ctx.channel());


### PR DESCRIPTION
This change is mostly a clean up/refactor which drops intermediate MessageToMessageEncoder and MessageToMessageDecoder from BookieProtoEncoding

