### PR TITLE
BP-14 force() API - client side implementation

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -737,6 +737,20 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                     throw new IllegalArgumentException("Unable to convert digest type " + digestType);
             }
         }
+        public org.apache.bookkeeper.client.api.DigestType toApiDigestType() {
+            switch (this) {
+                case MAC:
+                    return org.apache.bookkeeper.client.api.DigestType.MAC;
+                case CRC32:
+                    return org.apache.bookkeeper.client.api.DigestType.CRC32;
+                case CRC32C:
+                    return org.apache.bookkeeper.client.api.DigestType.CRC32C;
+                case DUMMY:
+                    return org.apache.bookkeeper.client.api.DigestType.DUMMY;
+                default:
+                    throw new IllegalArgumentException("Unable to convert digest type " + this);
+            }
+        }
     }
 
     boolean shouldReorderReadSequence() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -117,6 +117,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     private OpStatsLogger readLacAndEntryOpLogger;
     private OpStatsLogger readLacAndEntryRespLogger;
     private OpStatsLogger addOpLogger;
+    private OpStatsLogger forceOpLogger;
     private OpStatsLogger writeLacOpLogger;
     private OpStatsLogger readLacOpLogger;
     private OpStatsLogger recoverAddEntriesStats;
@@ -1493,6 +1494,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         readLacAndEntryRespLogger = stats.getOpStatsLogger(
                 BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE);
         addOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.ADD_OP);
+        forceOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.FORCE_OP);
         addOpUrCounter = stats.getCounter(BookKeeperClientStats.ADD_OP_UR);
         writeLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.WRITE_LAC_OP);
         readLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAC_OP);
