### PR TITLE
Issue 1491: fix GLIBC_2.14 dep issue for protoc-3.5.1-linux-x86_64

### DIFF
--- a/bookkeeper-proto/pom.xml
+++ b/bookkeeper-proto/pom.xml
@@ -50,7 +50,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protoc3.version}:exe:${os.detected.classifier}</protocArtifact>
           <checkStaleness>true</checkStaleness>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
     <prometheus.version>0.0.21</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
     <protobuf.version>3.5.1</protobuf.version>
+    <protoc3.version>3.5.1-1</protoc3.version>
     <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
     <rocksdb.version>5.13.1</rocksdb.version>
     <shrinkwrap.version>3.0.1</shrinkwrap.version>

--- a/stream/proto/pom.xml
+++ b/stream/proto/pom.xml
@@ -78,7 +78,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protoc3.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${protoc-gen-grpc-java.version}:exe:${os.detected.classifier}</pluginArtifact>
           <checkStaleness>true</checkStaleness>

--- a/stream/statelib/pom.xml
+++ b/stream/statelib/pom.xml
@@ -86,7 +86,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protoc3.version}:exe:${os.detected.classifier}</protocArtifact>
         </configuration>
         <executions>
           <execution>

--- a/stream/tests-common/pom.xml
+++ b/stream/tests-common/pom.xml
@@ -68,7 +68,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protoc3.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${protoc-gen-grpc-java.version}:exe:${os.detected.classifier}</pluginArtifact>
           <checkStaleness>true</checkStaleness>


### PR DESCRIPTION
Descriptions of the changes in this PR:

I tried to build the bookkeeper branch-4.7 on RHEL6 and ran into:

```
 /lib64/libc.so.6: version `GLIBC_2.14' not found (required by bookkeeper-proto/target/protoc-plugins/protoc-3.5.1-linux-x86_64.exe)
```
This is similar to google/protobuf#4109 and it's related to google/protobuf#4138


We can take advantage of pulsar's fix apache/incubator-pulsar#1914 here

Master Issue:  https://github.com/apache/bookkeeper/issues/1491