### PR TITLE
Update release procedure to use candidate tags for voting

### DIFF
--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -71,6 +71,7 @@ DEVELOPMENT_VERSION="${NEXT_VERSION}-SNAPSHOT"
 
 TAG="release-${VERSION}"
 RC_DIR="bookkeeper-${VERSION}-rc${RC_NUM}"
+RC_TAG="v${VERSION}-rc${RC_NUM}"
 
 CMD="
 gpg-agent --daemon --pinentry-program /usr/bin/pinentry --homedir \$HOME/.gnupg --use-standard-socket
@@ -89,6 +90,7 @@ echo 'BRANCH_NAME               = $BRANCH_NAME'
 echo 'TAG                       = $TAG'
 echo 'RC_NUM                    = $RC_NUM'
 echo 'RC_DIR                    = $RC_DIR'
+echo 'RC_TAG                    = $RC_TAG'
 echo
 echo 'Before executing any release scripts, PLEASE configure your git to cache your github password:'
 echo
@@ -114,6 +116,7 @@ docker run -i -t \
   -e DEVELOPMENT_VERSION=${DEVELOPMENT_VERSION} \
   -e RC_NUM=${RC_NUM} \
   -e TAG=${TAG} \
+  -e RC_TAG=${RC_TAG} \
   -e RC_DIR=${RC_DIR} \
   ${IMAGE_NAME}-${USER_NAME} \
   bash -c "${CMD}"

--- a/dev/release/005-cleanup-rc-tags.sh
+++ b/dev/release/005-cleanup-rc-tags.sh
@@ -22,10 +22,7 @@ BK_HOME=`cd $BINDIR/../..;pwd`
 
 cd $BK_HOME
 
-mvn release:prepare \
-    -DreleaseVersion=${VERSION} \
-    -Dtag=${RC_TAG} \
-    -DupdateWorkingCopyVersions=false \
-    -Darguments="-Dmaven.javadoc.skip=true -DskipTests=true -Dstream" \
-    -Dstream \
-    -Dresume=true 
+for num in $(seq 0 $RC_NUM); do
+    git tag -d "v${VERSION}-rc${num}"
+    git push apache :"v${VERSION}-rc${num}"
+done

--- a/site/community/release_guide.md
+++ b/site/community/release_guide.md
@@ -263,6 +263,7 @@ Set up a few environment variables to simplify Maven commands that follow. This 
     RC_NUM="0"
     TAG="release-${VERSION}"
     RC_DIR="bookkeeper-${VERSION}-rc${RC_NUM}"
+    RC_TAG="v${VERSION}-rc${RC_NUM}"
 
 > Please make sure `gpg` command is in your $PATH. The maven release plugin use `gpg` to sign generated jars and packages.
 
@@ -444,6 +445,24 @@ Use the Apache Nexus repository to release the staged binary artifacts to the Ma
 Copy the source release from the `dev` repository to the `release` repository at `dist.apache.org` using Subversion.
 
     svn move https://dist.apache.org/repos/dist/dev/bookkeeper/bookkeeper-${VERSION}-rc${RC_NUM} https://dist.apache.org/repos/dist/release/bookkeeper/bookkeeper-${VERSION}
+
+### Git tag
+
+Create and push a new signed for the released version by copying the tag for the final release tag, as follows
+
+```shell
+git tag -s "${TAG}" "${RC_TAG}"
+git push apache "${TAG}"
+```
+
+Remove rc tags:
+
+```shell
+for num in $(seq 0 ${RC_NUM}); do
+    git tag -d "v${VERSION}-rc${num}"
+    git push apache :"v${VERSION}-rc${num}"
+done
+```
 
 ### Update Website
 


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Motivation*

We used final release tag during release voting procedure. However there might be changes
happen between different candidate votes. So we ended up retagging the release tag for
different votes.

*Solution*

Use a candidate tag for voting. After a release is approved, create the final release tag.