### PR TITLE
[dlog] use Atomic***FieldUpdater and LongAdder if possible

### DIFF
--- a/stream/distributedlog/common/src/main/java/org/apache/distributedlog/common/rate/SampledMovingAverageRate.java
+++ b/stream/distributedlog/common/src/main/java/org/apache/distributedlog/common/rate/SampledMovingAverageRate.java
@@ -20,7 +20,7 @@ package org.apache.distributedlog.common.rate;
 import com.google.common.base.Ticker;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -30,7 +30,7 @@ class SampledMovingAverageRate implements MovingAverageRate {
 
     private static final long NANOS_PER_SEC = TimeUnit.SECONDS.toNanos(1);
 
-    private final AtomicLong total;
+    private final LongAdder total;
     private final Ticker ticker;
     private final double scaleFactor;
     private final LinkedBlockingDeque<Pair<Long, Long>> samples;
@@ -45,7 +45,7 @@ class SampledMovingAverageRate implements MovingAverageRate {
                              double scaleFactor,
                              Ticker ticker) {
         this.value = 0;
-        this.total = new AtomicLong(0);
+        this.total = new LongAdder();
         this.scaleFactor = scaleFactor;
         this.ticker = ticker;
         this.samples = new LinkedBlockingDeque<>(intervalSecs);
@@ -58,7 +58,7 @@ class SampledMovingAverageRate implements MovingAverageRate {
 
     @Override
     public void add(long amount) {
-        total.getAndAdd(amount);
+        total.add(amount);
     }
 
     @Override
@@ -71,7 +71,7 @@ class SampledMovingAverageRate implements MovingAverageRate {
     }
 
     private double doSample() {
-        long newSample = total.get();
+        long newSample = total.sum();
         long newTimestamp = ticker.read();
 
         double rate = 0;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogReader.java
@@ -28,8 +28,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import org.apache.bookkeeper.common.concurrent.FutureEventListener;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -77,12 +77,16 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
     private final String streamName;
     protected final BKDistributedLogManager bkDistributedLogManager;
     protected final BKLogReadHandler readHandler;
-    private final AtomicReference<Throwable> lastException = new AtomicReference<Throwable>();
+    private static final AtomicReferenceFieldUpdater<BKAsyncLogReader, Throwable> lastExceptionUpdater =
+        AtomicReferenceFieldUpdater.newUpdater(BKAsyncLogReader.class, Throwable.class, "lastException");
+    private volatile Throwable lastException = null;
     private final OrderedScheduler scheduler;
     private final ConcurrentLinkedQueue<PendingReadRequest> pendingRequests =
             new ConcurrentLinkedQueue<PendingReadRequest>();
     private final Object scheduleLock = new Object();
-    private final AtomicLong scheduleCount = new AtomicLong(0);
+    private static final AtomicLongFieldUpdater<BKAsyncLogReader> scheduleCountUpdater =
+        AtomicLongFieldUpdater.newUpdater(BKAsyncLogReader.class, "scheduleCount");
+    private volatile long scheduleCount = 0L;
     private final Stopwatch scheduleDelayStopwatch;
     private final Stopwatch readNextDelayStopwatch;
     private DLSN startDLSN;
@@ -340,7 +344,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
     }
 
     private boolean checkClosedOrInError(String operation) {
-        if (null == lastException.get()) {
+        if (null == lastExceptionUpdater.get(this)) {
             try {
                 if (null != readHandler && null != getReadAheadReader()) {
                     getReadAheadReader().checkLastException();
@@ -360,9 +364,10 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
             }
         }
 
-        if (null != lastException.get()) {
+        Throwable cause = lastExceptionUpdater.get(this);
+        if (null != cause) {
             LOG.trace("Cancelling pending reads");
-            cancelAllPendingReads(lastException.get());
+            cancelAllPendingReads(cause);
             return true;
         }
 
@@ -370,7 +375,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
     }
 
     private void setLastException(IOException exc) {
-        lastException.compareAndSet(null, exc);
+        lastExceptionUpdater.compareAndSet(this, null, exc);
     }
 
     @Override
@@ -446,7 +451,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
         }
 
         if (checkClosedOrInError("readNext")) {
-            readRequest.completeExceptionally(lastException.get());
+            readRequest.completeExceptionally(lastExceptionUpdater.get(this));
         } else {
             boolean queueEmpty = pendingRequests.isEmpty();
             pendingRequests.add(readRequest);
@@ -469,7 +474,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
             return;
         }
 
-        long prevCount = scheduleCount.getAndIncrement();
+        long prevCount = scheduleCountUpdater.getAndIncrement(this);
         if (0 == prevCount) {
             scheduleDelayStopwatch.reset().start();
             scheduler.submitOrdered(streamName, this);
@@ -574,7 +579,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
 
             Stopwatch runTime = Stopwatch.createStarted();
             int iterations = 0;
-            long scheduleCountLocal = scheduleCount.get();
+            long scheduleCountLocal = scheduleCountUpdater.get(this);
             LOG.debug("{}: Scheduled Background Reader", readHandler.getFullyQualifiedName());
             while (true) {
                 if (LOG.isTraceEnabled()) {
@@ -588,7 +593,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
                     // Queue is empty, nothing to read, return
                     if (null == nextRequest) {
                         LOG.trace("{}: Queue Empty waiting for Input", readHandler.getFullyQualifiedName());
-                        scheduleCount.set(0);
+                        scheduleCountUpdater.set(this, 0);
                         backgroundReaderRunTime.registerSuccessfulEvent(
                             runTime.stop().elapsed(TimeUnit.MICROSECONDS), TimeUnit.MICROSECONDS);
                         return;
@@ -605,7 +610,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
                 // If the oldest pending promise is interrupted then we must mark
                 // the reader in error and abort all pending reads since we dont
                 // know the last consumed read
-                if (null == lastException.get()) {
+                if (null == lastExceptionUpdater.get(this)) {
                     if (nextRequest.getPromise().isCancelled()) {
                         setLastException(new DLInterruptedException("Interrupted on reading "
                             + readHandler.getFullyQualifiedName()));
@@ -613,8 +618,9 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
                 }
 
                 if (checkClosedOrInError("readNext")) {
-                    if (!(lastException.get().getCause() instanceof LogNotFoundException)) {
-                        LOG.warn("{}: Exception", readHandler.getFullyQualifiedName(), lastException.get());
+                    Throwable lastException = lastExceptionUpdater.get(this);
+                    if (lastException != null && !(lastException.getCause() instanceof LogNotFoundException)) {
+                        LOG.warn("{}: Exception", readHandler.getFullyQualifiedName(), lastException);
                     }
                     backgroundReaderRunTime.registerFailedEvent(
                         runTime.stop().elapsed(TimeUnit.MICROSECONDS), TimeUnit.MICROSECONDS);
@@ -659,7 +665,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
                     setLastException(exc);
                     if (!(exc instanceof LogNotFoundException)) {
                         LOG.warn("{} : read with skip Exception",
-                                readHandler.getFullyQualifiedName(), lastException.get());
+                                readHandler.getFullyQualifiedName(), lastExceptionUpdater.get(this));
                     }
                     continue;
                 }
@@ -670,7 +676,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
                         backgroundReaderRunTime.registerSuccessfulEvent(
                             runTime.stop().elapsed(TimeUnit.MICROSECONDS), TimeUnit.MICROSECONDS);
                         scheduleDelayStopwatch.reset().start();
-                        scheduleCount.set(0);
+                        scheduleCountUpdater.set(this, 0);
                         // the request could still wait for more records
                         backgroundScheduleTask = scheduler.scheduleOrdered(
                                 streamName,
@@ -702,12 +708,12 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
                     }
                 } else {
                     if (0 == scheduleCountLocal) {
-                        LOG.trace("Schedule count dropping to zero", lastException.get());
+                        LOG.trace("Schedule count dropping to zero", lastExceptionUpdater.get(this));
                         backgroundReaderRunTime.registerSuccessfulEvent(
                             runTime.stop().elapsed(TimeUnit.MICROSECONDS), TimeUnit.MICROSECONDS);
                         return;
                     }
-                    scheduleCountLocal = scheduleCount.decrementAndGet();
+                    scheduleCountLocal = scheduleCountUpdater.decrementAndGet(this);
                 }
             }
         }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogReadHandler.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogReadHandler.java
@@ -272,7 +272,7 @@ class BKLogReadHandler extends BKLogHandler implements LogSegmentNamesListener {
                         || cause instanceof LogSegmentNotFoundException
                         || cause instanceof UnexpectedException) {
                     // indicate some inconsistent behavior, abort
-                    metadataException.compareAndSet(null, (IOException) cause);
+                    METADATA_EXCEPTION_UPDATER.compareAndSet(BKLogReadHandler.this, null, (IOException) cause);
                     // notify the reader that read handler is in error state
                     notifyReaderOnError(cause);
                     FutureUtils.completeExceptionally(promise, cause);
@@ -318,7 +318,7 @@ class BKLogReadHandler extends BKLogHandler implements LogSegmentNamesListener {
                         || cause instanceof LogSegmentNotFoundException
                         || cause instanceof UnexpectedException) {
                     // indicate some inconsistent behavior, abort
-                    metadataException.compareAndSet(null, (IOException) cause);
+                    METADATA_EXCEPTION_UPDATER.compareAndSet(BKLogReadHandler.this, null, (IOException) cause);
                     // notify the reader that read handler is in error state
                     notifyReaderOnError(cause);
                     return;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
@@ -30,9 +30,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -220,12 +220,12 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
          */
         boolean checkReturnCodeAndHandleFailure(int rc, boolean isLongPoll) {
             if (BKException.Code.OK == rc) {
-                numReadErrors.set(0);
+                numReadErrorsUpdater.set(BKLogSegmentEntryReader.this, 0);
                 return true;
             }
             if (BKException.Code.BookieHandleNotAvailableException == rc
                     || (isLongPoll && BKException.Code.NoSuchLedgerExistsException == rc)) {
-                int numErrors = Math.max(1, numReadErrors.incrementAndGet());
+                int numErrors = Math.max(1, numReadErrorsUpdater.incrementAndGet(BKLogSegmentEntryReader.this));
                 int nextReadBackoffTime = Math.min(numErrors * readAheadWaitTime, maxReadBackoffTime);
                 scheduler.scheduleOrdered(
                         getSegment().getLogSegmentId(),
@@ -301,15 +301,21 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
     private final List<LedgerHandle> openLedgerHandles;
     private CacheEntry outstandingLongPoll;
     private long nextEntryId;
-    private final AtomicReference<Throwable> lastException = new AtomicReference<Throwable>(null);
-    private final AtomicLong scheduleCount = new AtomicLong(0);
+    private static final AtomicReferenceFieldUpdater<BKLogSegmentEntryReader, Throwable> lastExceptionUpdater =
+        AtomicReferenceFieldUpdater.newUpdater(BKLogSegmentEntryReader.class, Throwable.class, "lastException");
+    private volatile Throwable lastException = null;
+    private static final AtomicLongFieldUpdater<BKLogSegmentEntryReader> scheduleCountUpdater =
+        AtomicLongFieldUpdater.newUpdater(BKLogSegmentEntryReader.class, "scheduleCount");
+    private volatile long scheduleCount = 0L;
     private volatile boolean hasCaughtupOnInprogress = false;
     private final CopyOnWriteArraySet<StateChangeListener> stateChangeListeners =
             new CopyOnWriteArraySet<StateChangeListener>();
     // read retries
     private int readAheadWaitTime;
     private final int maxReadBackoffTime;
-    private final AtomicInteger numReadErrors = new AtomicInteger(0);
+    private static final AtomicIntegerFieldUpdater<BKLogSegmentEntryReader> numReadErrorsUpdater =
+        AtomicIntegerFieldUpdater.newUpdater(BKLogSegmentEntryReader.class, "numReadErrors");
+    private volatile int numReadErrors = 0;
     private final boolean skipBrokenEntries;
     // readahead cache
     int cachedEntries = 0;
@@ -493,8 +499,9 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
     //
 
     private boolean checkClosedOrInError() {
-        if (null != lastException.get()) {
-            cancelAllPendingReads(lastException.get());
+        Throwable cause = lastExceptionUpdater.get(this);
+        if (null != cause) {
+            cancelAllPendingReads(cause);
             return true;
         }
         return false;
@@ -507,7 +514,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
      * @param isBackground is the reader set exception by background reads or foreground reads
      */
     private void completeExceptionally(Throwable throwable, boolean isBackground) {
-        lastException.compareAndSet(null, throwable);
+        lastExceptionUpdater.compareAndSet(this, null, throwable);
         if (isBackground) {
             notifyReaders();
         }
@@ -662,7 +669,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
         final PendingReadRequest readRequest = new PendingReadRequest(numEntries);
 
         if (checkClosedOrInError()) {
-            readRequest.completeExceptionally(lastException.get());
+            readRequest.completeExceptionally(lastExceptionUpdater.get(this));
         } else {
             boolean wasQueueEmpty;
             synchronized (readQueue) {
@@ -682,7 +689,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
             return;
         }
 
-        long prevCount = scheduleCount.getAndIncrement();
+        long prevCount = scheduleCountUpdater.getAndIncrement(this);
         if (0 == prevCount) {
             scheduler.submitOrdered(getSegment().getLogSegmentId(), this);
         }
@@ -693,7 +700,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
      */
     @Override
     public void safeRun() {
-        long scheduleCountLocal = scheduleCount.get();
+        long scheduleCountLocal = scheduleCountUpdater.get(this);
         while (true) {
             PendingReadRequest nextRequest = null;
             synchronized (readQueue) {
@@ -702,14 +709,14 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
 
             // if read queue is empty, nothing to read, return
             if (null == nextRequest) {
-                scheduleCount.set(0L);
+                scheduleCountUpdater.set(this, 0L);
                 return;
             }
 
             // if the oldest pending promise is interrupted then we must
             // mark the reader in error and abort all pending reads since
             // we don't know the last consumed read
-            if (null == lastException.get()) {
+            if (null == lastExceptionUpdater.get(this)) {
                 if (nextRequest.getPromise().isCancelled()) {
                     completeExceptionally(new DLInterruptedException("Interrupted on reading log segment "
                             + getSegment() + " : " + nextRequest.getPromise().isCancelled()), false);
@@ -745,7 +752,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
                 if (0 == scheduleCountLocal) {
                     return;
                 }
-                scheduleCountLocal = scheduleCount.decrementAndGet();
+                scheduleCountLocal = scheduleCountUpdater.decrementAndGet(this);
             }
         }
     }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/lock/TestZKSessionLock.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/lock/TestZKSessionLock.java
@@ -221,7 +221,7 @@ public class TestZKSessionLock extends ZooKeeperClusterTestCase {
 
         // lock action would be executed in same epoch
         final CountDownLatch latch1 = new CountDownLatch(1);
-        lock.executeLockAction(lock.getEpoch().get(), new LockAction() {
+        lock.executeLockAction(lock.getEpoch(), new LockAction() {
             @Override
             public void execute() {
                 counter.incrementAndGet();
@@ -238,7 +238,7 @@ public class TestZKSessionLock extends ZooKeeperClusterTestCase {
 
         // lock action would not be executed in same epoch
         final CountDownLatch latch2 = new CountDownLatch(1);
-        lock.executeLockAction(lock.getEpoch().get() + 1, new LockAction() {
+        lock.executeLockAction(lock.getEpoch() + 1, new LockAction() {
             @Override
             public void execute() {
                 counter.incrementAndGet();
@@ -249,7 +249,7 @@ public class TestZKSessionLock extends ZooKeeperClusterTestCase {
                 return "increment2";
             }
         });
-        lock.executeLockAction(lock.getEpoch().get(), new LockAction() {
+        lock.executeLockAction(lock.getEpoch(), new LockAction() {
             @Override
             public void execute() {
                 latch2.countDown();
@@ -265,7 +265,7 @@ public class TestZKSessionLock extends ZooKeeperClusterTestCase {
 
         // lock action would not be executed in same epoch and promise would be satisfied with exception
         CompletableFuture<Void> promise = new CompletableFuture<Void>();
-        lock.executeLockAction(lock.getEpoch().get() + 1, new LockAction() {
+        lock.executeLockAction(lock.getEpoch() + 1, new LockAction() {
             @Override
             public void execute() {
                 counter.incrementAndGet();


### PR DESCRIPTION

Descriptions of the changes in this PR:

AtomicFieldUpdater + volatile provides similar guarantees as Atomic but use much fewer memory.
In dlog, when handling large number of streams, there can be a lot of Atomic fields with `LogHandler`, `SegmentWriter` and such.
Switching using Atomic to using AtomicFieldUpdater + volatile will save a lot of memory. See [details](http://normanmaurer.me/blog/2013/10/28/Lesser-known-concurrent-classes-Part-1/)

LongAdder is less contended across threads, which is more preferable to AtomicLong when multiple threads update a common sum. E.g. SampledMovingAverageRate.
Switching to use LongAdder if AtomicLong is not needed. See [details](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/LongAdder.html)

Master Issue: #<master-issue-number>

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
