### PR TITLE
Improve precommit build time

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -126,8 +126,8 @@ class common_job_properties {
   // below to insulate callers from internal parameter defaults.
   private static void setPullRequestBuildTrigger(context,
                                                  String commitStatusContext,
-                                                 String successComment = '--none--',
                                                  String prTriggerPhrase = '',
+                                                 String prSkipBuildPhrase = '',
                                                  boolean onlyMaster = false) {
     context.triggers {
       githubPullRequest {
@@ -143,7 +143,9 @@ class common_job_properties {
         // required to start it.
         if (prTriggerPhrase) {
           triggerPhrase(prTriggerPhrase)
-          onlyTriggerPhrase()
+        }
+        if (prSkipBuildPhrase) {
+          skipBuildPhrase(prSkipBuildPhrase)
         }
         if (onlyMaster) {
           whiteListTargetBranches(['master'])
@@ -155,36 +157,7 @@ class common_job_properties {
             // for this Jenkins project.
             delegate.context("Jenkins: " + commitStatusContext)
           }
-
-          /*
-            This section is disabled, because of jenkinsci/ghprb-plugin#417 issue.
-            For the time being, an equivalent configure section below is added.
-
-          // Comment messages after build completes.
-          buildStatus {
-            completedStatus('SUCCESS', successComment)
-            completedStatus('FAILURE', '--none--')
-            completedStatus('ERROR', '--none--')
-          }
-          */
         }
-      }
-    }
-
-    // Comment messages after build completes.
-    context.configure {
-      def messages = it / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' / extensions / 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus' / messages
-      messages << 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage' {
-        message(successComment)
-        result('SUCCESS')
-      }
-      messages << 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage' {
-        message('--none--')
-        result('ERROR')
-      }
-      messages << 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage' {
-        message('--none--')
-        result('FAILURE')
       }
     }
   }
