### PR TITLE
Bookies should be from different racks in a Writequorum.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
@@ -52,15 +52,17 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
                                                           int stabilizePeriodSeconds,
                                                           boolean isWeighted,
                                                           int maxWeightMultiple,
+                                                          int minNumRacksPerWriteQuorum,
                                                           StatsLogger statsLogger) {
         if (stabilizePeriodSeconds > 0) {
-            super.initialize(dnsResolver, timer, reorderReadsRandom, 0, isWeighted, maxWeightMultiple, statsLogger);
+            super.initialize(dnsResolver, timer, reorderReadsRandom, 0, isWeighted, maxWeightMultiple,
+                    minNumRacksPerWriteQuorum, statsLogger);
             slave = new RackawareEnsemblePlacementPolicyImpl(enforceDurability);
             slave.initialize(dnsResolver, timer, reorderReadsRandom, stabilizePeriodSeconds, isWeighted,
-                    maxWeightMultiple, statsLogger);
+                    maxWeightMultiple, minNumRacksPerWriteQuorum, statsLogger);
         } else {
             super.initialize(dnsResolver, timer, reorderReadsRandom, stabilizePeriodSeconds, isWeighted,
-                    maxWeightMultiple, statsLogger);
+                    maxWeightMultiple, minNumRacksPerWriteQuorum, statsLogger);
             slave = null;
         }
         return this;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -133,12 +133,13 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements
                 if (writeQuorumSize < 2) {
                     return true;
                 }
-
-                if (seenBookies + 1 == writeQuorumSize) {
-                    return racksOrRegionsInQuorum.size()
-                        > (racksOrRegionsInQuorum.contains(candidate.getNetworkLocation(distanceFromLeaves)) ? 1 : 0);
-                }
-                return true;
+                /*
+                 * Ideally RackAwareEnsemblePlacementPolicy should try to select
+                 * bookies from different racks for a write quorum. So in a
+                 * WriteQuorum, bookies should be from WriteQuorum number of
+                 * racks.
+                 */
+                return !racksOrRegionsInQuorum.contains(candidate.getNetworkLocation(distanceFromLeaves));
             }
 
             @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -141,6 +141,9 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     // Validate bookie process user
     public static final String PERMITTED_STARTUP_USERS = "permittedStartupUsers";
 
