### PR TITLE
Issue 1472: [table service] TestStorageClientBuilder.testBuildClientInvalidNamespaceName failed

### DIFF
--- a/stream/clients/java/all/src/test/java/org/apache/bookkeeper/clients/TestStorageClientBuilder.java
+++ b/stream/clients/java/all/src/test/java/org/apache/bookkeeper/clients/TestStorageClientBuilder.java
@@ -50,7 +50,7 @@ public class TestStorageClientBuilder {
             .withSettings(StorageClientSettings.newBuilder()
                 .serviceUri("bk://localhost:4181")
                 .build())
-            .withNamespace("invalid-namespace")
+            .withNamespace("invalid namespace")
             .build();
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

 #1457 changed the validation of namespace/stream name. so "-" is a valid character.

*Solution*

Fix the test.

Master Issue: #1472