### PR TITLE
ISSUE #1495: Option to enforce minNumRacksPerWriteQuorum

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ITopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ITopologyAwareEnsemblePlacementPolicy.java
@@ -20,6 +20,10 @@ package org.apache.bookkeeper.client;
 import java.util.ArrayList;
 import java.util.Set;
 
+import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
+import org.apache.bookkeeper.client.ITopologyAwareEnsemblePlacementPolicy.Ensemble;
+import org.apache.bookkeeper.client.ITopologyAwareEnsemblePlacementPolicy.Predicate;
+import org.apache.bookkeeper.client.TopologyAwareEnsemblePlacementPolicy.BookieNode;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -109,14 +113,62 @@ public interface ITopologyAwareEnsemblePlacementPolicy<T extends Node> extends E
      *          predicate to apply
      * @param ensemble
      *          ensemble
+     * @param fallbackToRandom
+     *          fallbackToRandom
      * @return the selected bookie.
      * @throws BKException.BKNotEnoughBookiesException
      */
     T selectFromNetworkLocation(String networkLoc,
                                 Set<Node> excludeBookies,
                                 Predicate<T> predicate,
-                                Ensemble<T> ensemble)
+                                Ensemble<T> ensemble,
+                                boolean fallbackToRandom)
             throws BKException.BKNotEnoughBookiesException;
