### PR TITLE
Allow CI to publish a snapshot version with gitsha information

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_release_nightly_snapshot.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_release_nightly_snapshot.groovy
@@ -37,7 +37,28 @@ freeStyleJob('bookkeeper_release_nightly_snapshot') {
       'Release Snapshot',
       '/release-snapshot')
 
+  parameters {
+      stringParam(
+          'sha1',
+          defaultBranch,
+          'Commit id or refname (eg: origin/pr/9/head) you want to build.')
+        
+      stringParam(
+          'PUBLISH_GITSHA',
+          'false',
+          'Whether to publish a snapshot with gitsha information. Options: (true|false).')
+  }
+
   steps {
+    // update snapshot version if `PUBLISH_GITSHA` is `true`
+    shell '''
+export MAVEN_HOME=/home/jenkins/tools/maven/latest
+export PATH=$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH
+export MAVEN_OPTS=-Xmx2048m
+
+./dev/update-snapshot-version.sh
+    '''.stripIndent().trim()
+
     maven {
       // Set maven parameters.
       common_job_properties.setMavenConfig(delegate)

--- a/dev/common.sh
+++ b/dev/common.sh
@@ -33,7 +33,7 @@ function get_snapshot_version_with_gitsha() {
     local gitsha=$(git rev-parse --short HEAD)
     local commitdate=$(git log -1 --date=format:'%Y%m%d' --pretty=format:%cd)
     local version=$(get_bk_version)
-    echo ${version/-SNAPSHOT/}-${commitdate}-${gitsha}
+    echo ${version/-SNAPSHOT/}-${commitdate}-${gitsha}-SNAPSHOT
 }
 
 export BK_DEV_DIR=`dirname "$0"`

--- a/dev/common.sh
+++ b/dev/common.sh
@@ -33,7 +33,7 @@ function get_snapshot_version_with_gitsha() {
     local gitsha=$(git rev-parse --short HEAD)
     local commitdate=$(git log -1 --date=format:'%Y%m%d' --pretty=format:%cd)
     local version=$(get_bk_version)
-    echo ${version}-${commitdate}-${gitsha}
+    echo ${version/-SNAPSHOT/}-${commitdate}-${gitsha}
 }
 
 export BK_DEV_DIR=`dirname "$0"`

--- a/dev/update-snapshot-version.sh
+++ b/dev/update-snapshot-version.sh
@@ -28,7 +28,10 @@
 
 source `dirname "$0"`/common.sh
 
-VERSION=$(get_snapshot_version_with_gitsha)
+OLD_VERSION=$(get_bk_version)
+NEW_VERSION=$(get_snapshot_version_with_gitsha)
 
-mvn versions:set -DnewVersion=${VERSION}
-mvn versions:commit
+echo "Update version from ${OLD_VERSION} to ${NEW_VERSION}"
+
+mvn versions:set -DnewVersion=${VERSION} -Dstream
+mvn versions:commit -Dstream

--- a/dev/update-snapshot-version.sh
+++ b/dev/update-snapshot-version.sh
@@ -33,5 +33,5 @@ NEW_VERSION=$(get_snapshot_version_with_gitsha)
 
 echo "Update version from ${OLD_VERSION} to ${NEW_VERSION}"
 
-mvn versions:set -DnewVersion=${VERSION} -Dstream
+mvn versions:set -Dstream -DnewVersion=${NEW_VERSION} 
 mvn versions:commit -Dstream

--- a/dev/update-snapshot-version.sh
+++ b/dev/update-snapshot-version.sh
@@ -20,22 +20,15 @@
 # under the License.
 #
 
-function get_bk_version() {
-    bk_version=$(mvn -q \
-    -Dexec.executable="echo" \
-    -Dexec.args='${project.version}' \
-    --non-recursive \
-    org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
-    echo ${bk_version}
-}
+###############################################################################
+# Script to update the maven project version to a snapshot version with gitsha
+# before publishing snapshot versions.
+#
+# usage: ./dev/update-snapshot-version.sh
 
-function get_snapshot_version_with_gitsha() {
-    local gitsha=$(git rev-parse --short HEAD)
-    local commitdate=$(git log -1 --date=format:'%Y%m%d' --pretty=format:%cd)
-    local version=$(get_bk_version)
-    echo ${version}-${commitdate}-${gitsha}
-}
+source `dirname "$0"`/common.sh
 
-export BK_DEV_DIR=`dirname "$0"`
-export BK_HOME=`cd ${BK_DEV_DIR}/..;pwd`
-export BK_VERSION=`get_bk_version`
+VERSION=$(get_snapshot_version_with_gitsha)
+
+mvn versions:set -DnewVersion=${VERSION}
+mvn versions:commit

--- a/dev/update-snapshot-version.sh
+++ b/dev/update-snapshot-version.sh
@@ -29,9 +29,10 @@
 source `dirname "$0"`/common.sh
 
 OLD_VERSION=$(get_bk_version)
-NEW_VERSION=$(get_snapshot_version_with_gitsha)
+if [ "x${PUBLISH_GITSHA}" = "xtrue" ]; then
+    NEW_VERSION=$(get_snapshot_version_with_gitsha)
+    echo "Update version from ${OLD_VERSION} to ${NEW_VERSION}"
 
-echo "Update version from ${OLD_VERSION} to ${NEW_VERSION}"
-
-mvn versions:set -Dstream -DnewVersion=${NEW_VERSION} 
-mvn versions:commit -Dstream
+    mvn versions:set -Dstream -DnewVersion=${NEW_VERSION} 
+    mvn versions:commit -Dstream
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
     <dockerfile-maven-plugin.version>1.3.7</dockerfile-maven-plugin.version>
     <license-maven-plugin.version>1.6</license-maven-plugin.version>
+    <git-commit-id-plugin.version>2.2.4</git-commit-id-plugin.version>
     <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
@@ -866,6 +867,26 @@
             <exclude>dev/.vagrant/**</exclude>
           </excludes>
           <consoleOutput>true</consoleOutput>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>git-info</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <useNativeGit>true</useNativeGit>
+          <prefix>git</prefix>
+          <dateFormat>yyyyMMdd-HHmmss</dateFormat><!--  human-readable part of the version number -->
+          <generateGitPropertiesFile>false</generateGitPropertiesFile>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
     <dockerfile-maven-plugin.version>1.3.7</dockerfile-maven-plugin.version>
     <license-maven-plugin.version>1.6</license-maven-plugin.version>
-    <git-commit-id-plugin.version>2.2.4</git-commit-id-plugin.version>
     <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
@@ -867,26 +866,6 @@
             <exclude>dev/.vagrant/**</exclude>
           </excludes>
           <consoleOutput>true</consoleOutput>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>git-info</id>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-            <phase>validate</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <useNativeGit>true</useNativeGit>
-          <prefix>git</prefix>
-          <dateFormat>yyyyMMdd-HHmmss</dateFormat><!--  human-readable part of the version number -->
-          <generateGitPropertiesFile>false</generateGitPropertiesFile>
-          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

Currently bookkeeper publishes a snapshot release nightly to maven artifacts. It provides a convenient solution for people to try out new bookkeeper releases as soon as the changes land in master branch. However sometime it is also problematic when you reference this snapshot version in other projects, subsequent changes in bookkeeper might potentially break those projects.

*Solution*

Update the CI to provide a mechanism to publish a snapshot version with gitsha information. so it can publish a snapshot version that is pinned to the given gitsha. so the projects can safely use a snapshot version for development without worrying bookkeeper changes break it.

*NOTES*

The mechanism is a manual operation. It should be used when it is needed. 