### PR TITLE
Improve logging on ledger dirs monitor to avoid log flooding

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.MetadataBookieDriver;
 import org.apache.bookkeeper.stats.Gauge;
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
 /**
  * An implementation of StateManager.
  */
+@Slf4j
 public class BookieStateManager implements StateManager {
     private static final Logger LOG = LoggerFactory.getLogger(BookieStateManager.class);
     private final ServerConfiguration conf;
@@ -142,6 +144,11 @@ public class BookieStateManager implements StateManager {
 
     @Override
     public void setHighPriorityWritesAvailability(boolean available) {
+        if (this.availableForHighPriorityWrites && !available) {
+            log.info("Disable high priority writes on readonly bookie.");
+        } else if (!this.availableForHighPriorityWrites && available) {
+            log.info("Enable high priority writes on readonly bookie.");
+        }
         this.availableForHighPriorityWrites = available;
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

When a bookie is in readonly mode, the ledger dirs monitor will keep check the disk usage and generate tons of logs if the disk usage is unchanged. This makes debugging much difficult.

*Solution*

- Improve the logging logic in ledger dirs monitor to only log changes when disk usage is changed.
- Disable logging on checking threshold for high priority writes. Only log changes when high priority writes availability is changed.

*Result*

This reduces the logging when a bookie is outage in readonly mode.