### PR TITLE
Use unpooled buffers in BufferedChannel

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -22,7 +22,7 @@
 package org.apache.bookkeeper.bookie;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -78,7 +78,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
         this.writeCapacity = writeCapacity;
         this.position = new AtomicLong(fc.position());
         this.writeBufferStartPosition.set(position.get());
-        this.writeBuffer = ByteBufAllocator.DEFAULT.directBuffer(writeCapacity);
+        this.writeBuffer = Unpooled.buffer(writeCapacity);
         this.unpersistedBytes = new AtomicLong(0);
         this.unpersistedBytesBound = unpersistedBytesBound;
     }


### PR DESCRIPTION
This is a safer fix for #1414 to be included in 4.7.1. 

Use unpooled buffer to avoid mem leak in entry log rotation.