### PR TITLE
Added executeOrdered to complement submitOrdered

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
@@ -330,6 +330,16 @@ public class OrderedScheduler implements ScheduledExecutorService {
     }
 
     /**
+     * schedules a one time action to execute with an ordering guarantee on the <tt>orderingKey</tt>.
+     *
+     * @param orderingKey order key to submit the task
+     * @param r task to run
+     */
+    public void executeOrdered(Object orderingKey, SafeRunnable r) {
+        chooseThread(orderingKey).execute(timedRunnable(r));
+    }
+
+    /**
      * schedules a one time action to execute with an ordering guarantee on the key.
      *
      * @param orderingKey


### PR DESCRIPTION
In many cases, we are not interested in the `ListenableFuture` returned by `submitOrdered()` call. In these cases we can avoid creating the future object which will be ignored by calling the `execute()` instead of `submit()` on the underlying executor.