### PR TITLE
Fix TestCompatUpgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-bundle-plugin.version>3.2.0</maven-bundle-plugin.version>
-    <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>2.5</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>

--- a/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
+++ b/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
@@ -178,12 +178,12 @@ class TestCompatUpgrade {
 
     @Test
     public void test460to461() throws Exception {
-        testUpgrade("4.6.0", "4.6.1")
+        testUpgrade("4.6.0", "4.6.1", false, true)
     }
 
     @Test
     public void test461to462() throws Exception {
-        testUpgrade("4.6.1", "4.6.2")
+        testUpgrade("4.6.1", "4.6.2", false, true)
     }
 
     @Test
@@ -193,6 +193,6 @@ class TestCompatUpgrade {
 
     @Test
     public void test470toCurrentMaster() throws Exception {
-        testUpgrade("4.7.0", System.getProperty("currentVersion"), false, true)
+        testUpgrade("4.7.0", System.getProperty("currentVersion"))
     }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

 #1352 update the BC tests to include newer versions, however it removes the flags that used for 4.6.0 to handle badly shutdown.
 This change makes the BC tests become very flaky.

*Solution*

- apply `badlyshutdown` flag to both from 4.6.0 to 4.6.1 and from 4.6.1 to 4.6.2 upgrade