### PR TITLE
Append ledgersMap when entrylog is removed from cache.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
@@ -186,6 +186,12 @@ class EntryLogManagerForEntryLogPerLedger extends EntryLogManagerBase {
         lock.lock();
         try {
             BufferedLogChannel logChannel = logChannelWithDirInfo.getLogChannel();
+            // Append ledgers map at the end of entry log
+            try {
+                logChannel.appendLedgersMap();
+            } catch (Exception e) {
+                log.error("Got IOException while trying to appendLedgersMap in cacheEntryRemoval callback", e);
+            }
             replicaOfCurrentLogChannels.remove(logChannel.getLogId());
             rotatedLogChannels.add(logChannel);
         } finally {


### PR DESCRIPTION
Descriptions of the changes in this PR:

In EntryLogManagerForEntryLogPerLedger when ledger-entrylog
entry is removed from cache, it will be moved to
rotatedEntryLogs list. Before moving it to rotatedEntryLogs,
ledgersMap should be appended.