### PR TITLE
[bookie] [DbLedgerStorage] fix illegal reference count exception on filling read cache

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -521,7 +521,6 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
                     if (currentEntryLedgerId != orginalLedgerId) {
                         // Found an entry belonging to a different ledger, stopping read-ahead
-                        entry.release();
                         return;
                     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Problem*

ByteBuf is released at a finally block. DbLedgerStorage doesn't have to release it on return. If it does so, that will cause
double-release and it will throw IllegalReferenceCountException.

*Solution*

Remove `ByteBuf.release` at return.

Related Issue: #1487 