### PR TITLE
Improve "Failed to resolve network location" logging

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
@@ -81,7 +81,8 @@ public class BookieSocketAddress {
      * Maps the socketAddress to a "local" address.
      */
     public LocalAddress getLocalAddress() {
-        return new LocalAddress(socketAddress.toString());
+        // for local address, we just need "port" to differentiate different addresses.
+        return new LocalAddress("" + port);
     }
 
     // Return the String "serialized" version of this object.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/ScriptBasedMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/ScriptBasedMapping.java
@@ -145,6 +145,10 @@ public final class ScriptBasedMapping extends CachedDNSToSwitchMapping {
                 scriptName = null;
                 maxArgs = 0;
             }
+
+            if (null == scriptName) {
+                throw new RuntimeException("No network topology script is found when using script based DNS resolver.");
+            }
         }
 
         /**


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

Rackware/Region-Aware is using a script based DNS resolver for resolving network topology. If the network topology script is not configured, the DNS resolver will return `null` as network location. It results in using `default-rack` as the network location and log "Failed to resolve network location" for each resolution.

*Solution*

If a script file is not provided, throw a runtime exception. So the rackaware/region-aware placement policy can fallback to use the default-rack resolver. It would avoid the logging flood.

*Result*

Before this change, it will log following statement for each DNS resolution:

"Failed to resolve network location".

After this change, it will only log following statement during initialization:

```
INFO  - [Time-limited test:RackawareEnsemblePlacementPolicyImpl@313] - Failed to initialize DNS Resolver org.apache.bookkeeper.net.ScriptBasedMapping, used default subnet resolver.
java.lang.RuntimeException: No network topology script is found when using script based DNS resolver.
	at org.apache.bookkeeper.net.ScriptBasedMapping$RawScriptBasedMapping.setConf(ScriptBasedMapping.java:150)
	at org.apache.bookkeeper.net.ScriptBasedMapping.setConf(ScriptBasedMapping.java:122)
	at org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl.initialize(RackawareEnsemblePlacementPolicyImpl.java:306)
	at org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl.initialize(RackawareEnsemblePlacementPolicyImpl.java:75)
	at org.apache.bookkeeper.client.BookKeeper.initializeEnsemblePlacementPolicy(BookKeeper.java:598)
	at org.apache.bookkeeper.client.BookKeeper.<init>(BookKeeper.java:490)
```



