### PR TITLE
Exclude `.vagrant` from apache-rat:check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -867,6 +867,9 @@
 
             <!-- data -->
             <exclude>data/**</exclude>
+
+            <!-- vargrant -->
+            <exclude>dev/.vagrant/**</exclude>
           </excludes>
           <consoleOutput>true</consoleOutput>
         </configuration>


### PR DESCRIPTION

Descriptions of the changes in this PR:

*Motivation*

apache/bookkeeper#1401 provides a `Vagrantfile` for running integration tests on linux vm.
A `.vagrant` directory will be left under `dev` directory, which it will fail `apache-rat:check`.

*Solution*

Exclude `.vagrant` directory from apache-rat check

