### PR TITLE
OrderedScheduler#chooseThread(key) handle null key

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -348,7 +348,11 @@ public class OrderedExecutor implements ExecutorService {
             return threads[0];
         }
 
-        return threads[MathUtils.signSafeMod(orderingKey.hashCode(), threads.length)];
+        if (null == orderingKey) {
+            return threads[rand.nextInt(threads.length)];
+        } else {
+            return threads[MathUtils.signSafeMod(orderingKey.hashCode(), threads.length)];
+        }
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

It is more convenient if OrderedScheduler#chooseThread(key) can handle null key. so the applications who is using #chooseThread don't need to worry which method to choose - `chooseThread()` vs `chooseThread(key)`.

*Solution*

in `chooseThread(key)`, fallback to randomly pickup a thread if key is null.