@@ -1525,6 +1527,9 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     }
     OpStatsLogger getAddOpLogger() {
         return addOpLogger;
+    }
+    OpStatsLogger getForceOpLogger() {
+        return forceOpLogger;
     }
     OpStatsLogger getWriteLacOpLogger() {
         return writeLacOpLogger;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -41,6 +41,7 @@ public interface BookKeeperClientStats {
 
     String ADD_OP = "ADD_ENTRY";
     String ADD_OP_UR = "ADD_ENTRY_UR"; // Under Replicated during AddEntry.
+    String FORCE_OP = "FORCE";
     String READ_OP = "READ_ENTRY";
     // Corrupted entry (Digest Mismatch/ Under Replication) detected during ReadEntry
     String READ_OP_DM = "READ_ENTRY_DM";
@@ -64,7 +65,9 @@ public interface BookKeeperClientStats {
     String CHANNEL_ADD_OP = "ADD_ENTRY";
     String CHANNEL_TIMEOUT_ADD = "TIMEOUT_ADD_ENTRY";
     String CHANNEL_WRITE_LAC_OP = "WRITE_LAC";
+    String CHANNEL_FORCE_OP = "FORCE";
     String CHANNEL_TIMEOUT_WRITE_LAC = "TIMEOUT_WRITE_LAC";
+    String CHANNEL_TIMEOUT_FORCE = "TIMEOUT_FORCE";
     String CHANNEL_READ_LAC_OP = "READ_LAC";
     String CHANNEL_TIMEOUT_READ_LAC = "TIMEOUT_READ_LAC";
     String TIMEOUT_GET_BOOKIE_INFO = "TIMEOUT_GET_BOOKIE_INFO";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -41,7 +41,7 @@ public interface BookKeeperClientStats {
 
     String ADD_OP = "ADD_ENTRY";
     String ADD_OP_UR = "ADD_ENTRY_UR"; // Under Replicated during AddEntry.
-    String FORCE_OP = "FORCE";
+    String FORCE_OP = "FORCE"; // Number of force ledger operations
     String READ_OP = "READ_ENTRY";
     // Corrupted entry (Digest Mismatch/ Under Replication) detected during ReadEntry
     String READ_OP_DM = "READ_ENTRY_DM";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
@@ -142,19 +142,12 @@ public interface DistributionSchedule {
     WriteSet getWriteSet(long entryId);
 
     /**
-     * Return the set of bookies indices to send the messages to for longpoll reads.
+     * Return the set of bookies indices to send the messages to the whole ensemble.
      *
-     * @param entryId expected next entry id to read.
-     * @return the set of bookies indices to read from.
+     * @param entryId entry id use to calculate the ensemble.
+     * @return the set of bookies indices to send the request.
      */
-    WriteSet getWriteSetForLongPoll(long entryId);
-
-    /**
-     * Return the set of bookies indices to send the messages to for force ledger.
-     *
-     * @return the set of bookies indices to send force request to.
-     */
-    WriteSet getWriteSetForForceLedger();
+    WriteSet getEnsembleSet(long entryId);
 
     /**
      * An ack set represents the set of bookies from which
@@ -208,7 +201,7 @@ public interface DistributionSchedule {
      * Returns an ackset object useful to wait for all bookies in the ensemble,
      * responses should be checked against this.
      */
-    AckSet getAckSetForForceLedger();
+    AckSet getEnsembleAckSet();
 
     /**
      * Interface to keep track of which bookies in an ensemble, an action

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
@@ -144,7 +144,7 @@ public interface DistributionSchedule {
     /**
      * Return the set of bookies indices to send the messages to the whole ensemble.
      *
-     * @param entryId entry id use to calculate the ensemble.
+     * @param entryId entry id used to calculate the ensemble.
      * @return the set of bookies indices to send the request.
      */
     WriteSet getEnsembleSet(long entryId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
@@ -150,6 +150,13 @@ public interface DistributionSchedule {
     WriteSet getWriteSetForLongPoll(long entryId);
 
     /**
+     * Return the set of bookies indices to send the messages to for force ledger.
+     *
+     * @return the set of bookies indices to send force request to.
+     */
+    WriteSet getWriteSetForForceLedger();
+
+    /**
      * An ack set represents the set of bookies from which
      * a response must be received so that an entry can be
      * considered to be replicated on a quorum.
@@ -197,6 +204,11 @@ public interface DistributionSchedule {
      */
     AckSet getAckSet();
 
+    /**
+     * Returns an ackset object useful to wait for all bookies in the ensemble,
+     * responses should be checked against this.
+     */
+    AckSet getAckSetForForceLedger();
 
     /**
      * Interface to keep track of which bookies in an ensemble, an action

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -90,7 +90,7 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
         checkState(!completed, "We are waiting for all the bookies, it is not expected an early exit");
 
         if (errored) {
-            // alredy failed, we alread called the callback reporting a failure
+            // already failed, do not fire error callbacks twice
             return;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -17,8 +17,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Preconditions.checkState;
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -34,7 +34,6 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
 
     private static final Logger LOG = LoggerFactory.getLogger(ForceLedgerOp.class);
     final CompletableFuture<Void> cb;
-    BitSet receivedResponseSet;
 
     DistributionSchedule.AckSet ackSet;
     boolean completed = false;
@@ -65,17 +64,15 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
         // remember that we are inside OrderedExecutor, this induces a strict ordering
         // on the sequence of events
         this.currentNonDurableLastAddConfirmed = lh.pendingAddsSequenceHead;
-        LOG.debug("force {} clientNonDurableLac {}", lh.ledgerId, currentNonDurableLastAddConfirmed);
-
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("force {} clientNonDurableLac {}", lh.ledgerId, currentNonDurableLastAddConfirmed);
+        }
         // we need to send the request to every bookie in the ensamble
         this.currentEnsemble = lh.metadata.currentEnsemble;
-        this.ackSet = lh.distributionSchedule.getAckSetForForceLedger();
-        this.receivedResponseSet = new BitSet(
-                lh.getLedgerMetadata().getEnsembleSize());
-        this.receivedResponseSet.set(0,
-                lh.getLedgerMetadata().getEnsembleSize());
+        this.ackSet = lh.distributionSchedule.getEnsembleAckSet();
 
-        DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSetForForceLedger();
+        DistributionSchedule.WriteSet writeSet = lh.getDistributionSchedule()
+                                                   .getEnsembleSet(currentNonDurableLastAddConfirmed);
         try {
             for (int i = 0; i < writeSet.size(); i++) {
                 sendForceLedgerRequest(writeSet.get(i));
@@ -89,35 +86,30 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
     public void forceLedgerComplete(int rc, long ledgerId, BookieSocketAddress addr, Object ctx) {
         int bookieIndex = (Integer) ctx;
 
-        if (completed) {
-            return;
-        }
+        checkState(!completed, "We are waiting for all the bookies, it is not expected an early exit");
 
         if (BKException.Code.OK != rc) {
             lastSeenError = rc;
         }
 
-        // We got response.
-        receivedResponseSet.clear(bookieIndex);
-
         if (rc == BKException.Code.OK) {
-            if (ackSet.completeBookieAndCheck(bookieIndex) && !completed) {
+            if (ackSet.completeBookieAndCheck(bookieIndex)) {
                 completed = true;
                 // we are able to say that every bookie sync'd its own journal
                 // for every ackknowledged entry before issuing the force() call
-                LOG.debug("After force on ledger {} updating LastAddConfirmed to {} ",
-                        ledgerId, currentNonDurableLastAddConfirmed);
-                lh.lastAddConfirmed = currentNonDurableLastAddConfirmed;
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("After force on ledger {} updating LastAddConfirmed to {} ",
+                              ledgerId, currentNonDurableLastAddConfirmed);
+                }
+                lh.updateLastConfirmed(currentNonDurableLastAddConfirmed, lh.getLength());
                 FutureUtils.complete(cb, null);
-                return;
             }
         } else {
-            LOG.warn("ForceLedger did not succeed: Ledger {} on {}", new Object[]{ledgerId, addr});
-        }
-
-        if (receivedResponseSet.isEmpty()) {
-            completed = true;
+            // at least one bookie failed, as we are waiting for all the bookies
+            // we can fail immediately
+            LOG.info("ForceLedger did not succeed: Ledger {} on {}", ledgerId, addr);
             FutureUtils.completeExceptionally(cb, BKException.create(lastSeenError));
         }
+
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -65,7 +65,7 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
         // remember that we are inside OrderedExecutor, this induces a strict ordering
         // on the sequence of events
         this.currentNonDurableLastAddConfirmed = lh.pendingAddsSequenceHead;
-        LOG.debug("start force() on ledger {} capturing {} ", lh.ledgerId, currentNonDurableLastAddConfirmed);
+        LOG.debug("force {} clientNonDurableLac {}", lh.ledgerId, currentNonDurableLastAddConfirmed);
 
         // we need to send the request to every bookie in the ensamble
         this.currentEnsemble = lh.metadata.currentEnsemble;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -116,9 +116,6 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
             LOG.info("ForceLedger did not succeed: Ledger {} on {}", ledgerId, addr);
             errored = true;
 
-            // fail all pending writes
-            lh.errorOutPendingAdds(rc);
-
             // notify the failure
             FutureUtils.completeExceptionally(cb, BKException.create(lastSeenError));
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ForceLedgerCallback;
+import org.apache.bookkeeper.util.SafeRunnable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This represents a request to sync the ledger on every bookie.
+ */
+class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForceLedgerOp.class);
+    CompletableFuture<Void> cb;
+    BitSet receivedResponseSet;
+
+    DistributionSchedule.AckSet ackSet;
+    boolean completed = false;
+    int lastSeenError = BKException.Code.WriteException;
+    ArrayList<BookieSocketAddress> currentEnsemble;
+
+    long currentNonDurableLastAddConfirmed = LedgerHandle.INVALID_ENTRY_ID;
+
+    LedgerHandle lh;
+
+    ForceLedgerOp(LedgerHandle lh, CompletableFuture<Void> cb) {
+        this.lh = lh;
+        this.cb = cb;
+    }
+
+    void sendForceLedgerRequest(int bookieIndex) {
+        lh.bk.getBookieClient().forceLedger(currentEnsemble.get(bookieIndex), lh.ledgerId, this, bookieIndex);
+    }
+
+    @Override
+    public void safeRun() {
+        initiate();
+    }
+
+    void initiate() {
+
+        // capture currentNonDurableLastAddConfirmed, we are inside OrderedExecutor
+        this.currentNonDurableLastAddConfirmed = lh.pendingAddsSequenceHead;
+        LOG.debug("start force() on ledger {} capturing {} ", lh.ledgerId, currentNonDurableLastAddConfirmed);
+
+        // we need to send the request to every bookie in the ensamble
+        this.currentEnsemble = lh.metadata.currentEnsemble;
+        this.ackSet = lh.distributionSchedule.getAckSetForForceLedger();
+        this.receivedResponseSet = new BitSet(
+                lh.getLedgerMetadata().getEnsembleSize());
+        this.receivedResponseSet.set(0,
+                lh.getLedgerMetadata().getEnsembleSize());
+
+        DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSetForForceLedger();
+        try {
+            for (int i = 0; i < writeSet.size(); i++) {
+                sendForceLedgerRequest(writeSet.get(i));
+            }
+        } finally {
+            writeSet.recycle();
+        }
+    }
+
+    @Override
+    public void forceLedgerComplete(int rc, long ledgerId, BookieSocketAddress addr, Object ctx) {
+        int bookieIndex = (Integer) ctx;
+
+        if (completed) {
+            return;
+        }
+
+        if (BKException.Code.OK != rc) {
+            lastSeenError = rc;
+        }
+
+        // We got response.
+        receivedResponseSet.clear(bookieIndex);
+
+        if (rc == BKException.Code.OK) {
+            if (ackSet.completeBookieAndCheck(bookieIndex) && !completed) {
+                completed = true;
+                // we are able to say that every bookie sync'd its own journal
+                // for every ackknowledged entry before issuing the force() call
+                LOG.info("After force on ledger {} updating LastAddConfirmed to {} ",
+                        ledgerId, currentNonDurableLastAddConfirmed);
+                lh.lastAddConfirmed = currentNonDurableLastAddConfirmed;
+                FutureUtils.complete(cb, null);
+                return;
+            }
+        } else {
+            LOG.warn("ForceLedger did not succeed: Ledger {} on {}", new Object[]{ledgerId, addr});
+        }
+
+        if (receivedResponseSet.isEmpty()) {
+            completed = true;
+            FutureUtils.completeExceptionally(cb, BKException.create(lastSeenError));
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1904,7 +1904,7 @@ public class LedgerHandle implements WriteHandle {
             blockAddCompletions.decrementAndGet();
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Cannot perform ensemble change with write flags {}. "
-                        + "Retry sending to failed bookies {} for ledger {}.",
+                        + "Failed bookies {} for ledger {}.",
                     writeFlags, failedBookies, ledgerId);
             }
             handleUnrecoverableErrorDuringAdd(WriteException);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1131,7 +1131,7 @@ public class LedgerHandle implements WriteHandle {
                 bk.getMainWorkerPool().submit(new SafeRunnable() {
                     @Override
                     public void safeRun() {
-                        LOG.warn("Attempt to use a closed ledger: {}", ledgerId);
+                        LOG.warn("Force() attempted on a closed ledger: {}", ledgerId);
                         result.completeExceptionally(new BKException.BKLedgerClosedException());
                     }
 
@@ -1146,6 +1146,7 @@ public class LedgerHandle implements WriteHandle {
             return result;
         }
 
+        // early exit: no write has been issued yet
         if (pendingAddsSequenceHead == INVALID_ENTRY_ID) {
             bk.getMainWorkerPool().submit(new SafeRunnable() {
                     @Override
@@ -1862,7 +1863,7 @@ public class LedgerHandle implements WriteHandle {
         }
         if (writeFlags.contains(WriteFlag.DEFERRED_SYNC)) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Cannot perform ensemble changee with writeflags {}."
+                LOG.debug("Cannot perform ensemble change with writeflags {}."
                         + "Failed bookies {} for ledger {}.",
                         writeFlags, delayedWriteFailedBookies, ledgerId);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1128,7 +1128,7 @@ public class LedgerHandle implements WriteHandle {
         if (wasClosed) {
             // make sure the callback is triggered in main worker pool
             try {
-                bk.getMainWorkerPool().submit(new SafeRunnable() {
+                bk.getMainWorkerPool().executeOrdered(ledgerId, new SafeRunnable() {
                     @Override
                     public void safeRun() {
                         LOG.warn("Force() attempted on a closed ledger: {}", ledgerId);
@@ -1148,7 +1148,7 @@ public class LedgerHandle implements WriteHandle {
 
         // early exit: no write has been issued yet
         if (pendingAddsSequenceHead == INVALID_ENTRY_ID) {
-            bk.getMainWorkerPool().submit(new SafeRunnable() {
+            bk.getMainWorkerPool().executeOrdered(ledgerId, new SafeRunnable() {
                     @Override
                     public void safeRun() {
                         FutureUtils.complete(result, null);
@@ -1291,7 +1291,7 @@ public class LedgerHandle implements WriteHandle {
         if (wasClosed) {
             // make sure the callback is triggered in main worker pool
             try {
-                bk.getMainWorkerPool().submit(new SafeRunnable() {
+                bk.getMainWorkerPool().executeOrdered(ledgerId, new SafeRunnable() {
                     @Override
                     public void safeRun() {
                         LOG.warn("Attempt to add to closed ledger: {}", ledgerId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -284,7 +284,9 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
                 // Got an error after satisfying AQ. This means we are under replicated at the create itself.
                 // Update the stat to reflect it.
                 addOpUrCounter.inc();
-                if (!lh.bk.getDisableEnsembleChangeFeature().isAvailable() && !lh.bk.delayEnsembleChange) {
+                if (!lh.bk.getDisableEnsembleChangeFeature().isAvailable()
+                        && !lh.writeFlags.contains(WriteFlag.DEFERRED_SYNC)
+                        && !lh.bk.delayEnsembleChange) {
                     lh.getDelayedWriteFailedBookies().putIfAbsent(bookieIndex, addr);
                 }
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -285,7 +285,6 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
                 // Update the stat to reflect it.
                 addOpUrCounter.inc();
                 if (!lh.bk.getDisableEnsembleChangeFeature().isAvailable()
-                        && !lh.writeFlags.contains(WriteFlag.DEFERRED_SYNC)
                         && !lh.bk.delayEnsembleChange) {
                     lh.getDelayedWriteFailedBookies().putIfAbsent(bookieIndex, addr);
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
@@ -81,7 +81,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
         ReadLACAndEntryRequest(ArrayList<BookieSocketAddress> ensemble, long lId, long eId) {
             this.entryImpl = LedgerEntryImpl.create(lId, eId);
             this.ensemble = ensemble;
-            this.writeSet = lh.getDistributionSchedule().getWriteSetForLongPoll(eId);
+            this.writeSet = lh.getDistributionSchedule().getEnsembleSet(eId);
             if (lh.getBk().shouldReorderReadSequence()) {
                 this.orderedEnsemble = lh.getBk().getPlacementPolicy().reorderReadLACSequence(ensemble,
                         lh.getBookiesHealthInfo(), writeSet.copy());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
@@ -54,17 +54,10 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
     }
 
     @Override
-    public WriteSet getWriteSetForLongPoll(long entryId) {
-        // for long poll reads, we are trying all the bookies in the ensemble
+    public WriteSet getEnsembleSet(long entryId) {
+        // for long poll reads and force ledger , we are trying all the bookies in the ensemble
         // so we create a `WriteSet` with `writeQuorumSize == ensembleSize`.
         return WriteSetImpl.create(ensembleSize, ensembleSize /* writeQuorumSize */, entryId);
-    }
-
-    @Override
-    public WriteSet getWriteSetForForceLedger() {
-        // for long poll reads, we are trying all the bookies in the ensemble
-        // so we create a `WriteSet` with `writeQuorumSize == ensembleSize`.
-        return WriteSetImpl.create(ensembleSize, ensembleSize /* writeQuorumSize */, 0);
     }
 
     @VisibleForTesting
@@ -260,7 +253,7 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
     }
 
     @Override
-    public AckSet getAckSetForForceLedger() {
+    public AckSet getEnsembleAckSet() {
         return AckSetImpl.create(ensembleSize, ensembleSize, ensembleSize);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
@@ -60,6 +60,11 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
         return WriteSetImpl.create(ensembleSize, ensembleSize /* writeQuorumSize */, entryId);
     }
 
+    @Override
+    public WriteSet getWriteSetForForceLedger() {
+        return WriteSetImpl.create(ensembleSize, ensembleSize /* writeQuorumSize */, 0);
+    }
+
     @VisibleForTesting
     static WriteSet writeSetFromValues(Integer... values) {
         WriteSetImpl writeSet = WriteSetImpl.create(0, 0, 0);
@@ -250,6 +255,11 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
     @Override
     public AckSet getAckSet() {
         return AckSetImpl.create(ensembleSize, writeQuorumSize, ackQuorumSize);
+    }
+
+    @Override
+    public AckSet getAckSetForForceLedger() {
+        return AckSetImpl.create(ensembleSize, ensembleSize, ensembleSize);
     }
 
     private static class AckSetImpl implements AckSet {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
@@ -62,6 +62,8 @@ class RoundRobinDistributionSchedule implements DistributionSchedule {
 
     @Override
     public WriteSet getWriteSetForForceLedger() {
+        // for long poll reads, we are trying all the bookies in the ensemble
+        // so we create a `WriteSet` with `writeQuorumSize == ensembleSize`.
         return WriteSetImpl.create(ensembleSize, ensembleSize /* writeQuorumSize */, 0);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
@@ -97,7 +97,7 @@ public class BKException extends Exception {
         case Code.QuorumException:
             return "Invalid quorum size on ensemble size";
         case Code.NoBookieAvailableException:
-            return "Invalid quorum size on ensemble size";
+            return "No bookie available";
         case Code.DigestNotInitializedException:
             return "Digest engine not initialized";
         case Code.DigestMatchException:

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ForceableHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ForceableHandle.java
@@ -1,0 +1,50 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client.api;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
+import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
+
+/**
+ * Provide the ability to enforce durability guarantees to the writer.
+ *
+ * @see WriteAdvHandle
+ * @see WriteHandle
+ *
+ * @since 4.8
+ */
+@Public
+@Unstable
+public interface ForceableHandle {
+
+    /**
+     * Enforce durability to the entries written by this handle.
+     * <p>This API is useful with {@link WriteFlag#DEFERRED_SYNC}, because with
+     * that flag writes are acknowledged by the bookie without waiting for a
+     * durable write
+     * </p>
+     *
+     * @return an handle to the result
+     */
+    CompletableFuture<Void> force();
+
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/WriteAdvHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/WriteAdvHandle.java
@@ -39,7 +39,7 @@ import org.apache.bookkeeper.common.concurrent.FutureUtils;
  */
 @Public
 @Unstable
-public interface WriteAdvHandle extends ReadHandle {
+public interface WriteAdvHandle extends ReadHandle, ForceableHandle {
 
     /**
      * Add entry asynchronously to an open ledger.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/WriteFlag.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/WriteFlag.java
@@ -32,6 +32,8 @@ public enum WriteFlag {
     /**
      * Writes will be acknowledged after writing to the filesystem
      * but not yet been persisted to disks.
+     *
+     * @see ForceableHandle#force()
      */
     DEFERRED_SYNC(0x1 << 0);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/WriteHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/WriteHandle.java
@@ -38,7 +38,7 @@ import org.apache.bookkeeper.common.concurrent.FutureUtils;
  */
 @Public
 @Unstable
-public interface WriteHandle extends ReadHandle {
+public interface WriteHandle extends ReadHandle, ForceableHandle {
 
     /**
      * Add entry asynchronously to an open ledger.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClient.java
@@ -55,6 +55,7 @@ import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ForceLedgerCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GetBookieInfoCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
@@ -191,6 +192,30 @@ public class BookieClient implements PerChannelBookieClientFactory {
             }
         }
         return clientPool;
+    }
+
+    public void forceLedger(final BookieSocketAddress addr, final long ledgerId,
+            final ForceLedgerCallback cb, final Object ctx) {
+        final PerChannelBookieClientPool client = lookupClient(addr);
+        if (client == null) {
+            cb.forceLedgerComplete(getRc(BKException.Code.BookieHandleNotAvailableException),
+                              ledgerId, addr, null);
+            return;
+        }
+
+        client.obtain((rc, pcbc) -> {
+            if (rc != BKException.Code.OK) {
+                try {
+                    executor.executeOrdered(ledgerId, safeRun(() -> {
+                        cb.forceLedgerComplete(rc, ledgerId, addr, ctx);
+                    }));
+                } catch (RejectedExecutionException re) {
+                    cb.forceLedgerComplete(getRc(BKException.Code.InterruptedException), ledgerId, addr, ctx);
+                }
+            } else {
+                pcbc.forceLedger(ledgerId, cb, ctx);
+            }
+        }, ledgerId);
     }
 
     public void writeLac(final BookieSocketAddress addr, final long ledgerId, final byte[] masterKey,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClient.java
@@ -199,7 +199,7 @@ public class BookieClient implements PerChannelBookieClientFactory {
         final PerChannelBookieClientPool client = lookupClient(addr);
         if (client == null) {
             cb.forceLedgerComplete(getRc(BKException.Code.BookieHandleNotAvailableException),
-                              ledgerId, addr, null);
+                              ledgerId, addr, ctx);
             return;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookkeeperInternalCallbacks.java
@@ -91,6 +91,13 @@ public class BookkeeperInternalCallbacks {
     }
 
     /**
+     * Force callback interface.
+     */
+    public interface ForceLedgerCallback {
+        void forceLedgerComplete(int rc, long ledgerId, BookieSocketAddress addr, Object ctx);
+    }
+
+    /**
      * A callback interface for a STARTTLS command.
      */
     public interface StartTLSCallback {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -92,6 +92,7 @@ import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ForceLedgerCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GetBookieInfoCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
@@ -103,6 +104,8 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteLacCallback;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AddRequest;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AddResponse;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ForceLedgerRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ForceLedgerResponse;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoRequest;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.GetBookieInfoResponse;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType;
@@ -174,9 +177,11 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
     private final OpStatsLogger readTimeoutOpLogger;
     private final OpStatsLogger addEntryOpLogger;
     private final OpStatsLogger writeLacOpLogger;
+    private final OpStatsLogger forceLedgerOpLogger;
     private final OpStatsLogger readLacOpLogger;
     private final OpStatsLogger addTimeoutOpLogger;
     private final OpStatsLogger writeLacTimeoutOpLogger;
+    private final OpStatsLogger forceLedgerTimeoutOpLogger;
     private final OpStatsLogger readLacTimeoutOpLogger;
     private final OpStatsLogger getBookieInfoOpLogger;
     private final OpStatsLogger getBookieInfoTimeoutOpLogger;
@@ -281,11 +286,13 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         readEntryOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_READ_OP);
         addEntryOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_ADD_OP);
         writeLacOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_WRITE_LAC_OP);
+        forceLedgerOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_FORCE_OP);
         readLacOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_READ_LAC_OP);
         getBookieInfoOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.GET_BOOKIE_INFO_OP);
         readTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_READ);
         addTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_ADD);
         writeLacTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_WRITE_LAC);
+        forceLedgerTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_FORCE);
         readLacTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_TIMEOUT_READ_LAC);
         getBookieInfoTimeoutOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.TIMEOUT_GET_BOOKIE_INFO);
         startTLSOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_START_TLS_OP);
@@ -564,6 +571,30 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                 .setWriteLacRequest(writeLacBuilder)
                 .build();
         writeAndFlush(channel, completionKey, writeLacRequest);
+    }
+
+    void forceLedger(final long ledgerId, ForceLedgerCallback cb, Object ctx) {
+        final long txnId = getTxnId();
+        final CompletionKey completionKey = new V3CompletionKey(txnId,
+                                                                OperationType.FORCE_LEDGER);
+        // force is mostly like addEntry hence uses addEntryTimeout
+        completionObjects.put(completionKey,
+                              new ForceLedgerCompletion(completionKey, cb,
+                                                     ctx, ledgerId));
+
+        // Build the request
+        BKPacketHeader.Builder headerBuilder = BKPacketHeader.newBuilder()
+                .setVersion(ProtocolVersion.VERSION_THREE)
+                .setOperation(OperationType.FORCE_LEDGER)
+                .setTxnId(txnId);
+        ForceLedgerRequest.Builder writeLacBuilder = ForceLedgerRequest.newBuilder()
+                .setLedgerId(ledgerId);
+
+        final Request forceLedgerRequest = Request.newBuilder()
+                .setHeader(headerBuilder)
+                .setForceLedgerRequest(writeLacBuilder)
+                .build();
+        writeAndFlush(channel, completionKey, forceLedgerRequest);
     }
 
     /**
@@ -1550,6 +1581,55 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             }
             int rc = convertStatus(status, BKException.Code.WriteException);
             cb.writeLacComplete(rc, ledgerId, addr, ctx);
+        }
+    }
+
+    class ForceLedgerCompletion extends CompletionValue {
+        final ForceLedgerCallback cb;
+
+        public ForceLedgerCompletion(final CompletionKey key,
+                                  final ForceLedgerCallback originalCallback,
+                                  final Object originalCtx,
+                                  final long ledgerId) {
+            super("ForceLedger",
+                  originalCtx, ledgerId, BookieProtocol.LAST_ADD_CONFIRMED,
+                  forceLedgerOpLogger, forceLedgerTimeoutOpLogger);
+            this.cb = new ForceLedgerCallback() {
+                    @Override
+                    public void forceLedgerComplete(int rc, long ledgerId,
+                                                 BookieSocketAddress addr,
+                                                 Object ctx) {
+                        logOpResult(rc);
+                        originalCallback.forceLedgerComplete(rc, ledgerId,
+                                                          addr, originalCtx);
+                        key.release();
+                    }
+                };
+        }
+
+        @Override
+        public void errorOut() {
+            errorOut(BKException.Code.BookieHandleNotAvailableException);
+        }
+
+        @Override
+        public void errorOut(final int rc) {
+            errorOutAndRunCallback(
+                    () -> cb.forceLedgerComplete(rc, ledgerId, addr, ctx));
+        }
+
+        @Override
+        public void handleV3Response(BookkeeperProtocol.Response response) {
+            ForceLedgerResponse forceLedgerResponse = response.getForceLedgerResponse();
+            StatusCode status = response.getStatus() == StatusCode.EOK
+                ? forceLedgerResponse.getStatus() : response.getStatus();
+            long ledgerId = forceLedgerResponse.getLedgerId();
+
+            if (LOG.isDebugEnabled()) {
+                logResponse(status, "ledger", ledgerId);
+            }
+            int rc = convertStatus(status, BKException.Code.WriteException);
+            cb.forceLedgerComplete(rc, ledgerId, addr, ctx);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -574,6 +574,13 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
     }
 
     void forceLedger(final long ledgerId, ForceLedgerCallback cb, Object ctx) {
+        if (useV2WireProtocol) {
+                LOG.error("force is not allowed with v2 protocol");
+                executor.executeOrdered(ledgerId, () -> {
+                    cb.forceLedgerComplete(BKException.Code.IllegalOpException, ledgerId, addr, ctx);
+                });
+                return;
+        }
         final long txnId = getTxnId();
         final CompletionKey completionKey = new V3CompletionKey(txnId,
                                                                 OperationType.FORCE_LEDGER);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieDeferredSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieDeferredSyncTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.EnumSet;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.client.api.LedgerEntries;
+import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.client.api.WriteHandle;
@@ -124,14 +125,14 @@ public class BookieDeferredSyncTest extends BookKeeperClusterTestCase {
 
                 try (LedgerEntries entries = readLh.read(0, n - 1)) {
                     for (int i = 0; i < n; i++) {
-                        org.apache.bookkeeper.client.api.LedgerEntry entry = entries.getEntry(i);
+                        LedgerEntry entry = entries.getEntry(i);
                         assertEquals("entry-" + i, new String(entry.getEntryBytes()));
                     }
                 }
 
                 try (LedgerEntries entries = readLh.readUnconfirmed(0, n - 1)) {
                     for (int i = 0; i < n; i++) {
-                        org.apache.bookkeeper.client.api.LedgerEntry entry = entries.getEntry(i);
+                        LedgerEntry entry = entries.getEntry(i);
                         assertEquals("entry-" + i, new String(entry.getEntryBytes()));
                     }
                 }
@@ -148,7 +149,7 @@ public class BookieDeferredSyncTest extends BookKeeperClusterTestCase {
                 // entry will be readable with readUnconfirmed
                 try (LedgerEntries entries = readLh.readUnconfirmed(0, n - 1)) {
                     for (int i = 0; i < n; i++) {
-                        org.apache.bookkeeper.client.api.LedgerEntry entry = entries.getEntry(i);
+                        LedgerEntry entry = entries.getEntry(i);
                         assertEquals("entry-" + i, new String(entry.getEntryBytes()));
                     }
                 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieDeferredSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieDeferredSyncTest.java
@@ -1,0 +1,197 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.bookkeeper.client.api.LedgerEntries;
+import org.apache.bookkeeper.client.api.ReadHandle;
+import org.apache.bookkeeper.client.api.WriteFlag;
+import org.apache.bookkeeper.client.api.WriteHandle;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Test;
+
+/**
+ * Test the bookie journal without sync, driven by client with {@link WriteFlag#DEFERRED_SYNC} write flag.
+ */
+public class BookieDeferredSyncTest extends BookKeeperClusterTestCase {
+
+    public BookieDeferredSyncTest() {
+        super(1);
+    }
+
+    @Test
+    public void testWriteAndRecovery() throws Exception {
+        WriteHandle lh = result(bkc.newCreateLedgerOp()
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withWriteFlags(WriteFlag.DEFERRED_SYNC)
+                .withDigestType(org.apache.bookkeeper.client.api.DigestType.CRC32C)
+                .withPassword(new byte[0])
+                .execute());
+
+        int n = 10;
+
+        long ledgerId = lh.getId();
+
+        for (int i = 0; i < n; i++) {
+            lh.append(("entry-" + i).getBytes());
+        }
+
+        restartBookies();
+
+        try (ReadHandle readLh = result(bkc.newOpenLedgerOp()
+                .withLedgerId(ledgerId)
+                .withRecovery(true)
+                .withPassword(new byte[0])
+                .execute());) {
+
+            try (LedgerEntries entries = readLh.read(0, n - 1)) {
+                for (int i = 0; i < n; i++) {
+                    org.apache.bookkeeper.client.api.LedgerEntry entry = entries.getEntry(i);
+                    assertEquals("entry-" + i, new String(entry.getEntryBytes()));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCloseNoForce() throws Exception {
+        WriteHandle lh = result(bkc.newCreateLedgerOp()
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withWriteFlags(WriteFlag.DEFERRED_SYNC)
+                .withDigestType(org.apache.bookkeeper.client.api.DigestType.CRC32C)
+                .withPassword(new byte[0])
+                .execute());
+
+        int n = 10;
+
+        long ledgerId = lh.getId();
+
+        for (int i = 0; i < n; i++) {
+            lh.append(("entry-" + i).getBytes());
+        }
+
+        // this will close metadata, writing LastAddConfirmed = -1
+        assertEquals(-1, lh.getLastAddConfirmed());
+        lh.close();
+
+        restartBookies();
+
+        try (ReadHandle readLh = result(bkc.newOpenLedgerOp()
+                .withLedgerId(ledgerId)
+                .withRecovery(true)
+                .withPassword(new byte[0])
+                .execute());) {
+            assertEquals(-1, readLh.getLastAddConfirmed());
+        }
+
+    }
+
+    @Test
+    public void testCloseWithForce() throws Exception {
+        WriteHandle lh = result(bkc.newCreateLedgerOp()
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withWriteFlags(WriteFlag.DEFERRED_SYNC)
+                .withDigestType(org.apache.bookkeeper.client.api.DigestType.CRC32C)
+                .withPassword(new byte[0])
+                .execute());
+
+        int n = 10;
+
+        long ledgerId = lh.getId();
+
+        for (int i = 0; i < n; i++) {
+            lh.append(("entry-" + i).getBytes());
+        }
+
+        result(lh.force());
+        assertEquals(n - 1, lh.getLastAddConfirmed());
+
+        lh.close();
+
+        restartBookies();
+
+        try (ReadHandle readLh = result(bkc.newOpenLedgerOp()
+                .withLedgerId(ledgerId)
+                .withRecovery(true)
+                .withPassword(new byte[0])
+                .execute());) {
+
+            try (LedgerEntries entries = readLh.read(0, n - 1)) {
+                for (int i = 0; i < n; i++) {
+                    org.apache.bookkeeper.client.api.LedgerEntry entry = entries.getEntry(i);
+                    assertEquals("entry-" + i, new String(entry.getEntryBytes()));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testForceRoundTripWithDeferredSync() throws Exception {
+        try (WriteHandle lh = result(bkc.newCreateLedgerOp()
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withWriteFlags(WriteFlag.DEFERRED_SYNC)
+                .withDigestType(org.apache.bookkeeper.client.api.DigestType.CRC32C)
+                .withPassword(new byte[0])
+                .execute());) {
+            int n = 10;
+            for (int i = 0; i < n; i++) {
+                lh.append(("entry-" + i).getBytes());
+            }
+            result(lh.force());
+            assertEquals(n - 1, lh.getLastAddConfirmed());
+
+            lh.close();
+        }
+    }
+
+    @Test
+    public void testForceRoundTripWithoutDeferredSync() throws Exception {
+        try (WriteHandle lh = result(bkc.newCreateLedgerOp()
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withWriteFlags(WriteFlag.NONE)
+                .withDigestType(org.apache.bookkeeper.client.api.DigestType.CRC32C)
+                .withPassword(new byte[0])
+                .execute());) {
+            int n = 10;
+            for (int i = 0; i < n; i++) {
+                lh.append(("entry-" + i).getBytes());
+            }
+            // this should work even with non-DEFERRED_SYNC writers
+            result(lh.force());
+            assertEquals(n - 1, lh.getLastAddConfirmed());
+
+            lh.close();
+        }
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -801,4 +801,21 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         }
     }
 
+    @Test(expected = BKIllegalOpException.class)
+    public void testCannotUseForceOnV2Protocol() throws Exception {
+        ClientConfiguration conf = new ClientConfiguration(baseClientConf);
+        conf.setUseV2WireProtocol(true);
+        try (BookKeeperTestClient bkc = new BookKeeperTestClient(conf);) {
+            try (WriteHandle wh = result(bkc.newCreateLedgerOp()
+                    .withEnsembleSize(3)
+                    .withWriteQuorumSize(3)
+                    .withAckQuorumSize(2)
+                    .withPassword("".getBytes())
+                    .withWriteFlags(WriteFlag.NONE)
+                    .execute())) {
+               result(wh.appendAsync("".getBytes()));
+               result(wh.force());
+            }
+        }
+    }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/DeferredSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/DeferredSyncTest.java
@@ -111,39 +111,6 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
     }
 
     @Test
-    public void testForceFailPendingAdds() throws Exception {
-        try (WriteAdvHandle wh = result(newCreateLedgerOp()
-                .withEnsembleSize(3)
-                .withWriteQuorumSize(3)
-                .withAckQuorumSize(2)
-                .withPassword(PASSWORD)
-                .withWriteFlags(WriteFlag.DEFERRED_SYNC)
-                .makeAdv()
-                .execute())) {
-            CompletableFuture<Long> w0 = wh.writeAsync(0, DATA);
-            CompletableFuture<Long> pendingWrite = wh.writeAsync(2, DATA);
-            result(w0);
-
-            BookieSocketAddress bookieAddress = wh.getLedgerMetadata().getEnsembleAt(0).get(0);
-            killBookie(bookieAddress);
-
-            try {
-                // force will fail
-                result(wh.force());
-                fail();
-            } catch (BKException.BKBookieException err){
-            }
-
-            // all pending writes should fail immediately
-            try {
-                result(pendingWrite);
-            } catch (BKException.BKWriteException err){
-            }
-
-        }
-    }
-
-    @Test
     public void testForceRequiresFullEnsemble() throws Exception {
         try (WriteHandle wh = result(newCreateLedgerOp()
                 .withEnsembleSize(3)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/DeferredSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/DeferredSyncTest.java
@@ -111,6 +111,39 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
     }
 
     @Test
+    public void testForceFailPendingAdds() throws Exception {
+        try (WriteAdvHandle wh = result(newCreateLedgerOp()
+                .withEnsembleSize(3)
+                .withWriteQuorumSize(3)
+                .withAckQuorumSize(2)
+                .withPassword(PASSWORD)
+                .withWriteFlags(WriteFlag.DEFERRED_SYNC)
+                .makeAdv()
+                .execute())) {
+            CompletableFuture<Long> w0 = wh.writeAsync(0, DATA);
+            CompletableFuture<Long> pendingWrite = wh.writeAsync(2, DATA);
+            result(w0);
+
+            BookieSocketAddress bookieAddress = wh.getLedgerMetadata().getEnsembleAt(0).get(0);
+            killBookie(bookieAddress);
+
+            try {
+                // force will fail
+                result(wh.force());
+                fail();
+            } catch (BKException.BKBookieException err){
+            }
+
+            // all pending writes should fail immediately
+            try {
+                result(pendingWrite);
+            } catch (BKException.BKWriteException err){
+            }
+
+        }
+    }
+
+    @Test
     public void testForceRequiresFullEnsemble() throws Exception {
         try (WriteHandle wh = result(newCreateLedgerOp()
                 .withEnsembleSize(3)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/DeferredSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/DeferredSyncTest.java
@@ -217,4 +217,17 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
         }
     }
 
+    @Test(expected = BKException.BKLedgerClosedException.class)
+    public void testCannotIssueForceOnClosedLedgerHandle() throws Exception {
+        WriteHandle wh = result(newCreateLedgerOp()
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withPassword(PASSWORD)
+                .withWriteFlags(WriteFlag.DEFERRED_SYNC)
+                .execute());
+        wh.close();
+        result(wh.force());
+    }
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
@@ -29,6 +29,7 @@ import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.bookie.SortedLedgerStorage;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.TestUtils;
@@ -165,6 +166,86 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
         assertTrue(
                 "Expected LAC of rlh: " + (2 * numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
                 (rlh.getLastAddConfirmed() == (2 * numOfEntries - 2)));
+
+        long explicitlac = TestUtils.waitUntilExplicitLacUpdated(rlh, 2 * numOfEntries - 1);
+        assertTrue("Expected Explicit LAC of rlh: " + (2 * numOfEntries - 1)
+                + " actual ExplicitLAC of rlh: " + explicitlac,
+                (explicitlac == (2 * numOfEntries - 1)));
+        // readExplicitLastConfirmed updates the lac of rlh.
+        assertTrue(
+                "Expected LAC of rlh: " + (2 * numOfEntries - 1) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                (rlh.getLastAddConfirmed() == (2 * numOfEntries - 1)));
+
+        Enumeration<LedgerEntry> entries = rlh.readEntries(numOfEntries, 2 * numOfEntries - 1);
+        int entryId = numOfEntries;
+        while (entries.hasMoreElements()) {
+            LedgerEntry entry = entries.nextElement();
+            String entryString = new String(entry.getEntry());
+            assertTrue("Expected entry String: " + ("foobar" + entryId) + " actual entry String: " + entryString,
+                    entryString.equals("foobar" + entryId));
+            entryId++;
+        }
+
+        rlh.close();
+        wlh.close();
+        bkcWithExplicitLAC.close();
+    }
+
+    @Test
+    public void testReadHandleWithExplicitLACAndDeferredSync() throws Exception {
+        ClientConfiguration confWithExplicitLAC = new ClientConfiguration();
+        confWithExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        int explicitLacIntervalMillis = 1000;
+        confWithExplicitLAC.setExplictLacInterval(explicitLacIntervalMillis);
+
+        BookKeeper bkcWithExplicitLAC = new BookKeeper(confWithExplicitLAC);
+
+        LedgerHandle wlh = (LedgerHandle) bkcWithExplicitLAC.newCreateLedgerOp()
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withWriteFlags(WriteFlag.DEFERRED_SYNC)
+                .withDigestType(digestType.toApiDigestType())
+                .withPassword("testPasswd".getBytes())
+                .execute()
+                .get();
+        long ledgerId = wlh.getId();
+
+        // start like testReadHandleWithExplicitLAC
+        int numOfEntries = 5;
+        for (int i = 0; i < numOfEntries; i++) {
+            // if you perform force() + addEntry() you will piggy back LAC as usual
+            wlh.force().get();
+            wlh.addEntry(("foobar" + i).getBytes());
+        }
+
+        LedgerHandle rlh = bkcWithExplicitLAC.openLedgerNoRecovery(ledgerId, digestType, "testPasswd".getBytes());
+
+        assertTrue(
+                "Expected LAC of rlh: " + (numOfEntries - 2) + " actual LAC of rlh: " + rlh.getLastAddConfirmed(),
+                (rlh.getLastAddConfirmed() == (numOfEntries - 2)));
+
+        for (int i = numOfEntries; i < 2 * numOfEntries; i++) {
+            wlh.addEntry(("foobar" + i).getBytes());
+        }
+
+        // running a force() will update local LAC on the writer
+        // ExplicitLAC timer will send the value even without writes
+        wlh.force().get();
+
+        // wait for explicit lac to be sent to bookies
+        TestUtils.waitUntilExplicitLacUpdated(rlh, 2 * numOfEntries - 2);
+
+        // we need to wait for atleast 2 explicitlacintervals,
+        // since in writehandle for the first call
+        // lh.getExplicitLastAddConfirmed() will be <
+        // lh.getPiggyBackedLastAddConfirmed(),
+        // so it wont make explicit writelac in the first run
+        TestUtils.waitUntilLacUpdated(rlh, 2 * numOfEntries - 2);
+
+        assertTrue(
+                "Expected LAC of wlh: " + (2 * numOfEntries - 1) + " actual LAC of wlh: " + wlh.getLastAddConfirmed(),
+                (wlh.getLastAddConfirmed() == (2 * numOfEntries - 1)));
 
         long explicitlac = TestUtils.waitUntilExplicitLacUpdated(rlh, 2 * numOfEntries - 1);
         assertTrue("Expected Explicit LAC of rlh: " + (2 * numOfEntries - 1)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -17,6 +17,7 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Preconditions.checkState;
 import static org.apache.bookkeeper.client.api.BKException.Code.NoBookieAvailableException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -36,6 +37,7 @@ import io.netty.buffer.Unpooled;
 
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -44,7 +46,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -95,6 +97,9 @@ public abstract class MockBookKeeperTestCase {
     protected ConcurrentSkipListSet<Long> fencedLedgers;
     protected ConcurrentMap<Long, Map<BookieSocketAddress, Map<Long, MockEntry>>> mockLedgerData;
 
+    private Map<BookieSocketAddress, List<Runnable>> slowBookieResponses;
+    private Set<BookieSocketAddress> suspendedBookiesForWrites;
+
     List<BookieSocketAddress> failedBookies;
     Set<BookieSocketAddress> availableBookies;
     private int lastIndexForBK;
@@ -129,6 +134,8 @@ public abstract class MockBookKeeperTestCase {
 
     @Before
     public void setup() throws Exception {
+        slowBookieResponses = new ConcurrentHashMap<>();
+        suspendedBookiesForWrites = Collections.synchronizedSet(new HashSet<>());
         mockLedgerMetadataRegistry = new ConcurrentHashMap<>();
         mockLedgerData = new ConcurrentHashMap<>();
         mockNextLedgerId = new AtomicLong(1);
@@ -174,6 +181,7 @@ public abstract class MockBookKeeperTestCase {
         setupBookieWatcherForEnsembleChange();
         setupBookieClientReadEntry();
         setupBookieClientAddEntry();
+        setupBookieClientForceLedger();
     }
 
     protected void mockBookKeeperGetConf(ClientConfiguration conf) {
@@ -235,6 +243,25 @@ public abstract class MockBookKeeperTestCase {
         availableBookies.remove(killedBookieSocketAddress);
     }
 
+    protected void startKilledBookie(BookieSocketAddress killedBookieSocketAddress) {
+        checkState(failedBookies.contains(killedBookieSocketAddress));
+        checkState(!availableBookies.contains(killedBookieSocketAddress));
+        failedBookies.remove(killedBookieSocketAddress);
+        availableBookies.add(killedBookieSocketAddress);
+    }
+
+    protected void suspendBookieWriteAcks(BookieSocketAddress address) {
+        suspendedBookiesForWrites.add(address);
+    }
+
+    protected void resumeBookieWriteAcks(BookieSocketAddress address) {
+        suspendedBookiesForWrites.remove(address);
+        List<Runnable> pendingResponses = slowBookieResponses.remove(address);
+        if (pendingResponses != null) {
+            pendingResponses.forEach(Runnable::run);
+        }
+    }
+
     protected BookieSocketAddress startNewBookie() {
         BookieSocketAddress address = generateBookieSocketAddress(lastIndexForBK++);
         availableBookies.add(address);
@@ -286,13 +313,6 @@ public abstract class MockBookKeeperTestCase {
                         throw BKException.create(BKException.Code.NotEnoughBookiesException);
                     }
                 });
-    }
-    private void submit(Runnable operation) {
-        try {
-            scheduler.submit(operation);
-        } catch (RejectedExecutionException rejected) {
-            operation.run();
-        }
     }
 
     protected void registerMockEntryForRead(long ledgerId, long entryId, BookieSocketAddress bookieSocketAddress,
@@ -491,31 +511,44 @@ public abstract class MockBookKeeperTestCase {
             boolean isRecoveryAdd =
                 ((short) options & BookieProtocol.FLAG_RECOVERY_ADD) == BookieProtocol.FLAG_RECOVERY_ADD;
 
-            executor.executeOrdered(ledgerId, () -> {
-                byte[] entry;
-                try {
-                    entry = extractEntryPayload(ledgerId, entryId, toSend);
-                } catch (BKDigestMatchException e) {
-                    callback.writeComplete(Code.DigestMatchException, ledgerId, entryId, bookieSocketAddress, ctx);
-                    return;
-                }
-                boolean fenced = fencedLedgers.contains(ledgerId);
-                if (fenced && !isRecoveryAdd) {
-                    callback.writeComplete(BKException.Code.LedgerFencedException,
-                        ledgerId, entryId, bookieSocketAddress, ctx);
-                } else {
-                    if (failedBookies.contains(bookieSocketAddress)) {
-                        callback.writeComplete(NoBookieAvailableException, ledgerId, entryId, bookieSocketAddress, ctx);
+            Runnable activity = () -> {
+                executor.executeOrdered(ledgerId, () -> {
+                    byte[] entry;
+                    try {
+                        entry = extractEntryPayload(ledgerId, entryId, toSend);
+                    } catch (BKDigestMatchException e) {
+                        callback.writeComplete(Code.DigestMatchException,
+                                ledgerId, entryId, bookieSocketAddress, ctx);
                         return;
                     }
-                    if (getMockLedgerContentsInBookie(ledgerId, bookieSocketAddress).isEmpty()) {
-                            registerMockEntryForRead(ledgerId, BookieProtocol.LAST_ADD_CONFIRMED, bookieSocketAddress,
-                                    new byte[0], BookieProtocol.INVALID_ENTRY_ID);
+                    boolean fenced = fencedLedgers.contains(ledgerId);
+                    if (fenced && !isRecoveryAdd) {
+                        callback.writeComplete(BKException.Code.LedgerFencedException,
+                            ledgerId, entryId, bookieSocketAddress, ctx);
+                    } else {
+                        if (failedBookies.contains(bookieSocketAddress)) {
+                            callback.writeComplete(NoBookieAvailableException,
+                                    ledgerId, entryId, bookieSocketAddress, ctx);
+                            return;
+                        }
+                        if (getMockLedgerContentsInBookie(ledgerId, bookieSocketAddress).isEmpty()) {
+                                registerMockEntryForRead(ledgerId, BookieProtocol.LAST_ADD_CONFIRMED,
+                                        bookieSocketAddress, new byte[0], BookieProtocol.INVALID_ENTRY_ID);
+                        }
+                        registerMockEntryForRead(ledgerId, entryId, bookieSocketAddress, entry, ledgerId);
+                        callback.writeComplete(BKException.Code.OK,
+                                ledgerId, entryId, bookieSocketAddress, ctx);
                     }
-                    registerMockEntryForRead(ledgerId, entryId, bookieSocketAddress, entry, ledgerId);
-                    callback.writeComplete(BKException.Code.OK, ledgerId, entryId, bookieSocketAddress, ctx);
-                }
-            });
+                });
+            };
+            if (suspendedBookiesForWrites.contains(bookieSocketAddress)) {
+                 List<Runnable> suspendedCallbacks =
+                         slowBookieResponses.computeIfAbsent(bookieSocketAddress, (k)->new CopyOnWriteArrayList<>());
+                 suspendedCallbacks.add(activity);
+            } else {
+                activity.run();
+            }
+
             return null;
         });
 
@@ -524,6 +557,33 @@ public abstract class MockBookKeeperTestCase {
                 anyLong(), any(ByteBufList.class),
                 any(BookkeeperInternalCallbacks.WriteCallback.class),
                 any(), anyInt(), anyBoolean(), any(EnumSet.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void setupBookieClientForceLedger() {
+        final Stubber stub = doAnswer(invokation -> {
+            Object[] args = invokation.getArguments();
+            BookieSocketAddress bookieSocketAddress = (BookieSocketAddress) args[0];
+            long ledgerId = (Long) args[1];
+            BookkeeperInternalCallbacks.ForceLedgerCallback callback =
+                    (BookkeeperInternalCallbacks.ForceLedgerCallback) args[2];
+            Object ctx = args[3];
+
+            executor.executeOrdered(ledgerId, () -> {
+                if (failedBookies.contains(bookieSocketAddress)) {
+                    callback.forceLedgerComplete(NoBookieAvailableException, ledgerId, bookieSocketAddress, ctx);
+                    return;
+                }
+                callback.forceLedgerComplete(BKException.Code.OK, ledgerId, bookieSocketAddress, ctx);
+
+            });
+            return null;
+        });
+
+        stub.when(bookieClient).forceLedger(any(BookieSocketAddress.class),
+                anyLong(),
+                any(BookkeeperInternalCallbacks.ForceLedgerCallback.class),
+                any());
     }
 
 }


### PR DESCRIPTION
- Introduce the client side force() API
- Implementation on the client side wire protocol for FORCE_LEDGER RPC
- Disable ensemble changes for DEFERRED_SYNC writers
- Prevent v2 client from using force() API.

The force() API enables the client (usually with DEFERRED_SYNC write flags) to require a point of synchronization with all the bookies in the ensemble, to have guarantees about durability of previously written entries (and ackknowledgerd), this way LastAddConfirmed is able to advance.

For DEFERRED_SYNC writers LastAddConfirmed will advance only using this API