### PR TITLE
Issue 1455: Unable to process suppressions file during checkstyle execution

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -25,4 +25,19 @@
   <artifactId>buildtools</artifactId>
   <name>Apache BookKeeper :: Build Tools</name>
   <version>4.8.0-SNAPSHOT</version>
+  <properties>
+    <spotbugs-maven-plugin.version>3.1.0-RC6</spotbugs-maven-plugin.version>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs-maven-plugin.version}</version>
+        <configuration>
+          <excludeFilterFile>${session.executionRootDirectory}/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -18,9 +18,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
-    <artifactId>bookkeeper</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>18</version>
   </parent>
   <artifactId>buildtools</artifactId>
   <name>Apache BookKeeper :: Build Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -623,6 +623,12 @@
   <dependencies>
     <!-- provided dependencies (available at compilation and test classpths and *NOT* packaged) -->
     <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>buildtools</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION

Descriptions of the changes in this PR:

*Motivation*

Failed to run `mvn clean apache-rat:check checkstyle:check install -DskipTests`

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check (default-cli) on project bookkeeper-stats-api: Failed during checkstyle execution: Unable to process suppressions file location: bookkeeper/suppressions.xml: Cannot create file-based resource:invalid block type -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :bookkeeper-stats-api
```

*Solution*

- Make `buildtools` not inherit from bookkeeper root pom.
- Make bookkeeper root pom includes `buildtools` as a `provided` dependency for each module.

Master Issue: #1455 
Related Issues: #1435 
