### PR TITLE
Enable Prometheus stats provider to use custom http container

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -17,11 +17,14 @@
 package org.apache.bookkeeper.stats.prometheus;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.junit.Test;
 
 /**
@@ -46,6 +49,33 @@ public class TestPrometheusMetricsProvider {
         StatsLogger scope1 = statsLogger.scope("scopetest");
         StatsLogger scope2 = statsLogger.scope("scopetest");
         assertSame(scope1, scope2);
+    }
+
+    @Test
+    public void testStartNoHttp() {
+        PropertiesConfiguration config = new PropertiesConfiguration();
+        config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ENABLE, false);
+        PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
+        try {
+            provider.start(config);
+            assertNull(provider.server);
+        } finally {
+            provider.stop();
+        }
+    }
+
+    @Test
+    public void testStartWithHttp() {
+        PropertiesConfiguration config = new PropertiesConfiguration();
+        config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ENABLE, true);
+        config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_PORT, 0); // ephemeral
+        PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
+        try {
+            provider.start(config);
+            assertNotNull(provider.server);
+        } finally {
+            provider.stop();
+        }
     }
 
     @Test


### PR DESCRIPTION
This change enable Prometheus stats provider to:
- use an user supplied registry
- do not start internal Jetty server

The context is to run the Bookie inside a process together with a servlet container (like Apache Tomcat) and use the existing web endpoint instead of opening another http (plain) port