+    // minimum number of racks per write quorum
+    public static final String MIN_NUM_RACKS_PER_WRITE_QUORUM = "minNumRacksPerWriteQuorum";
+
     protected AbstractConfiguration() {
         super();
         if (READ_SYSTEM_PROPERTIES) {
@@ -779,6 +782,19 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
         return getString(TLS_ENABLED_PROTOCOLS, null);
     }
 
+    /**
+     * Set the minimum number of racks per write quorum.
+     */
+    public void setMinNumRacksPerWriteQuorum(int minNumRacksPerWriteQuorum) {
+        setProperty(MIN_NUM_RACKS_PER_WRITE_QUORUM, minNumRacksPerWriteQuorum);
+    }
+
+    /**
+     * Get the minimum number of racks per write quorum.
+     */
+    public int getMinNumRacksPerWriteQuorum() {
+        return getInteger(MIN_NUM_RACKS_PER_WRITE_QUORUM, 2);
+    }
 
     /**
      * Trickery to allow inheritance with fluent style.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopologyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopologyImpl.java
@@ -18,6 +18,7 @@
 package org.apache.bookkeeper.net;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -43,6 +44,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
 
     public static final int DEFAULT_HOST_LEVEL = 2;
     public static final Logger LOG = LoggerFactory.getLogger(NetworkTopologyImpl.class);
+    public static final String NODE_SEPARATOR = ",";
 
     /**
      * A marker for an InvalidTopology Exception.
@@ -772,7 +774,11 @@ public class NetworkTopologyImpl implements NetworkTopology {
         try {
             if (scope.startsWith("~")) {
                 Set<Node> allNodes = doGetLeaves(NodeBase.ROOT);
-                Set<Node> excludeNodes = doGetLeaves(scope.substring(1));
+                String[] excludeScopes = scope.substring(1).split(NODE_SEPARATOR);
+                Set<Node> excludeNodes = new HashSet<Node>();
+                Arrays.stream(excludeScopes).forEach((excludeScope) -> {
+                    excludeNodes.addAll(doGetLeaves(excludeScope));
+                });
                 allNodes.removeAll(excludeNodes);
                 return allNodes;
             } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicy.java
@@ -498,9 +498,9 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
             ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null, new HashSet<>());
-            assertEquals(0, getNumCoveredWriteQuorums(ensemble, 2));
+            assertEquals(0, getNumCoveredWriteQuorums(ensemble, 2, 1));
             ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<>());
-            assertEquals(0, getNumCoveredWriteQuorums(ensemble2, 2));
+            assertEquals(0, getNumCoveredWriteQuorums(ensemble2, 2, 1));
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
         }
@@ -517,6 +517,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r2");
         StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
         StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r2");
+        int numOfAvailableRacks = 2;
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -525,12 +526,84 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         addrs.add(addr4);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, null, new HashSet<>());
-            int numCovered = getNumCoveredWriteQuorums(ensemble, 2);
+            int ensembleSize = 3;
+            int writeQuorumSize = 2;
+            int acqQuorumSize = 2;
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(ensembleSize, writeQuorumSize, acqQuorumSize,
+                    null, new HashSet<>());
+            int numCovered = getNumCoveredWriteQuorums(ensemble, 2, numOfAvailableRacks);
             assertTrue(numCovered >= 1 && numCovered < 3);
-            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<>());
-            numCovered = getNumCoveredWriteQuorums(ensemble2, 2);
+            ensembleSize = 4;
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(ensembleSize, writeQuorumSize, acqQuorumSize,
+                    null, new HashSet<>());
+            numCovered = getNumCoveredWriteQuorums(ensemble2, 2, numOfAvailableRacks);
             assertTrue(numCovered >= 1 && numCovered < 3);
+        } catch (BKNotEnoughBookiesException bnebe) {
+            fail("Should not get not enough bookies exception even there is only one rack.");
+        }
+    }
+
+    @Test
+    public void testWriteQuorumNumberOfRacks() throws Exception {
+        BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
+        BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
+        BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
+        BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
+        BookieSocketAddress addr5 = new BookieSocketAddress("127.0.0.6", 3181);
+        BookieSocketAddress addr6 = new BookieSocketAddress("127.0.0.7", 3181);
+        BookieSocketAddress addr7 = new BookieSocketAddress("127.0.0.8", 3181);
+        BookieSocketAddress addr8 = new BookieSocketAddress("127.0.0.9", 3181);
+        BookieSocketAddress addr9 = new BookieSocketAddress("127.0.0.10", 3181);
+        BookieSocketAddress addr10 = new BookieSocketAddress("127.0.0.11", 3181);
+        BookieSocketAddress addr11 = new BookieSocketAddress("127.0.0.12", 3181);
+        BookieSocketAddress addr12 = new BookieSocketAddress("127.0.0.13", 3181);
+
+        // update dns mapping
+        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/default-region/r4");
+        StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/default-region/r4");
+        StaticDNSResolver.addNodeToRack(addr9.getHostName(), "/default-region/r5");
+        StaticDNSResolver.addNodeToRack(addr10.getHostName(), "/default-region/r5");
+        StaticDNSResolver.addNodeToRack(addr11.getHostName(), "/default-region/r6");
+        StaticDNSResolver.addNodeToRack(addr12.getHostName(), "/default-region/r6");
+        int totalNumOfAvailableRacks = 6;
+        // Update cluster
+        Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
+        addrs.add(addr1);
+        addrs.add(addr2);
+        addrs.add(addr3);
+        addrs.add(addr4);
+        addrs.add(addr5);
+        addrs.add(addr6);
+        addrs.add(addr7);
+        addrs.add(addr8);
+        addrs.add(addr9);
+        addrs.add(addr10);
+        addrs.add(addr11);
+        addrs.add(addr12);
+
+        repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
+        try {
+            int ensembleSize = 12;
+            int writeQuorumSize = 6;
+            ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(ensembleSize, writeQuorumSize, writeQuorumSize,
+                    null, new HashSet<>());
+            int numCovered = getNumCoveredWriteQuorums(ensemble, writeQuorumSize, totalNumOfAvailableRacks);
+            assertEquals("minimum number of racks covered for writequorum ensemble: " + ensemble, ensembleSize,
+                    numCovered);
+
+            ensembleSize = 6;
+            writeQuorumSize = 6;
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(ensembleSize, writeQuorumSize, writeQuorumSize,
+                    null, new HashSet<>());
+            numCovered = getNumCoveredWriteQuorums(ensemble2, writeQuorumSize, totalNumOfAvailableRacks);
+            assertEquals("minimum number of racks covered for writequorum", ensembleSize, numCovered);
+
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
         }
@@ -555,6 +628,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/default-region/r2");
         StaticDNSResolver.addNodeToRack(addr7.getHostName(), "/default-region/r3");
         StaticDNSResolver.addNodeToRack(addr8.getHostName(), "/default-region/r4");
+        int availableNumOfRacks = 4;
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
         addrs.add(addr1);
@@ -567,10 +641,17 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         addrs.add(addr8);
         repp.onClusterChanged(addrs, new HashSet<BookieSocketAddress>());
         try {
-            ArrayList<BookieSocketAddress> ensemble1 = repp.newEnsemble(3, 2, 2, null, new HashSet<>());
-            assertEquals(3, getNumCoveredWriteQuorums(ensemble1, 2));
-            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(4, 2, 2, null, new HashSet<>());
-            assertEquals(4, getNumCoveredWriteQuorums(ensemble2, 2));
+            int ensembleSize = 3;
+            int writeQuorumSize = 3;
+            int ackQuorumSize = 2;
+            ArrayList<BookieSocketAddress> ensemble1 = repp.newEnsemble(ensembleSize, writeQuorumSize, ackQuorumSize,
+                    null, new HashSet<>());
+            assertEquals(3, getNumCoveredWriteQuorums(ensemble1, 2, availableNumOfRacks));
+            ensembleSize = 4;
+            writeQuorumSize = 4;
+            ArrayList<BookieSocketAddress> ensemble2 = repp.newEnsemble(ensembleSize, writeQuorumSize, 2, null,
+                    new HashSet<>());
+            assertEquals(4, getNumCoveredWriteQuorums(ensemble2, 2, availableNumOfRacks));
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
         }
@@ -750,6 +831,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
                 NetworkTopology.DEFAULT_REGION + "/r3");
         StaticDNSResolver.addNodeToRack(addr9.getSocketAddress().getAddress().getHostAddress(),
                 NetworkTopology.DEFAULT_REGION + "/r3");
+        int numOfAvailableRacks = 3;
 
         // Update cluster
         Set<BookieSocketAddress> addrs = new HashSet<BookieSocketAddress>();
@@ -791,13 +873,18 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
 
         Set<BookieSocketAddress> excludeList = new HashSet<BookieSocketAddress>();
         ArrayList<BookieSocketAddress> ensemble;
+        int ensembleSize = 3;
+        int writeQuorumSize = 2;
+        int acqQuorumSize = 2;
         for (int i = 0; i < numTries; i++) {
             // addr2 is on /r2 and this is the only one on this rack. So the replacement
             // will come from other racks. However, the weight should be honored in such
             // selections as well
-            ensemble = repp.newEnsemble(3, 2, 2, null, excludeList);
-            assertTrue("Rackaware selection not happening " + getNumCoveredWriteQuorums(ensemble, 2),
-                    getNumCoveredWriteQuorums(ensemble, 2) >= 2);
+            ensemble = repp.newEnsemble(ensembleSize, writeQuorumSize, acqQuorumSize, null, excludeList);
+            assertTrue(
+                    "Rackaware selection not happening "
+                            + getNumCoveredWriteQuorums(ensemble, writeQuorumSize, numOfAvailableRacks),
+                    getNumCoveredWriteQuorums(ensemble, writeQuorumSize, numOfAvailableRacks) >= 2);
             for (BookieSocketAddress b : ensemble) {
                 selectionCounts.put(b, selectionCounts.get(b) + 1);
             }
@@ -875,8 +962,8 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         }
     }
 
-    static int getNumCoveredWriteQuorums(ArrayList<BookieSocketAddress> ensemble, int writeQuorumSize)
-            throws Exception {
+    static int getNumCoveredWriteQuorums(ArrayList<BookieSocketAddress> ensemble, int writeQuorumSize,
+            int availableNumOfRacks) throws Exception {
         int ensembleSize = ensemble.size();
         int numCoveredWriteQuorums = 0;
         for (int i = 0; i < ensembleSize; i++) {
@@ -886,9 +973,27 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
                 BookieSocketAddress addr = ensemble.get(bookieIdx);
                 racks.add(StaticDNSResolver.getRack(addr.getHostName()));
             }
-            numCoveredWriteQuorums += (racks.size() > 1 ? 1 : 0);
+            numCoveredWriteQuorums += (racks.size() == Math.min(writeQuorumSize, Math.max(availableNumOfRacks, 2)) ? 1
+                    : 0);
         }
         return numCoveredWriteQuorums;
+    }
+
+    static int getMinNumOfRacksForAWriteQuorum(ArrayList<BookieSocketAddress> ensemble, int writeQuorumSize)
+            throws Exception {
+        int ensembleSize = ensemble.size();
+        int minNumOfRacksForAWriteQuorum = Integer.MAX_VALUE;
+        Set<String> racks = new HashSet<String>();
+        for (int i = 0; i < ensembleSize; i++) {
+            racks.clear();
+            for (int j = 0; j < writeQuorumSize; j++) {
+                int bookieIdx = (i + j) % ensembleSize;
+                BookieSocketAddress addr = ensemble.get(bookieIdx);
+                racks.add(StaticDNSResolver.getRack(addr.getHostName()));
+            }
+            minNumOfRacksForAWriteQuorum = Math.min(minNumOfRacksForAWriteQuorum, racks.size());
+        }
+        return minNumOfRacksForAWriteQuorum;
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawarePolicyNotificationUpdates.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawarePolicyNotificationUpdates.java
@@ -107,7 +107,7 @@ public class TestRackawarePolicyNotificationUpdates extends TestCase {
         ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(ensembleSize, writeQuorumSize, acqQuorumSize,
                 Collections.emptyMap(), Collections.emptySet());
         int numCovered = TestRackawareEnsemblePlacementPolicy.getNumCoveredWriteQuorums(ensemble, writeQuorumSize,
-                numOfAvailableRacks);
+                conf.getMinNumRacksPerWriteQuorum());
         assertTrue(numCovered >= 1 && numCovered < 3);
         assertTrue(ensemble.contains(addr1));
 
@@ -121,7 +121,7 @@ public class TestRackawarePolicyNotificationUpdates extends TestCase {
         ensemble = repp.newEnsemble(ensembleSize, writeQuorumSize, acqQuorumSize, Collections.emptyMap(),
                 Collections.emptySet());
         assertEquals(3, TestRackawareEnsemblePlacementPolicy.getNumCoveredWriteQuorums(ensemble, writeQuorumSize,
-                numOfAvailableRacks));
+                conf.getMinNumRacksPerWriteQuorum()));
         assertTrue(ensemble.contains(addr1));
         assertTrue(ensemble.contains(addr2));
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawarePolicyNotificationUpdates.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawarePolicyNotificationUpdates.java
@@ -95,14 +95,19 @@ public class TestRackawarePolicyNotificationUpdates extends TestCase {
         StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/rack-2");
         StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/rack-2");
         StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/rack-2");
+        int numOfAvailableRacks = 2;
 
         // Update cluster
         Set<BookieSocketAddress> addrs = Sets.newHashSet(addr1, addr2, addr3, addr4);
         repp.onClusterChanged(addrs, new HashSet<>());
 
-        ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(3, 2, 2, Collections.emptyMap(),
-                Collections.emptySet());
-        int numCovered = TestRackawareEnsemblePlacementPolicy.getNumCoveredWriteQuorums(ensemble, 2);
+        int ensembleSize = 3;
+        int writeQuorumSize = 2;
+        int acqQuorumSize = 2;
+        ArrayList<BookieSocketAddress> ensemble = repp.newEnsemble(ensembleSize, writeQuorumSize, acqQuorumSize,
+                Collections.emptyMap(), Collections.emptySet());
+        int numCovered = TestRackawareEnsemblePlacementPolicy.getNumCoveredWriteQuorums(ensemble, writeQuorumSize,
+                numOfAvailableRacks);
         assertTrue(numCovered >= 1 && numCovered < 3);
         assertTrue(ensemble.contains(addr1));
 
@@ -111,9 +116,12 @@ public class TestRackawarePolicyNotificationUpdates extends TestCase {
         bookieAddressList.add(addr2);
         rackList.add("/default-region/rack-3");
         StaticDNSResolver.changeRack(bookieAddressList, rackList);
-
-        ensemble = repp.newEnsemble(3, 2, 1, Collections.emptyMap(), Collections.emptySet());
-        assertEquals(3, TestRackawareEnsemblePlacementPolicy.getNumCoveredWriteQuorums(ensemble, 2));
+        numOfAvailableRacks = numOfAvailableRacks + 1;
+        acqQuorumSize = 1;
+        ensemble = repp.newEnsemble(ensembleSize, writeQuorumSize, acqQuorumSize, Collections.emptyMap(),
+                Collections.emptySet());
+        assertEquals(3, TestRackawareEnsemblePlacementPolicy.getNumCoveredWriteQuorums(ensemble, writeQuorumSize,
+                numOfAvailableRacks));
         assertTrue(ensemble.contains(addr1));
         assertTrue(ensemble.contains(addr2));
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Ideally RackAwareEnsemblePlacementPolicy should try to select
bookies from different racks for a write quorum. So in a
WriteQuorum, bookies should be from WriteQuorum number of racks,
provided there are sufficient number of available racks and
bookies.