### PR TITLE
[CI] Run integration tests concurrently if possible

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
@@ -29,6 +29,9 @@ freeStyleJob('bookkeeper_precommit_integrationtests') {
         'JDK 1.8 (latest)',
         120)
 
+    // Execute concurrent builds if necessary.
+    concurrentBuild()
+
     // Sets that this is a PreCommit job.
     common_job_properties.setPreCommit(delegate, 'Integration Tests')
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Execute integration tests concurrently if necessary.