### PR TITLE
Support build on JDK10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
     - os: linux
       env: CUSTOM_JDK="oraclejdk9"
     - os: linux
+      env: CUSTOM_JDK="oraclejdk10"
+    - os: linux
       dist: trusty
       env: CUSTOM_JDK="openjdk8"
 

--- a/circe-checksum/pom.xml
+++ b/circe-checksum/pom.xml
@@ -68,7 +68,7 @@
             <compilerArg>-Xlint:unchecked</compilerArg>
             <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
             <compilerArg>-Xpkginfo:always</compilerArg>
-            </compilerArgs>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>
@@ -142,16 +142,16 @@
                 <source>1.8</source>
                 <target>1.8</target>
                 <compilerArgs>
-                   <!-- Object.finalize() is deprecated at java 9 -->
-                   <!-- <compilerArg>-Werror</compilerArg> -->
-                   <compilerArg>-Xlint:deprecation</compilerArg>
-                   <compilerArg>-Xlint:unchecked</compilerArg>
+                  <!-- Object.finalize() is deprecated at java 9 -->
+                  <!-- <compilerArg>-Werror</compilerArg> -->
+                  <compilerArg>-Xlint:deprecation</compilerArg>
+                  <compilerArg>-Xlint:unchecked</compilerArg>
                    <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
-                   <compilerArg>-Xpkginfo:always</compilerArg>
-                   <!-- add -h flag to javac -->
-                   <compilerArg>-h</compilerArg>
-                   <compilerArg>${project.build.directory}/nar/javah-include</compilerArg>
-               </compilerArgs>
+                  <compilerArg>-Xpkginfo:always</compilerArg>
+                  <!-- add -h flag to javac -->
+                  <compilerArg>-h</compilerArg>
+                  <compilerArg>${project.build.directory}/nar/javah-include</compilerArg>
+                </compilerArgs>
              </configuration>
           </plugin>
             </plugins>

--- a/circe-checksum/pom.xml
+++ b/circe-checksum/pom.xml
@@ -114,6 +114,9 @@
 
   <profiles>
     <profile>
+      <!-- from JDK10 javah command is not available
+           see http://openjdk.java.net/jeps/313
+      -->
       <id>jdk-without-javah</id>
       <activation>
          <jdk>[10,)</jdk>

--- a/circe-checksum/pom.xml
+++ b/circe-checksum/pom.xml
@@ -68,7 +68,7 @@
             <compilerArg>-Xlint:unchecked</compilerArg>
             <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
             <compilerArg>-Xpkginfo:always</compilerArg>
-          </compilerArgs>
+            </compilerArgs>
         </configuration>
       </plugin>
       <plugin>
@@ -113,6 +113,50 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>jdk-without-javah</id>
+      <activation>
+         <jdk>[10,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.maven-nar</groupId>
+            <artifactId>nar-maven-plugin</artifactId>
+            <version>${nar-maven-plugin.version}</version>
+            <extensions>true</extensions>
+            <executions>
+               <execution>
+               <!-- javah is not present in JDK10 onwards,
+                    you have to to use javac -h -->
+                  <id>default-nar-javah</id>
+                  <phase>none</phase>
+               </execution>
+             </executions>
+          </plugin>
+          <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+             <artifactId>maven-compiler-plugin</artifactId>
+             <version>${maven-compiler-plugin.version}</version>
+             <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+                <compilerArgs>
+                   <!-- Object.finalize() is deprecated at java 9 -->
+                   <!-- <compilerArg>-Werror</compilerArg> -->
+                   <compilerArg>-Xlint:deprecation</compilerArg>
+                   <compilerArg>-Xlint:unchecked</compilerArg>
+                   <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
+                   <compilerArg>-Xpkginfo:always</compilerArg>
+                   <!-- add -h flag to javac -->
+                   <compilerArg>-h</compilerArg>
+                   <compilerArg>${project.build.directory}/nar/javah-include</compilerArg>
+               </compilerArgs>
+             </configuration>
+          </plugin>
+            </plugins>
+        </build>
+    </profile>
     <profile>
       <id>mac</id>
       <activation>


### PR DESCRIPTION
- switch to "javac -h" in circe-checksum instead of 'javah' because in JDK10 javah has been dropped (see http://openjdk.java.net/jeps/313)
- add openjdk10 to Travis-CI