@@ -213,10 +186,11 @@ class common_job_properties {
   // Sets common config for PreCommit jobs.
   static void setPreCommit(context,
                            String commitStatusName,
-                           String successComment = '--none--',
+                           String prTriggerPhrase = '',
+                           String prSkipBuildPhrase = '',
                            boolean onlyMaster = false) {
     // Set pull request build trigger.
-    setPullRequestBuildTrigger(context, commitStatusName, successComment, '', onlyMaster)
+    setPullRequestBuildTrigger(context, commitStatusName, prTriggerPhrase, prSkipBuildPhrase, onlyMaster)
   }
 
   // Enable triggering postcommit runs against pull requests. Users can comment the trigger phrase
@@ -228,7 +202,6 @@ class common_job_properties {
     setPullRequestBuildTrigger(
       context,
       commitStatusName,
-      '--none--',
       prTriggerPhrase)
   }
 

--- a/.test-infra/jenkins/job_bookkeeper_precommit_bookie_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_bookie_tests.groovy
@@ -18,18 +18,9 @@
 
 import common_job_properties
 
-// This is the Java precommit which runs a maven install, and the current set of precommit tests.
-mavenJob('bookkeeper_precommit_pullrequest_java9') {
-  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 9.')
-
-  // Temporary information gathering to see if full disks are causing the builds to flake
-  preBuildSteps {
-    shell("id")
-    shell("ulimit -a")
-    shell("pwd")
-    shell("df -h")
-    shell("ps aux")
-  }
+// test `org.apache.bookkeeper.bookie.**`
+freeStyleJob('bookkeeper_precommit_bookie_tests') {
+  description('Run bookkeeper bookie tests in Java 8.')
 
   // Execute concurrent builds if necessary.
   concurrentBuild()
@@ -38,7 +29,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   common_job_properties.setTopLevelMainJobProperties(
     delegate,
     'master',
-    'JDK 1.9 (latest)',
+    'JDK 1.8 (latest)',
     200,
     'ubuntu',
     '${ghprbTargetBranch}')
@@ -46,13 +37,34 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(
     delegate,
-    'Build (Java 9)',
-    '.*(re)?build( java9)?.*',
-    '.*\[skip build( java9)?\].*')
+    'Bookie Tests',
+    '.*(re)?run (bookie )?tests.*',
+    '.*\[skip (bookie )?tests\].*',
+    true)
 
-  // Set Maven parameters.
-  common_job_properties.setMavenConfig(delegate)
+  steps {
+    // Temporary information gathering to see if full disks are causing the builds to flake
+    shell("id")
+    shell("ulimit -a")
+    shell("pwd")
+    shell("df -h")
+    shell("ps aux")
 
-  // Maven build project
-  goals('clean package spotbugs:check -Dstream -DskipBookKeeperServerTests')
+    // Build everything
+    maven {
+      // Set Maven parameters.
+      common_job_properties.setMavenConfig(delegate)
+
+      goals('-B -am -pl bookkeeper-server clean install -DskipTests')
+    }
+
+    // Test the package
+    maven {
+      // Set Maven parameters.
+      common_job_properties.setMavenConfig(delegate)
+
+      goals('-pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.**"')
+    }
+  }
+
 }

--- a/.test-infra/jenkins/job_bookkeeper_precommit_client_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_client_tests.groovy
@@ -18,18 +18,9 @@
 
 import common_job_properties
 
-// This is the Java precommit which runs a maven install, and the current set of precommit tests.
-mavenJob('bookkeeper_precommit_pullrequest_java9') {
-  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 9.')
-
-  // Temporary information gathering to see if full disks are causing the builds to flake
-  preBuildSteps {
-    shell("id")
-    shell("ulimit -a")
-    shell("pwd")
-    shell("df -h")
-    shell("ps aux")
-  }
+// test `org.apache.bookkeeper.client.**`
+freeStyleJob('bookkeeper_precommit_client_tests') {
+  description('Run bookkeeper client tests in Java 8.')
 
   // Execute concurrent builds if necessary.
   concurrentBuild()
@@ -38,7 +29,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   common_job_properties.setTopLevelMainJobProperties(
     delegate,
     'master',
-    'JDK 1.9 (latest)',
+    'JDK 1.8 (latest)',
     200,
     'ubuntu',
     '${ghprbTargetBranch}')
@@ -46,13 +37,34 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(
     delegate,
-    'Build (Java 9)',
-    '.*(re)?build( java9)?.*',
-    '.*\[skip build( java9)?\].*')
+    'Client Tests',
+    '.*(re)?run (client )?tests.*',
+    '.*\[skip (client )?tests\].*',
+    true)
 
-  // Set Maven parameters.
-  common_job_properties.setMavenConfig(delegate)
+  steps {
+    // Temporary information gathering to see if full disks are causing the builds to flake
+    shell("id")
+    shell("ulimit -a")
+    shell("pwd")
+    shell("df -h")
+    shell("ps aux")
 
-  // Maven build project
-  goals('clean package spotbugs:check -Dstream -DskipBookKeeperServerTests')
+    // Build everything
+    maven {
+      // Set Maven parameters.
+      common_job_properties.setMavenConfig(delegate)
+
+      goals('-B -am -pl bookkeeper-server clean install -DskipTests')
+    }
+
+    // Test the package
+    maven {
+      // Set Maven parameters.
+      common_job_properties.setMavenConfig(delegate)
+
+      goals('-pl bookkeeper-server test -Dtest="org.apache.bookkeeper.client.**"')
+    }
+  }
+
 }

--- a/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
@@ -35,7 +35,11 @@ freeStyleJob('bookkeeper_precommit_integrationtests') {
     concurrentBuild()
 
     // Sets that this is a PreCommit job.
-    common_job_properties.setPreCommit(delegate, 'Integration Tests')
+    common_job_properties.setPreCommit(
+        delegate,
+        'Integration Tests',
+        '.*(re)?run integration tests.*',
+        '.*\[skip integration tests\].*')
 
     steps {
         // Temporary information gathering to see if full disks are causing the builds to flake

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -44,11 +44,15 @@ mavenJob('bookkeeper_precommit_pullrequest_java8') {
     '${ghprbTargetBranch}')
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, 'Maven clean install (Java 8)')
+  common_job_properties.setPreCommit(
+    delegate,
+    'Build (Java 8)',
+    '.*(re)?build( java8)?.*',
+    '.*\[skip build( java8)?\].*')
 
   // Set Maven parameters.
   common_job_properties.setMavenConfig(delegate)
 
   // Maven build project
-  goals('clean apache-rat:check package spotbugs:check -Dstream')
+  goals('clean package spotbugs:check -Dstream -DskipBookKeeperServerTests')
 }

--- a/.test-infra/jenkins/job_bookkeeper_precommit_remaining_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_remaining_tests.groovy
@@ -18,18 +18,13 @@
 
 import common_job_properties
 
-// This is the Java precommit which runs a maven install, and the current set of precommit tests.
-mavenJob('bookkeeper_precommit_pullrequest_java9') {
-  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 9.')
-
-  // Temporary information gathering to see if full disks are causing the builds to flake
-  preBuildSteps {
-    shell("id")
-    shell("ulimit -a")
-    shell("pwd")
-    shell("df -h")
-    shell("ps aux")
-  }
+// run tests except:
+//   - `org.apache.bookkeeper.client.**`
+//   - `org.apache.bookkeeper.bookie.**`
+//   - `org.apache.bookkeeper.replication.**`
+//   - `org.apache.bookkeeper.tls.**`
+freeStyleJob('bookkeeper_precommit_remaining_tests') {
+  description('Run bookkeeper remaining tests in Java 8.')
 
   // Execute concurrent builds if necessary.
   concurrentBuild()
@@ -38,7 +33,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   common_job_properties.setTopLevelMainJobProperties(
     delegate,
     'master',
-    'JDK 1.9 (latest)',
+    'JDK 1.8 (latest)',
     200,
     'ubuntu',
     '${ghprbTargetBranch}')
@@ -46,13 +41,34 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(
     delegate,
-    'Build (Java 9)',
-    '.*(re)?build( java9)?.*',
-    '.*\[skip build( java9)?\].*')
+    'All Other Tests',
+    '.*(re)?run (remaining )?tests.*',
+    '.*\[skip (remaining )?tests\].*',
+    true)
 
-  // Set Maven parameters.
-  common_job_properties.setMavenConfig(delegate)
+  steps {
+    // Temporary information gathering to see if full disks are causing the builds to flake
+    shell("id")
+    shell("ulimit -a")
+    shell("pwd")
+    shell("df -h")
+    shell("ps aux")
 
-  // Maven build project
-  goals('clean package spotbugs:check -Dstream -DskipBookKeeperServerTests')
+    // Build everything
+    maven {
+      // Set Maven parameters.
+      common_job_properties.setMavenConfig(delegate)
+
+      goals('-B -am -pl bookkeeper-server clean install -DskipTests')
+    }
+
+    // Test the package
+    maven {
+      // Set Maven parameters.
+      common_job_properties.setMavenConfig(delegate)
+
+      goals('-pl bookkeeper-server test -Dtest="!org.apache.bookkeeper.client.**,!org.apache.bookkeeper.bookie.**,!org.apache.bookkeeper.replication.**,!org.apache.bookkeeper.tls.**"')
+    }
+  }
+
 }

--- a/.test-infra/jenkins/job_bookkeeper_precommit_tls_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_tls_tests.groovy
@@ -18,18 +18,9 @@
 
 import common_job_properties
 
-// This is the Java precommit which runs a maven install, and the current set of precommit tests.
-mavenJob('bookkeeper_precommit_pullrequest_java9') {
-  description('precommit verification for pull requests of <a href="http://bookkeeper.apache.org">Apache BookKeeper</a> in Java 9.')
-
-  // Temporary information gathering to see if full disks are causing the builds to flake
-  preBuildSteps {
-    shell("id")
-    shell("ulimit -a")
-    shell("pwd")
-    shell("df -h")
-    shell("ps aux")
-  }
+// test `org.apache.bookkeeper.tls.**`
+freeStyleJob('bookkeeper_precommit_tls_tests') {
+  description('Run bookkeeper tls tests in Java 8.')
 
   // Execute concurrent builds if necessary.
   concurrentBuild()
@@ -38,7 +29,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   common_job_properties.setTopLevelMainJobProperties(
     delegate,
     'master',
-    'JDK 1.9 (latest)',
+    'JDK 1.8 (latest)',
     200,
     'ubuntu',
     '${ghprbTargetBranch}')
@@ -46,13 +37,34 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(
     delegate,
-    'Build (Java 9)',
-    '.*(re)?build( java9)?.*',
-    '.*\[skip build( java9)?\].*')
+    'TLS Tests',
+    '.*(re)?run (tls )?tests.*',
+    '.*\[skip (tls )?tests\].*',
+    true)
 
-  // Set Maven parameters.
-  common_job_properties.setMavenConfig(delegate)
+  steps {
+    // Temporary information gathering to see if full disks are causing the builds to flake
+    shell("id")
+    shell("ulimit -a")
+    shell("pwd")
+    shell("df -h")
+    shell("ps aux")
 
-  // Maven build project
-  goals('clean package spotbugs:check -Dstream -DskipBookKeeperServerTests')
+    // Build everything
+    maven {
+      // Set Maven parameters.
+      common_job_properties.setMavenConfig(delegate)
+
+      goals('-B -am -pl bookkeeper-server clean install -DskipTests')
+    }
+
+    // Test the package
+    maven {
+      // Set Maven parameters.
+      common_job_properties.setMavenConfig(delegate)
+
+      goals('-pl bookkeeper-server test -Dtest="org.apache.bookkeeper.tls.**"')
+    }
+  }
+
 }

--- a/.test-infra/jenkins/job_bookkeeper_precommit_validation.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_validation.groovy
@@ -35,7 +35,12 @@ mavenJob('bookkeeper_precommit_pullrequest_validation') {
     '${ghprbTargetBranch}')
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, 'Pull Request Validation', '--none--', true)
+  common_job_properties.setPreCommit(
+    delegate,
+    'PR Validation',
+    '.*(re)?run pr validation.*',
+    ''
+    true)
 
   // Set Maven parameters.
   common_job_properties.setMavenConfig(delegate)

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -270,5 +270,25 @@
         </plugins>
       </build>
     </profile>
