### PR TITLE
Fix dev/check-binary-license on macOS

### DIFF
--- a/.travis_scripts/build.sh
+++ b/.travis_scripts/build.sh
@@ -23,10 +23,8 @@ BINDIR=`dirname "$0"`
 BK_HOME=`cd $BINDIR/..;pwd`
 
 mvn --batch-mode clean apache-rat:check compile spotbugs:check install -DskipTests -Dstream
-if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    $BK_HOME/dev/check-binary-license ./bookkeeper-dist/all/target/bookkeeper-all-*-bin.tar.gz;
-    $BK_HOME/dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-*-bin.tar.gz;
-fi
+$BK_HOME/dev/check-binary-license ./bookkeeper-dist/all/target/bookkeeper-all-*-bin.tar.gz;
+$BK_HOME/dev/check-binary-license ./bookkeeper-dist/server/target/bookkeeper-server-*-bin.tar.gz;
 if [ "$DLOG_MODIFIED" == "true" ]; then
     cd $BK_HOME/stream/distributedlog
     mvn --batch-mode clean package -Ddistributedlog

--- a/dev/check-binary-license
+++ b/dev/check-binary-license
@@ -31,12 +31,18 @@ if [ -z $TARBALL ]; then
     exit -1
 fi
 
-JARS=$(tar -tf $TARBALL '*.jar' | sed 's!.*/!!' | sort)
+TAR='tar'
+unamestr=`uname`
+if [[ "$unamestr" == 'Linux' ]]; then
+   TAR='tar --wildcards'
+fi
 
-LICENSEPATH=$(tar -tf $TARBALL  | awk '/^[^\/]*\/LICENSE/')
-LICENSE=$(tar -O -xf $TARBALL "$LICENSEPATH")
-NOTICEPATH=$(tar -tf $TARBALL  | awk '/^[^\/]*\/NOTICE/')
-NOTICE=$(tar -O -xf $TARBALL $NOTICEPATH)
+JARS=$(${TAR} -tf $TARBALL '*.jar' | sed 's!.*/!!' | sort)
+
+LICENSEPATH=$(${TAR} -tf $TARBALL  | awk '/^[^\/]*\/LICENSE/')
+LICENSE=$(${TAR} -O -xf $TARBALL "$LICENSEPATH")
+NOTICEPATH=$(${TAR} -tf $TARBALL  | awk '/^[^\/]*\/NOTICE/')
+NOTICE=$(${TAR} -O -xf $TARBALL $NOTICEPATH)
 
 LICENSEJARS=$(echo "$LICENSE" | sed -nE 's!.*lib/(.*\.jar).*!\1!gp')
 NOTICEJARS=$(echo "$NOTICE" | sed -nE 's!.*lib/(.*\.jar).*!\1!gp')
@@ -47,7 +53,7 @@ LINKEDINLICENSE=$(echo "$LICENSE" | sed -nE 's!.*(deps/[[:graph:]]*).*!\1!gp' | 
 set +e
 
 # this can error if there's no deps directory in tarball, we still want to continue with checks
-BUNDLEDLICENSES=$(tar -tf $TARBALL '*/deps/*' | sed 's!^[^/]*/!!' | grep -v /$)
+BUNDLEDLICENSES=$(${TAR} -tf $TARBALL '*/deps/*' | sed 's!^[^/]*/!!' | grep -v /$)
 
 EXIT=0
 

--- a/dev/check-binary-license
+++ b/dev/check-binary-license
@@ -31,12 +31,12 @@ if [ -z $TARBALL ]; then
     exit -1
 fi
 
-JARS=$(tar --wildcards -tf $TARBALL '*.jar' | sed 's!.*/!!' | sort)
+JARS=$(tar -tf $TARBALL '*.jar' | sed 's!.*/!!' | sort)
 
 LICENSEPATH=$(tar -tf $TARBALL  | awk '/^[^\/]*\/LICENSE/')
-LICENSE=$(tar --wildcards -O -xf $TARBALL "$LICENSEPATH")
+LICENSE=$(tar -O -xf $TARBALL "$LICENSEPATH")
 NOTICEPATH=$(tar -tf $TARBALL  | awk '/^[^\/]*\/NOTICE/')
-NOTICE=$(tar --wildcards -O -xf $TARBALL $NOTICEPATH)
+NOTICE=$(tar -O -xf $TARBALL $NOTICEPATH)
 
 LICENSEJARS=$(echo "$LICENSE" | sed -nE 's!.*lib/(.*\.jar).*!\1!gp')
 NOTICEJARS=$(echo "$NOTICE" | sed -nE 's!.*lib/(.*\.jar).*!\1!gp')
@@ -47,7 +47,7 @@ LINKEDINLICENSE=$(echo "$LICENSE" | sed -nE 's!.*(deps/[[:graph:]]*).*!\1!gp' | 
 set +e
 
 # this can error if there's no deps directory in tarball, we still want to continue with checks
-BUNDLEDLICENSES=$(tar --wildcards -tf $TARBALL '*/deps/*' | sed 's!^[^/]*/!!' | grep -v /$)
+BUNDLEDLICENSES=$(tar -tf $TARBALL '*/deps/*' | sed 's!^[^/]*/!!' | grep -v /$)
 
 EXIT=0
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

`dev/check-binary-license` is used for checking whether LICENSE files are updated to reflect the dependencies included in the distribution packages.
However this script doesn't work on macOS, which makes the development on macOS inconvinient.

*Solution*

The change removes `--wildcards` from tar command. The option only works on linux machines.


