### PR TITLE
Issue 1476: LedgerEntry is recycled twice at ReadLastConfirmedAndEntryOp

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
@@ -153,17 +153,17 @@ public class DiskChecker {
             float free = (float) usableSpace / (float) totalSpace;
             float used = 1f - free;
             if (used > diskUsageThreshold) {
-                LOG.error("Space left on device {} : {}, Used space fraction: {} < threshold {}.",
+                LOG.error("Space left on device {} : {}, Used space fraction: {} > threshold {}.",
                         dir, usableSpace, used, diskUsageThreshold);
                 throw new DiskOutOfSpaceException("Space left on device "
-                        + usableSpace + " Used space fraction:" + used + " < threshold " + diskUsageThreshold, used);
+                        + usableSpace + " Used space fraction:" + used + " > threshold " + diskUsageThreshold, used);
             }
             // Warn should be triggered only if disk usage threshold doesn't trigger first.
             if (used > diskUsageWarnThreshold) {
-                LOG.warn("Space left on device {} : {}, Used space fraction: {} < WarnThreshold {}.",
+                LOG.warn("Space left on device {} : {}, Used space fraction: {} > WarnThreshold {}.",
                         dir, usableSpace, used, diskUsageThreshold);
                 throw new DiskWarnThresholdException("Space left on device:"
-                        + usableSpace + " Used space fraction:" + used + " < WarnThreshold:" + diskUsageWarnThreshold,
+                        + usableSpace + " Used space fraction:" + used + " > WarnThreshold:" + diskUsageWarnThreshold,
                         used);
             }
             return used;

--- a/dev/bk-merge-pr.py
+++ b/dev/bk-merge-pr.py
@@ -500,7 +500,7 @@ def is_jenkins_check(check):
     return check["context"].startswith("Jenkins:")
 
 def is_jenkins_passed(url):
-    jenkins_status = get_json("%sapi/json" % (url))
+    jenkins_status = get_json("%sapi/json?tree=result" % (url))
     return "SUCCESS" == jenkins_status['result'] 
 
 def is_integration_test_check(check):

--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -4,6 +4,9 @@
       <p>
         Copyright &copy; 2016 - {{ 'now' | date: '%Y' }} <a href="https://www.apache.org/">The Apache Software Foundation</a>,<br /> licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, version 2.0</a>.
       </p>
+      <p>
+        Apache BookKeeper, BookKeeper®, Apache®, the Apache feature logo, and the Apache BookKeeper logo are either registered trademarks or trademarks of The Apache Software Foundation.
+      </p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Descriptions of the changes in this PR:

The issue #1476 is caused by peculative reads with object recycling, same request object will be added to the CompletionObjects multiple times with different txnid.  In fact the logic of process the request already take this into account, only on place inside `ReadLastConfirmedAndEntryOp.requestComplete` forget to check requestComplete before calling `submitCallback` which in turn call request.close.



### Motivation

to fix #1476 

### Changes

check `requestComplete` before `submitCallback` in `ReadLastConfirmedAndEntryOp.requestComplete`

Master Issue: #1476 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
