### PR TITLE
Add printreplicationworkerid option to ListUnderreplicatedCmd.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
@@ -164,4 +164,17 @@ public interface LedgerUnderreplicationManager extends AutoCloseable {
      */
     void notifyLostBookieRecoveryDelayChanged(GenericCallback<Void> cb)
             throws ReplicationException.UnavailableException;
+
+    /**
+     * If a replicationworker has acquired lock on an underreplicated ledger,
+     * then getReplicationWorkerIdRereplicatingLedger should return
+     * ReplicationWorkerId (BookieId) of the ReplicationWorker that is holding
+     * lock. If lock for the underreplicated ledger is not yet acquired or if it
+     * is released then it is supposed to return null.
+     *
+     * @param ledgerId
+     * @return
+     * @throws ReplicationException.UnavailableException
+     */
+    String getReplicationWorkerIdRereplicatingLedger(long ledgerId) throws ReplicationException.UnavailableException;
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Add printreplicationworkerid option to ListUnderreplicatedCmd.
This helps in knowing who is holding lock on UnderReplicated ledger,
and diagnosing that ReplicationWorker if we are seeing any issues in
rereplication.
