### PR TITLE
[devtools] Use ASF Jenkins API properly

### DIFF
--- a/dev/bk-merge-pr.py
+++ b/dev/bk-merge-pr.py
@@ -500,7 +500,7 @@ def is_jenkins_check(check):
     return check["context"].startswith("Jenkins:")
 
 def is_jenkins_passed(url):
-    jenkins_status = get_json("%sapi/json" % (url))
+    jenkins_status = get_json("%sapi/json?tree=result" % (url))
     return "SUCCESS" == jenkins_status['result'] 
 
 def is_integration_test_check(check):


### PR DESCRIPTION


Descriptions of the changes in this PR:

According to https://cwiki.apache.org/confluence/display/INFRA/Using+the+ASF+Jenkins+API,
we need to include 'tree' or 'depth' when using ASF jenkins API.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [x] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [x] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [x] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [x] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [x] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [x] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [x] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [x] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---