+    <!-- test profiles -->
+    <profile>
+      <id>skipBookKeeperServerTests</id>
+      <activation>
+        <property>
+          <name>skipBookKeeperServerTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION

Descriptions of the changes in this PR:

*Motivation*

The build/test time of `bookkeeper-server` is almost close to or more than 1 hr.

*Solution*

Split the precommit jobs into multiple jobs:

- *PR Validation* : run `apache-rat:check`, `checkstyle:check`, to ensure codestyle and license headers
- *Build (Java x)* : run `package` `spotbugs:check`, to ensure PR can be compiled and tested on different java environments. No spotbugs errors. `bookkeeper-server` tests are skipped.
- *Integration Tests* : run integration tests with docker environment
- *bookkeeper-server Tests* : tests `bookkeeper-server` on certain packages:
  - bookie: `org.apache.bookkeeper.bookie`
  - client: `org.apache.bookkeeper.client`
  - replication: `org.apache.bookkeeper.replication`
  - tls: `org.apache.bookkeeper.tls`
  - all others: all other tests in `bookkeeper-server` module

Each job can be triggered and skipped individually.

- *PR Validation* : "(re)run pr validation" | "" (unskippable)
- *Build (Java x)* : "(re)build java(8|9)" | "skip build java(8|9)"
  - "(re)build" to build on both java8 and java9
  - "skip build" to skip building jobs on both java8 and java9
- *Integration Tests* : "(re)run integration tests" | "skip integration tests"
- *bookkeeper-server tests* : "(re)run (bookie|client|replication|tls|remaining) tests" | "skip (bookie|client|replication|tls|remaining) tests"
  - "(re)run tests" to run all bookkeeper-server test jobs
  - "skip tests" to skip all bookkeeper-server test jobs


