### PR TITLE
Fix bookkeeper post commit CI

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_codecoverage.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_codecoverage.groovy
@@ -36,5 +36,5 @@ mavenJob('bookkeeper_codecoverage') {
   common_job_properties.setMavenConfig(delegate)
 
   // Maven build project.
-  goals('clean verify jacoco:report coveralls:report -Pcode-coverage -DrepoToken=$COVERALLS_REPO_TOKEN -Dmaven.test.failure.ignore=true')
+  goals('clean verify jacoco:report coveralls:report -Pcode-coverage -DrepoToken=$COVERALLS_REPO_TOKEN -Dmaven.test.failure.ignore=true -Dstream')
 }


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Motivation*

apache/bookkeeper#1422 includes stream storage integration tests in tests/integration.
so we need to include `-Dstream` on building the tests.

*Solution*

Update the bookkeeper post commit CI jobs to include `-Dstream`
