### PR TITLE
Fallback to use `getZkServers` and `getZkLedgersPath` when resolving from metadata service uri

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -64,19 +64,21 @@ public class ZKMetadataDriverBase implements AutoCloseable {
         return uri.getAuthority().replace(";", ",");
     }
 
+    @SuppressWarnings("deprecation")
     public static String resolveZkServers(AbstractConfiguration<?> conf) {
         String metadataServiceUriStr = conf.getMetadataServiceUriUnchecked();
         if (null == metadataServiceUriStr) {
-            return null;
+            return conf.getZkServers();
         }
         URI metadataServiceUri = URI.create(metadataServiceUriStr);
         return getZKServersFromServiceUri(metadataServiceUri);
     }
 
+    @SuppressWarnings("deprecation")
     public static String resolveZkLedgersRootPath(AbstractConfiguration<?> conf) {
         String metadataServiceUriStr = conf.getMetadataServiceUriUnchecked();
         if (null == metadataServiceUriStr) {
-            return null;
+            return conf.getZkLedgersRootPath();
         }
         URI metadataServiceUri = URI.create(metadataServiceUriStr);
         return metadataServiceUri.getPath();

--- a/stream/distributedlog/pom.xml
+++ b/stream/distributedlog/pom.xml
@@ -110,3 +110,4 @@
     </profile>
   </profiles>
 </project>
+

--- a/stream/pom.xml
+++ b/stream/pom.xml
@@ -89,3 +89,4 @@
   </profiles>
 
 </project>
+


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problme*

Dlog tests are failing because dlog is using an external zookeeper client, where both `zkServers` and `metadataServiceUri`
are not set on client configuration. It will throw NPE when trying to resolve `zkServers` and `zkLedgersRootPath` from metadata service uri.

*Solution*

Fallback to use deprecated `getZkServers` and `getZkLedgersPath` when metadata service uri is null

Related Issues: #1336 

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
