### PR TITLE
ZKLedgerManager.writeLedgerMetadata should return appropriate error.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -443,6 +443,9 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                     // update metadata version
                     metadata.setVersion(zv.setLongVersion(stat.getVersion()));
                     cb.operationComplete(BKException.Code.OK, null);
+                } else if (KeeperException.Code.NONODE.intValue() == rc) {
+                    LOG.warn("Ledger node does not exist in ZooKeeper: ledgerId={}", ledgerId);
+                    cb.operationComplete(BKException.Code.NoSuchLedgerExistsException, null);
                 } else {
                     LOG.warn("Conditional update ledger metadata failed: {}", KeeperException.Code.get(rc));
                     cb.operationComplete(BKException.Code.ZKException, null);


### PR DESCRIPTION
Descriptions of the changes in this PR:

ZKLedgerManager.writeLedgerMetadata should return
NoSuchLedgerExistsException error in the case it
gets KeeperException.Code.NONODE rc value from ZK.
ZKLedgerManager.removeLedgerMetadata does that as well.
