### PR TITLE
ISSUE-1490 BookieJournalForceTest is flaky

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -22,6 +22,7 @@
 package org.apache.bookkeeper.bookie;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.MoreExecutors;
 
@@ -392,12 +393,13 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
         @Override
         public String toString() {
-            return "ForceWriteRequest{"
-                    + "forceWriteWaiters=" + forceWriteWaiters
-                    + ", shouldClose=" + shouldClose
-                    + ", isMarker=" + isMarker
-                    + ", lastFlushedPosition=" + lastFlushedPosition
-                    + ", logId=" + logId + '}';
+            return MoreObjects.toStringHelper(ForceWriteRequest.class)
+                .add("forceWriteWaiters", forceWriteWaiters)
+                .add("shouldClose", shouldClose)
+                .add("isMarker", isMarker)
+                .add("lastFlushedPosition", lastFlushedPosition)
+                .add("logId", logId)
+                .toString();
         }
 
         public void closeFileIfNecessary() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -390,6 +390,16 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
             }
         }
 
+        @Override
+        public String toString() {
+            return "ForceWriteRequest{"
+                    + "forceWriteWaiters=" + forceWriteWaiters
+                    + ", shouldClose=" + shouldClose
+                    + ", isMarker=" + isMarker
+                    + ", lastFlushedPosition=" + lastFlushedPosition
+                    + ", logId=" + logId + '}';
+        }
+
         public void closeFileIfNecessary() {
             // Close if shouldClose is set
             if (shouldClose) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalForceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalForceTest.java
@@ -302,7 +302,7 @@ public class BookieJournalForceTest {
         LinkedBlockingQueue<ForceWriteRequest> supportQueue = new LinkedBlockingQueue<>();
         BlockingQueue<ForceWriteRequest> forceWriteRequests = mock(BlockingQueue.class);
         doAnswer((Answer) (InvocationOnMock iom) -> {
-            log.error("something put " + iom.getArgument(0) + " on journal queue",
+            log.error("something put {} on journal queue", iom.getArgument(0),
                     new Exception().fillInStackTrace());
             supportQueue.put(iom.getArgument(0));
             return null;


### PR DESCRIPTION


Descriptions of the changes in this PR:



### Motivation
The test if flaky because the Journal is putting some ForceWriteRequest in the internal queue. This test controls the journal and the queue of ForceWriteRequests, but in the end this control is lost and the final assertion can fail if the journal 'works'.
My guess is about the flag setJournalFlushWhenQueueEmpty which is turned by default to true in tests in order t ospped up the execution.

### Changes

- add debug
- add toString to ForceWriteRequest
- add setJournalFlushWhenQueueEmpty(false) to the flaky test

Master Issue: #1490
