### PR TITLE
Issue 1442: Assembly descriptor contains a filesystem-root relative reference '/'

### DIFF
--- a/bookkeeper-dist/src/assemble/bin-all.xml
+++ b/bookkeeper-dist/src/assemble/bin-all.xml
@@ -25,24 +25,24 @@
   <fileSets>
     <fileSet>
       <directory>target</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>${project.artifactId}-${project.version}.jar</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>../../conf</directory>
-      <outputDirectory>/conf</outputDirectory>
+      <outputDirectory>conf</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>../../bin</directory>
       <fileMode>755</fileMode>
-      <outputDirectory>/bin</outputDirectory>
+      <outputDirectory>bin</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>../../bookkeeper-benchmark/bin</directory>
       <fileMode>755</fileMode>
-      <outputDirectory>/bin</outputDirectory>
+      <outputDirectory>bin</outputDirectory>
     </fileSet>
     <fileSet>
       <fileMode>644</fileMode>
@@ -52,7 +52,7 @@
     </fileSet>
     <fileSet>
       <directory>../src/main/resources/deps</directory>
-      <outputDirectory>/deps</outputDirectory>
+      <outputDirectory>deps</outputDirectory>
       <includes>
         <include>google-auth-library-credentials-0.4.0/LICENSE</include>
         <include>javax.servlet-api-3.1.0/CDDL+GPL-1.1</include>
@@ -74,25 +74,25 @@
   <files>
     <file>
       <source>../../README.md</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <fileMode>644</fileMode>
     </file>
     <file>
       <source>../src/main/resources/LICENSE-all.bin.txt</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <destName>LICENSE</destName>
       <fileMode>644</fileMode>
     </file>
     <file>
       <source>../src/main/resources/NOTICE-all.bin.txt</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <destName>NOTICE</destName>
       <fileMode>644</fileMode>
     </file>
   </files>
   <dependencySets>
     <dependencySet>
-      <outputDirectory>/lib</outputDirectory>
+      <outputDirectory>lib</outputDirectory>
       <unpack>false</unpack>
       <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>

--- a/bookkeeper-dist/src/assemble/bin-server.xml
+++ b/bookkeeper-dist/src/assemble/bin-server.xml
@@ -25,19 +25,19 @@
   <fileSets>
     <fileSet>
       <directory>target</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>${project.artifactId}-${project.version}.jar</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>../../conf</directory>
-      <outputDirectory>/conf</outputDirectory>
+      <outputDirectory>conf</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>../../bin</directory>
       <fileMode>755</fileMode>
-      <outputDirectory>/bin</outputDirectory>
+      <outputDirectory>bin</outputDirectory>
     </fileSet>
     <fileSet>
       <fileMode>644</fileMode>
@@ -47,7 +47,7 @@
     </fileSet>
     <fileSet>
       <directory>../src/main/resources/deps</directory>
-      <outputDirectory>/deps</outputDirectory>
+      <outputDirectory>deps</outputDirectory>
       <includes>
         <include>google-auth-library-credentials-0.4.0/LICENSE</include>
         <include>javax.servlet-api-3.1.0/CDDL+GPL-1.1</include>
@@ -63,25 +63,25 @@
   <files>
     <file>
       <source>../../README.md</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <fileMode>644</fileMode>
     </file>
     <file>
       <source>../src/main/resources/LICENSE-server.bin.txt</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <destName>LICENSE</destName>
       <fileMode>644</fileMode>
     </file>
     <file>
       <source>../src/main/resources/NOTICE-server.bin.txt</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <destName>NOTICE</destName>
       <fileMode>644</fileMode>
     </file>
   </files>
   <dependencySets>
     <dependencySet>
-      <outputDirectory>/lib</outputDirectory>
+      <outputDirectory>lib</outputDirectory>
       <unpack>false</unpack>
       <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

Warnings on buidling bookkeeper dist packages. See #1442.

*Solution*

Remove "/" from the relative reference.

See https://lonelycoding.com/maven-assembly-plugin-warning-the-assembly-descriptor-contains-a-filesystem-root-relative-reference/ for details.

Master Issue: #1442 