### PR TITLE
[table service] dlog configuration settings are not propagated

### DIFF
--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -226,6 +226,7 @@ public class StorageServer {
         BookieWatchService bkWatchService;
         {
             DistributedLogConfiguration dlogConf = new DistributedLogConfiguration();
+            dlogConf.loadConf(dlConf);
             bkWatchService = new BookieWatchService(
                 dlogConf.getEnsembleSize(),
                 bkConf,

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieWatchService.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieWatchService.java
@@ -81,7 +81,8 @@ public class BookieWatchService
         while (bookies.size() < minNumBookies) {
             TimeUnit.SECONDS.sleep(1);
             bookies = FutureUtils.result(client.getWritableBookies()).getValue();
-            log.info("Only {} bookies are live since {} seconds elapsed, wait for another {} bookies for another 1 second",
+            log.info("Only {} bookies are live since {} seconds elapsed, "
+                + "wait for another {} bookies for another 1 second",
                 bookies.size(), minNumBookies - bookies.size(), stopwatch.elapsed(TimeUnit.SECONDS));
         }
     }

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieWatchService.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieWatchService.java
@@ -81,8 +81,8 @@ public class BookieWatchService
         while (bookies.size() < minNumBookies) {
             TimeUnit.SECONDS.sleep(1);
             bookies = FutureUtils.result(client.getWritableBookies()).getValue();
-            log.info("Only {} bookies are live since {} seconds elapsed, wait for another 1 second",
-                bookies.size(), stopwatch.elapsed(TimeUnit.SECONDS));
+            log.info("Only {} bookies are live since {} seconds elapsed, wait for another {} bookies for another 1 second",
+                bookies.size(), minNumBookies - bookies.size(), stopwatch.elapsed(TimeUnit.SECONDS));
         }
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

When stream storage server starts the bookie watcher service, it waits for at least `ensembleSize` bookies
available before starting other components. However the dlog settings are not propagated correctly. so when
using this component in an environment that only has 1 bookie (e.g. pulsar standalone). Startup will be hanging
on waiting 3 bookies.

*Solution*

load the dlog settings from the base configuration.

