### PR TITLE
Make CRC32C_HASH a final static variable and log when we cannot use native crc32c library

### DIFF
--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Crc32cIntChecksum.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Crc32cIntChecksum.java
@@ -33,7 +33,7 @@ public class Crc32cIntChecksum {
     private static final Logger log = LoggerFactory.getLogger(Crc32cIntChecksum.class);
 
     @VisibleForTesting
-    static IncrementalIntHash CRC32C_HASH;
+    final static IncrementalIntHash CRC32C_HASH;
 
     static {
         if (Sse42Crc32C.isSupported()) {
@@ -41,6 +41,7 @@ public class Crc32cIntChecksum {
             log.info("SSE4.2 CRC32C provider initialized");
         } else {
             CRC32C_HASH = new StandardCrcProvider().getIncrementalInt(CRC32C);
+            log.warn("Failed to load Circe JNI library. Falling back to Java based CRC32c provider");
         }
     }
 

--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Crc32cLongChecksum.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Crc32cLongChecksum.java
@@ -33,7 +33,7 @@ public class Crc32cLongChecksum {
     private static final Logger log = LoggerFactory.getLogger(Crc32cLongChecksum.class);
 
     @VisibleForTesting
-    static IncrementalIntHash CRC32C_HASH;
+    final static IncrementalIntHash CRC32C_HASH;
 
     static {
         if (Sse42Crc32C.isSupported()) {
@@ -43,6 +43,7 @@ public class Crc32cLongChecksum {
             }
         } else {
             CRC32C_HASH = new StandardCrcProvider().getIncrementalInt(CRC32C);
+            log.warn("Failed to load Circe JNI library. Falling back to Java based CRC32c provider");
         }
     }
 


### PR DESCRIPTION
For CRC32c there is a marked performance difference when the JNI library is available versus when it's not, since the fallback involves creating many `ByteBuffer`s and copy payloads. 

Additionally we should set the static variable to `final` so the optimizer can get rid of the `(CRC32C_HASH instanceof Sse42Crc32C)` checks. 