### PR TITLE
ISSUE #1390 Ensemble change on delayed write error

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -118,7 +118,7 @@ public class LedgerHandle implements WriteHandle {
     ScheduledFuture<?> timeoutFuture = null;
 
     final long waitForWriteSetMs;
-    Map<Integer, BookieSocketAddress> delayedWriteFailedBookies = new HashMap<Integer, BookieSocketAddress>();
+    private Map<Integer, BookieSocketAddress> delayedWriteFailedBookies = new HashMap<Integer, BookieSocketAddress>();
 
     /**
      * Invalid entry id. This value is returned from methods which
@@ -1755,7 +1755,7 @@ public class LedgerHandle implements WriteHandle {
         return new EnsembleInfo(newEnsemble, failedBookies, replacedBookies);
     }
 
-    void handleDelayeWriteBookieFailure() {
+    void handleDelayedWriteBookieFailure() {
         int curBlockAddCompletions = blockAddCompletions.get();
         if (bk.getDisableEnsembleChangeFeature().isAvailable()) {
             if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -117,6 +118,7 @@ public class LedgerHandle implements WriteHandle {
     ScheduledFuture<?> timeoutFuture = null;
 
     final long waitForWriteSetMs;
+    Map<Integer, BookieSocketAddress> delayedWriteFailedBookies = new HashMap<Integer, BookieSocketAddress>();
 
     /**
      * Invalid entry id. This value is returned from methods which
@@ -149,6 +151,10 @@ public class LedgerHandle implements WriteHandle {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public Map<Integer, BookieSocketAddress> getDelayedWriteFailedBookies() {
+        return delayedWriteFailedBookies;
     }
 
     LedgerHandle(BookKeeper bk, long ledgerId, LedgerMetadata metadata,
@@ -1749,6 +1755,42 @@ public class LedgerHandle implements WriteHandle {
         return new EnsembleInfo(newEnsemble, failedBookies, replacedBookies);
     }
 
+    void handleDelayeWriteBookieFailure() {
+        int curBlockAddCompletions = blockAddCompletions.get();
+        if (bk.getDisableEnsembleChangeFeature().isAvailable()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ensemble change is disabled. Failed bookies {} for ledger {}.",
+                        delayedWriteFailedBookies, ledgerId);
+            }
+            return;
+        }
+        int curNumEnsembleChanges = numEnsembleChanges.incrementAndGet();
+        if (curNumEnsembleChanges > maxAllowedEnsembleChanges) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Exceeding maxAllowedEnsembeChanges {}. Failed bookies {} for ledger {}.",
+                        maxAllowedEnsembleChanges, delayedWriteFailedBookies, ledgerId);
+            }
+            return;
+        }
+        synchronized (metadata) {
+            try {
+                EnsembleInfo ensembleInfo = replaceBookieInMetadata(delayedWriteFailedBookies, curNumEnsembleChanges);
+                if (ensembleInfo.replacedBookies.isEmpty()) {
+                    return;
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("[EnsembleChange-L{}-{}] : writing new ensemble info = {}",
+                            getId(), curNumEnsembleChanges, ensembleInfo);
+                }
+                writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions,
+                        curNumEnsembleChanges, false));
+            } catch (BKException.BKNotEnoughBookiesException e) {
+                LOG.error("Could not get additional bookie to remake ensemble: {}", ledgerId);
+            }
+            delayedWriteFailedBookies.clear();
+        }
+    }
+
     void handleBookieFailure(final Map<Integer, BookieSocketAddress> failedBookies) {
         int curBlockAddCompletions = blockAddCompletions.incrementAndGet();
         if (bk.getDisableEnsembleChangeFeature().isAvailable()) {
@@ -1764,7 +1806,7 @@ public class LedgerHandle implements WriteHandle {
         int curNumEnsembleChanges = numEnsembleChanges.incrementAndGet();
 
         // when the ensemble changes are too frequent, close handle
-        if (curNumEnsembleChanges > maxAllowedEnsembleChanges){
+        if (curNumEnsembleChanges > maxAllowedEnsembleChanges) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Ledger {} reaches max allowed ensemble change number {}",
                         ledgerId, maxAllowedEnsembleChanges);
@@ -1783,7 +1825,10 @@ public class LedgerHandle implements WriteHandle {
                     LOG.debug("[EnsembleChange-L{}-{}] : writing new ensemble info = {}, block add completions = {}",
                             getId(), curNumEnsembleChanges, ensembleInfo, curBlockAddCompletions);
                 }
-                writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions, curNumEnsembleChanges));
+                writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions,
+                        curNumEnsembleChanges, true));
+                // clear if there are any delayed write failures were recorded.
+                delayedWriteFailedBookies.clear();
             } catch (BKException.BKNotEnoughBookiesException e) {
                 LOG.error("Could not get additional bookie to remake ensemble, closing ledger: {}", ledgerId);
                 handleUnrecoverableErrorDuringAdd(e.getCode());
@@ -1825,14 +1870,17 @@ public class LedgerHandle implements WriteHandle {
         private final EnsembleInfo ensembleInfo;
         private final int curBlockAddCompletions;
         private final int ensembleChangeIdx;
+        private final boolean addEntryFailureRecovery;
 
         ChangeEnsembleCb(EnsembleInfo ensembleInfo,
                          int curBlockAddCompletions,
-                         int ensembleChangeIdx) {
+                         int ensembleChangeIdx,
+                         boolean addEntryFailureRecovery) {
             super(bk.getMainWorkerPool(), ledgerId);
             this.ensembleInfo = ensembleInfo;
             this.curBlockAddCompletions = curBlockAddCompletions;
             this.ensembleChangeIdx = ensembleChangeIdx;
+            this.addEntryFailureRecovery = addEntryFailureRecovery;
         }
 
         @Override
@@ -1853,10 +1901,17 @@ public class LedgerHandle implements WriteHandle {
             } else if (rc != BKException.Code.OK) {
                 LOG.error("[EnsembleChange-L{}-{}] : could not persist ledger metadata : info = {}, "
                         + "closing ledger : {}.", getId(), ensembleChangeIdx, ensembleInfo, rc);
-                handleUnrecoverableErrorDuringAdd(rc);
+                if (addEntryFailureRecovery) {
+                    handleUnrecoverableErrorDuringAdd(rc);
+                }
                 return;
             }
-            int newBlockAddCompletions = blockAddCompletions.decrementAndGet();
+            int newBlockAddCompletions;
+            if (addEntryFailureRecovery) {
+                newBlockAddCompletions = blockAddCompletions.decrementAndGet();
+            } else {
+                newBlockAddCompletions = blockAddCompletions.get();
+            }
 
             if (LOG.isDebugEnabled()) {
                 LOG.info("[EnsembleChange-L{}-{}] : completed ensemble change, block add completion {} => {}",
@@ -1867,8 +1922,10 @@ public class LedgerHandle implements WriteHandle {
             ensembleChangeCounter.inc();
             LOG.info("New Ensemble: {} for ledger: {}", ensembleInfo.newEnsemble, ledgerId);
 
-            // the failed bookie has been replaced
-            unsetSuccessAndSendWriteRequest(ensembleInfo.replacedBookies);
+            if (addEntryFailureRecovery) {
+                // the failed bookie has been replaced
+                unsetSuccessAndSendWriteRequest(ensembleInfo.replacedBookies);
+            }
         }
 
         @Override
@@ -2041,7 +2098,8 @@ public class LedgerHandle implements WriteHandle {
             // merge ensemble infos from new meta except last ensemble
             // since they might be modified by recovery tool.
             metadata.mergeEnsembles(newMeta.getEnsembles());
-            writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions, ensembleChangeIdx));
+            writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions,
+                    ensembleChangeIdx, true));
             return true;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -118,7 +118,8 @@ public class LedgerHandle implements WriteHandle {
     ScheduledFuture<?> timeoutFuture = null;
 
     final long waitForWriteSetMs;
-    private Map<Integer, BookieSocketAddress> delayedWriteFailedBookies = new HashMap<Integer, BookieSocketAddress>();
+    private final Map<Integer, BookieSocketAddress> delayedWriteFailedBookies =
+            new HashMap<Integer, BookieSocketAddress>();
 
     /**
      * Invalid entry id. This value is returned from methods which

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -241,6 +241,12 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
                 entryId, lh.lastAddConfirmed, currentLedgerLength,
                 payload);
 
+        // We are about to send. Check if we need to make an ensemble change
+        // becasue of delayed write errors
+        Map <Integer, BookieSocketAddress> delayedWriteFailedBookies = lh.getDelayedWriteFailedBookies();
+        if (!delayedWriteFailedBookies.isEmpty()) {
+            lh.handleDelayeWriteBookieFailure();
+        }
         // Iterate over set and trigger the sendWriteRequests
         DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSet(entryId);
         try {
@@ -276,6 +282,9 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
                 // Got an error after satisfying AQ. This means we are under replicated at the create itself.
                 // Update the stat to reflect it.
                 addOpUrCounter.inc();
+                if (!lh.bk.getDisableEnsembleChangeFeature().isAvailable() && !lh.bk.delayEnsembleChange) {
+                    lh.getDelayedWriteFailedBookies().putIfAbsent(bookieIndex, addr);
+                }
             }
             // even the add operation is completed, but because we don't reset completed flag back to false when
             // #unsetSuccessAndSendWriteRequest doesn't break ack quorum constraint. we still have current pending

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -245,7 +245,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         // becasue of delayed write errors
         Map <Integer, BookieSocketAddress> delayedWriteFailedBookies = lh.getDelayedWriteFailedBookies();
         if (!delayedWriteFailedBookies.isEmpty()) {
-            lh.handleDelayeWriteBookieFailure();
+            lh.handleDelayedWriteBookieFailure();
         }
         // Iterate over set and trigger the sendWriteRequests
         DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSet(entryId);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -303,7 +303,7 @@ public class BookieWriteLedgerTest extends
             lh.addEntry(entry.array());
         }
         // Sleep to receive delayed error on the write directed to the sleeping bookie
-        Thread.sleep(baseClientConf.getAddEntryTimeout() * 1000 * 2 );
+        Thread.sleep(baseClientConf.getAddEntryTimeout() * 1000 * 2);
         assertTrue(
                 "Stats should have captured a new UnderReplication during write",
                 bkc.getTestStatsProvider().getCounter(

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -25,6 +25,7 @@ import static org.apache.bookkeeper.client.BookKeeperClientStats.ADD_OP_UR;
 import static org.apache.bookkeeper.client.BookKeeperClientStats.CLIENT_SCOPE;
 import static org.apache.bookkeeper.client.BookKeeperClientStats.READ_OP_DM;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import io.netty.buffer.ByteBuf;
@@ -262,7 +263,75 @@ public class BookieWriteLedgerTest extends
                         .get() > 0);
         lh.close();
     }
+    /**
+     * Verty delayedWriteError causes ensemble changes.
+     */
+    @Test
+    public void testDelayedWriteEnsembleChange() throws Exception {
+        // Create a ledger
+        lh = bkc.createLedger(3, 3, 2, digestType, ledgerPassword);
+        baseClientConf.setAddEntryTimeout(1);
 
+        int numEntriesToWrite = 10;
+        // write-batch-1
+        for (int i = 0; i < numEntriesToWrite; i++) {
+            ByteBuffer entry = ByteBuffer.allocate(4);
+            entry.putInt(rng.nextInt(maxInt));
+            entry.position(0);
+
+            entries1.add(entry.array());
+            lh.addEntry(entry.array());
+        }
+
+        CountDownLatch sleepLatch1 = new CountDownLatch(1);
+
+        // get bookie at index-0
+        BookieSocketAddress bookie1 = lh.getLedgerMetadata().currentEnsemble.get(0);
+        sleepBookie(bookie1, sleepLatch1);
+
+        int i = numEntriesToWrite;
+        numEntriesToWrite = numEntriesToWrite + 10;
+
+        // write-batch-2
+
+        for (; i < numEntriesToWrite; i++) {
+            ByteBuffer entry = ByteBuffer.allocate(4);
+            entry.putInt(rng.nextInt(maxInt));
+            entry.position(0);
+
+            entries1.add(entry.array());
+            lh.addEntry(entry.array());
+        }
+        // Sleep to receive delayed error on the write directed to the sleeping bookie
+        Thread.sleep(baseClientConf.getAddEntryTimeout() * 1000 * 2 );
+        assertTrue(
+                "Stats should have captured a new UnderReplication during write",
+                bkc.getTestStatsProvider().getCounter(
+                        CLIENT_SCOPE + "." + ADD_OP_UR)
+                        .get() > 0);
+
+        i = numEntriesToWrite;
+        numEntriesToWrite = numEntriesToWrite + 10;
+
+        // write-batch-3
+        for (; i < numEntriesToWrite; i++) {
+            ByteBuffer entry = ByteBuffer.allocate(4);
+            entry.putInt(rng.nextInt(maxInt));
+            entry.position(0);
+
+            entries1.add(entry.array());
+            lh.addEntry(entry.array());
+        }
+
+        sleepLatch1.countDown();
+        // get the bookie at index-0 again, this must be different.
+        BookieSocketAddress bookie2 = lh.getLedgerMetadata().currentEnsemble.get(0);
+
+        assertFalse(
+                "Delayed write error must have forced ensemble change",
+                        bookie1.equals(bookie2));
+        lh.close();
+    }
     /**
      * Verify the functionality Ledgers with different digests.
      *


### PR DESCRIPTION
Error on delayed writes are dropped if the addEntry
is in complete state (ack quorum satisfied).
This change records the delayed write failure and forces
ensemble change onthe next write. This saves from having
extended under replicated status on the ledger and also
avoids unnecessary build up at PCBC channel.

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>

Descriptions of the changes in this PR:

(PR description content here)...

Master Issue: #<master-issue-number>

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
