### PR TITLE
Build stream modules for integration tests

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
@@ -49,7 +49,7 @@ freeStyleJob('bookkeeper_precommit_integrationtests') {
             // Set Maven parameters.
             common_job_properties.setMavenConfig(delegate)
 
-            goals('-B clean install -Pdocker')
+            goals('-B clean install -Dstream -Pdocker')
             properties(skipTests: true, interactiveMode: false)
         }
 
@@ -57,7 +57,7 @@ freeStyleJob('bookkeeper_precommit_integrationtests') {
             // Set Maven parameters.
             common_job_properties.setMavenConfig(delegate)
             rootPOM('tests/pom.xml')
-            goals('-B test -DintegrationTests')
+            goals('-B test -Dstream -DintegrationTests')
         }
 
         shell('kill $(cat docker-log.pid) || true')


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

apache/bookkeeper#1422 adds table service as part of integration tests. so we need to build stream modules
in order to run integration tests for apache/bookkeeper#1422

*Solution*

Add "-Dstream" in the maven commands for `precommit-integrationtests` CI job.


