### PR TITLE
[table service] Improve logging message on initializing table range stores.

### DIFF
--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/store/MVCCStoreFactoryImpl.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/store/MVCCStoreFactoryImpl.java
@@ -136,8 +136,8 @@ public class MVCCStoreFactoryImpl implements MVCCStoreFactory {
         if (null != oldStore) {
             store.closeAsync();
         } else {
-            log.info("Add store (scId = {}, streamId = {}, rangeId = {})",
-                scId, streamId, rangeId);
+            log.info("Add store (scId = {}, streamId = {}, rangeId = {}) at storage container ({})",
+                scId, streamId, rangeId, scId);
             scStores.put(rid, store);
         }
     }
@@ -168,6 +168,9 @@ public class MVCCStoreFactoryImpl implements MVCCStoreFactory {
                 return FutureUtils.exception(new ObjectClosedException("MVCCStoreFactory"));
             }
         }
+
+        log.info("Initializing stream({})/range({}) at storage container ({})",
+            streamId, rangeId, scId);
 
         MVCCAsyncStore<byte[], byte[]> store = storeSupplier.get();
 
@@ -205,6 +208,8 @@ public class MVCCStoreFactoryImpl implements MVCCStoreFactory {
             .build();
 
         return store.init(spec).thenApply(ignored -> {
+            log.info("Successfully initialize stream({})/range({}) at storage container ({})",
+                streamId, rangeId, scId);
             addStore(scId, streamId, rangeId, store);
             return store;
         });


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Motivation*

Exceptions might be throwing on starting/stopping table ranges. It would be good to have logging messages about the state transition for debugging purpose.

*Build*

Only touch following stream modules, skip bookkeeper-server related tests:

[skip tests]
