### PR TITLE
In EntryLogger.addEntry method, rollLog flag should not be ignored.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1223,7 +1223,7 @@ public class EntryLogger {
     }
 
     public long addEntry(long ledger, ByteBuf entry, boolean rollLog) throws IOException {
-        return entryLogManager.addEntry(ledger, entry, true);
+        return entryLogManager.addEntry(ledger, entry, rollLog);
     }
 
     private final FastThreadLocal<ByteBuf> sizeBuffer = new FastThreadLocal<ByteBuf>() {


### PR DESCRIPTION
In EntryLogger.addEntry method, rollLog flag should not be ignored.


