### PR TITLE
Issue-1415: [DLOG] org.apache.distributedlog.fs.TestDLFileSystem fails on CI

### DIFF
--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
@@ -97,12 +97,6 @@ public class TestDistributedLogBase {
     protected static int numBookies = 3;
     private static final List<File> tmpDirs = new ArrayList<File>();
 
-    protected static File newTempDir(String name) throws IOException {
-        File zkTmpDir = IOUtils.createTempDir(name, "distrlog");
-        tmpDirs.add(zkTmpDir);
-        return zkTmpDir;
-    }
-
     @BeforeClass
     public static void setupCluster() throws Exception {
         File zkTmpDir = IOUtils.createTempDir("zookeeper", "distrlog");

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
@@ -97,6 +97,12 @@ public class TestDistributedLogBase {
     protected static int numBookies = 3;
     private static final List<File> tmpDirs = new ArrayList<File>();
 
+    protected static File newTempDir(String name) throws IOException {
+        File zkTmpDir = IOUtils.createTempDir(name, "distrlog");
+        tmpDirs.add(zkTmpDir);
+        return zkTmpDir;
+    }
+
     @BeforeClass
     public static void setupCluster() throws Exception {
         File zkTmpDir = IOUtils.createTempDir("zookeeper", "distrlog");

--- a/stream/distributedlog/io/dlfs/src/test/java/org/apache/distributedlog/fs/TestDLFileSystem.java
+++ b/stream/distributedlog/io/dlfs/src/test/java/org/apache/distributedlog/fs/TestDLFileSystem.java
@@ -61,7 +61,7 @@ public class TestDLFileSystem extends TestDLFSBase {
         }
         assertTrue(fs.exists(path));
 
-        File tempFile = new File("/tmp/" + runtime.getMethodName());
+        File tempFile = new File(newTempDir(runtime.getMethodName()), "test.bin");
         tempFile.delete();
         Path localDst = new Path(tempFile.getPath());
         // copy the file

--- a/stream/distributedlog/io/dlfs/src/test/java/org/apache/distributedlog/fs/TestDLFileSystem.java
+++ b/stream/distributedlog/io/dlfs/src/test/java/org/apache/distributedlog/fs/TestDLFileSystem.java
@@ -33,13 +33,18 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Integration test for {@link DLFileSystem}.
  */
 @Slf4j
 public class TestDLFileSystem extends TestDLFSBase {
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
 
     @Test(expected = FileNotFoundException.class)
     public void testOpenFileNotFound() throws Exception {
@@ -61,8 +66,7 @@ public class TestDLFileSystem extends TestDLFSBase {
         }
         assertTrue(fs.exists(path));
 
-        File tempFile = new File(newTempDir(runtime.getMethodName()), "test.bin");
-        tempFile.delete();
+        File tempFile = tmpDir.newFile();
         Path localDst = new Path(tempFile.getPath());
         // copy the file
         fs.copyToLocalFile(path, localDst);


### PR DESCRIPTION
Use a generated tempDir for DL FS tests instead of using an hard coded /tmp path

Fix for #1415 