### PR TITLE
Fix TestSmoke#testTailingReads

### DIFF
--- a/tests/integration/smoke/src/test/java/org/apache/bookkeeper/tests/integration/TestSmoke.java
+++ b/tests/integration/smoke/src/test/java/org/apache/bookkeeper/tests/integration/TestSmoke.java
@@ -154,7 +154,8 @@ public class TestSmoke {
                         assertEquals(lac + 1, nextEntryId);
                     }
 
-                    if (nextEntryId >= lastExpectedConfirmedEntryId) {
+                    if (nextEntryId >= lastExpectedConfirmedEntryId
+                        && lac >= lastExpectedConfirmedEntryId) {
                         break;
                     }
 
@@ -189,9 +190,9 @@ public class TestSmoke {
         result(readFuture);
         result(writeFuture);
 
-        assertEquals(readLh.getLastAddConfirmed(), numEntries - 2);
-        assertEquals(writeLh.getLastAddConfirmed(), numEntries - 1);
-        assertEquals(writeLh.getLastAddPushed(), numEntries - 1);
+        assertEquals(numEntries - 2, readLh.getLastAddConfirmed());
+        assertEquals(numEntries - 1, writeLh.getLastAddConfirmed());
+        assertEquals(numEntries - 1, writeLh.getLastAddPushed());
     }
 
 }

--- a/tests/integration/smoke/src/test/java/org/apache/bookkeeper/tests/integration/TestSmoke.java
+++ b/tests/integration/smoke/src/test/java/org/apache/bookkeeper/tests/integration/TestSmoke.java
@@ -154,8 +154,7 @@ public class TestSmoke {
                         assertEquals(lac + 1, nextEntryId);
                     }
 
-                    if (nextEntryId >= lastExpectedConfirmedEntryId
-                        && lac >= lastExpectedConfirmedEntryId) {
+                    if (nextEntryId > lastExpectedConfirmedEntryId) {
                         break;
                     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

TestSmoke#testTailingReads is testing the tailing behavior at bookkeeper. However the current testing logic is a bit
problematic on checking whether the reader has caught up with the expected last add confirmed. so the read logic break
earlier before reading the expectedLastConfirmedEntry.

*Solution*

Fix the checking logic on breaking the read loop.