### PR TITLE
Issue #1335: LocalBookKeeper doesn't work with metadata service uri

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -635,7 +635,7 @@ ledgerDirectories=/tmp/bk-data
 #############################################################################
 
 # metadata service uri that bookkeeper is used for loading corresponding metadata driver and resolving its metadata service location
-metadataServiceUri="zk+hierarchical://localhost:2181/ledgers"
+metadataServiceUri=zk+hierarchical://localhost:2181/ledgers
 
 # @Deprecated - `ledgerManagerFactoryClass` is deprecated in favor of using `metadataServiceUri`
 # Ledger Manager Class
@@ -652,7 +652,7 @@ metadataServiceUri="zk+hierarchical://localhost:2181/ledgers"
 # allowShadedLedgerManagerFactoryClass=false
 
 # the shaded ledger manager factory prefix. this is used when `allowShadedLedgerManagerFactoryClass` is set to true.
-# shadedLedgerManagerFactoryClassPrefix="dlshade."
+# shadedLedgerManagerFactoryClassPrefix=dlshade.
 
 #############################################################################
 ## ZooKeeper Metadata Service settings


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

`"zk+hierarchical://localhost:2181/ledgers"` is invalid because `"` is an invalid character.

*Solution*

Fix the invalid settings in `bk_server.conf`