### PR TITLE
[table service] replaying TxnRequest is not implemented

### DIFF
--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/journal/AbstractStateStoreWithJournal.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/journal/AbstractStateStoreWithJournal.java
@@ -325,6 +325,10 @@ public abstract class AbstractStateStoreWithJournal<LocalStateStoreT extends Sta
                         record, record.getDlsn(), name());
                 }
                 try {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Applying command transaction {} - record {} @ {} to mvcc store {}",
+                            record.getTransactionId(), record, record.getDlsn(), name());
+                    }
                     commandProcessor.applyCommand(record.getTransactionId(), record.getPayloadBuf(), localStore);
 
                     if (record.getDlsn().compareTo(endDLSN) >= 0) {
@@ -334,9 +338,15 @@ public abstract class AbstractStateStoreWithJournal<LocalStateStoreT extends Sta
                         return;
                     }
 
+                    if (log.isDebugEnabled()) {
+                        log.debug("Read next record after {} at mvcc store {}",
+                            record.getDlsn(), name());
+                    }
                     // read next record
                     replayJournal(reader, endDLSN, future);
-                } catch (StateStoreRuntimeException e) {
+                } catch (Exception e) {
+                    log.error("Exception is thrown when applying command record {} @ {} to mvcc store {}",
+                        record, record.getDlsn(), name());
                     FutureUtils.completeExceptionally(future, e);
                 }
             }

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoCompareImpl.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoCompareImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.statelib.impl.mvcc.op.proto;
+
+import static org.apache.bookkeeper.statelib.impl.Constants.INVALID_REVISION;
+import static org.apache.bookkeeper.statelib.impl.mvcc.MVCCUtils.toApiCompareResult;
+import static org.apache.bookkeeper.statelib.impl.mvcc.MVCCUtils.toApiCompareTarget;
+
+import com.google.protobuf.ByteString;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.bookkeeper.api.kv.op.CompareOp;
+import org.apache.bookkeeper.api.kv.op.CompareResult;
+import org.apache.bookkeeper.api.kv.op.CompareTarget;
+import org.apache.bookkeeper.stream.proto.kv.rpc.Compare;
+
+/**
+ * A protobuf encoded compare operation.
+ */
+@RequiredArgsConstructor
+@Setter(AccessLevel.PRIVATE)
+@ToString(exclude = "recyclerHandle")
+public class ProtoCompareImpl implements CompareOp<byte[], byte[]> {
+
+    /**
+     * Create a protobuf encoded compare operation.
+     *
+     * @param protoCompare the protobuf representation of a compare operation.
+     * @return a protobuf encoded compare operation
+     */
+    public static ProtoCompareImpl newCompareOp(Compare protoCompare) {
+        ProtoCompareImpl op = RECYCLER.get();
+        op.setRequest(protoCompare);
+        op.setTarget(toApiCompareTarget(protoCompare.getTarget()));
+        op.setResult(toApiCompareResult(protoCompare.getResult()));
+        return op;
+    }
+
+    private static final Recycler<ProtoCompareImpl> RECYCLER = new Recycler<ProtoCompareImpl>() {
+        @Override
+        protected ProtoCompareImpl newObject(Handle<ProtoCompareImpl> handle) {
+            return new ProtoCompareImpl(handle);
+        }
+    };
+
+    private final Handle<ProtoCompareImpl> recyclerHandle;
+    private Compare request;
+    private CompareTarget target;
+    private CompareResult result;
+    private byte[] key;
+    private byte[] value;
+
+    private void reset() {
+        request = null;
+        key = null;
+        value = null;
+        target = null;
+        result = null;
+    }
+
+    @Override
+    public CompareTarget target() {
+        return target;
+    }
+
+    @Override
+    public CompareResult result() {
+        return result;
+    }
+
+    @Override
+    public byte[] key() {
+        if (null != key) {
+            return key;
+        }
+        if (ByteString.EMPTY == request.getKey()) {
+            key = null;
+        } else {
+            key = request.getKey().toByteArray();
+        }
+        return key;
+    }
+
+    @Override
+    public byte[] value() {
+        if (null != value) {
+            return value;
+        }
+        if (ByteString.EMPTY == request.getValue()) {
+            value = null;
+        } else {
+            value = request.getValue().toByteArray();
+        }
+        return value;
+    }
+
+    @Override
+    public long revision() {
+        Compare req = request;
+        if (null == req) {
+            return INVALID_REVISION;
+        } else {
+            switch (req.getTarget()) {
+                case MOD:
+                    return req.getModRevision();
+                case CREATE:
+                    return req.getCreateRevision();
+                case VERSION:
+                    return req.getVersion();
+                default:
+                    return INVALID_REVISION;
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        reset();
+        recyclerHandle.recycle(this);
+    }
+}

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoPutOpImpl.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoPutOpImpl.java
@@ -42,6 +42,12 @@ public class ProtoPutOpImpl implements PutOp<byte[], byte[]>, PutOption<byte[]> 
         return op;
     }
 
+    public static ProtoPutOpImpl newPutOp(PutRequest req) {
+        ProtoPutOpImpl op = RECYCLER.get();
+        op.setPutRequest(req);
+        return op;
+    }
+
     private static final Recycler<ProtoPutOpImpl> RECYCLER = new Recycler<ProtoPutOpImpl>() {
         @Override
         protected ProtoPutOpImpl newObject(Handle<ProtoPutOpImpl> handle) {
@@ -71,6 +77,10 @@ public class ProtoPutOpImpl implements PutOp<byte[], byte[]>, PutOption<byte[]> 
 
     public void setCommand(Command command) {
         this.req = command.getPutReq();
+    }
+
+    public void setPutRequest(PutRequest request) {
+        this.req = request;
     }
 
     @Override

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoTxnOpImpl.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoTxnOpImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.statelib.impl.mvcc.op.proto;
+
+import static org.apache.bookkeeper.statelib.impl.mvcc.MVCCUtils.toApiOp;
+
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.bookkeeper.api.kv.op.CompareOp;
+import org.apache.bookkeeper.api.kv.op.Op;
+import org.apache.bookkeeper.api.kv.op.OpType;
+import org.apache.bookkeeper.api.kv.op.TxnOp;
+import org.apache.bookkeeper.common.collections.RecyclableArrayList;
+import org.apache.bookkeeper.stream.proto.kv.rpc.Compare;
+import org.apache.bookkeeper.stream.proto.kv.rpc.RequestOp;
+import org.apache.bookkeeper.stream.proto.kv.rpc.TxnRequest;
+
+/**
+ * A protobuf encoded transaction operation.
+ */
+@RequiredArgsConstructor
+@ToString(exclude = "recyclerHandle")
+@Setter(AccessLevel.PRIVATE)
+public class ProtoTxnOpImpl implements TxnOp<byte[], byte[]> {
+
+    public static ProtoTxnOpImpl newTxnOp(TxnRequest request) {
+        ProtoTxnOpImpl op = RECYCLER.get();
+        op.setRequest(request);
+        RecyclableArrayList<CompareOp<byte[], byte[]>> compareOps = COMPARE_OPS_RECYCLER.newInstance();
+        for (Compare compare : request.getCompareList()) {
+            compareOps.add(ProtoCompareImpl.newCompareOp(compare));
+        }
+        op.setCompareOps(compareOps);
+        RecyclableArrayList<Op<byte[], byte[]>> successOps = OPS_RECYCLER.newInstance();
+        for (RequestOp reqOp : request.getSuccessList()) {
+            successOps.add(toApiOp(reqOp));
+        }
+        op.setSuccessOps(successOps);
+        RecyclableArrayList<Op<byte[], byte[]>> failureOps = OPS_RECYCLER.newInstance();
+        for (RequestOp reqOp : request.getFailureList()) {
+            failureOps.add(toApiOp(reqOp));
+        }
+        return op;
+    }
+
+    private static final Recycler<ProtoTxnOpImpl> RECYCLER = new Recycler<ProtoTxnOpImpl>() {
+        @Override
+        protected ProtoTxnOpImpl newObject(Handle<ProtoTxnOpImpl> handle) {
+            return new ProtoTxnOpImpl(handle);
+        }
+    };
+
+    private static final RecyclableArrayList.Recycler<CompareOp<byte[], byte[]>> COMPARE_OPS_RECYCLER =
+        new RecyclableArrayList.Recycler<>();
+    private static final RecyclableArrayList.Recycler<Op<byte[], byte[]>> OPS_RECYCLER =
+        new RecyclableArrayList.Recycler<>();
+
+    private final Handle<ProtoTxnOpImpl> recyclerHandle;
+    private TxnRequest request;
+    private RecyclableArrayList<CompareOp<byte[], byte[]>> compareOps;
+    private RecyclableArrayList<Op<byte[], byte[]>> successOps;
+    private RecyclableArrayList<Op<byte[], byte[]>> failureOps;
+
+    private void reset() {
+        request = null;
+        if (null != compareOps) {
+            compareOps.forEach(CompareOp::close);
+            compareOps.recycle();
+        }
+        if (null != successOps) {
+            successOps.forEach(Op::close);
+            successOps.recycle();
+        }
+        if (null != failureOps) {
+            failureOps.forEach(Op::close);
+            failureOps.recycle();
+        }
+    }
+
+    @Override
+    public List<CompareOp<byte[], byte[]>> compareOps() {
+        return compareOps;
+    }
+
+    @Override
+    public List<Op<byte[], byte[]>> successOps() {
+        return successOps;
+    }
+
+    @Override
+    public List<Op<byte[], byte[]>> failureOps() {
+        return failureOps;
+    }
+
+    @Override
+    public OpType type() {
+        return OpType.TXN;
+    }
+
+    @Override
+    public void close() {
+        reset();
+        recyclerHandle.recycle(this);
+    }
+}

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoCompareImplTest.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoCompareImplTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.statelib.impl.mvcc.op.proto;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.protobuf.ByteString;
+import lombok.Cleanup;
+import org.apache.bookkeeper.stream.proto.kv.rpc.Compare;
+import org.apache.bookkeeper.stream.proto.kv.rpc.Compare.CompareResult;
+import org.apache.bookkeeper.stream.proto.kv.rpc.Compare.CompareTarget;
+import org.junit.Test;
+
+/**
+ * Unit test {@link ProtoCompareImpl}
+ */
+public class ProtoCompareImplTest {
+
+    private static final ByteString KEY = ByteString.copyFromUtf8("test-key");
+    private static final ByteString VAL = ByteString.copyFromUtf8("test-value");
+    private static final long MOD_REV = System.currentTimeMillis();
+    private static final long CREATE_REV = MOD_REV + 1;
+    private static final long VERSION = CREATE_REV + 1;
+
+    @Test
+    public void testCompareEmptyValue() {
+        Compare compare = Compare.newBuilder()
+            .setKey(KEY)
+            .setResult(CompareResult.EQUAL)
+            .setTarget(CompareTarget.VALUE)
+            .build();
+
+        @Cleanup ProtoCompareImpl protoCompare = ProtoCompareImpl.newCompareOp(compare);
+        assertArrayEquals("test-key".getBytes(UTF_8), protoCompare.key());
+        assertNull(protoCompare.value());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareResult.EQUAL, protoCompare.result());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareTarget.VALUE, protoCompare.target());
+    }
+
+    @Test
+    public void testCompareValue() {
+        Compare compare = Compare.newBuilder()
+            .setKey(KEY)
+            .setValue(VAL)
+            .setResult(CompareResult.EQUAL)
+            .setTarget(CompareTarget.VALUE)
+            .build();
+
+        @Cleanup ProtoCompareImpl protoCompare = ProtoCompareImpl.newCompareOp(compare);
+        assertArrayEquals("test-key".getBytes(UTF_8), protoCompare.key());
+        assertArrayEquals("test-value".getBytes(UTF_8), protoCompare.value());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareResult.EQUAL, protoCompare.result());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareTarget.VALUE, protoCompare.target());
+    }
+
+    @Test
+    public void testCompareMod() {
+        Compare compare = Compare.newBuilder()
+            .setKey(KEY)
+            .setModRevision(MOD_REV)
+            .setResult(CompareResult.EQUAL)
+            .setTarget(CompareTarget.MOD)
+            .build();
+
+        @Cleanup ProtoCompareImpl protoCompare = ProtoCompareImpl.newCompareOp(compare);
+        assertArrayEquals("test-key".getBytes(UTF_8), protoCompare.key());
+        assertEquals(MOD_REV, protoCompare.revision());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareResult.EQUAL, protoCompare.result());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareTarget.MOD, protoCompare.target());
+    }
+
+    @Test
+    public void testCompareCreate() {
+        Compare compare = Compare.newBuilder()
+            .setKey(KEY)
+            .setCreateRevision(CREATE_REV)
+            .setResult(CompareResult.EQUAL)
+            .setTarget(CompareTarget.CREATE)
+            .build();
+
+        @Cleanup ProtoCompareImpl protoCompare = ProtoCompareImpl.newCompareOp(compare);
+        assertArrayEquals("test-key".getBytes(UTF_8), protoCompare.key());
+        assertEquals(CREATE_REV, protoCompare.revision());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareResult.EQUAL, protoCompare.result());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareTarget.CREATE, protoCompare.target());
+    }
+
+    @Test
+    public void testCompareVersion() {
+        Compare compare = Compare.newBuilder()
+            .setKey(KEY)
+            .setVersion(VERSION)
+            .setResult(CompareResult.EQUAL)
+            .setTarget(CompareTarget.VERSION)
+            .build();
+
+        @Cleanup ProtoCompareImpl protoCompare = ProtoCompareImpl.newCompareOp(compare);
+        assertArrayEquals("test-key".getBytes(UTF_8), protoCompare.key());
+        assertEquals(VERSION, protoCompare.revision());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareResult.EQUAL, protoCompare.result());
+        assertEquals(org.apache.bookkeeper.api.kv.op.CompareTarget.VERSION, protoCompare.target());
+    }
+
+}

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoCompareImplTest.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/mvcc/op/proto/ProtoCompareImplTest.java
@@ -31,7 +31,7 @@ import org.apache.bookkeeper.stream.proto.kv.rpc.Compare.CompareTarget;
 import org.junit.Test;
 
 /**
- * Unit test {@link ProtoCompareImpl}
+ * Unit test {@link ProtoCompareImpl}.
  */
 public class ProtoCompareImplTest {
 


### PR DESCRIPTION


*Motivation*

when enabling table service for pulsar at apache/incubator-pulsar#1922, I noticed that replaying TxnRequest is missed somehow.

*Solution*

This PR implements the replaying TxnRequest logic in the command process.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [x] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [x] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [x] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [x] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [x] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

