### PR TITLE
Add a test docker image for current version only

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -82,6 +82,9 @@ Vagrant.configure("2") do |config|
     yum update -y
     yum install -y kernel-devel
     yum install -y kernel-headers
-    yum install -y wget vim java-1.8.0-openjdk-devel maven docker gcc-c++
+    yum install -y wget vim java-1.8.0-openjdk-devel maven gcc-c++ yum-utils device-mapper-persistent-data lvm2
+    yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y docker-ce
+    systemctl start docker
   SHELL
 end

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
     <dockerfile-maven-plugin.version>1.3.7</dockerfile-maven-plugin.version>
     <license-maven-plugin.version>1.6</license-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>
+    <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-bundle-plugin.version>3.2.0</maven-bundle-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
     <shrinkwrap.version>3.0.1</shrinkwrap.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.1</spotbugs-annotations.version>
+    <testcontainers.version>1.7.0</testcontainers.version>
     <twitter-server.version>1.29.0</twitter-server.version>
     <vertx.version>3.4.1</vertx.version>
     <zookeeper.version>3.5.3-beta</zookeeper.version>
@@ -590,6 +591,11 @@
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
         <artifactId>shrinkwrap-resolver-api</artifactId>
         <version>${shrinkwrap.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
       </dependency>
 
       <!-- benchmark dependencies -->

--- a/tests/docker-images/current-version-image/Dockerfile
+++ b/tests/docker-images/current-version-image/Dockerfile
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM centos:7
+MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
+
+ARG BK_VERSION=DOESNOTEXISTS
+ARG DISTRO_NAME=bookkeeper-dist-server-${BK_VERSION}-bin
+ARG PKG_NAME=bookkeeper-server-${BK_VERSION}
+
+ENV BOOKIE_PORT=3181
+EXPOSE $BOOKIE_PORT
+ENV BK_USER=bookkeeper
+
+# prepare utils
+RUN set -x \
+    && adduser "${BK_USER}" \
+    && yum install -y java-1.8.0-openjdk-headless wget bash python sudo netcat \
+    && mkdir -pv /opt \
+    && cd /opt \
+    && yum clean all
+
+# untar tarballs
+ADD target/${DISTRO_NAME}.tar.gz /opt
+RUN mv /opt/${PKG_NAME} /opt/bookkeeper
+
+WORKDIR /opt/bookkeeper
+
+COPY target/scripts/apply-config-from-env.py target/scripts/entrypoint.sh target/scripts/healthcheck.sh /opt/bookkeeper/
+
+ENTRYPOINT [ "/bin/bash", "/opt/bookkeeper/entrypoint.sh" ]
+CMD ["/opt/bookkeepr/bin/bookkeeper", "bookie"]
+
+HEALTHCHECK --interval=10s --timeout=60s CMD /bin/bash /opt/bookkeeper/healthcheck.sh

--- a/tests/docker-images/current-version-image/pom.xml
+++ b/tests/docker-images/current-version-image/pom.xml
@@ -1,0 +1,125 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.apache.bookkeeper.tests</groupId>
+    <artifactId>docker-images</artifactId>
+    <version>4.8.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.bookkeeper.tests</groupId>
+  <artifactId>current-version-image</artifactId>
+  <name>Apache BookKeeper :: Tests :: Docker Images :: Current Version</name>
+  <packaging>pom</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-dist-server</artifactId>
+      <version>${project.parent.version}</version>
+      <classifier>bin</classifier>
+      <type>tar.gz</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <activation>
+        <property>
+          <name>integrationTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>${dockerfile-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>default</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>add-latest-tag</id>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
+                <configuration>
+                  <repository>apachebookkeeper/bookkeeper-current</repository>
+                  <tag>latest</tag>
+                </configuration>
+              </execution>
+            </executions>
+            <configuration>
+              <repository>apachebookkeeper/bookkeeper-current</repository>
+              <tag>${project.version}</tag>
+              <pullNewerImage>false</pullNewerImage>
+              <noCache>true</noCache>
+              <buildArgs>
+                <BK_VERSION>${project.version}</BK_VERSION>
+              </buildArgs>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>${maven-dependency-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>copy-docker-dependencies</id>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/</outputDirectory>
+                  <includeArtifactIds>bookkeeper-dist-server</includeArtifactIds>
+                  <excludeTransitive>true</excludeTransitive>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- this task is used for copy docker scripts to build docker image -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>${maven-antrun-plugin.version}</version>
+            <executions>
+              <execution>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>copying docker scripts</echo>
+                    <mkdir dir="${basedir}/target/scripts"/>
+                    <copydir src="${basedir}/../../../docker/scripts" dest="${basedir}/target/scripts"/>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/tests/docker-images/pom.xml
+++ b/tests/docker-images/pom.xml
@@ -29,5 +29,6 @@
   <modules>
     <module>all-released-versions-image</module>
     <module>all-versions-image</module>
+    <module>current-version-image</module>
   </modules>
 </project>

--- a/tests/integration-tests-topologies/pom.xml
+++ b/tests/integration-tests-topologies/pom.xml
@@ -27,6 +27,18 @@
   <artifactId>integration-tests-topologies</artifactId>
   <packaging>jar</packaging>
 
-  <name>Apache BookKeeper :: Tests :: Common topologies for Arquillian based integration tests</name>
+  <name>Apache BookKeeper :: Tests :: Common topologies for Docker based integration tests</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/tests/integration-tests-topologies/src/main/java/org/apache/bookkeeper/tests/containers/BKStandaloneContainer.java
+++ b/tests/integration-tests-topologies/src/main/java/org/apache/bookkeeper/tests/containers/BKStandaloneContainer.java
@@ -25,6 +25,8 @@ import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.core.command.LogContainerResultCallback;
 import java.time.Duration;
+import java.util.Objects;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.testcontainers.containers.GenericContainer;
@@ -122,4 +124,22 @@ public class BKStandaloneContainer<SELF extends BKStandaloneContainer<SELF>> ext
         log.info("Start a standalone bookkeeper cluster at container {}", containerName);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof BKStandaloneContainer)) {
+            return false;
+        }
+
+        BKStandaloneContainer another = (BKStandaloneContainer) o;
+        return containerName.equals(another.containerName)
+            && numBookies == another.numBookies
+            && super.equals(another);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * super.hashCode() + Objects.hash(
+            containerName,
+            numBookies);
+    }
 }

