### PR TITLE
RegionAwareEnsemblePlacementPolicy class should use super class's minNumRacksPerWriteQuorum variable

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -79,7 +79,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
     int maxWeightMultiple;
     private Map<BookieNode, WeightedObject> bookieInfoMap = new HashMap<BookieNode, WeightedObject>();
     private WeightedRandomSelection<BookieNode> weightedSelection;
-    private int minNumRacksPerWriteQuorum;
+    protected int minNumRacksPerWriteQuorum;
 
     public static final String REPP_DNS_RESOLVER_CLASS = "reppDnsResolverClass";
     public static final String REPP_RANDOM_READ_REORDERING = "ensembleRandomReadReordering";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -75,7 +75,6 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
     protected boolean enableValidation = true;
     protected boolean enforceDurabilityInReplace = false;
     protected Feature disableDurabilityFeature;
-    protected int minNumRacksPerWriteQuorum;
 
     RegionAwareEnsemblePlacementPolicy() {
         super();
@@ -203,7 +202,6 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                         conf.getString(REPP_DISABLE_DURABILITY_FEATURE_NAME,
                                 BookKeeperConstants.FEATURE_REPP_DISABLE_DURABILITY_ENFORCEMENT));
         }
-        this.minNumRacksPerWriteQuorum = conf.getMinNumRacksPerWriteQuorum();
         return this;
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

RegionAwareEnsemblePlacementPolicy class should use minNumRacksPerWriteQuorum
variable which is declared in its super class - RackawareEnsemblePlacementPolicyImpl,
since it is related to its super class.
