### PR TITLE
MockLedgerHandle duplicates LedgerEntries on read

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -108,7 +108,7 @@ public class MockLedgerHandle extends LedgerHandle {
                 final Queue<LedgerEntry> seq = new ArrayDeque<LedgerEntry>();
                 long entryId = firstEntry;
                 while (entryId <= lastEntry && entryId < entries.size()) {
-                    seq.add(new LedgerEntry(entries.get((int) entryId++)));
+                    seq.add(new LedgerEntry(entries.get((int) entryId++).duplicate()));
                 }
 
                 log.debug("Entries read: {}", seq);


### PR DESCRIPTION
Previously it was not duplicating, so the underlying ByteBuf was being
returned to the client, and this was having its reader index modified,
which meant that if it was read again, the data could not be read.

By calling duplicate() on the LedgerEntryImpl, the underlying ByteBuf
is sliced and retained, so it has a new set of indices. The retention
does nothing, as the buffer is unpooled.