--- a/tests/integration-tests-topologies/src/main/java/org/apache/bookkeeper/tests/containers/BKStandaloneContainer.java
+++ b/tests/integration-tests-topologies/src/main/java/org/apache/bookkeeper/tests/containers/BKStandaloneContainer.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.tests.containers;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.command.LogContainerResultCallback;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+/**
+ * Test Container for Bookies.
+ */
+@Slf4j
+public class BKStandaloneContainer<SELF extends BKStandaloneContainer<SELF>> extends GenericContainer<SELF> {
+
+    private static final int ZK_PORT = 2181;
+    private static final int BOOKIE_BASE_PORT = 3181;
+
+    private static final String IMAGE_NAME = "apachebookkeeper/bookkeeper-current:latest";
+
+    private static final String STANDALONE_HOST_NAME = "standalone";
+    private static final String CONTAINER_NAME_BASE = "bk-standalone-test";
+
+    private final String containerName;
+    private final int numBookies;
+
+    public BKStandaloneContainer(String containerName, int numBookies) {
+        super(IMAGE_NAME);
+        this.containerName = containerName;
+        this.numBookies = numBookies;
+    }
+
+    @Override
+    public String getContainerName() {
+        return CONTAINER_NAME_BASE + "-" + containerName + "-" + numBookies + "-bookies-" + System.currentTimeMillis();
+    }
+
+    public String getContainerLog() {
+        StringBuilder sb = new StringBuilder();
+
+        LogContainerCmd logContainerCmd = this.dockerClient.logContainerCmd(containerId);
+        logContainerCmd.withStdOut(true).withStdErr(true);
+        try {
+            logContainerCmd.exec(new LogContainerResultCallback() {
+                @Override
+                public void onNext(Frame item) {
+                    sb.append(new String(item.getPayload(), UTF_8));
+                }
+            }).awaitCompletion();
+        } catch (InterruptedException e) {
+
+        }
+        return sb.toString();
+    }
+
+    public ExecResult execCmd(String... cmd) throws Exception {
+        String cmdString = StringUtils.join(cmd, " ");
+
+        log.info("DOCKER.exec({}:{}): Executing ...", containerId, cmdString);
+
+        ExecResult result = execInContainer(cmd);
+
+        log.info("Docker.exec({}:{}): Done", containerId, cmdString);
+        log.info("Docker.exec({}:{}): Stdout -\n{}", containerId, cmdString, result.getStdout());
+        log.info("Docker.exec({}:{}): Stderr -\n{}", containerId, cmdString, result.getStderr());
+
+        return result;
+    }
+
+    @Override
+    protected void configure() {
+        addExposedPorts(
+            ZK_PORT
+        );
+        for (int i = 0; i < numBookies; i++) {
+            addExposedPort(BOOKIE_BASE_PORT + i);
+        }
+        setCommand(
+            "/opt/bookkeeper/bin/bookkeeper",
+            "localbookie",
+            "" + numBookies
+        );
+        addEnv("JAVA_HOME", "/usr/lib/jvm/jre-1.8.0");
+    }
+
+    @Override
+    public void start() {
+        this.waitStrategy = new LogMessageWaitStrategy()
+            .withRegEx(".*ForceWrite Thread started.*\\s")
+            .withTimes(numBookies)
+            .withStartupTimeout(Duration.of(60, SECONDS));
+        this.withCreateContainerCmdModifier(createContainerCmd -> {
+            createContainerCmd.withHostName(STANDALONE_HOST_NAME);
+            createContainerCmd.withName(getContainerName());
+            createContainerCmd.withEntrypoint("/bin/bash");
+        });
+
+        super.start();
+        log.info("Start a standalone bookkeeper cluster at container {}", containerName);
+    }
+
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -20,14 +20,54 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
-    <artifactId>integration-tests-base</artifactId>
+    <artifactId>tests-parent</artifactId>
     <version>4.8.0-SNAPSHOT</version>
-    <relativePath>../integration-tests-base</relativePath>
+    <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper.tests.integration</groupId>
   <artifactId>tests-parent</artifactId>
   <name>Apache BookKeeper :: Tests :: Integration</name>
   <modules>
     <module>smoke</module>
+    <module>standalone</module>
   </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- only run tests when -DintegrationTests is specified //-->
+          <skipTests>true</skipTests>
+          <systemPropertyVariables>
+            <currentVersion>${project.version}</currentVersion>
+            <maven.buildDirectory>${project.build.directory}</maven.buildDirectory>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>integrationTests</id>
+      <activation>
+        <property>
+          <name>integrationTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>false</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/tests/integration/standalone/pom.xml
+++ b/tests/integration/standalone/pom.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
--->
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://maven.apache.org/POM/4.0.0   http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -24,9 +25,9 @@
   </parent>
 
   <groupId>org.apache.bookkeeper.tests.integration</groupId>
-  <artifactId>smoke</artifactId>
+  <artifactId>standalone</artifactId>
   <packaging>jar</packaging>
-  <name>Apache BookKeeper :: Tests :: Integration :: Smoke test</name>
+  <name>Apache BookKeeper :: Tests :: Integration :: Standalone test</name>
 
   <dependencies>
     <dependency>
@@ -38,23 +39,11 @@
 
     <dependency>
       <groupId>org.apache.bookkeeper.tests</groupId>
-      <artifactId>integration-tests-utils</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.bookkeeper.tests</groupId>
       <artifactId>integration-tests-topologies</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/tests/integration/standalone/src/test/java/org/apache/bookkeeper/tests/integration/standalone/StandaloneTest.java
+++ b/tests/integration/standalone/src/test/java/org/apache/bookkeeper/tests/integration/standalone/StandaloneTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.tests.integration.standalone;
+
+import static org.junit.Assert.assertTrue;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.tests.containers.BKStandaloneContainer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.containers.Container.ExecResult;
+
+/**
+ * A simple test to cover running current docker image in standalone mode.
+ */
+@Slf4j
+public class StandaloneTest {
+
+    @ClassRule
+    public static BKStandaloneContainer bkContainer = new BKStandaloneContainer<>("integrationtest", 3);
+
+    @Test
+    public void runSimpleTest() throws Exception {
+        ExecResult result = bkContainer.execCmd(
+            "/opt/bookkeeper/bin/bookkeeper",
+            "shell",
+            "simpletest",
+            "-ensemble", "3",
+            "-writeQuorum", "3",
+            "-ackQuorum", "2",
+            "-numEntries", "100"
+        );
+        assertTrue(
+            result.getStdout().contains("100 entries written to ledger"));
+    }
+
+}

--- a/tests/integration/standalone/src/test/resources/log4j.properties
+++ b/tests/integration/standalone/src/test/resources/log4j.properties
@@ -1,0 +1,42 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+#
+# Bookkeeper Logging Configuration
+#
+
+# Format is "<default threshold> (, <appender>)+
+
+# DEFAULT: console appender only, level INFO
+bookkeeper.root.logger=INFO,CONSOLE
+log4j.rootLogger=${bookkeeper.root.logger}
+
+#
+# Log INFO level and above messages to the console
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n
+
+#disable zookeeper logging
+log4j.logger.org.apache.zookeeper=OFF
+log4j.logger.org.apache.bookkeeper.bookie=INFO
+log4j.logger.org.apache.bookkeeper.meta=INFO


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

The current test images don't use any scripts that shipped with official docker image.
We basically don't have any test coverage on the official docker image we shipped for each release.

*Solution*

Introduce a `bookkeeper-current` image representing an image for latest master.

Use `apachebookkeeper/all-versions-image` for BC tests, use `apachebookkeeper/bookkeeper-current` as tests only needs latest master image.

Add an integration test to test standalone mode using the `bookkeeper-current` image 
