### PR TITLE
Use metadata service uri rather than zkServers

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/TestClient.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/TestClient.java
@@ -126,7 +126,7 @@ public class TestClient {
 
                 ClientConfiguration conf = new ClientConfiguration();
                 conf.setThrottleValue(bkthrottle);
-                conf.setZkServers(zkservers);
+                conf.setMetadataServiceUri("zk://" + zkservers + "/ledgers");
 
                 bkc = new BookKeeper(conf);
                 List<LedgerHandle> handles = new ArrayList<LedgerHandle>();

--- a/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
+++ b/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
@@ -48,6 +48,11 @@ public class TestBenchmark extends BookKeeperClusterTestCase {
         super.setUp();
     }
 
+    @Override
+    protected String getMetadataServiceUri(String ledgersRootPath) {
+        return zkUtil.getMetadataServiceUri(ledgersRootPath, "flat");
+    }
+
     @Test
     public void testThroughputLatency() throws Exception {
         String latencyFile = System.getProperty("test.latency.file", "latencyDump.dat");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -40,6 +40,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.RoundingMode;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -95,6 +96,7 @@ import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRange;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookieProtocol;
@@ -1805,8 +1807,10 @@ public class BookieShell implements Tool {
         int runCmd(CommandLine cmdLine) throws Exception {
             ZooKeeper zk = null;
             try {
+                String metadataServiceUri = bkConf.getMetadataServiceUri();
+                String zkServers = ZKMetadataDriverBase.getZKServersFromServiceUri(URI.create(metadataServiceUri));
                 zk = ZooKeeperClient.newBuilder()
-                        .connectString(bkConf.getZkServers())
+                        .connectString(zkServers)
                         .sessionTimeoutMs(bkConf.getZkTimeout())
                         .build();
                 BookieSocketAddress bookieId = AuditorElector.getCurrentAuditor(bkConf, zk);
@@ -1859,8 +1863,8 @@ public class BookieShell implements Tool {
                 } catch (BookieException e) {
                     throw new UncheckedExecutionException(e);
                 }
-                LOG.info("ZKServers: {} ZkLedgersRootPath: {} InstanceId: {}", bkConf.getZkServers(),
-                        bkConf.getZkLedgersRootPath(), readInstanceId);
+                LOG.info("Metadata Service Uri: {} InstanceId: {}",
+                    bkConf.getMetadataServiceUriUnchecked(), readInstanceId);
                 return null;
             });
             return 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -328,7 +328,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      */
     public BookKeeper(String servers) throws IOException, InterruptedException,
         BKException {
-        this(new ClientConfiguration().setZkServers(servers));
+        this(new ClientConfiguration().setMetadataServiceUri("zk+null://" + servers + "/ledgers"));
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -68,6 +68,7 @@ import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.MultiCallback;
@@ -134,7 +135,7 @@ public class BookKeeperAdmin implements AutoCloseable {
      *             BookKeeper client.
      */
     public BookKeeperAdmin(String zkServers) throws IOException, InterruptedException, BKException {
-        this(new ClientConfiguration().setZkServers(zkServers));
+        this(new ClientConfiguration().setMetadataServiceUri("zk+null://" + zkServers + "/ledgers"));
     }
 
     /**
@@ -1205,7 +1206,7 @@ public class BookKeeperAdmin implements AutoCloseable {
      */
     public static boolean nukeExistingCluster(ServerConfiguration conf, String ledgersRootPath, String instanceId,
             boolean force) throws Exception {
-        String confLedgersRootPath = conf.getZkLedgersRootPath();
+        String confLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         if (!confLedgersRootPath.equals(ledgersRootPath)) {
             LOG.error("Provided ledgerRootPath : {} is not matching with config's ledgerRootPath: {}, "
                     + "so exiting nuke operation", ledgersRootPath, confLedgersRootPath);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -248,10 +248,11 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
             }
             String zkServers = getZkServers();
             if (null != zkServers) {
+                // URI doesn't accept ','
                 serviceUri = String.format(
                     "zk+%s://%s%s",
                     ledgerManagerType,
-                    getZkServers(),
+                    zkServers.replace(",", ";"),
                     getZkLedgersRootPath());
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.net.ssl.SSLEngine;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.feature.Feature;
 import org.apache.bookkeeper.meta.AbstractZkLedgerManagerFactory;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
@@ -47,6 +48,7 @@ import org.apache.commons.lang.StringUtils;
 /**
  * Abstract configuration.
  */
+@Slf4j
 public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     extends CompositeConfiguration {
 
@@ -194,7 +196,26 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     /**
      * Get metadata service uri.
      *
+     * <p><b>Warning:</b> this method silently converts checked exceptions to unchecked exceptions.
+     * It is useful to use this method in lambda expressions. However it should not be used with places
+     * which have logics to handle checked exceptions. In such cases use {@link #getMetadataServiceUri()} instead.
+     *
+     * @return metadata service uri
+     * @throws UncheckedConfigurationException if the metadata service uri is invalid.
+     */
+    public String getMetadataServiceUriUnchecked() throws UncheckedConfigurationException {
+        try {
+            return getMetadataServiceUri();
+        } catch (ConfigurationException e) {
+            throw new UncheckedConfigurationException(e);
+        }
+    }
+
+    /**
+     * Get metadata service uri.
+     *
      * @return metadata service uri.
+     * @throws ConfigurationException if the metadata service uri is invalid.
      */
     @SuppressWarnings("deprecation")
     public String getMetadataServiceUri() throws ConfigurationException {
@@ -252,8 +273,12 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     /**
      * Get zookeeper servers to connect.
      *
+     * <p>`zkServers` is deprecating, in favor of using `metadataServiceUri`
+     *
      * @return zookeeper servers
+     * @deprecated since 4.7.0
      */
+    @Deprecated
     public String getZkServers() {
         List servers = getList(ZK_SERVERS, null);
         if (null == servers || 0 == servers.size()) {
@@ -265,9 +290,12 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     /**
      * Set zookeeper servers to connect.
      *
+     * <p>`zkServers` is deprecating, in favor of using `metadataServiceUri`
+     *
      * @param zkServers
      *          ZooKeeper servers to connect
      */
+    @Deprecated
     public T setZkServers(String zkServers) {
         setProperty(ZK_SERVERS, zkServers);
         return getThis();
@@ -351,7 +379,6 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      * @param classPrefix
      *          the class prefix of shaded ledger manager factory class
      * @return configuration instance.
-     * @see #setAllowLedgerManagerFactoryClass(boolean)
      */
     public T setShadedLedgerManagerFactoryClassPrefix(String classPrefix) {
         setProperty(SHADED_LEDGER_MANAGER_FACTORY_CLASS_PREFIX, classPrefix);
@@ -418,6 +445,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      *
      * @param zkLedgersPath zk ledgers root path
      */
+    @Deprecated
     public void setZkLedgersRootPath(String zkLedgersPath) {
         setProperty(ZK_LEDGERS_ROOT_PATH, zkLedgersPath);
     }
@@ -427,6 +455,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      *
      * @return zk ledgers root path
      */
+    @Deprecated
     public String getZkLedgersRootPath() {
         return getString(ZK_LEDGERS_ROOT_PATH, "/ledgers");
     }
@@ -473,6 +502,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      *
      * @return Node under which available bookies are stored.
      */
+    @Deprecated
     public String getZkAvailableBookiesPath() {
         return getZkLedgersRootPath() + "/" + AVAILABLE_NODE;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/UncheckedConfigurationException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/UncheckedConfigurationException.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.conf;
+
+import java.util.Objects;
+import org.apache.commons.configuration.ConfigurationException;
+
+/**
+ * Wraps a {@link org.apache.commons.configuration.ConfigurationException} with an unchecked exception.
+ *
+ * @since 4.7.0
+ */
+public class UncheckedConfigurationException extends RuntimeException {
+
+    /**
+     * Constructs an instance of this class.
+     *
+     * @param   message
+     *          the detail message, can be null
+     * @param   cause
+     *          the {@code ConfigurationException}
+     *
+     * @throws  NullPointerException
+     *          if the cause is {@code null}
+     */
+    public UncheckedConfigurationException(String message, ConfigurationException cause) {
+        super(message, Objects.requireNonNull(cause));
+    }
+
+    /**
+     * Constructs an instance of this class.
+     *
+     * @param   cause
+     *          the {@code IOException}
+     *
+     * @throws  NullPointerException
+     *          if the cause is {@code null}
+     */
+    public UncheckedConfigurationException(ConfigurationException cause) {
+        super(Objects.requireNonNull(cause));
+    }
+
+    /**
+     * Returns the cause of this exception.
+     *
+     * @return  the {@code IOException} which is the cause of this exception.
+     */
+    @Override
+    public ConfigurationException getCause() {
+        return (ConfigurationException) super.getCause();
+    }
+
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationManager.java
@@ -49,6 +49,7 @@ import org.apache.bookkeeper.meta.LayoutManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.ZkLayoutManager;
 import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.bookkeeper.util.ZkUtils;
@@ -111,7 +112,7 @@ public class ZKRegistrationManager implements RegistrationManager {
         this.zk = zk;
         this.zkAcls = ZkUtils.getACLs(conf);
 
-        this.ledgersRootPath = conf.getZkLedgersRootPath();
+        this.ledgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         this.cookiePath = ledgersRootPath + "/" + COOKIE_NODE;
         this.bookieRegistrationPath = ledgersRootPath + "/" + AVAILABLE_NODE;
         this.bookieReadonlyRegistrationPath = this.bookieRegistrationPath + "/" + READONLY;
@@ -119,7 +120,7 @@ public class ZKRegistrationManager implements RegistrationManager {
 
         this.layoutManager = new ZkLayoutManager(
             zk,
-            conf.getZkLedgersRootPath(),
+            ledgersRootPath,
             zkAcls);
 
         this.zk.register(event -> {
@@ -405,7 +406,7 @@ public class ZKRegistrationManager implements RegistrationManager {
 
     @Override
     public boolean initNewCluster() throws Exception {
-        String zkServers = conf.getZkServers();
+        String zkServers = ZKMetadataDriverBase.resolveZkServers(conf);
         String instanceIdPath = ledgersRootPath + "/" + INSTANCEID;
         log.info("Initializing ZooKeeper metadata for new cluster, ZKServers: {} ledger root path: {}", zkServers,
                 ledgersRootPath);
@@ -450,7 +451,7 @@ public class ZKRegistrationManager implements RegistrationManager {
 
     @Override
     public boolean nukeExistingCluster() throws Exception {
-        String zkServers = conf.getZkServers();
+        String zkServers = ZKMetadataDriverBase.resolveZkServers(conf);
         log.info("Nuking ZooKeeper metadata of existing cluster, ZKServers: {} ledger root path: {}",
                 zkServers, ledgersRootPath);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.LedgerMetadata;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.LedgerMetadataListener;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.MultiCallback;
@@ -159,7 +160,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
     protected AbstractZkLedgerManager(AbstractConfiguration conf, ZooKeeper zk) {
         this.conf = conf;
         this.zk = zk;
-        this.ledgerRootPath = conf.getZkLedgersRootPath();
+        this.ledgerRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         this.scheduler = Executors
                 .newSingleThreadScheduledExecutor(new DefaultThreadFactory("ZkLedgerManagerScheduler"));
         if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
@@ -45,7 +45,7 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
     public void format(AbstractConfiguration<?> conf, LayoutManager layoutManager)
             throws InterruptedException, KeeperException, IOException {
         try (AbstractZkLedgerManager ledgerManager = (AbstractZkLedgerManager) newLedgerManager()) {
-            String ledgersRootPath = conf.getZkLedgersRootPath();
+            String ledgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
             List<String> children = zk.getChildren(ledgersRootPath, false);
             for (String child : children) {
                 if (!AbstractZkLedgerManager.isSpecialZnode(child) && ledgerManager.isLedgerParentNode(child)) {
@@ -69,8 +69,8 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
     @Override
     public boolean validateAndNukeExistingCluster(AbstractConfiguration<?> conf, LayoutManager layoutManager)
             throws InterruptedException, KeeperException, IOException {
-        String zkLedgersRootPath = conf.getZkLedgersRootPath();
-        String zkServers = conf.getZkServers();
+        String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
+        String zkServers = ZKMetadataDriverBase.resolveZkServers(conf);
         AbstractZkLedgerManager zkLedgerManager = (AbstractZkLedgerManager) newLedgerManager();
 
         /*
@@ -147,7 +147,7 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
                 throw new IOException(
                     "Failed to get ledger manager factory class when using an external zookeeper client", e);
             }
-            ledgerRootPath = conf.getZkLedgersRootPath();
+            ledgerRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         } else {
             URI metadataServiceUri = URI.create(metadataServiceUriStr);
             factoryClass = ZKMetadataDriverBase.resolveLedgerManagerFactory(metadataServiceUri);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
@@ -147,7 +147,7 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
                 throw new IOException(
                     "Failed to get ledger manager factory class when using an external zookeeper client", e);
             }
-            ledgerRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
+            ledgerRootPath = conf.getZkLedgersRootPath();
         } else {
             URI metadataServiceUri = URI.create(metadataServiceUriStr);
             factoryClass = ZKMetadataDriverBase.resolveLedgerManagerFactory(metadataServiceUri);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManagerFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.zookeeper.KeeperException;
@@ -72,7 +73,8 @@ public class FlatLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
     @Override
     public LedgerIdGenerator newLedgerIdGenerator() {
         List<ACL> zkAcls = ZkUtils.getACLs(conf);
-        return new ZkLedgerIdGenerator(zk, conf.getZkLedgersRootPath(), null, zkAcls);
+        String ledgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
+        return new ZkLedgerIdGenerator(zk, ledgersRootPath, null, zkAcls);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManagerFactory.java
@@ -19,6 +19,7 @@ package org.apache.bookkeeper.meta;
 
 import java.util.List;
 
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.zookeeper.data.ACL;
 
@@ -32,9 +33,10 @@ public class HierarchicalLedgerManagerFactory extends LegacyHierarchicalLedgerMa
     @Override
     public LedgerIdGenerator newLedgerIdGenerator() {
         List<ACL> zkAcls = ZkUtils.getACLs(conf);
-        ZkLedgerIdGenerator subIdGenerator = new ZkLedgerIdGenerator(zk, conf.getZkLedgersRootPath(),
+        String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
+        ZkLedgerIdGenerator subIdGenerator = new ZkLedgerIdGenerator(zk, zkLedgersRootPath,
                 LegacyHierarchicalLedgerManager.IDGEN_ZNODE, zkAcls);
-        return new LongZkLedgerIdGenerator(zk, conf.getZkLedgersRootPath(), LongHierarchicalLedgerManager.IDGEN_ZNODE,
+        return new LongZkLedgerIdGenerator(zk, zkLedgersRootPath, LongHierarchicalLedgerManager.IDGEN_ZNODE,
                 subIdGenerator, zkAcls);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManagerFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.zookeeper.KeeperException;
@@ -70,8 +71,11 @@ public class LegacyHierarchicalLedgerManagerFactory extends AbstractZkLedgerMana
     @Override
     public LedgerIdGenerator newLedgerIdGenerator() {
         List<ACL> zkAcls = ZkUtils.getACLs(conf);
-        return new ZkLedgerIdGenerator(zk, conf.getZkLedgersRootPath(), LegacyHierarchicalLedgerManager.IDGEN_ZNODE,
-                zkAcls);
+        return new ZkLedgerIdGenerator(
+            zk,
+            ZKMetadataDriverBase.resolveZkLedgersRootPath(conf),
+            LegacyHierarchicalLedgerManager.IDGEN_ZNODE,
+            zkAcls);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.LedgerMetadata;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.metastore.MSException;
 import org.apache.bookkeeper.metastore.MSWatchedEvent;
 import org.apache.bookkeeper.metastore.MetaStore;
@@ -198,7 +199,11 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
     @Override
     public LedgerIdGenerator newLedgerIdGenerator() {
         List<ACL> zkAcls = ZkUtils.getACLs(conf);
-        return new ZkLedgerIdGenerator(zk, conf.getZkLedgersRootPath(), MsLedgerManager.IDGEN_ZNODE, zkAcls);
+        return new ZkLedgerIdGenerator(
+            zk,
+            ZKMetadataDriverBase.resolveZkLedgersRootPath(conf),
+            MsLedgerManager.IDGEN_ZNODE,
+            zkAcls);
     }
 
     static class MsLedgerManager implements LedgerManager, MetastoreWatcher {
@@ -761,8 +766,8 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
     @Override
     public boolean validateAndNukeExistingCluster(AbstractConfiguration<?> conf, LayoutManager layoutManager)
             throws InterruptedException, KeeperException, IOException {
-        String zkLedgersRootPath = conf.getZkLedgersRootPath();
-        String zkServers = conf.getZkServers();
+        String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
+        String zkServers = ZKMetadataDriverBase.resolveZkServers(conf);
 
         /*
          * before proceeding with nuking existing cluster, make sure there

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
@@ -40,6 +40,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.DNS;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat;
@@ -116,7 +117,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
     public ZkLedgerUnderreplicationManager(AbstractConfiguration conf, ZooKeeper zkc)
             throws KeeperException, InterruptedException, ReplicationException.CompatibilityException {
         this.conf = conf;
-        basePath = getBasePath(conf.getZkLedgersRootPath());
+        basePath = getBasePath(ZKMetadataDriverBase.resolveZkLedgersRootPath(conf));
         layoutZNode = basePath + '/' + BookKeeperConstants.LAYOUT_ZNODE;
         urLedgerPath = basePath
                 + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -144,6 +144,7 @@ public class ZKMetadataDriverBase implements AutoCloseable {
         return SCHEME;
     }
 
+    @SuppressWarnings("deprecation")
     @SneakyThrows(InterruptedException.class)
     protected void initialize(AbstractConfiguration<?> conf,
                               StatsLogger statsLogger,
@@ -154,7 +155,7 @@ public class ZKMetadataDriverBase implements AutoCloseable {
 
         if (optionalCtx.isPresent()
             && optionalCtx.get() instanceof ZooKeeper) {
-            this.ledgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
+            this.ledgersRootPath = conf.getZkLedgersRootPath();
 
             log.info("Initialize zookeeper metadata driver with external zookeeper client : ledgersRootPath = {}.",
                 ledgersRootPath);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -60,8 +60,26 @@ public class ZKMetadataDriverBase implements AutoCloseable {
 
     protected static final String SCHEME = "zk";
 
-    protected static String getZKServersFromServiceUri(URI uri) {
+    public static String getZKServersFromServiceUri(URI uri) {
         return uri.getAuthority().replace(";", ",");
+    }
+
+    public static String resolveZkServers(AbstractConfiguration<?> conf) {
+        String metadataServiceUriStr = conf.getMetadataServiceUriUnchecked();
+        if (null == metadataServiceUriStr) {
+            return null;
+        }
+        URI metadataServiceUri = URI.create(metadataServiceUriStr);
+        return getZKServersFromServiceUri(metadataServiceUri);
+    }
+
+    public static String resolveZkLedgersRootPath(AbstractConfiguration<?> conf) {
+        String metadataServiceUriStr = conf.getMetadataServiceUriUnchecked();
+        if (null == metadataServiceUriStr) {
+            return null;
+        }
+        URI metadataServiceUri = URI.create(metadataServiceUriStr);
+        return metadataServiceUri.getPath();
     }
 
     @SuppressWarnings("deprecation")
@@ -136,7 +154,7 @@ public class ZKMetadataDriverBase implements AutoCloseable {
 
         if (optionalCtx.isPresent()
             && optionalCtx.get() instanceof ZooKeeper) {
-            this.ledgersRootPath = conf.getZkLedgersRootPath();
+            this.ledgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
 
             log.info("Initialize zookeeper metadata driver with external zookeeper client : ledgersRootPath = {}.",
                 ledgersRootPath);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -49,6 +49,7 @@ import org.apache.bookkeeper.meta.AbstractZkLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.Processor;
@@ -72,6 +73,8 @@ import org.slf4j.LoggerFactory;
  * bookie failed or disconnected from zk, he will start initiating the
  * re-replication activities by keeping all the corresponding ledgers of the
  * failed bookie as underreplicated znode in zk.
+ *
+ * <p>TODO: eliminate the direct usage of zookeeper here {@link https://github.com/apache/bookkeeper/issues/1332}
  */
 public class Auditor {
     private static final Logger LOG = LoggerFactory.getLogger(Auditor.class);
@@ -607,7 +610,7 @@ public class Auditor {
     void checkAllLedgers() throws BKAuditException, BKException,
             IOException, InterruptedException, KeeperException {
         ZooKeeper newzk = ZooKeeperClient.newBuilder()
-                .connectString(conf.getZkServers())
+                .connectString(ZKMetadataDriverBase.resolveZkServers(conf))
                 .sessionTimeoutMs(conf.getZkTimeout())
                 .build();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.DataFormats.AuditorVoteFormat;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
@@ -133,7 +134,7 @@ public class AuditorElector {
         this.zkc = zkc;
         this.statsLogger = statsLogger;
         this.electionAttempts = statsLogger.getCounter(ELECTION_ATTEMPTS);
-        basePath = conf.getZkLedgersRootPath() + '/'
+        basePath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf) + '/'
                 + BookKeeperConstants.UNDER_REPLICATION_NODE;
         electionPath = basePath + '/' + ELECTION_ZNODE;
         createElectorPath();
@@ -315,7 +316,7 @@ public class AuditorElector {
      */
     public static BookieSocketAddress getCurrentAuditor(ServerConfiguration conf, ZooKeeper zk)
             throws KeeperException, InterruptedException, IOException {
-        String electionRoot = conf.getZkLedgersRootPath() + '/'
+        String electionRoot = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf) + '/'
             + BookKeeperConstants.UNDER_REPLICATION_NODE + '/' + ELECTION_ZNODE;
 
         List<String> children = zk.getChildren(electionRoot, false);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.bookie.ExitCode;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
 import org.apache.bookkeeper.http.HttpServerLoader;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.server.http.BKHttpServiceProvider;
@@ -58,6 +59,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Class to start/stop the AutoRecovery daemons Auditor and ReplicationWorker.
+ *
+ * <p>TODO: eliminate the direct usage of zookeeper here {@link https://github.com/apache/bookkeeper/issues/1332}
  */
 public class AutoRecoveryMain {
     private static final Logger LOG = LoggerFactory
@@ -99,7 +102,7 @@ public class AutoRecoveryMain {
             }
         });
         zk = ZooKeeperClient.newBuilder()
-                .connectString(conf.getZkServers())
+                .connectString(ZKMetadataDriverBase.resolveZkServers(conf))
                 .sessionTimeoutMs(conf.getZkTimeout())
                 .watchers(watchers)
                 .build();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookieInfoService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookieInfoService.java
@@ -82,7 +82,6 @@ public class ListBookieInfoService implements HttpEndpointService {
 
         if (HttpServer.Method.GET == request.getMethod()) {
             ClientConfiguration clientConf = new ClientConfiguration(conf);
-            clientConf.setZkServers(conf.getZkServers());
             clientConf.setDiskWeightBasedPlacementEnabled(true);
             BookKeeper bk = new BookKeeper(clientConf);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/verifier/BookkeeperVerifierMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/verifier/BookkeeperVerifierMain.java
@@ -146,8 +146,7 @@ public class BookkeeperVerifierMain {
         }
 
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkString);
-        conf.setZkLedgersRootPath(ledgerPath);
+        conf.setMetadataServiceUri("zk://" + zkString + ledgerPath);
         BookKeeper bkclient = new BookKeeper(conf);
 
         BookkeeperVerifier verifier = new BookkeeperVerifier(

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/AdvertisedAddressTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/AdvertisedAddressTest.java
@@ -64,7 +64,7 @@ public class AdvertisedAddressTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(newDirectory(false))
             .setLedgerDirNames(new String[] { newDirectory(false) })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         conf.setAdvertisedAddress("10.0.0.1");
         assertEquals("10.0.0.1", conf.getAdvertisedAddress());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalForceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalForceTest.java
@@ -76,9 +76,9 @@ public class BookieJournalForceTest {
         File journalDir = tempDir.newFolder();
         Bookie.checkDirectoryStructure(Bookie.getCurrentDirectory(journalDir));
 
-        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
-        conf.setJournalDirName(journalDir.getPath())
-            .setZkServers(null);
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+            .setJournalDirName(journalDir.getPath())
+            .setMetadataServiceUri(null);
 
         JournalChannel jc = spy(new JournalChannel(journalDir, 1));
         whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);
@@ -140,7 +140,7 @@ public class BookieJournalForceTest {
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         JournalChannel jc = spy(new JournalChannel(journalDir, 1));
         whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);
@@ -195,7 +195,7 @@ public class BookieJournalForceTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setJournalBufferedEntriesThreshold(journalBufferedEntriesThreshold)
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         JournalChannel jc = spy(new JournalChannel(journalDir, 1));
         whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);
@@ -254,7 +254,7 @@ public class BookieJournalForceTest {
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         JournalChannel jc = spy(new JournalChannel(journalDir, 1));
         whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -348,7 +348,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = new Bookie(conf);
         b.readJournal();
@@ -377,7 +377,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = new Bookie(conf);
         b.readJournal();
@@ -408,7 +408,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = new Bookie(conf);
         b.readJournal();
@@ -445,7 +445,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = null;
         try {
@@ -480,7 +480,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = new Bookie(conf);
     }
@@ -502,7 +502,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = new Bookie(conf);
     }
@@ -528,7 +528,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = null;
         try {
@@ -568,7 +568,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = new Bookie(conf);
         b.readJournal();
@@ -612,7 +612,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = new Bookie(conf);
         b.readJournal();
@@ -674,7 +674,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         if (truncateMasterKey) {
             try {
@@ -732,7 +732,7 @@ public class BookieJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
 
         Bookie b = new Bookie(conf);
         b.readJournal();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieMultipleJournalsTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieMultipleJournalsTest.java
@@ -43,9 +43,9 @@ public class BookieMultipleJournalsTest extends BookKeeperClusterTestCase {
         super(1);
     }
 
-    protected ServerConfiguration newServerConfiguration(int port, String zkServers, File journalDir,
+    protected ServerConfiguration newServerConfiguration(int port, File journalDir,
             File[] ledgerDirs) {
-        ServerConfiguration conf = super.newServerConfiguration(port, zkServers, journalDir, ledgerDirs);
+        ServerConfiguration conf = super.newServerConfiguration(port, journalDir, ledgerDirs);
 
         // Use 4 journals
         String[] journalDirs = new String[4];

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
@@ -73,7 +73,7 @@ public class BookieWriteToJournalTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[]{ledgerDir.getPath()})
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
         BookieSocketAddress bookieAddress = Bookie.getBookieAddress(conf);
         CountDownLatch journalJoinLatch = new CountDownLatch(1);
         Journal journal = mock(Journal.class);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CookieTest.java
@@ -83,7 +83,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         this.metadataBookieDriver = MetadataDrivers.getBookieDriver(
             URI.create(baseConf.getMetadataServiceUri()));
         this.metadataBookieDriver.initialize(baseConf, () -> {}, NullStatsLogger.INSTANCE);
@@ -107,7 +107,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(newDirectory(false))
             .setLedgerDirNames(new String[] { newDirectory(false) })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
             Bookie b = new Bookie(conf);
         } catch (Exception e) {
@@ -136,7 +136,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf2.setJournalDirName(journalDir)
             .setLedgerDirNames(new String[] { ledgerDir })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         Cookie.Builder cookieBuilder2 = Cookie.generateCookie(conf2);
         Cookie c2 = cookieBuilder2.build();
         c2.writeToDirectory(new File(journalDir, "current"));
@@ -164,7 +164,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -205,7 +205,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -235,7 +235,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -265,7 +265,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(new String[] { ledgerDir0 })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -300,7 +300,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setIndexDirName(new String[] { indexDir0 })
             .setBookiePort(bookiePort)
             .setAllowStorageExpansion(true)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -383,7 +383,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setIndexDirName(new String[] { indexDir0 })
             .setBookiePort(bookiePort)
             .setAllowStorageExpansion(true)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -435,7 +435,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(new String[] { ledgerDir0 , newDirectory() })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -460,7 +460,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(newDirectory())
             .setLedgerDirNames(new String[] { newDirectory() , newDirectory() })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         Bookie b = new Bookie(conf); // should work fine
         b.start();
         b.shutdown();
@@ -486,7 +486,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(newDirectory())
             .setLedgerDirNames(new String[] { newDirectory() , newDirectory() })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         Bookie b = new Bookie(conf); // should work fine
         b.start();
         b.shutdown();
@@ -495,7 +495,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(newDirectory())
             .setLedgerDirNames(new String[] { newDirectory() , newDirectory() })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
             b = new Bookie(conf);
             fail("Shouldn't have been able to start");
@@ -510,7 +510,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
     @Test
     public void testVerifyCookieWithFormat() throws Exception {
         ServerConfiguration adminConf = new ServerConfiguration();
-        adminConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        adminConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         adminConf.setProperty("bookkeeper.format", true);
         // Format the BK Metadata and generate INSTANCEID
@@ -520,7 +520,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         bookieConf.setJournalDirName(newDirectory(false))
             .setLedgerDirNames(new String[] { newDirectory(false) })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         // Bookie should start successfully for fresh env.
         new Bookie(bookieConf);
 
@@ -556,7 +556,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
             Bookie b = new Bookie(conf);
             fail("Shouldn't have been able to start");
@@ -581,7 +581,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[]{ledgerDir.getPath()})
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
             Bookie b = new Bookie(conf);
             fail("Shouldn't have been able to start");
@@ -604,7 +604,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         Bookie b = new Bookie(conf); // should work fine
         b.start();
         b.shutdown();
@@ -630,7 +630,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         conf.setUseHostNameAsBookieID(false);
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -657,7 +657,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir).setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         conf.setUseHostNameAsBookieID(true);
         Bookie b = new Bookie(conf); // should work fine
         b.start();
@@ -687,7 +687,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
             conf.setUseHostNameAsBookieID(true);
             new Bookie(conf);
@@ -710,7 +710,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         Bookie b = new Bookie(conf); // should work fine
         b.start();
         b.shutdown();
@@ -742,7 +742,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         Bookie b = new Bookie(conf); // should work fine
         b.start();
         b.shutdown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EnableZkSecurityBasicTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EnableZkSecurityBasicTest.java
@@ -82,7 +82,7 @@ public class EnableZkSecurityBasicTest extends BookKeeperClusterTestCase {
         startNewBookie();
 
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         conf.setZkTimeout(20000);
 
         conf.setZkEnableSecurity(true);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/IndexPersistenceMgrTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/IndexPersistenceMgrTest.java
@@ -66,7 +66,7 @@ public class IndexPersistenceMgrTest {
         Bookie.getCurrentDirectory(ledgerDir).mkdir();
 
         conf = new ServerConfiguration();
-        conf.setZkServers(null);
+        conf.setMetadataServiceUri(null);
         conf.setJournalDirName(journalDir.getPath());
         conf.setLedgerDirNames(new String[] { ledgerDir.getPath() });
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -80,7 +80,7 @@ public class LedgerCacheTest {
         new File(ledgerDir, BookKeeperConstants.CURRENT_DIR).mkdir();
 
         conf = TestBKConfiguration.newServerConfiguration();
-        conf.setZkServers(null);
+        conf.setMetadataServiceUri(null);
         conf.setJournalDirName(txnDir.getPath());
         conf.setLedgerDirNames(new String[] { ledgerDir.getPath() });
         bookie = new Bookie(conf);
@@ -316,7 +316,7 @@ public class LedgerCacheTest {
         Bookie.checkDirectoryStructure(Bookie.getCurrentDirectory(ledgerDir));
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
-        conf.setZkServers(null);
+        conf.setMetadataServiceUri(null);
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setFlushInterval(1000)
@@ -331,7 +331,7 @@ public class LedgerCacheTest {
         }
 
         conf = TestBKConfiguration.newServerConfiguration();
-        conf.setZkServers(null);
+        conf.setMetadataServiceUri(null);
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() });
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
@@ -201,7 +201,7 @@ public class LedgerStorageCheckpointTest {
         File tmpDir = createTempDir("DiskCheck", "test");
 
         final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
-                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri())
                 .setZkTimeout(5000)
                 .setJournalDirName(tmpDir.getPath())
                 .setLedgerDirNames(new String[] { tmpDir.getPath() })
@@ -217,7 +217,7 @@ public class LedgerStorageCheckpointTest {
         BookieServer server = new BookieServer(conf);
         server.start();
         ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        clientConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkClient = new BookKeeper(clientConf);
 
         int numOfLedgers = 2;
@@ -327,7 +327,7 @@ public class LedgerStorageCheckpointTest {
         File tmpDir = createTempDir("DiskCheck", "test");
 
         final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
-                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri())
                 .setZkTimeout(5000)
                 .setJournalDirName(tmpDir.getPath())
                 .setLedgerDirNames(new String[] { tmpDir.getPath() })
@@ -345,7 +345,7 @@ public class LedgerStorageCheckpointTest {
         BookieServer server = new BookieServer(conf);
         server.start();
         ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        clientConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkClient = new BookKeeper(clientConf);
         InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) server.getBookie().ledgerStorage;
 
@@ -402,7 +402,7 @@ public class LedgerStorageCheckpointTest {
         File tmpDir = createTempDir("DiskCheck", "test");
 
         final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
-                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri())
                 .setZkTimeout(5000)
                 .setJournalDirName(tmpDir.getPath())
                 .setLedgerDirNames(new String[] { tmpDir.getPath() })
@@ -423,9 +423,8 @@ public class LedgerStorageCheckpointTest {
         BookieServer server = new BookieServer(conf);
         server.start();
         ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        clientConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkClient = new BookKeeper(clientConf);
-        InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) server.getBookie().ledgerStorage;
 
         Random rand = new Random();
         byte[] dataBytes = new byte[10 * 1000];
@@ -467,7 +466,7 @@ public class LedgerStorageCheckpointTest {
         File tmpDir = createTempDir("DiskCheck", "test");
 
         final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
-                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri())
                 .setZkTimeout(5000)
                 .setJournalDirName(tmpDir.getPath())
                 .setLedgerDirNames(new String[] { tmpDir.getPath() })
@@ -487,7 +486,7 @@ public class LedgerStorageCheckpointTest {
         BookieServer server = new BookieServer(conf);
         server.start();
         ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        clientConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkClient = new BookKeeper(clientConf);
         InterleavedLedgerStorage ledgerStorage = (InterleavedLedgerStorage) server.getBookie().ledgerStorage;
         EntryLogger entryLogger = ledgerStorage.entryLogger;
@@ -575,7 +574,7 @@ public class LedgerStorageCheckpointTest {
         File tmpDir = createTempDir("DiskCheck", "test");
 
         final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
-                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri())
                 .setZkTimeout(5000)
                 .setJournalDirName(tmpDir.getPath())
                 .setLedgerDirNames(new String[] { tmpDir.getPath() })
@@ -592,7 +591,7 @@ public class LedgerStorageCheckpointTest {
         BookieServer server = new BookieServer(conf);
         server.start();
         ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        clientConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         final BookKeeper bkClient = new BookKeeper(clientConf);
 
         int numOfLedgers = 12;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageTestBase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageTestBase.java
@@ -64,7 +64,7 @@ public abstract class LedgerStorageTestBase {
         Bookie.getCurrentDirectory(ledgerDir).mkdir();
 
         // build the configuration
-        conf.setZkServers(null);
+        conf.setMetadataServiceUri(null);
         conf.setJournalDirName(journalDir.getPath());
         conf.setLedgerDirNames(new String[] { ledgerDir.getPath() });
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SingleBookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SingleBookieInitializationTest.java
@@ -59,7 +59,6 @@ public class SingleBookieInitializationTest {
         this.conf.setJournalDirsName(new String[] { journalDir.getAbsolutePath() });
         this.conf.setLedgerDirNames(new String[] { ledgerDir.getAbsolutePath() });
         this.conf.setMetadataServiceUri(null);
-        this.conf.setZkServers(null);
     }
 
     @After

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/StateManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/StateManagerTest.java
@@ -46,8 +46,8 @@ public class StateManagerTest extends BookKeeperClusterTestCase {
     public StateManagerTest(){
         super(0);
         String ledgersPath = "/" + "ledgers" + runtime.getMethodName();
-        baseClientConf.setZkLedgersRootPath(ledgersPath);
-        baseConf.setZkLedgersRootPath(ledgersPath);
+        baseClientConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri(ledgersPath));
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri(ledgersPath));
         conf = TestBKConfiguration.newServerConfiguration();
         driver = new ZKMetadataBookieDriver();
 
@@ -61,7 +61,7 @@ public class StateManagerTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(tmpDir.getPath())
                 .setLedgerDirNames(new String[] { tmpDir.getPath() })
                 .setJournalDirName(tmpDir.toString())
-                .setZkServers(zkUtil.getZooKeeperConnectString());
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
     }
 
     @Override
@@ -150,7 +150,7 @@ public class StateManagerTest extends BookKeeperClusterTestCase {
         readOnlyConf.setJournalDirName(tmpDir.getPath())
                 .setLedgerDirNames(new String[] { tmpDir.getPath() })
                 .setJournalDirName(tmpDir.toString())
-                .setZkServers(zkUtil.getZooKeeperConnectString())
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri())
                 .setForceReadOnlyBookie(true);
         ReadOnlyBookie readOnlyBookie = new ReadOnlyBookie(readOnlyConf, NullStatsLogger.INSTANCE);
         readOnlyBookie.start();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestGcOverreplicatedLedger.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestGcOverreplicatedLedger.java
@@ -43,6 +43,7 @@ import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManagerTestCase;
 import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
@@ -204,8 +205,11 @@ public class TestGcOverreplicatedLedger extends LedgerManagerTestCase {
 
         lh.close();
 
-        ZkLedgerUnderreplicationManager.acquireUnderreplicatedLedgerLock(zkc, baseConf.getZkLedgersRootPath(),
-                lh.getId(), ZooDefs.Ids.OPEN_ACL_UNSAFE);
+        ZkLedgerUnderreplicationManager.acquireUnderreplicatedLedgerLock(
+            zkc,
+            ZKMetadataDriverBase.resolveZkLedgersRootPath(baseConf),
+            lh.getId(),
+            ZooDefs.Ids.OPEN_ACL_UNSAFE);
 
         final CompactableLedgerStorage mockLedgerStorage = new MockLedgerStorage();
         final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(ledgerManager, mockLedgerStorage,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
@@ -152,7 +152,7 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
 
     private static void testUpgradeProceedure(String zkServers, String journalDir, String ledgerDir) throws Exception {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
-        conf.setZkServers(zkServers);
+        conf.setMetadataServiceUri("zk://" + zkServers + "/ledgers");
         conf.setJournalDirName(journalDir)
             .setLedgerDirNames(new String[] { ledgerDir })
             .setBookiePort(bookiePort);
@@ -219,7 +219,7 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setBookiePort(bookiePort)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         FileSystemUpgrade.upgrade(conf); // should work fine with current directory
         Bookie b = new Bookie(conf);
         b.start();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageBookieTest.java
@@ -60,7 +60,7 @@ public class DbLedgerStorageBookieTest extends BookKeeperClusterTestCase {
     public void testV2ReadWrite() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
         conf.setUseV2WireProtocol(true);
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeper bkc = new BookKeeper(conf);
         LedgerHandle lh1 = bkc.createLedger(1, 1, DigestType.CRC32, new byte[0]);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperAdminTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperAdminTest.java
@@ -21,6 +21,7 @@
 package org.apache.bookkeeper.client;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -39,6 +40,7 @@ import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
@@ -160,7 +162,9 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
         Assert.assertFalse("initBookie shouldn't have succeeded, since cookie in ZK is not deleted yet",
                 BookKeeperAdmin.initBookie(confOfExistingBookie));
         String bookieId = Bookie.getBookieAddress(confOfExistingBookie).toString();
-        String bookieCookiePath = confOfExistingBookie.getZkLedgersRootPath() + "/" + BookKeeperConstants.COOKIE_NODE
+        String bookieCookiePath =
+            ZKMetadataDriverBase.resolveZkLedgersRootPath(confOfExistingBookie)
+                + "/" + BookKeeperConstants.COOKIE_NODE
                 + "/" + bookieId;
         zkc.delete(bookieCookiePath, -1);
 
@@ -172,19 +176,19 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
     public void testInitNewCluster() throws Exception {
         ServerConfiguration newConfig = new ServerConfiguration(baseConf);
         String ledgersRootPath = "/testledgers";
-        newConfig.setZkLedgersRootPath(ledgersRootPath);
-        newConfig.setZkServers(zkUtil.getZooKeeperConnectString());
+        newConfig.setMetadataServiceUri(newMetadataServiceUri(ledgersRootPath));
         Assert.assertTrue("New cluster should be initialized successfully", BookKeeperAdmin.initNewCluster(newConfig));
 
         Assert.assertTrue("Cluster rootpath should have been created successfully " + ledgersRootPath,
                 (zkc.exists(ledgersRootPath, false) != null));
-        String availableBookiesPath = newConfig.getZkAvailableBookiesPath();
+        String availableBookiesPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig) + "/" + AVAILABLE_NODE;
         Assert.assertTrue("AvailableBookiesPath should have been created successfully " + availableBookiesPath,
                 (zkc.exists(availableBookiesPath, false) != null));
         String readonlyBookiesPath = availableBookiesPath + "/" + READONLY;
         Assert.assertTrue("ReadonlyBookiesPath should have been created successfully " + readonlyBookiesPath,
             (zkc.exists(readonlyBookiesPath, false) != null));
-        String instanceIdPath = newConfig.getZkLedgersRootPath() + "/" + BookKeeperConstants.INSTANCEID;
+        String instanceIdPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig)
+            + "/" + BookKeeperConstants.INSTANCEID;
         Assert.assertTrue("InstanceId node should have been created successfully" + instanceIdPath,
                 (zkc.exists(instanceIdPath, false) != null));
 
@@ -199,7 +203,8 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
         Random rand = new Random();
         for (int i = 0; i < numOfBookies; i++) {
             String ipString = InetAddresses.fromInteger(rand.nextInt()).getHostAddress();
-            String regPath = newConfig.getZkAvailableBookiesPath() + "/" + ipString + ":3181";
+            String regPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig)
+                + "/" + AVAILABLE_NODE + "/" + ipString + ":3181";
             zkc.create(regPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
         }
 
@@ -217,7 +222,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
     public void testNukeExistingClusterWithForceOption() throws Exception {
         String ledgersRootPath = "/testledgers";
         ServerConfiguration newConfig = new ServerConfiguration(baseConf);
-        newConfig.setZkLedgersRootPath(ledgersRootPath);
+        newConfig.setMetadataServiceUri(newMetadataServiceUri(ledgersRootPath));
         List<String> bookiesRegPaths = new ArrayList<String>();
         initiateNewClusterAndCreateLedgers(newConfig, bookiesRegPaths);
 
@@ -239,7 +244,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
     public void testNukeExistingClusterWithInstanceId() throws Exception {
         String ledgersRootPath = "/testledgers";
         ServerConfiguration newConfig = new ServerConfiguration(baseConf);
-        newConfig.setZkLedgersRootPath(ledgersRootPath);
+        newConfig.setMetadataServiceUri(newMetadataServiceUri(ledgersRootPath));
         List<String> bookiesRegPaths = new ArrayList<String>();
         initiateNewClusterAndCreateLedgers(newConfig, bookiesRegPaths);
 
@@ -251,7 +256,9 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
             zkc.delete(bookiesRegPaths.get(i), -1);
         }
 
-        byte[] data = zkc.getData(newConfig.getZkLedgersRootPath() + "/" + BookKeeperConstants.INSTANCEID, false, null);
+        byte[] data = zkc.getData(
+            ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig) + "/" + BookKeeperConstants.INSTANCEID,
+            false, null);
         String readInstanceId = new String(data, UTF_8);
 
         Assert.assertTrue("New cluster should be nuked successfully",
@@ -264,7 +271,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
     public void tryNukingExistingClustersWithInvalidParams() throws Exception {
         String ledgersRootPath = "/testledgers";
         ServerConfiguration newConfig = new ServerConfiguration(baseConf);
-        newConfig.setZkLedgersRootPath(ledgersRootPath);
+        newConfig.setMetadataServiceUri(newMetadataServiceUri(ledgersRootPath));
         List<String> bookiesRegPaths = new ArrayList<String>();
         initiateNewClusterAndCreateLedgers(newConfig, bookiesRegPaths);
 
@@ -279,15 +286,17 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
         /*
          * read instanceId
          */
-        byte[] data = zkc.getData(newConfig.getZkLedgersRootPath() + "/" + BookKeeperConstants.INSTANCEID, false, null);
+        byte[] data = zkc.getData(
+            ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig) + "/" + BookKeeperConstants.INSTANCEID,
+            false, null);
         String readInstanceId = new String(data, UTF_8);
 
         /*
          * register a RO bookie
          */
         String ipString = InetAddresses.fromInteger((new Random()).nextInt()).getHostAddress();
-        String roBookieRegPath = newConfig.getZkAvailableBookiesPath() + "/" + READONLY + "/"
-                + ipString + ":3181";
+        String roBookieRegPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig)
+            + "/" + AVAILABLE_NODE + "/" + READONLY + "/" + ipString + ":3181";
         zkc.create(roBookieRegPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
         Assert.assertFalse("Cluster should'nt be nuked since instanceid is not provided and force option is not set",
@@ -310,10 +319,11 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
          */
         Assert.assertTrue("Cluster rootpath should be existing " + ledgersRootPath,
                 (zkc.exists(ledgersRootPath, false) != null));
-        String availableBookiesPath = newConfig.getZkAvailableBookiesPath();
+        String availableBookiesPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig) + "/" + AVAILABLE_NODE;
         Assert.assertTrue("AvailableBookiesPath should be existing " + availableBookiesPath,
                 (zkc.exists(availableBookiesPath, false) != null));
-        String instanceIdPath = newConfig.getZkLedgersRootPath() + "/" + BookKeeperConstants.INSTANCEID;
+        String instanceIdPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig)
+            + "/" + BookKeeperConstants.INSTANCEID;
         Assert.assertTrue("InstanceId node should be existing" + instanceIdPath,
                 (zkc.exists(instanceIdPath, false) != null));
         String ledgersLayout = ledgersRootPath + "/" + BookKeeperConstants.LAYOUT_ZNODE;
@@ -339,7 +349,6 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
 
     void initiateNewClusterAndCreateLedgers(ServerConfiguration newConfig, List<String> bookiesRegPaths)
             throws Exception {
-        newConfig.setZkServers(zkUtil.getZooKeeperConnectString());
         Assert.assertTrue("New cluster should be initialized successfully", BookKeeperAdmin.initNewCluster(newConfig));
 
         /**
@@ -349,7 +358,8 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
         Random rand = new Random();
         for (int i = 0; i < numberOfBookies; i++) {
             String ipString = InetAddresses.fromInteger(rand.nextInt()).getHostAddress();
-            bookiesRegPaths.add(newConfig.getZkAvailableBookiesPath() + "/" + ipString + ":3181");
+            bookiesRegPaths.add(ZKMetadataDriverBase.resolveZkLedgersRootPath(newConfig)
+                + "/" + AVAILABLE_NODE + "/" + ipString + ":3181");
             zkc.create(bookiesRegPaths.get(i), new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperClientTestsWithBookieErrors.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperClientTestsWithBookieErrors.java
@@ -126,7 +126,7 @@ public class BookKeeperClientTestsWithBookieErrors extends BookKeeperClusterTest
     // In this testcase all the bookies will return corrupt entry
     @Test(timeout = 60000)
     public void testBookkeeperAllDigestErrors() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration().setZkServers(zkUtil.getZooKeeperConnectString());
+        ClientConfiguration conf = new ClientConfiguration().setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkc = new BookKeeper(conf);
 
         byte[] passwd = "AAAAAAA".getBytes();
@@ -157,7 +157,7 @@ public class BookKeeperClientTestsWithBookieErrors extends BookKeeperClusterTest
     // and the last one will return corrupt data
     @Test(timeout = 60000)
     public void testBKReadFirstTimeoutThenDigestError() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration().setZkServers(zkUtil.getZooKeeperConnectString());
+        ClientConfiguration conf = new ClientConfiguration().setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkc = new BookKeeper(conf);
 
         byte[] passwd = "AAAAAAA".getBytes();
@@ -187,7 +187,7 @@ public class BookKeeperClientTestsWithBookieErrors extends BookKeeperClusterTest
     // sleep (for ReadEntryTimeout+2 secs) before returning the data
     @Test(timeout = 60000)
     public void testBKReadFirstDigestErrorThenTimeout() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration().setZkServers(zkUtil.getZooKeeperConnectString());
+        ClientConfiguration conf = new ClientConfiguration().setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkc = new BookKeeper(conf);
 
         byte[] passwd = "AAAAAAA".getBytes();
@@ -217,7 +217,7 @@ public class BookKeeperClientTestsWithBookieErrors extends BookKeeperClusterTest
     // and the last one will return corrupt data
     @Test(timeout = 60000)
     public void testBKReadFirstBookiesDownThenDigestError() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration().setZkServers(zkUtil.getZooKeeperConnectString());
+        ClientConfiguration conf = new ClientConfiguration().setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkc = new BookKeeper(conf);
 
         byte[] passwd = "AAAAAAA".getBytes();
@@ -247,7 +247,7 @@ public class BookKeeperClientTestsWithBookieErrors extends BookKeeperClusterTest
     // In this testcase all the bookies will sleep (for ReadEntryTimeout+2 secs) before returning the data
     @Test(timeout = 60000)
     public void testBKReadAllTimeouts() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration().setZkServers(zkUtil.getZooKeeperConnectString());
+        ClientConfiguration conf = new ClientConfiguration().setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkc = new BookKeeper(conf);
 
         byte[] passwd = "AAAAAAA".getBytes();
@@ -277,7 +277,7 @@ public class BookKeeperClientTestsWithBookieErrors extends BookKeeperClusterTest
     // but the last one will return as expected
     @Test(timeout = 60000)
     public void testBKReadTwoBookiesTimeout() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration().setZkServers(zkUtil.getZooKeeperConnectString());
+        ClientConfiguration conf = new ClientConfiguration().setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkc = new BookKeeper(conf);
 
         byte[] passwd = "AAAAAAA".getBytes();
@@ -306,7 +306,8 @@ public class BookKeeperClientTestsWithBookieErrors extends BookKeeperClusterTest
     // but the last one will return as expected
     @Test(timeout = 60000)
     public void testBKReadTwoBookiesWithDigestError() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration().setZkServers(zkUtil.getZooKeeperConnectString());
+        ClientConfiguration conf = new ClientConfiguration()
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkc = new BookKeeper(conf);
 
         byte[] passwd = "AAAAAAA".getBytes();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
@@ -144,7 +144,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         conf.setDiskWeightBasedPlacementEnabled(true)
             .setGetBookieInfoRetryIntervalSeconds(1, TimeUnit.SECONDS)
             .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
         for (int i = 0; i < numBookies; i++) {
@@ -194,7 +194,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         conf.setDiskWeightBasedPlacementEnabled(true)
             .setGetBookieInfoRetryIntervalSeconds(1, TimeUnit.SECONDS)
             .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
         for (int i = 0; i < numBookies; i++) {
@@ -284,7 +284,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         conf.setDiskWeightBasedPlacementEnabled(true)
             .setGetBookieInfoRetryIntervalSeconds(1, TimeUnit.SECONDS)
             .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
         for (int i = 0; i < numBookies; i++) {
@@ -365,7 +365,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         conf.setDiskWeightBasedPlacementEnabled(true)
             .setGetBookieInfoRetryIntervalSeconds(1, TimeUnit.SECONDS)
             .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         final BookKeeperCheckInfoReader client = new BookKeeperCheckInfoReader(conf);
 
         for (int i = 0; i < numBookies; i++) {
@@ -437,8 +437,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
 
         int updateIntervalSecs = 6;
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
-        conf.setDiskWeightBasedPlacementEnabled(true)
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri())
+            .setDiskWeightBasedPlacementEnabled(true)
             .setGetBookieInfoRetryIntervalSeconds(1, TimeUnit.SECONDS)
             .setBookieMaxWeightMultipleForWeightBasedPlacement(multiple)
             .setGetBookieInfoIntervalSeconds(updateIntervalSecs, TimeUnit.SECONDS);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -64,7 +64,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     @Test
     public void testConstructionZkDelay() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString())
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri())
             .setZkTimeout(20000);
 
         CountDownLatch l = new CountDownLatch(1);
@@ -79,7 +79,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     @Test
     public void testConstructionNotConnectedExplicitZk() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString())
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri())
             .setZkTimeout(20000);
 
         CountDownLatch l = new CountDownLatch(1);
@@ -116,7 +116,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
 
     void testBookkeeperDigestPassword(boolean autodetection) throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         conf.setEnableDigestTypeAutodetection(autodetection);
         BookKeeper bkc = new BookKeeper(conf);
 
@@ -207,7 +207,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     @Test
     public void testCloseDuringOp() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         for (int i = 0; i < 10; i++) {
             final BookKeeper client = new BookKeeper(conf);
             final CountDownLatch l = new CountDownLatch(1);
@@ -243,7 +243,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     @Test
     public void testIsClosed() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeper bkc = new BookKeeper(conf);
         LedgerHandle lh = bkc.createLedger(digestType, "testPasswd".getBytes());
@@ -263,7 +263,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     @Test
     public void testReadFailureCallback() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeper bkc = new BookKeeper(conf);
         LedgerHandle lh = bkc.createLedger(digestType, "testPasswd".getBytes());
@@ -303,14 +303,12 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         assertEquals(BKException.Code.BookieHandleNotAvailableException, returnCode.get());
 
         bkc.close();
-
-        startBKCluster();
     }
 
     @Test
     public void testAutoCloseableBookKeeper() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkc2;
         try (BookKeeper bkc = new BookKeeper(conf)) {
             bkc2 = bkc;
@@ -330,7 +328,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     public void testReadAfterLastAddConfirmed() throws Exception {
 
         ClientConfiguration clientConfiguration = new ClientConfiguration();
-        clientConfiguration.setZkServers(zkUtil.getZooKeeperConnectString());
+        clientConfiguration.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         try (BookKeeper bkWriter = new BookKeeper(clientConfiguration)) {
             LedgerHandle writeLh = bkWriter.createLedger(digestType, "testPasswd".getBytes());
@@ -546,7 +544,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     @Test
     public void testReadWriteWithV2WireProtocol() throws Exception {
         ClientConfiguration conf = new ClientConfiguration().setUseV2WireProtocol(true);
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         int numEntries = 100;
         byte[] data = "foobar".getBytes();
         try (BookKeeper bkc = new BookKeeper(conf)) {
@@ -591,7 +589,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     @Test
     public void testReadEntryReleaseByteBufs() throws Exception {
         ClientConfiguration confWriter = new ClientConfiguration();
-        confWriter.setZkServers(zkUtil.getZooKeeperConnectString());
+        confWriter.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         int numEntries = 10;
         byte[] data = "foobar".getBytes();
         long ledgerId;
@@ -607,8 +605,8 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         // v2 protocol, using pooled buffers
         ClientConfiguration confReader1 = new ClientConfiguration()
             .setUseV2WireProtocol(true)
-            .setNettyUsePooledBuffers(true);
-        confReader1.setZkServers(zkUtil.getZooKeeperConnectString());
+            .setNettyUsePooledBuffers(true)
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         try (BookKeeper bkc = new BookKeeper(confReader1)) {
             try (LedgerHandle lh = bkc.openLedger(ledgerId, digestType, "testPasswd".getBytes())) {
@@ -629,7 +627,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         ClientConfiguration confReader2 = new ClientConfiguration()
             .setUseV2WireProtocol(true)
             .setNettyUsePooledBuffers(false);
-        confReader2.setZkServers(zkUtil.getZooKeeperConnectString());
+        confReader2.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         try (BookKeeper bkc = new BookKeeper(confReader2)) {
             try (LedgerHandle lh = bkc.openLedger(ledgerId, digestType, "testPasswd".getBytes())) {
@@ -649,8 +647,8 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         // v3 protocol, not using pooled buffers
         ClientConfiguration confReader3 = new ClientConfiguration()
             .setUseV2WireProtocol(false)
-            .setNettyUsePooledBuffers(false);
-        confReader3.setZkServers(zkUtil.getZooKeeperConnectString());
+            .setNettyUsePooledBuffers(false)
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try (BookKeeper bkc = new BookKeeper(confReader3)) {
             try (LedgerHandle lh = bkc.openLedger(ledgerId, digestType, "testPasswd".getBytes())) {
                 assertEquals(numEntries - 1, lh.readLastConfirmed());
@@ -672,8 +670,8 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         // v3 protocol from 4.5 always "wraps" buffers returned by protobuf
         ClientConfiguration confReader4 = new ClientConfiguration()
             .setUseV2WireProtocol(false)
-            .setNettyUsePooledBuffers(true);
-        confReader4.setZkServers(zkUtil.getZooKeeperConnectString());
+            .setNettyUsePooledBuffers(true)
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         try (BookKeeper bkc = new BookKeeper(confReader4)) {
             try (LedgerHandle lh = bkc.openLedger(ledgerId, digestType, "testPasswd".getBytes())) {
@@ -695,7 +693,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
 
         // cannot read twice an entry
         ClientConfiguration confReader5 = new ClientConfiguration();
-        confReader5.setZkServers(zkUtil.getZooKeeperConnectString());
+        confReader5.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try (BookKeeper bkc = new BookKeeper(confReader5)) {
             try (LedgerHandle lh = bkc.openLedger(ledgerId, digestType, "testPasswd".getBytes())) {
                 assertEquals(numEntries - 1, lh.readLastConfirmed());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
@@ -118,7 +118,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         sync = new SyncObject();
         bookieRecoverCb = new BookieRecoverCallback();
         ClientConfiguration adminConf = new ClientConfiguration(baseClientConf);
-        adminConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        adminConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         bkAdmin = new BookKeeperAdmin(adminConf);
     }
 
@@ -249,7 +249,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
     @Test
     public void testMetadataConflictWhenDelayingEnsembleChange() throws Exception {
         ClientConfiguration newConf = new ClientConfiguration(baseClientConf);
-        newConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        newConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         newConf.setDelayEnsembleChange(true);
         try (BookKeeper newBkc = new BookKeeper(newConf)) {
             metadataConflictWithRecovery(newBkc);
@@ -835,7 +835,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         // This is fine, because it only falls back to the configured
         // password if the password info is missing from the metadata
         ClientConfiguration adminConf = new ClientConfiguration();
-        adminConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        adminConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         adminConf.setBookieRecoveryDigestType(digestCorrect);
         adminConf.setBookieRecoveryPasswd(passwdBad);
         setMetastoreImplClass(adminConf);
@@ -860,7 +860,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Try to recover with no password in conf
         adminConf = new ClientConfiguration();
-        adminConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        adminConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         setMetastoreImplClass(adminConf);
 
         bka = new BookKeeperAdmin(adminConf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
@@ -63,7 +63,7 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
     @Test
     public void testReadHandleWithNoExplicitLAC() throws Exception {
         ClientConfiguration confWithNoExplicitLAC = new ClientConfiguration();
-        confWithNoExplicitLAC.setZkServers(zkUtil.getZooKeeperConnectString());
+        confWithNoExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         confWithNoExplicitLAC.setExplictLacInterval(0);
 
         BookKeeper bkcWithNoExplicitLAC = new BookKeeper(confWithNoExplicitLAC);
@@ -126,7 +126,7 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
     @Test
     public void testReadHandleWithExplicitLAC() throws Exception {
         ClientConfiguration confWithExplicitLAC = new ClientConfiguration();
-        confWithExplicitLAC.setZkServers(zkUtil.getZooKeeperConnectString());
+        confWithExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         int explicitLacIntervalMillis = 1000;
         confWithExplicitLAC.setExplictLacInterval(explicitLacIntervalMillis);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/GenericEnsemblePlacementPolicyTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/GenericEnsemblePlacementPolicyTest.java
@@ -87,7 +87,7 @@ public class GenericEnsemblePlacementPolicyTest extends BookKeeperClusterTestCas
     @Test
     public void testNewEnsemble() throws Exception {
         numBookies = 1;
-        startBKCluster();
+        startBKCluster(zkUtil.getMetadataServiceUri());
         try {
             Map<String, byte[]> customMetadata = new HashMap<>();
             customMetadata.put(property, value);
@@ -105,7 +105,7 @@ public class GenericEnsemblePlacementPolicyTest extends BookKeeperClusterTestCas
     public void testNewEnsembleWithNotEnoughtBookies() throws Exception {
         numBookies = 0;
         try {
-            startBKCluster();
+            startBKCluster(zkUtil.getMetadataServiceUri());
             Map<String, byte[]> customMetadata = new HashMap<>();
             customMetadata.put(property, value);
             try (BookKeeper bk = new BookKeeper(baseClientConf, zkc)) {
@@ -124,7 +124,7 @@ public class GenericEnsemblePlacementPolicyTest extends BookKeeperClusterTestCas
     @Test
     public void testReplaceBookie() throws Exception {
         numBookies = 3;
-        startBKCluster();
+        startBKCluster(zkUtil.getMetadataServiceUri());
         try {
             Map<String, byte[]> customMetadata = new HashMap<>();
             customMetadata.put(property, value);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
@@ -71,7 +71,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
     @Test
     public void testLedgerCloseWithConsistentLength() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         conf.setReadTimeout(1);
 
         BookKeeper bkc = new BookKeeper(conf);
@@ -91,7 +91,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
         assertEquals(i.get(), BKException.Code.NotEnoughBookiesException);
         assertEquals(0, lh.getLength());
         assertEquals(LedgerHandle.INVALID_ENTRY_ID, lh.getLastAddConfirmed());
-        startBKCluster();
+        startBKCluster(zkUtil.getMetadataServiceUri());
         LedgerHandle newLh = bkc.openLedger(lh.getId(), DigestType.CRC32, new byte[] {});
         assertEquals(0, newLh.getLength());
         assertEquals(LedgerHandle.INVALID_ENTRY_ID, newLh.getLastAddConfirmed());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
@@ -443,7 +443,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
             .setAddEntryTimeout(60000)
             .setRecoveryReadBatchSize(batchSize);
 
-        newConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        newConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper newBk = new BookKeeper(newConf);
 
         LedgerHandle lh = newBk.createLedger(numBookies, 2, 2, digestType, "".getBytes());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ListLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ListLedgersTest.java
@@ -45,7 +45,7 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
         int numOfLedgers = 10;
 
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeper bkc = new BookKeeper(conf);
         for (int i = 0; i < numOfLedgers; i++) {
@@ -70,7 +70,7 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
     public void testEmptyList()
     throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeperAdmin admin = new BookKeeperAdmin(zkUtil.
                 getZooKeeperConnectString());
@@ -85,7 +85,7 @@ public class ListLedgersTest extends BookKeeperClusterTestCase {
         int numOfLedgers = 1;
 
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeper bkc = new BookKeeper(conf);
         for (int i = 0; i < numOfLedgers; i++) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
@@ -204,19 +204,15 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
     }
 
     @Override
-    protected void startBKCluster() throws Exception {
+    protected void startBKCluster(String metadataServiceUri) throws Exception {
         MetadataDrivers.registerClientDriver("zk", TestMetadataClientDriver.class, true);
         MetadataDrivers.registerBookieDriver("zk", TestMetadataBookieDriver.class, true);
-        baseConf.setMetadataServiceUri(
-            "zk://" + zkUtil.getZooKeeperConnectString() + baseConf.getZkLedgersRootPath());
         baseConf.setLedgerManagerFactoryClass(TestLedgerManagerFactory.class);
-        baseClientConf.setMetadataServiceUri(
-            "zk://" + zkUtil.getZooKeeperConnectString() + baseConf.getZkLedgersRootPath());
         baseClientConf.setLedgerManagerFactoryClass(TestLedgerManagerFactory.class);
         baseClientConf.setReadEntryTimeout(60000);
         baseClientConf.setAddEntryTimeout(60000);
 
-        super.startBKCluster();
+        super.startBKCluster(metadataServiceUri);
     }
 
     @After

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
@@ -55,7 +55,8 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
     @Test
     public void testSlowBookie() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setReadTimeout(360).setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setReadTimeout(360)
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeper bkc = new BookKeeper(conf);
 
@@ -101,7 +102,8 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
     @Test
     public void testBookieFailureWithSlowBookie() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setReadTimeout(5).setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setReadTimeout(5)
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeper bkc = new BookKeeper(conf);
 
@@ -155,7 +157,8 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
     @Test
     public void testManyBookieFailureWithSlowBookies() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setReadTimeout(5).setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setReadTimeout(5)
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         BookKeeper bkc = new BookKeeper(conf);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestAddEntryQuorumTimeout.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestAddEntryQuorumTimeout.java
@@ -56,7 +56,7 @@ public class TestAddEntryQuorumTimeout extends BookKeeperClusterTestCase impleme
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
     }
 
     private static class SyncObj {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestBookieWatcher.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestBookieWatcher.java
@@ -98,6 +98,8 @@ public class TestBookieWatcher extends BookKeeperClusterTestCase {
     private void runBookieWatcherWhenSessionExpired(ZooKeeper zk, int timeout, boolean reconnectable)
             throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
+        conf.setMetadataServiceUri(metadataServiceUri);
+
         BookKeeper bkc = new BookKeeper(conf, zk);
 
         LedgerHandle lh;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
@@ -69,8 +69,8 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
 
     void disableEnsembleChangeTest(boolean startNewBookie) throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
-        conf.setDelayEnsembleChange(false)
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri())
+            .setDelayEnsembleChange(false)
             .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE);
 
         SettableFeatureProvider featureProvider = new SettableFeatureProvider("test", 0);
@@ -172,8 +172,8 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
     @Test
     public void testRetryFailureBookie() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
-        conf.setDelayEnsembleChange(false)
+        conf.setMetadataServiceUri(zkUtil.getZooKeeperConnectString())
+            .setDelayEnsembleChange(false)
             .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE);
 
         SettableFeatureProvider featureProvider = new SettableFeatureProvider("test", 0);
@@ -223,8 +223,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
             .setAddEntryTimeout(readTimeout)
             .setDelayEnsembleChange(false)
             .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE)
-            .setZkServers(zkUtil.getZooKeeperConnectString());
-
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         SettableFeatureProvider featureProvider = new SettableFeatureProvider("test", 0);
         BookKeeper bkc = BookKeeper.forConfig(conf)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
@@ -69,7 +69,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
 
     void disableEnsembleChangeTest(boolean startNewBookie) throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri())
+        conf.setMetadataServiceUri(metadataServiceUri)
             .setDelayEnsembleChange(false)
             .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE);
 
@@ -172,7 +172,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
     @Test
     public void testRetryFailureBookie() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setMetadataServiceUri(zkUtil.getZooKeeperConnectString())
+        conf.setMetadataServiceUri(metadataServiceUri)
             .setDelayEnsembleChange(false)
             .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE);
 
@@ -223,7 +223,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
             .setAddEntryTimeout(readTimeout)
             .setDelayEnsembleChange(false)
             .setDisableEnsembleChangeFeatureName(FEATURE_DISABLE_ENSEMBLE_CHANGE)
-            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+            .setMetadataServiceUri(metadataServiceUri);
 
         SettableFeatureProvider featureProvider = new SettableFeatureProvider("test", 0);
         BookKeeper bkc = BookKeeper.forConfig(conf)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestParallelRead.java
@@ -146,7 +146,7 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
 
         ClientConfiguration newConf = new ClientConfiguration()
             .setReadEntryTimeout(30000);
-        newConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        newConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper newBk = new BookKeeper(newConf);
 
         LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
@@ -179,7 +179,7 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
 
         ClientConfiguration newConf = new ClientConfiguration()
             .setReadEntryTimeout(30000);
-        newConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        newConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper newBk = new BookKeeper(newConf);
 
         LedgerHandle lh = bkc.openLedger(id, digestType, passwd);
@@ -217,7 +217,7 @@ public class TestParallelRead extends BookKeeperClusterTestCase {
 
         ClientConfiguration newConf = new ClientConfiguration()
             .setReadEntryTimeout(30000);
-        newConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        newConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper newBk = new BookKeeper(newConf);
 
         LedgerHandle lh = bkc.openLedger(id, digestType, passwd);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
@@ -77,8 +77,8 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
             .setSpeculativeReadTimeout(specTimeout)
             .setReadTimeout(30000)
             .setReorderReadSequenceEnabled(true)
-            .setEnsemblePlacementPolicySlowBookies(true);
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+            .setEnsemblePlacementPolicySlowBookies(true)
+            .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         return new BookKeeperTestClient(conf, new TestStatsProvider());
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWatchEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWatchEnsembleChange.java
@@ -111,7 +111,7 @@ public class TestWatchEnsembleChange extends BookKeeperClusterTestCase {
 
     @Test
     public void testWatchMetadataRemoval() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         runFunctionWithLedgerManagerFactory(baseConf, factory -> {
             try {
                 testWatchMetadataRemoval(factory);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/AbstractConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/AbstractConfigurationTest.java
@@ -48,6 +48,7 @@ public class AbstractConfigurationTest {
     private AbstractConfiguration conf;
 
     @Before
+    @SuppressWarnings("deprecation")
     public void setup() {
         this.conf = new ClientConfiguration();
         this.conf.setZkServers("127.0.0.1");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
@@ -53,6 +53,7 @@ import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerMetadata;
 import org.apache.bookkeeper.common.testing.executors.MockExecutorController;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.LedgerMetadataListener;
 import org.apache.bookkeeper.test.TestCallbacks.GenericCallbackFuture;
 import org.apache.bookkeeper.util.ZkUtils;
@@ -127,7 +128,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
         }).when(ledgerManager).getLedgerId(anyString());
 
         // verify constructor
-        assertEquals(conf.getZkLedgersRootPath(), ledgerManager.ledgerRootPath);
+        assertEquals(ZKMetadataDriverBase.resolveZkLedgersRootPath(conf), ledgerManager.ledgerRootPath);
         assertSame(mockZk, ledgerManager.zk);
         assertSame(conf, ledgerManager.conf);
         assertSame(scheduler, ledgerManager.scheduler);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -59,6 +59,7 @@ import org.junit.runners.Parameterized.Parameters;
 public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
 
     protected MetadataClientDriver clientDriver;
+    protected Class<? extends LedgerManagerFactory> lmFactoryClass;
     protected LedgerManagerFactory ledgerManagerFactory;
     protected LedgerManager ledgerManager = null;
     protected LedgerIdGenerator ledgerIdGenerator = null;
@@ -72,8 +73,25 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
     public LedgerManagerTestCase(Class<? extends LedgerManagerFactory> lmFactoryCls, int numBookies) {
         super(numBookies);
         activeLedgers = new SnapshotMap<Long, Boolean>();
+        this.lmFactoryClass = lmFactoryCls;
         baseConf.setLedgerManagerFactoryClass(lmFactoryCls);
         baseClientConf.setLedgerManagerFactoryClass(lmFactoryCls);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected String getMetadataServiceUri(String ledgersRootPath) {
+        String ledgerManagerType;
+        if (lmFactoryClass == org.apache.bookkeeper.meta.FlatLedgerManagerFactory.class) {
+            ledgerManagerType = org.apache.bookkeeper.meta.FlatLedgerManagerFactory.NAME;
+        } else if (lmFactoryClass == LongHierarchicalLedgerManagerFactory.class) {
+            ledgerManagerType = LongHierarchicalLedgerManagerFactory.NAME;
+        } else if (lmFactoryClass == org.apache.bookkeeper.meta.MSLedgerManagerFactory.class) {
+            ledgerManagerType = org.apache.bookkeeper.meta.MSLedgerManagerFactory.NAME;
+        } else {
+            ledgerManagerType = HierarchicalLedgerManagerFactory.NAME;
+        }
+        return zkUtil.getMetadataServiceUri(ledgersRootPath, ledgerManagerType);
     }
 
     public LedgerManager getIndependentLedgerManager() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -109,7 +109,7 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         scheduler = OrderedScheduler.newSchedulerBuilder()
             .name("test-scheduler")

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerMetadataCreationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerMetadataCreationTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.Assume;
 import org.junit.Test;
@@ -145,7 +146,7 @@ public class LedgerMetadataCreationTest extends LedgerManagerTestCase {
         ZooKeeper zkc = new ZooKeeper(zkUtil.getZooKeeperConnectString(), 10000, null);
         BookKeeper bookKeeper = new BookKeeper(baseClientConf);
         bookKeeper.createLedgerAdv(1, 3, 2, 2, DigestType.CRC32, "passwd".getBytes(), null);
-        String ledgersRootPath = baseClientConf.getZkLedgersRootPath();
+        String ledgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(baseClientConf);
         String parentZnodePath;
         if (baseClientConf.getLedgerManagerFactoryClass().equals(HierarchicalLedgerManagerFactory.class)) {
             /*

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/ZkLedgerLayoutTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/ZkLedgerLayoutTest.java
@@ -45,9 +45,14 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
         super(0);
     }
 
+    protected ClientConfiguration newClientConfiguration() {
+        return new ClientConfiguration()
+            .setMetadataServiceUri(metadataServiceUri);
+    }
+
     @Test
     public void testLedgerLayout() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
+        ClientConfiguration conf = newClientConfiguration();
         conf.setLedgerManagerFactoryClass(HierarchicalLedgerManagerFactory.class);
         String ledgerRootPath = "/testLedgerLayout";
         ZkLayoutManager zkLayoutManager = new ZkLayoutManager(zkc, ledgerRootPath, Ids.OPEN_ACL_UNSAFE);
@@ -85,7 +90,7 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testBadVersionLedgerLayout() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
+        ClientConfiguration conf = newClientConfiguration();
         String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         // write bad version ledger layout
         writeLedgerLayout(zkLedgersRootPath,
@@ -105,8 +110,8 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testAbsentLedgerManagerLayout() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
-        String ledgersLayout = ZKMetadataDriverBase.resolveZkServers(conf) + "/"
+        ClientConfiguration conf = newClientConfiguration();
+        String ledgersLayout = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf) + "/"
                 + BookKeeperConstants.LAYOUT_ZNODE;
         // write bad format ledger layout
         StringBuilder sb = new StringBuilder();
@@ -126,7 +131,7 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testBaseLedgerManagerLayout() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
+        ClientConfiguration conf = newClientConfiguration();
         String rootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         String ledgersLayout = rootPath + "/"
                 + BookKeeperConstants.LAYOUT_ZNODE;
@@ -148,7 +153,7 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testReadV1LedgerManagerLayout() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
+        ClientConfiguration conf = newClientConfiguration();
         String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         // write v1 ledger layout
         writeLedgerLayout(zkLedgersRootPath,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/ZkLedgerLayoutTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/ZkLedgerLayoutTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.zookeeper.CreateMode;
@@ -85,13 +86,14 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
     @Test
     public void testBadVersionLedgerLayout() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
+        String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         // write bad version ledger layout
-        writeLedgerLayout(conf.getZkLedgersRootPath(),
+        writeLedgerLayout(zkLedgersRootPath,
                           HierarchicalLedgerManagerFactory.class.getName(),
                           HierarchicalLedgerManagerFactory.CUR_VERSION,
                           LedgerLayout.LAYOUT_FORMAT_VERSION + 1);
 
-        ZkLayoutManager zkLayoutManager = new ZkLayoutManager(zkc, conf.getZkLedgersRootPath(), Ids.OPEN_ACL_UNSAFE);
+        ZkLayoutManager zkLayoutManager = new ZkLayoutManager(zkc, zkLedgersRootPath, Ids.OPEN_ACL_UNSAFE);
 
         try {
             zkLayoutManager.readLedgerLayout();
@@ -104,14 +106,15 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
     @Test
     public void testAbsentLedgerManagerLayout() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        String ledgersLayout = conf.getZkLedgersRootPath() + "/"
+        String ledgersLayout = ZKMetadataDriverBase.resolveZkServers(conf) + "/"
                 + BookKeeperConstants.LAYOUT_ZNODE;
         // write bad format ledger layout
         StringBuilder sb = new StringBuilder();
         sb.append(LedgerLayout.LAYOUT_FORMAT_VERSION).append("\n");
         zkc.create(ledgersLayout, sb.toString().getBytes(),
                                  Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        ZkLayoutManager zkLayoutManager = new ZkLayoutManager(zkc, conf.getZkLedgersRootPath(), Ids.OPEN_ACL_UNSAFE);
+        ZkLayoutManager zkLayoutManager = new ZkLayoutManager(
+            zkc, ZKMetadataDriverBase.resolveZkLedgersRootPath(conf), Ids.OPEN_ACL_UNSAFE);
 
         try {
             zkLayoutManager.readLedgerLayout();
@@ -124,7 +127,7 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
     @Test
     public void testBaseLedgerManagerLayout() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        String rootPath = conf.getZkLedgersRootPath();
+        String rootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         String ledgersLayout = rootPath + "/"
                 + BookKeeperConstants.LAYOUT_ZNODE;
         // write bad format ledger layout
@@ -146,11 +149,12 @@ public class ZkLedgerLayoutTest extends BookKeeperClusterTestCase {
     @Test
     public void testReadV1LedgerManagerLayout() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
+        String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         // write v1 ledger layout
-        writeLedgerLayout(conf.getZkLedgersRootPath(),
+        writeLedgerLayout(zkLedgersRootPath,
                           HierarchicalLedgerManagerFactory.NAME,
                           HierarchicalLedgerManagerFactory.CUR_VERSION, 1);
-        ZkLayoutManager zkLayoutManager = new ZkLayoutManager(zkc, conf.getZkLedgersRootPath(), Ids.OPEN_ACL_UNSAFE);
+        ZkLayoutManager zkLayoutManager = new ZkLayoutManager(zkc, zkLedgersRootPath, Ids.OPEN_ACL_UNSAFE);
 
         LedgerLayout layout = zkLayoutManager.readLedgerLayout();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/NetworkLessBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/NetworkLessBookieTest.java
@@ -47,7 +47,7 @@ public class NetworkLessBookieTest extends BookKeeperClusterTestCase {
     @Test
     public void testUseLocalBookie() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         conf.setZkTimeout(20000);
 
         try (BookKeeper bkc = new BookKeeper(conf)) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorBookieTest.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
@@ -56,14 +57,15 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
 
     public AuditorBookieTest() {
         super(6);
-        electionPath = baseConf.getZkLedgersRootPath()
-                + "/underreplication/auditorelection";
     }
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         startAuditorElectors();
+
+        electionPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(baseConf)
+            + "/underreplication/auditorelection";
     }
 
     @Override
@@ -138,7 +140,7 @@ public class AuditorBookieTest extends BookKeeperClusterTestCase {
         stopBKCluster();
         stopAuditorElectors();
 
-        startBKCluster();
+        startBKCluster(zkUtil.getMetadataServiceUri());
         startAuditorElectors();
         BookieServer newAuditor = waitForNewAuditor(auditor);
         assertNotSame(

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -58,6 +58,7 @@ import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.MetadataClientDriver;
 import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat;
@@ -92,9 +93,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
 
     private DigestType digestType;
 
-    private final String underreplicatedPath = baseClientConf
-            .getZkLedgersRootPath()
-            + "/underreplication/ledgers";
+    private String underreplicatedPath;
     private Map<String, AuditorElector> auditorElectors = new ConcurrentHashMap<>();
     private ZkLedgerUnderreplicationManager urLedgerMgr;
     private Set<Long> urLedgerList;
@@ -119,20 +118,23 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         baseConf.setLedgerManagerFactoryClassName(ledgerManagerFactoryClass);
         baseClientConf
                 .setLedgerManagerFactoryClassName(ledgerManagerFactoryClass);
-        electionPath = baseConf.getZkLedgersRootPath()
-                + "/underreplication/auditorelection";
     }
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
+        underreplicatedPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(baseClientConf)
+            + "/underreplication/ledgers";
+        electionPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(baseConf)
+            + "/underreplication/auditorelection";
+
         urLedgerMgr = new ZkLedgerUnderreplicationManager(baseClientConf, zkc);
         startAuditorElectors();
         rng = new Random(System.currentTimeMillis()); // Initialize the Random
         urLedgerList = new HashSet<Long>();
         ledgerList = new ArrayList<Long>(2);
-        baseClientConf.setZkServers(zkUtil.getZooKeeperConnectString());
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseClientConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
     }
 
     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
@@ -34,6 +34,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.test.TestCallbacks;
@@ -70,10 +71,11 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setAuditorPeriodicBookieCheckInterval(CHECK_INTERVAL);
+        conf.setMetadataServiceUri(metadataServiceUri);
         String addr = bs.get(0).getLocalAddress().toString();
 
         auditorZookeeper = ZooKeeperClient.newBuilder()
-                .connectString(zkUtil.getZooKeeperConnectString())
+                .connectString(ZKMetadataDriverBase.resolveZkServers(conf))
                 .sessionTimeoutMs(10000)
                 .build();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
@@ -96,7 +96,7 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testPeriodicBookieCheckInterval() throws Exception {
-        bsConfs.get(0).setZkServers(zkUtil.getZooKeeperConnectString());
+        bsConfs.get(0).setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         runFunctionWithLedgerManagerFactory(bsConfs.get(0), mFactory -> {
             try (LedgerManager ledgerManager = mFactory.newLedgerManager()) {
                 @Cleanup final LedgerUnderreplicationManager underReplicationManager =

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -79,8 +79,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
     private LedgerManager ledgerManager;
     private OrderedScheduler scheduler;
 
-    private final String underreplicatedPath = baseClientConf
-            .getZkLedgersRootPath() + "/underreplication/ledgers";
+    private final String underreplicatedPath = "/ledgers/underreplication/ledgers";
 
     public BookieAutoRecoveryTest() throws IOException, KeeperException,
             InterruptedException, UnavailableException, CompatibilityException {
@@ -99,8 +98,8 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
-        baseClientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        baseClientConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         scheduler = OrderedScheduler.newSchedulerBuilder()
             .name("test-scheduler")

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.meta.AbstractZkLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.ZkLayoutManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.replication.ReplicationException.BKAuditException;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.ZkUtils;
@@ -85,7 +86,7 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         rng = new Random(System.currentTimeMillis()); // Initialize the Random
         // Number Generator
         entries = new ArrayList<byte[]>(); // initialize the entries list
@@ -93,7 +94,8 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
         // initialize ledger manager
         newLedgerManagerFactory = AbstractZkLedgerManagerFactory.newLedgerManagerFactory(
             baseConf,
-            new ZkLayoutManager(zkc, baseConf.getZkLedgersRootPath(), ZkUtils.getACLs(baseConf)));
+            new ZkLayoutManager(zkc,
+                ZKMetadataDriverBase.resolveZkLedgersRootPath(baseConf), ZkUtils.getACLs(baseConf)));
 
         ledgerManager = newLedgerManagerFactory.newLedgerManager();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
@@ -35,6 +35,7 @@ import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.BookKeeperConstants;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -48,9 +49,17 @@ public class TestAutoRecoveryAlongWithBookieServers extends
     public TestAutoRecoveryAlongWithBookieServers() {
         super(3);
         setAutoRecoveryEnabled(true);
+
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
         basePath = ZKMetadataDriverBase.resolveZkLedgersRootPath(baseClientConf) + '/'
-                + BookKeeperConstants.UNDER_REPLICATION_NODE
-                + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH;
+            + BookKeeperConstants.UNDER_REPLICATION_NODE
+            + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH;
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
@@ -31,6 +31,7 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.LedgerHandleAdapter;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.BookKeeperConstants;
@@ -47,7 +48,7 @@ public class TestAutoRecoveryAlongWithBookieServers extends
     public TestAutoRecoveryAlongWithBookieServers() {
         super(3);
         setAutoRecoveryEnabled(true);
-        basePath = baseClientConf.getZkLedgersRootPath() + '/'
+        basePath = ZKMetadataDriverBase.resolveZkLedgersRootPath(baseClientConf) + '/'
                 + BookKeeperConstants.UNDER_REPLICATION_NODE
                 + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestLedgerUnderreplicationManager.java
@@ -50,6 +50,7 @@ import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
 import org.apache.bookkeeper.meta.ZkLayoutManager;
 import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
@@ -94,7 +95,7 @@ public class TestLedgerUnderreplicationManager {
         zkUtil.startServer();
 
         conf = TestBKConfiguration.newServerConfiguration();
-        conf.setZkServers(zkUtil.getZooKeeperConnectString());
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
         executor = Executors.newCachedThreadPool();
 
@@ -107,7 +108,9 @@ public class TestLedgerUnderreplicationManager {
                 .sessionTimeoutMs(10000)
                 .build();
 
-        basePath = conf.getZkLedgersRootPath() + '/'
+        String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
+
+        basePath = zkLedgersRootPath + '/'
                 + BookKeeperConstants.UNDER_REPLICATION_NODE;
         urLedgerPath = basePath
                 + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH;
@@ -116,13 +119,13 @@ public class TestLedgerUnderreplicationManager {
             conf,
             new ZkLayoutManager(
                 zkc1,
-                conf.getZkLedgersRootPath(),
+                zkLedgersRootPath,
                 ZkUtils.getACLs(conf)));
         lmf2 = AbstractZkLedgerManagerFactory.newLedgerManagerFactory(
             conf,
             new ZkLayoutManager(
                 zkc2,
-                conf.getZkLedgersRootPath(),
+                zkLedgersRootPath,
                 ZkUtils.getACLs(conf)));
 
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -82,7 +82,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         this.bkHttpServiceProvider = new BKHttpServiceProvider.Builder()
             .setBookieServer(bs.get(numberOfBookies - 1))
             .setServerConfiguration(baseConf)
@@ -162,7 +162,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testListBookiesService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         HttpEndpointService listBookiesService = bkHttpServiceProvider
           .provideHttpEndpointService(HttpServer.ApiType.LIST_BOOKIES);
 
@@ -230,7 +229,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
      */
     @Test
     public void testListLedgerService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
         int numLedgers = 430;
         LedgerHandle[] lh = new LedgerHandle[numLedgers];
@@ -294,7 +292,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
      */
     @Test
     public void testDeleteLedgerService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
         int numLedgers = 4;
         int numMsgs = 100;
@@ -349,7 +347,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testGetLedgerMetaService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
         int numLedgers = 4;
         int numMsgs = 100;
@@ -394,7 +392,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testReadLedgerEntryService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
         int numLedgers = 1;
         int numMsgs = 100;
@@ -453,7 +450,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testListBookieInfoService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         HttpEndpointService listBookieInfoService = bkHttpServiceProvider
           .provideHttpEndpointService(HttpServer.ApiType.LIST_BOOKIE_INFO);
 
@@ -476,7 +472,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testGetLastLogMarkService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
         int numLedgers = 4;
         int numMsgs = 100;
@@ -516,7 +511,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testListDiskFilesService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
         int numLedgers = 4;
         int numMsgs = 100;
@@ -561,8 +555,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testRecoveryBookieService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
-
         HttpEndpointService recoveryBookieService = bkHttpServiceProvider
           .provideHttpEndpointService(HttpServer.ApiType.RECOVERY_BOOKIE);
 
@@ -613,7 +605,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testTriggerAuditService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         startAuditorElector();
 
         HttpEndpointService triggerAuditService = bkHttpServiceProvider
@@ -635,7 +626,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testWhoIsAuditorService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         startAuditorElector();
 
         HttpEndpointService whoIsAuditorService = bkHttpServiceProvider
@@ -651,7 +641,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testListUnderReplicatedLedgerService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
         runFunctionWithLedgerManagerFactory(baseConf, mFactory -> {
             try {
                 testListUnderReplicatedLedgerService(mFactory);
@@ -705,8 +694,6 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testLostBookieRecoveryDelayService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
-
         HttpEndpointService lostBookieRecoveryDelayService = bkHttpServiceProvider
           .provideHttpEndpointService(HttpServer.ApiType.LOST_BOOKIE_RECOVERY_DELAY);
 
@@ -729,7 +716,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     @Test
     public void testDecommissionService() throws Exception {
-        baseConf.setZkServers(zkUtil.getZooKeeperConnectString());
+        baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         startAuditorElector();
 
         HttpEndpointService decommissionService = bkHttpServiceProvider

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -593,6 +593,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         String addr = bs.get(0).getLocalAddress().toString();
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setAuditorPeriodicBookieCheckInterval(1);
+        conf.setMetadataServiceUri("zk://" + zkUtil.getZooKeeperConnectString() + "/ledgers");
         auditorElector = new AuditorElector(addr, conf,
           auditorZookeeper);
         auditorElector.start();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -138,7 +138,7 @@ public abstract class BookKeeperClusterTestCase {
             // start zookeeper service
             startZKCluster();
             // start bookkeeper service
-            this.metadataServiceUri = zkUtil.getMetadataServiceUri(ledgersRootPath);
+            this.metadataServiceUri = getMetadataServiceUri(ledgersRootPath);
             startBKCluster(metadataServiceUri);
             LOG.info("Setup testcase {} @ metadata service {} in {} ms.",
                 runtime.getMethodName(), metadataServiceUri,  sw.elapsed(TimeUnit.MILLISECONDS));
@@ -146,6 +146,10 @@ public abstract class BookKeeperClusterTestCase {
             LOG.error("Error setting up", e);
             throw e;
         }
+    }
+
+    protected String getMetadataServiceUri(String ledgersRootPath) {
+        return zkUtil.getMetadataServiceUri(ledgersRootPath);
     }
 
     @After

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -21,6 +21,7 @@
 
 package org.apache.bookkeeper.test;
 
+import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Stopwatch;
@@ -44,6 +45,7 @@ import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.metastore.InMemoryMetaStore;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
@@ -76,9 +78,10 @@ public abstract class BookKeeperClusterTestCase {
     @Rule
     public final Timeout globalTimeout;
 
-    // ZooKeeper related variables
+    // Metadata service related variables
     protected final ZooKeeperUtil zkUtil = new ZooKeeperUtil();
     protected ZooKeeper zkc;
+    protected String metadataServiceUri;
 
     // BookKeeper related variables
     protected final List<File> tmpDirs = new LinkedList<File>();
@@ -121,6 +124,10 @@ public abstract class BookKeeperClusterTestCase {
 
     @Before
     public void setUp() throws Exception {
+        setUp("/ledgers");
+    }
+
+    protected void setUp(String ledgersRootPath) throws Exception {
         LOG.info("Setting up test {}", getClass());
         InMemoryMetaStore.reset();
         setMetastoreImplClass(baseConf);
@@ -131,8 +138,10 @@ public abstract class BookKeeperClusterTestCase {
             // start zookeeper service
             startZKCluster();
             // start bookkeeper service
-            startBKCluster();
-            LOG.info("Setup testcase {} in {} ms.", runtime.getMethodName(), sw.elapsed(TimeUnit.MILLISECONDS));
+            this.metadataServiceUri = zkUtil.getMetadataServiceUri(ledgersRootPath);
+            startBKCluster(metadataServiceUri);
+            LOG.info("Setup testcase {} @ metadata service {} in {} ms.",
+                runtime.getMethodName(), metadataServiceUri,  sw.elapsed(TimeUnit.MILLISECONDS));
         } catch (Exception e) {
             LOG.error("Error setting up", e);
             throw e;
@@ -208,8 +217,9 @@ public abstract class BookKeeperClusterTestCase {
      *
      * @throws Exception
      */
-    protected void startBKCluster() throws Exception {
-        baseClientConf.setZkServers(zkUtil.getZooKeeperConnectString());
+    protected void startBKCluster(String metadataServiceUri) throws Exception {
+        baseConf.setMetadataServiceUri(metadataServiceUri);
+        baseClientConf.setMetadataServiceUri(metadataServiceUri);
         if (numBookies > 0) {
             bkc = new BookKeeperTestClient(baseClientConf, new TestStatsProvider());
         }
@@ -259,19 +269,16 @@ public abstract class BookKeeperClusterTestCase {
         } else {
             port = 0;
         }
-        return newServerConfiguration(port, zkUtil.getZooKeeperConnectString(),
-                                      f, new File[] { f });
+        return newServerConfiguration(port, f, new File[] { f });
     }
 
     protected ClientConfiguration newClientConfiguration() {
         return new ClientConfiguration(baseConf);
     }
 
-    protected ServerConfiguration newServerConfiguration(int port, String zkServers, File journalDir,
-            File[] ledgerDirs) {
+    protected ServerConfiguration newServerConfiguration(int port, File journalDir, File[] ledgerDirs) {
         ServerConfiguration conf = new ServerConfiguration(baseConf);
         conf.setBookiePort(port);
-        conf.setZkServers(zkServers);
         conf.setJournalDirName(journalDir.getPath());
         String[] ledgerDirNames = new String[ledgerDirs.length];
         for (int i = 0; i < ledgerDirs.length; i++) {
@@ -298,6 +305,10 @@ public abstract class BookKeeperClusterTestCase {
         for (ServerConfiguration conf : bsConfs) {
             bs.add(startBookie(conf));
         }
+    }
+
+    protected String newMetadataServiceUri(String ledgersRootPath) {
+        return zkUtil.getMetadataServiceUri(ledgersRootPath);
     }
 
     /**
@@ -408,7 +419,7 @@ public abstract class BookKeeperClusterTestCase {
         }
         BookieServer server = bs.get(index);
         ServerConfiguration ret = killBookie(index);
-        while (zkc.exists(baseConf.getZkAvailableBookiesPath() + "/"
+        while (zkc.exists(ZKMetadataDriverBase.resolveZkLedgersRootPath(baseConf) + "/" + AVAILABLE_NODE + "/"
                 + server.getLocalAddress().toString(), false) != null) {
             Thread.sleep(500);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
@@ -81,7 +81,7 @@ public class BookieClientTest {
         conf.setBookiePort(port)
             .setJournalDirName(tmpDir.getPath())
             .setLedgerDirNames(new String[] { tmpDir.getPath() })
-            .setZkServers(null);
+            .setMetadataServiceUri(null);
         bs = new BookieServer(conf);
         bs.start();
         eventLoopGroup = new NioEventLoopGroup();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
@@ -61,8 +61,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
                 }
             }
 
-            ServerConfiguration conf = newServerConfiguration(PortManager.nextFreePort(),
-                                                              zkUtil.getZooKeeperConnectString(), f, new File[] { f });
+            ServerConfiguration conf = newServerConfiguration(PortManager.nextFreePort(), f, new File[] { f });
             server = new BookieServer(conf);
             server.start();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
@@ -84,7 +84,7 @@ public class ConcurrentLedgerTest {
         ledgerDir.mkdirs();
 
         conf.setBookiePort(5000);
-        conf.setZkServers(null);
+        conf.setMetadataServiceUri(null);
         conf.setJournalDirName(txnDir.getPath());
         conf.setLedgerDirNames(new String[] { ledgerDir.getPath() });
         bookie = new Bookie(conf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConfigurationTest.java
@@ -67,12 +67,12 @@ public class ConfigurationTest {
 
     @Test
     public void testGetZkServers() {
-        System.setProperty("metadataServiceUri", "zk://server1:port1,server2:port2/ledgers");
+        System.setProperty("metadataServiceUri", "zk://server1:port1;server2:port2/ledgers");
         ServerConfiguration conf = new ServerConfiguration();
         ClientConfiguration clientConf = new ClientConfiguration();
         assertEquals("zookeeper connect string doesn't match in server configuration",
-                     "zk://server1:port1,server2:port2/ledgers", conf.getMetadataServiceUriUnchecked());
+                     "zk://server1:port1;server2:port2/ledgers", conf.getMetadataServiceUriUnchecked());
         assertEquals("zookeeper connect string doesn't match in client configuration",
-                     "zk://server1:port1,server2:port2/ledgers", clientConf.getMetadataServiceUriUnchecked());
+                     "zk://server1:port1;server2:port2/ledgers", clientConf.getMetadataServiceUriUnchecked());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConfigurationTest.java
@@ -41,38 +41,38 @@ public class ConfigurationTest {
 
     @Test
     public void testConfigurationOverwrite() {
-        System.clearProperty("zkServers");
+        System.clearProperty("metadataServiceUri");
 
         ServerConfiguration conf = new ServerConfiguration();
-        assertEquals(null, conf.getZkServers());
+        assertEquals(null, conf.getMetadataServiceUriUnchecked());
 
         // override setting from property
-        System.setProperty("zkServers", "server1");
+        System.setProperty("metadataServiceUri", "zk://server:2181/ledgers");
         // it affects previous created configurations, if the setting is not overwrite
-        assertEquals("server1", conf.getZkServers());
+        assertEquals("zk://server:2181/ledgers", conf.getMetadataServiceUriUnchecked());
 
         ServerConfiguration conf2 = new ServerConfiguration();
-        assertEquals("server1", conf2.getZkServers());
+        assertEquals("zk://server:2181/ledgers", conf2.getMetadataServiceUriUnchecked());
 
-        System.clearProperty("zkServers");
+        System.clearProperty("metadataServiceUri");
 
         // load other configuration
         ServerConfiguration newConf = new ServerConfiguration();
-        assertEquals(null, newConf.getZkServers());
-        newConf.setZkServers("newserver");
-        assertEquals("newserver", newConf.getZkServers());
+        assertEquals(null, newConf.getMetadataServiceUriUnchecked());
+        newConf.setMetadataServiceUri("zk://newserver:2181/ledgers");
+        assertEquals("zk://newserver:2181/ledgers", newConf.getMetadataServiceUriUnchecked());
         conf2.loadConf(newConf);
-        assertEquals("newserver", conf2.getZkServers());
+        assertEquals("zk://newserver:2181/ledgers", conf2.getMetadataServiceUriUnchecked());
     }
 
     @Test
     public void testGetZkServers() {
-        System.setProperty("zkServers", "server1:port1,server2:port2");
+        System.setProperty("metadataServiceUri", "zk://server1:port1,server2:port2/ledgers");
         ServerConfiguration conf = new ServerConfiguration();
         ClientConfiguration clientConf = new ClientConfiguration();
         assertEquals("zookeeper connect string doesn't match in server configuration",
-                     "server1:port1,server2:port2", conf.getZkServers());
+                     "zk://server1:port1,server2:port2/ledgers", conf.getMetadataServiceUriUnchecked());
         assertEquals("zookeeper connect string doesn't match in client configuration",
-                     "server1:port1,server2:port2", clientConf.getZkServers());
+                     "zk://server1:port1,server2:port2/ledgers", clientConf.getMetadataServiceUriUnchecked());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -245,7 +245,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         }
 
         ServerConfiguration newConf = newServerConfiguration(
-                conf.getBookiePort() + 1, zkUtil.getZooKeeperConnectString(),
+                conf.getBookiePort() + 1,
                 ledgerDirs[0], ledgerDirs);
         bsConfs.add(newConf);
         bs.add(startBookie(newConf));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
@@ -83,6 +83,18 @@ public class ZooKeeperUtil {
         return connectString;
     }
 
+    public String getMetadataServiceUri() {
+        return getMetadataServiceUri("/ledgers");
+    }
+
+    public String getMetadataServiceUri(String zkLedgersRootPath) {
+        return "zk://" + connectString + zkLedgersRootPath;
+    }
+
+    public String getMetadataServiceUri(String zkLedgersRootPath, String type) {
+        return "zk+" + type + "://" + connectString + zkLedgersRootPath;
+    }
+
     public void startServer() throws Exception {
         // create a ZooKeeper server(dataDir, dataLogDir, port)
         LOG.debug("Running ZK server");

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/cluster/StreamCluster.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/cluster/StreamCluster.java
@@ -142,8 +142,7 @@ public class StreamCluster
         try (StorageController controller = new HelixStorageController(zkEnsemble)) {
             // initialize the configuration
             ServerConfiguration serverConf = new ServerConfiguration();
-            serverConf.setZkServers(zkEnsemble);
-            serverConf.setZkLedgersRootPath(LEDGERS_PATH);
+            serverConf.setMetadataServiceUri("zk://" + zkEnsemble + LEDGERS_PATH);
             serverConf.setAllowLoopback(true);
             serverConf.setGcWaitTime(300000);
             serverConf.setDiskUsageWarnThreshold(0.9999f);

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.component.ComponentStarter;
 import org.apache.bookkeeper.common.component.LifecycleComponent;
 import org.apache.bookkeeper.common.component.LifecycleComponentStack;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stream.proto.common.Endpoint;
 import org.apache.bookkeeper.stream.server.conf.BookieConfiguration;
@@ -201,7 +202,7 @@ public class StorageServer {
             // with the storage container manager (currently it is helix)
             .withStorageContainerManagerFactory((ignored, storeConf, registry) ->
                 new HelixStorageContainerManager(
-                    bookieService.serverConf().getZkServers(),
+                    ZKMetadataDriverBase.resolveZkServers(bookieService.serverConf()),
                     "stream/helix",
                     storeConf,
                     registry,

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
@@ -54,10 +54,10 @@ public class BookieService extends AbstractLifecycleComponent<BookieConfiguratio
             indexDirs = Arrays.asList(serverConf.getIndexDirs());
         }
         log.info("Hello, I'm your bookie, listening on port {} :"
-                + " zkServers = {}, journals = {}, ledgers = {}, index = {}",
+                + " metadata service uri = {}, journals = {}, ledgers = {}, index = {}",
             new Object[]{
                 serverConf.getBookiePort(),
-                serverConf.getZkServers(),
+                serverConf.getMetadataServiceUriUnchecked(),
                 Arrays.asList(serverConf.getJournalDirNames()),
                 Arrays.asList(serverConf.getLedgerDirs()),
                 indexDirs

--- a/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
+++ b/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
@@ -145,6 +145,7 @@ class TestCompatRecoveryNoPassword {
      * Test that when we try to recover a ledger which doesn't have
      * the password stored in the configuration, we don't succeed.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testRecoveryWithoutPasswordInMetadata() throws Exception {
         int numEntries = 10


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Motivation*

Metadata service uri is introduced as part of BP-29. However most of the tests and tools are still assuming `zkServers`.
This causes a problem if people configures `metadataServiceUri`, some of the admin tools don't actually work.

*Solution*

This change changes bookkeeper to use `metadataServiceUri` in all the possible places and provides methods to resolve zkServers
and zkLedgersRootPath from metadata service uri. This ensures:

1) if users configure `metadataServiceUri`, all the tools would work properly.
2) if users doesn't configure `metadataServiceUri` and still use `zkServers` and `zkLedgersRootPath`, all the tools would still work.

*Changes*

The main changes are:

- deprecated direct usage of `getZkServers`, `setZkServers`, `getZkLedgersRootPath`, `setZkLedgersRootPath, `getZkAvailablePath` at AbstractConfiguration
- provide util methods `resolveZkServers` and `resolverZkLedgersRootPath` in `ZkMetadataDriverBase` for resolving zookeeper specific settings from metadata service uri
- change the tools to use `getMetadataServiceUri`
- change the tests to use `getMetadataServiceUri` to ensure code coverage

*NOTES*

There are a few places still using `getZkServers`, `setZkServers`. those are hard to change at this moment.

Related Issue:
- #1335