### PR TITLE
Upgrade Maven Assembly Plugin to 3.1.0

### DIFF
--- a/bookkeeper-dist/all/pom.xml
+++ b/bookkeeper-dist/all/pom.xml
@@ -103,6 +103,7 @@
           <descriptors>
             <descriptor>../src/assemble/bin-all.xml</descriptor>
           </descriptors>
+          <tarLongFileMode>posix</tarLongFileMode>
         </configuration>
         <executions>
           <execution>

--- a/bookkeeper-dist/pom.xml
+++ b/bookkeeper-dist/pom.xml
@@ -53,6 +53,7 @@
           <descriptors>
             <descriptor>src/assemble/src.xml</descriptor>
           </descriptors>
+          <tarLongFileMode>posix</tarLongFileMode>
         </configuration>
         <executions>
           <execution>

--- a/bookkeeper-dist/server/pom.xml
+++ b/bookkeeper-dist/server/pom.xml
@@ -81,6 +81,7 @@
           <descriptors>
             <descriptor>../src/assemble/bin-server.xml</descriptor>
           </descriptors>
+          <tarLongFileMode>posix</tarLongFileMode>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
     <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
-    <maven-assembly-plugin.version>2.2.1</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
   </properties>
 
   <!-- dependencies for all modules -->


### PR DESCRIPTION
Upgrade Maven Assembly Plugin to 3.1.0
    - upgrade Maven Assembly Plugin because 2.2.1 version has issues about file permissions
    - explicitly set tarLongFileMode to 'posix' in order to handle user ids with large values