### PR TITLE
Issue #1287: NPE at DNS.reverse

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNS.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNS.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashSet;
 import java.util.Vector;
 
 import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
@@ -87,7 +88,20 @@ public class DNS {
             ictx.close();
         }
 
-        return attribute.get("PTR").get().toString();
+        if (null == attribute) {
+            throw new NamingException("No attribute is found");
+        }
+
+        Attribute ptrAttr = attribute.get("PTR");
+        if (null == ptrAttr) {
+            throw new NamingException("No PTR attribute is found");
+        }
+
+        if (null == ptrAttr.get()) {
+            throw new NamingException("PTR attribute value is null");
+        }
+
+        return ptrAttr.get().toString();
     }
 
     /**


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Problem*

Null value can be returned on retrieving attributes.

*Solution*

If null value is returned, throw NamingException so cached localhost name is used.

Master Issue: #1287 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