+
+    /**
+     * Select a node from cluster excluding excludeBookies and bookie nodes of
+     * excludeRacks. If there isn't a BookieNode excluding those racks and
+     * nodes, then if fallbackToRandom is set to true then pick a random node
+     * from cluster just excluding excludeBookies.
+     *
+     * @param excludeRacks
+     * @param excludeBookies
+     * @param predicate
+     * @param ensemble
+     * @param fallbackToRandom
+     * @return
+     * @throws BKException.BKNotEnoughBookiesException
+     */
+    T selectFromNetworkLocation(Set<String> excludeRacks,
+                                Set<Node> excludeBookies,
+                                Predicate<BookieNode> predicate,
+                                Ensemble<BookieNode> ensemble,
+                                boolean fallbackToRandom)
+            throws BKException.BKNotEnoughBookiesException;
+
+    /**
+     * Select a node from networkLoc rack excluding excludeBookies. If there
+     * isn't any node in 'networkLoc', then it will try to get a node from
+     * cluster excluding excludeRacks and excludeBookies. If fallbackToRandom is
+     * set to true then it will get a random bookie from cluster excluding
+     * excludeBookies if it couldn't find a bookie
+     *
+     * @param networkLoc
+     * @param excludeRacks
+     * @param excludeBookies
+     * @param predicate
+     * @param ensemble
+     * @param fallbackToRandom
+     * @return
+     * @throws BKNotEnoughBookiesException
+     */
+    T selectFromNetworkLocation(String networkLoc,
+                                Set<String> excludeRacks,
+                                Set<Node> excludeBookies,
+                                Predicate<BookieNode> predicate,
+                                Ensemble<BookieNode> ensemble,
+                                boolean fallbackToRandom)
+            throws BKNotEnoughBookiesException;
 
     /**
      * Handle bookies that left.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -131,7 +131,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                 perRegionPlacement.put(region, new RackawareEnsemblePlacementPolicy()
                         .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds,
                                 this.reorderThresholdPendingRequests, this.isWeighted, this.maxWeightMultiple,
-                                this.minNumRacksPerWriteQuorum, statsLogger)
+                                this.minNumRacksPerWriteQuorum, this.enforceMinNumRacksPerWriteQuorum, statsLogger)
                         .withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK));
             }
 
@@ -176,11 +176,11 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             // Regions are specified as
             // R1;R2;...
             String[] regions = regionsString.split(";");
-            for (String region: regions) {
+            for (String region : regions) {
                 perRegionPlacement.put(region, new RackawareEnsemblePlacementPolicy(true)
                         .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds,
                                 this.reorderThresholdPendingRequests, this.isWeighted, this.maxWeightMultiple,
-                                this.minNumRacksPerWriteQuorum, statsLogger)
+                                this.minNumRacksPerWriteQuorum, this.enforceMinNumRacksPerWriteQuorum, statsLogger)
                         .withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK));
             }
             minRegionsForDurability = conf.getInt(REPP_MINIMUM_REGIONS_FOR_DURABILITY,
@@ -502,7 +502,8 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                         bookieNodeToReplace.getNetworkLocation(),
                         excludeBookies,
                         TruePredicate.INSTANCE,
-                        EnsembleForReplacementWithNoConstraints.INSTANCE);
+                        EnsembleForReplacementWithNoConstraints.INSTANCE,
+                        true);
                 } catch (BKException.BKNotEnoughBookiesException e) {
                     LOG.warn("Failed to choose a bookie from {} : "
                             + "excluded {}, fallback to choose bookie randomly from the cluster.",

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -144,6 +144,9 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     // minimum number of racks per write quorum
     public static final String MIN_NUM_RACKS_PER_WRITE_QUORUM = "minNumRacksPerWriteQuorum";
 
+    // enforce minimum number of racks per write quorum
+    public static final String ENFORCE_MIN_NUM_RACKS_PER_WRITE_QUORUM = "enforceMinNumRacksPerWriteQuorum";
+
     protected AbstractConfiguration() {
         super();
         if (READ_SYSTEM_PROPERTIES) {
@@ -793,6 +796,20 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      */
     public int getMinNumRacksPerWriteQuorum() {
         return getInteger(MIN_NUM_RACKS_PER_WRITE_QUORUM, 2);
+    }
+
+    /**
+     * Set the flag to enforce minimum number of racks per write quorum.
+     */
+    public void setEnforceMinNumRacksPerWriteQuorum(boolean enforceMinNumRacksPerWriteQuorum) {
+        setProperty(ENFORCE_MIN_NUM_RACKS_PER_WRITE_QUORUM, enforceMinNumRacksPerWriteQuorum);
+    }
+
+    /**
+     * Get the flag which enforces the minimum number of racks per write quorum.
+     */
+    public boolean getEnforceMinNumRacksPerWriteQuorum() {
+        return getBoolean(ENFORCE_MIN_NUM_RACKS_PER_WRITE_QUORUM, false);
     }
 
     /**

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -860,6 +860,15 @@ zkEnableSecurity=false
 # The max number of args used in the script provided at `networkTopologyScriptFileName`
 # networkTopologyScriptNumberArgs=100
 
+# minimum number of racks per write quorum. RackawareEnsemblePlacementPolicy will try to
+# get bookies from atleast 'minNumRacksPerWriteQuorum' racks for a writeQuorum.
+# minNumRacksPerWriteQuorum=2
+
+# 'enforceMinNumRacksPerWriteQuorum' enforces RackawareEnsemblePlacementPolicy to pick
+# bookies from 'minNumRacksPerWriteQuorum' racks for a writeQuorum. If it cann't find
+# bookie then it would throw BKNotEnoughBookiesException instead of picking random one.
+# enforceMinNumRacksPerWriteQuorum=false
+
 #############################################################################
 ## Auditor settings
 #############################################################################

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -610,6 +610,12 @@ groups:
   - param: networkTopologyScriptNumberArgs
     description: |
       The max number of args used in the script provided at `networkTopologyScriptFileName`.
+  - param: minNumRacksPerWriteQuorum
+    description: |
+      minimum number of racks per write quorum. RackawareEnsemblePlacementPolicy will try to get bookies from atleast 'minNumRacksPerWriteQuorum' racks for a writeQuorum.
+  - param: enforceMinNumRacksPerWriteQuorum
+    description: |
+      'enforceMinNumRacksPerWriteQuorum' enforces RackawareEnsemblePlacementPolicy to pick bookies from 'minNumRacksPerWriteQuorum' racks for a writeQuorum. If it cann't find bookie then it would throw BKNotEnoughBookiesException instead of picking random one.
 
 - name: AutoRecovery auditor settings
   params:


### PR DESCRIPTION
Descriptions of the changes in this PR:

Provide an option to enforce the guarantee of minNumRacksPerWriteQuorum
if it is enabled. If it cann't find a bookie to enforce the guarantee
then the API in RackawareEnsemblePlacementPolicy should throw
BKNotEnoughBookiesException.

Master Issue: #1495

