### PR TITLE
Use reflection based CRC32 to pass direct memory pointer

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
@@ -29,7 +29,7 @@ import org.apache.bookkeeper.proto.checksum.CRC32DigestManager.CRC32Digest;
  * Specialized implementation of CRC32 digest that uses reflection on {@link CRC32} class to get access to
  * "updateByteBuffer" method and pass a direct memory pointer.
  */
-public class DirectMemoryCRC32Digest implements CRC32Digest {
+class DirectMemoryCRC32Digest implements CRC32Digest {
 
     public static boolean isSupported() {
         return updateBytes != null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
@@ -1,0 +1,94 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.bookkeeper.proto.checksum;
+
+import io.netty.buffer.ByteBuf;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.zip.CRC32;
+
+import org.apache.bookkeeper.proto.checksum.CRC32DigestManager.CRC32Digest;
+
+/**
+ * Specialized implementation of CRC32 digest that uses reflection on {@link CRC32} class to get access to
+ * "updateByteBuffer" method and pass a direct memory pointer.
+ */
+public class DirectMemoryCRC32Digest implements CRC32Digest {
+
+    public static boolean isSupported() {
+        return updateBytes != null;
+    }
+
+    private int crcValue;
+
+    @Override
+    public long getValueAndReset() {
+        long value = crcValue & 0xffffffffL;
+        crcValue = 0;
+        return value;
+    }
+
+    @Override
+    public void update(ByteBuf buf) {
+        int index = buf.readerIndex();
+        int length = buf.readableBytes();
+
+        try {
+            if (buf.hasMemoryAddress()) {
+                // Calculate CRC directly from the direct memory pointer
+                crcValue = (int) updateByteBuffer.invoke(null, crcValue, buf.memoryAddress(), index, length);
+            } else if (buf.hasArray()) {
+                // Use the internal method to update from array based
+                crcValue = (int) updateBytes.invoke(null, crcValue, buf.array(), buf.arrayOffset() + index, length);
+            } else {
+                // Fallback to data copy if buffer is not contiguous
+                byte[] b = new byte[length];
+                buf.getBytes(index, b, 0, length);
+                crcValue = (int) updateBytes.invoke(null, crcValue, b, 0, b.length);
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final Method updateByteBuffer;
+    private static final Method updateBytes;
+
+    static {
+        // Access CRC32 class private native methods to compute the crc on the ByteBuf direct memory,
+        // without necessity to convert to a nio ByteBuffer.
+        Method updateByteBufferMethod = null;
+        Method updateBytesMethod = null;
+        try {
+            updateByteBufferMethod = CRC32.class.getDeclaredMethod("updateByteBuffer", int.class, long.class, int.class,
+                    int.class);
+            updateByteBufferMethod.setAccessible(true);
+
+            updateBytesMethod = CRC32.class.getDeclaredMethod("updateBytes", int.class, byte[].class, int.class,
+                    int.class);
+            updateBytesMethod.setAccessible(true);
+        } catch (NoSuchMethodException | SecurityException e) {
+            updateByteBufferMethod = null;
+            updateBytesMethod = null;
+        }
+
+        updateByteBuffer = updateByteBufferMethod;
+        updateBytes = updateBytesMethod;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/StandardCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/StandardCRC32Digest.java
@@ -26,13 +26,15 @@ import org.apache.bookkeeper.proto.checksum.CRC32DigestManager.CRC32Digest;
 /**
  * Regular implementation of CRC32 digest that makes use of {@link CRC32} class.
  */
-public class StandardCRC32Digest implements CRC32Digest {
+class StandardCRC32Digest implements CRC32Digest {
 
     private final CRC32 crc = new CRC32();
 
     @Override
     public long getValueAndReset() {
-        return crc.getValue();
+        long value = crc.getValue();
+        crc.reset();
+        return value;
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/StandardCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/StandardCRC32Digest.java
@@ -1,0 +1,42 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.bookkeeper.proto.checksum;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.zip.CRC32;
+
+import org.apache.bookkeeper.proto.checksum.CRC32DigestManager.CRC32Digest;
+
+/**
+ * Regular implementation of CRC32 digest that makes use of {@link CRC32} class.
+ */
+public class StandardCRC32Digest implements CRC32Digest {
+
+    private final CRC32 crc = new CRC32();
+
+    @Override
+    public long getValueAndReset() {
+        return crc.getValue();
+    }
+
+    @Override
+    public void update(ByteBuf buf) {
+        crc.update(buf.nioBuffer());
+    }
+}


### PR DESCRIPTION
The crc update with the bytebuffer is very expensive, especially in netty > 4.1.12.

```java
crc.get().update(data.nioBuffer());
```

Converting a direct`ByteBuf` into a `ByteBuffer` with `data.nioBuffer()` is actually resorting to allocating an unpooled `DirectByteBuffer` which is actually killing the GC (since direct memory is freed when the `DirectByteBuffer` instances are GCed, but the pauses are > 1 second).

This is an adaptation of a change from Yahoo branch at https://github.com/yahoo/bookkeeper/commit/6c01ca2921a998f3bf2e85cacb27867773e7ea28

Initially I though this change was not needed anymore in 4.7 codebase, and that is true for the CRC32c variant. For the regular CRC32, though, we need to avoid the bad behavior of unpooled direct buffers.

Additionally, as in #1306, the thread local variable was made static to avoid the leakage of instances per each ledger.