### PR TITLE
Fix checkstyle warnings

### DIFF
--- a/stream/common/src/main/java/org/apache/bookkeeper/common/grpc/proxy/ProxyServerCallHandler.java
+++ b/stream/common/src/main/java/org/apache/bookkeeper/common/grpc/proxy/ProxyServerCallHandler.java
@@ -27,7 +27,7 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 
 /**
- * Abstract server call handler
+ * Abstract server call handler.
  */
 class ProxyServerCallHandler<ReqT, RespT> implements ServerCallHandler<ReqT, RespT> {
 

--- a/stream/tests-common/src/main/java/org/apache/bookkeeper/tests/rpc/package-info.java
+++ b/stream/tests-common/src/main/java/org/apache/bookkeeper/tests/rpc/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Common rpc classes used for testing.
+ */
+package org.apache.bookkeeper.tests.rpc;


### PR DESCRIPTION

Descriptions of the changes in this PR:

*Motivation*

There were two concurrent PRs merged at the same time.

apache/bookkeeper#1435 (checkstyle changes) was merged before apache/bookkeeper#1430. so checkstyle warnings
introduced by apache/bookkeeper#1430 were not caught by any CI jobs.

*Solution*

Address the checkstyle warnings introduced by apache/bookkeeper#1430
