### PR TITLE
[CI] Issue 1458: Fix bookkeeper-seed CI Job

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_release_nightly_snapshot.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_release_nightly_snapshot.groovy
@@ -40,7 +40,7 @@ freeStyleJob('bookkeeper_release_nightly_snapshot') {
   parameters {
       stringParam(
           'sha1',
-          defaultBranch,
+          'master',
           'Commit id or refname (eg: origin/pr/9/head) you want to build.')
         
       stringParam(


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

Issue #1454 introduced a typo, which cause the seed job can not parse groovy DSL files.

*Solution*

Fix the typo.

Master Issue: #1458 