### PR TITLE
Include stream modules in bookkeeper distributions only when `-Dstream` is specified

### DIFF
--- a/bookkeeper-dist/all/pom.xml
+++ b/bookkeeper-dist/all/pom.xml
@@ -92,13 +92,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- stream.storage -->
-    <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
-      <artifactId>stream-storage-server</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
     <!-- bookkeeper benchmark -->
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
@@ -152,4 +145,22 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>stream</id>
+      <activation>
+        <property>
+          <name>stream</name>
+        </property>
+      </activation>
+      <dependencies>
+        <!-- stream.storage -->
+        <dependency>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>stream-storage-server</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/bookkeeper-dist/server/pom.xml
+++ b/bookkeeper-dist/server/pom.xml
@@ -76,13 +76,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- stream.storage -->
-    <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
-      <artifactId>stream-storage-server</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
     <!-- slf4j binding -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -130,4 +123,22 @@
 
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>stream</id>
+      <activation>
+        <property>
+          <name>stream</name>
+        </property>
+      </activation>
+      <dependencies>
+        <!-- stream.storage -->
+        <dependency>
+          <groupId>org.apache.bookkeeper</groupId>
+          <artifactId>stream-storage-server</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -30,7 +30,6 @@
   <modules>
     <module>smoke</module>
     <module>standalone</module>
-    <module>cluster</module>
   </modules>
 
   <build>
@@ -69,6 +68,20 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <!-- enable building table service related tests only when -Dstream is provided -->
+    <profile>
+      <id>stream</id>
+      <activation>
+        <property>
+          <name>stream</name>
+        </property>
+      </activation>
+      <modules>
+        <!-- enable cluster testing -->
+        <module>cluster</module>
+      </modules>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

stream modules are only built when `-Dstream` is specified. so if we want to include
binary distribution, `-Dstream` is needed. This updates those modules with profiles
that enabled when `-Dstream` is specified.