### PR TITLE
Use maven-exec-plugin to get the maven project version for CI jobs

### DIFF
--- a/dev/common.sh
+++ b/dev/common.sh
@@ -21,7 +21,11 @@
 #
 
 function get_bk_version() {
-    bk_version=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)' 2> /dev/null`
+    bk_version=$(mvn -q \
+    -Dexec.executable="echo" \
+    -Dexec.args='${project.version}' \
+    --non-recursive \
+    org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
     echo ${bk_version}
 }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

The current approach to get project version isn't reliable on CI environment. It might have garbage output (e.g. exceptions).

*Solution*

Changed to use `exec-maven-plugin` to echo `${project.vesion}`. It provides a more reliable approach to get version on CI environments.