### PR TITLE
Ensure BufferedChannel instance is properly closed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -86,8 +86,9 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         writeBuffer.release();
+        fileChannel.close();
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -23,6 +23,7 @@ package org.apache.bookkeeper.bookie;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -39,7 +40,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
     // The position of the file channel's write pointer.
     protected AtomicLong writeBufferStartPosition = new AtomicLong(0);
     // The buffer used to write operations.
-    protected final ByteBuf writeBuffer;
+    protected ByteBuf writeBuffer;
     // The absolute position of the next write operation.
     protected final AtomicLong position;
 
@@ -87,7 +88,11 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
 
     @Override
     public synchronized void close() throws IOException {
-        writeBuffer.release();
+        if (writeBuffer != null) {
+            ReferenceCountUtil.safeRelease(writeBuffer);
+            writeBuffer = null;
+        }
+
         fileChannel.close();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -40,7 +40,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
     // The position of the file channel's write pointer.
     protected AtomicLong writeBufferStartPosition = new AtomicLong(0);
     // The buffer used to write operations.
-    protected ByteBuf writeBuffer;
+    protected final ByteBuf writeBuffer;
     // The absolute position of the next write operation.
     protected final AtomicLong position;
 
@@ -88,11 +88,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
 
     @Override
     public synchronized void close() throws IOException {
-        if (writeBuffer != null) {
-            ReferenceCountUtil.safeRelease(writeBuffer);
-            writeBuffer = null;
-        }
-
+        ReferenceCountUtil.safeRelease(writeBuffer);
         fileChannel.close();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannelBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannelBase.java
@@ -49,11 +49,4 @@ public abstract class BufferedChannelBase {
         return validateAndGetFileChannel().size();
     }
 
-    /**
-     * Get the {@link FileChannel} that this BufferedChannel wraps around.
-     * @return
-     */
-    public FileChannel getFileChannel() {
-        return fileChannel;
-    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
@@ -61,6 +61,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.collections.ConcurrentLongHashMap;
 import org.apache.commons.lang3.mutable.MutableInt;
 
@@ -554,7 +555,7 @@ class EntryLogManagerForEntryLogPerLedger extends EntryLogManagerBase {
     public void close() throws IOException {
         Set<BufferedLogChannelWithDirInfo> copyOfCurrentLogsWithDirInfo = getCopyOfCurrentLogs();
         for (BufferedLogChannelWithDirInfo currentLogWithDirInfo : copyOfCurrentLogsWithDirInfo) {
-            EntryLogger.closeFileChannel(currentLogWithDirInfo.getLogChannel());
+            IOUtils.close(log, currentLogWithDirInfo.getLogChannel());
         }
     }
 
@@ -562,7 +563,7 @@ class EntryLogManagerForEntryLogPerLedger extends EntryLogManagerBase {
     public void forceClose() {
         Set<BufferedLogChannelWithDirInfo> copyOfCurrentLogsWithDirInfo = getCopyOfCurrentLogs();
         for (BufferedLogChannelWithDirInfo currentLogWithDirInfo : copyOfCurrentLogsWithDirInfo) {
-            EntryLogger.forceCloseFileChannel(currentLogWithDirInfo.getLogChannel());
+            IOUtils.close(log, currentLogWithDirInfo.getLogChannel());
         }
     }
 
@@ -652,7 +653,7 @@ class EntryLogManagerForEntryLogPerLedger extends EntryLogManagerBase {
             // since this channel is only used for writing, after flushing the channel,
             // we had to close the underlying file channel. Otherwise, we might end up
             // leaking fds which cause the disk spaces could not be reclaimed.
-            EntryLogger.closeFileChannel(channel);
+            channel.close();
             recentlyCreatedEntryLogsStatus.flushRotatedEntryLog(channel.getLogId());
             rotatedLogChannels.remove(channel);
             log.info("Synced entry logger {} to disk.", channel.getLogId());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
@@ -555,7 +555,9 @@ class EntryLogManagerForEntryLogPerLedger extends EntryLogManagerBase {
     public void close() throws IOException {
         Set<BufferedLogChannelWithDirInfo> copyOfCurrentLogsWithDirInfo = getCopyOfCurrentLogs();
         for (BufferedLogChannelWithDirInfo currentLogWithDirInfo : copyOfCurrentLogsWithDirInfo) {
-            IOUtils.close(log, currentLogWithDirInfo.getLogChannel());
+            if (currentLogWithDirInfo.getLogChannel() != null) {
+                currentLogWithDirInfo.getLogChannel().close();
+            }
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -650,7 +650,7 @@ public class EntryLogger {
                 // since this channel is only used for writing, after flushing the channel,
                 // we had to close the underlying file channel. Otherwise, we might end up
                 // leaking fds which cause the disk spaces could not be reclaimed.
-                closeFileChannel(compactionLogChannel);
+                compactionLogChannel.close();
             } else {
                 throw new IOException("Failed to flush compaction log which has already been removed.");
             }
@@ -675,10 +675,12 @@ public class EntryLogger {
                 if (!compactionLogChannel.getLogFile().delete()) {
                     LOG.warn("Could not delete compaction log file {}", compactionLogChannel.getLogFile());
                 }
+
                 try {
-                    closeFileChannel(compactionLogChannel);
+                    compactionLogChannel.close();
                 } catch (IOException e) {
-                    LOG.error("Failed to close file channel for compaction log {}", compactionLogChannel.getLogId());
+                    LOG.error("Failed to close file channel for compaction log {}: {}", compactionLogChannel.getLogId(),
+                            e.getMessage());
                 }
                 compactionLogChannel = null;
             }
@@ -1069,8 +1071,10 @@ public class EntryLogger {
             logid2FileChannel.clear();
             entryLogManager.close();
             synchronized (compactionLogLock) {
-                closeFileChannel(compactionLogChannel);
-                compactionLogChannel = null;
+                if (compactionLogChannel != null) {
+                    compactionLogChannel.close();
+                    compactionLogChannel = null;
+                }
             }
         } catch (IOException ie) {
             // we have no idea how to avoid io exception during shutting down, so just ignore it
@@ -1082,23 +1086,11 @@ public class EntryLogger {
 
             entryLogManager.forceClose();
             synchronized (compactionLogLock) {
-                forceCloseFileChannel(compactionLogChannel);
+                IOUtils.close(LOG, compactionLogChannel);
             }
         }
         // shutdown the pre-allocation thread
         entryLoggerAllocator.stop();
-    }
-
-    static void closeFileChannel(BufferedChannel channel) throws IOException {
-        if (channel != null) {
-            channel.close();
-        }
-    }
-
-    static void forceCloseFileChannel(BufferedChannel channel) {
-        if (channel != null) {
-            IOUtils.close(LOG, channel);
-        }
     }
 
     protected LedgerDirsManager getLedgerDirsManager() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1089,24 +1089,15 @@ public class EntryLogger {
         entryLoggerAllocator.stop();
     }
 
-    static void closeFileChannel(BufferedChannelBase channel) throws IOException {
-        if (null == channel) {
-            return;
-        }
-
-        FileChannel fileChannel = channel.getFileChannel();
-        if (null != fileChannel) {
-            fileChannel.close();
+    static void closeFileChannel(BufferedChannel channel) throws IOException {
+        if (channel != null) {
+            channel.close();
         }
     }
 
-    static void forceCloseFileChannel(BufferedChannelBase channel) {
-        if (null == channel) {
-            return;
-        }
-        FileChannel fileChannel = channel.getFileChannel();
-        if (null != fileChannel) {
-            IOUtils.close(LOG, fileChannel);
+    static void forceCloseFileChannel(BufferedChannel channel) {
+        if (channel != null) {
+            IOUtils.close(LOG, channel);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -679,8 +679,8 @@ public class EntryLogger {
                 try {
                     compactionLogChannel.close();
                 } catch (IOException e) {
-                    LOG.error("Failed to close file channel for compaction log {}: {}", compactionLogChannel.getLogId(),
-                            e.getMessage());
+                    LOG.error("Failed to close file channel for compaction log {}", compactionLogChannel.getLogId(),
+                            e);
                 }
                 compactionLogChannel = null;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1084,9 +1084,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                             // check whether journal file is over file limit
                             if (shouldRolloverJournal) {
                                 // if the journal file is rolled over, the journal file will be closed after last
-                                // entry is force written to disk. the `bc` is not used anymore, so close it to release
-                                // the buffers in `bc`.
-                                IOUtils.close(LOG, bc);
+                                // entry is force written to disk.
                                 logFile = null;
                                 continue;
                             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1144,7 +1144,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
             // close will flush the file system cache making any previous
             // cached writes durable so this is fine as well.
             IOUtils.close(LOG, bc);
-            IOUtils.close(LOG, logFile);
         }
         LOG.info("Journal exited loop!");
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -257,8 +257,11 @@ class JournalChannel implements Closeable {
         return fc.read(dst);
     }
 
+    @Override
     public void close() throws IOException {
-        bc.close();
+        if (bc != null) {
+            bc.close();
+        }
     }
 
     public void forceWrite(boolean forceMetadata) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -258,7 +258,7 @@ class JournalChannel implements Closeable {
     }
 
     public void close() throws IOException {
-        fc.close();
+        bc.close();
     }
 
     public void forceWrite(boolean forceMetadata) throws IOException {


### PR DESCRIPTION
Whenever the the `EntryLogger` is closing the `BufferedChannel` instance (the channel used for writing) it is closing the file descriptor but it's not calling `close()` on the object itself. 

This causes a small mem leak for each log file, because the `writeBuffer` from `BufferedChannel` is never released.

I think this should be considered for a 4.7.1 release.