### PR TITLE
Remove WriteFlags from public API

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -23,6 +23,7 @@ package org.apache.bookkeeper.client;
 
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -238,7 +239,7 @@ class LedgerCreateOp implements GenericCallback<Void> {
         cb.createComplete(rc, lh, ctx);
     }
 
-    static class CreateBuilderImpl implements CreateBuilder {
+    public static class CreateBuilderImpl implements CreateBuilder {
 
         private final BookKeeper bk;
         private int builderEnsembleSize = 3;
@@ -260,10 +261,13 @@ class LedgerCreateOp implements GenericCallback<Void> {
             return this;
         }
 
-        @Override
         public CreateBuilder withWriteFlags(EnumSet<WriteFlag> writeFlags) {
             this.builderWriteFlags = writeFlags;
             return this;
+        }
+
+        public CreateBuilder withWriteFlags(WriteFlag... writeFlags) {
+            return withWriteFlags(EnumSet.copyOf(Arrays.asList(writeFlags)));
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -21,6 +21,7 @@
 
 package org.apache.bookkeeper.client;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -282,6 +283,7 @@ class LedgerCreateOp implements GenericCallback<Void> {
             return this;
         }
 
+        @SuppressFBWarnings("EI_EXPOSE_REP2")
         @Override
         public CreateBuilder withPassword(byte[] password) {
             this.builderPassword = password;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/CreateBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/CreateBuilder.java
@@ -20,8 +20,6 @@
  */
 package org.apache.bookkeeper.client.api;
 
-import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Map;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
@@ -92,26 +90,6 @@ public interface CreateBuilder extends OpBuilder<WriteHandle> {
      * @return the builder itself
      */
     CreateBuilder withDigestType(DigestType digestType);
-
-    /**
-     * Set write flags. Write wlags specify the behaviour of writes
-     *
-     * @param writeFlags the flags
-     *
-     * @return the builder itself
-     */
-    CreateBuilder withWriteFlags(EnumSet<WriteFlag> writeFlags);
-
-    /**
-     * Set write flags. Write wlags specify the behaviour of writes
-     *
-     * @param writeFlags the flags
-     *
-     * @return the builder itself
-     */
-    default CreateBuilder withWriteFlags(WriteFlag ... writeFlags) {
-        return withWriteFlags(EnumSet.copyOf(Arrays.asList(writeFlags)));
-    }
 
     /**
      * Switch the ledger into 'Advanced' mode. A ledger used in Advanced mode will explicitly generate the sequence of

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -48,7 +48,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.client.BKException.Code;
-import org.apache.bookkeeper.client.api.CreateBuilder;
+import org.apache.bookkeeper.client.LedgerCreateOp.CreateBuilderImpl;
 import org.apache.bookkeeper.client.api.DeleteBuilder;
 import org.apache.bookkeeper.client.api.OpenBuilder;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
@@ -209,7 +209,7 @@ public abstract class MockBookKeeperTestCase {
         when(bk.getConf()).thenReturn(config);
     }
 
-    protected CreateBuilder newCreateLedgerOp() {
+    protected CreateBuilderImpl newCreateLedgerOp() {
         return new LedgerCreateOp.CreateBuilderImpl(bk);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
@@ -225,12 +225,12 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
     public void testCreateAdvLedgerWriteFlags() throws Exception {
         setNewGeneratedLedgerId(ledgerId);
         WriteAdvHandle writer = newCreateLedgerOp()
+            .withWriteFlags(writeFlagsDeferredSync)
             .withAckQuorumSize(ackQuorumSize)
             .withEnsembleSize(ensembleSize)
             .withPassword(password)
             .withWriteQuorumSize(writeQuorumSize)
             .withCustomMetadata(customMetadata)
-            .withWriteFlags(writeFlagsDeferredSync)
             .makeAdv()
             .execute()
             .get();
@@ -248,12 +248,12 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
     public void testCreateLedgerWriteFlags() throws Exception {
         setNewGeneratedLedgerId(ledgerId);
         WriteHandle writer = newCreateLedgerOp()
+            .withWriteFlags(writeFlagsDeferredSync)
             .withAckQuorumSize(ackQuorumSize)
             .withEnsembleSize(ensembleSize)
             .withPassword(password)
             .withWriteQuorumSize(writeQuorumSize)
             .withCustomMetadata(customMetadata)
-            .withWriteFlags(writeFlagsDeferredSync)
             .execute()
             .get();
         assertEquals(ledgerId, writer.getId());
@@ -270,12 +270,12 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
     public void testCreateLedgerWriteFlagsVarargs() throws Exception {
         setNewGeneratedLedgerId(ledgerId);
         WriteHandle writer = newCreateLedgerOp()
+            .withWriteFlags(DEFERRED_SYNC)
             .withAckQuorumSize(ackQuorumSize)
             .withEnsembleSize(ensembleSize)
             .withPassword(password)
             .withWriteQuorumSize(writeQuorumSize)
             .withCustomMetadata(customMetadata)
-            .withWriteFlags(DEFERRED_SYNC)
             .execute()
             .get();
         assertEquals(ledgerId, writer.getId());


### PR DESCRIPTION

Descriptions of the changes in this PR:

`DeferredSync` is not implemented at server side. So remove `withWriteFlags` from builder API.

