### PR TITLE
Allow bookie to start if failed to load extra server components

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -48,6 +48,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A bookie server is a server that run bookie and serving rpc requests.
@@ -327,13 +328,18 @@ public class Main {
         // 5. build extra services
         String[] extraComponents = conf.getServerConf().getExtraServerComponents();
         if (null != extraComponents) {
-            List<ServerLifecycleComponent> components = loadServerComponents(
-                extraComponents,
-                conf,
-                rootStatsLogger);
-            for (ServerLifecycleComponent component : components) {
-                serverBuilder.addComponent(component);
-                log.info("Load lifecycle component : {}", component.getClass().getName());
+            try {
+                List<ServerLifecycleComponent> components = loadServerComponents(
+                    extraComponents,
+                    conf,
+                    rootStatsLogger);
+                for (ServerLifecycleComponent component : components) {
+                    serverBuilder.addComponent(component);
+                    log.info("Load lifecycle component : {}", component.getClass().getName());
+                }
+            } catch (Exception e) {
+                log.info("Failed to load extra components '{}' - {}. Continuing without those components.",
+                    StringUtils.join(extraComponents), e.getMessage());
             }
         }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

`extraServerComponents` provides the flexibility to allow bookie to start with extra server components.
It acts as a plugin mechanism to extend the functionality of bookies. However it is okay to allow bookie
start up when failed to load extra server components.

This is a change for allowing starting table service as extra components in bookies.

*Solution*

Catch the exception and log it when failed to load extra server components.