### PR TITLE
Throttle integration tests to run 1 build per host

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
@@ -31,8 +31,10 @@ freeStyleJob('bookkeeper_precommit_integrationtests') {
         'ubuntu',
         '${ghprbTargetBranch}')
 
-    // Execute concurrent builds if necessary.
-    concurrentBuild()
+    throttleConcurrentBuilds {
+        // limit builds to 1 per node to avoid conflicts on building docker images
+        maxPerNode(1)
+    }
 
     // Sets that this is a PreCommit job.
     common_job_properties.setPreCommit(delegate, 'Integration Tests')


### PR DESCRIPTION
Descriptions of the changes in this PR:

If running multiple integration tests build on same host, they will be conflicting on installing docker images. So throttle integration tests to run max 1 build per host.

See discussions at : http://mail-archives.apache.org/mod_mbox/pulsar-dev/201806.mbox/%3CCAJdLeK0nj9n-TKC4t43Nyc8bO9UUW17wM%2By_fF68EgFL6Fpo8w%40mail.gmail.com%3E