### PR TITLE
Issue 1490: BookieJournalForceTest is flaky

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalForceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalForceTest.java
@@ -78,7 +78,8 @@ public class BookieJournalForceTest {
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
             .setJournalDirName(journalDir.getPath())
-            .setMetadataServiceUri(null);
+            .setMetadataServiceUri(null)
+            .setJournalAdaptiveGroupWrites(false);
 
         JournalChannel jc = spy(new JournalChannel(journalDir, 1));
         whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);
@@ -140,7 +141,8 @@ public class BookieJournalForceTest {
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
-            .setMetadataServiceUri(null);
+            .setMetadataServiceUri(null)
+            .setJournalAdaptiveGroupWrites(false);
 
         JournalChannel jc = spy(new JournalChannel(journalDir, 1));
         whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);
@@ -195,7 +197,8 @@ public class BookieJournalForceTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
             .setJournalBufferedEntriesThreshold(journalBufferedEntriesThreshold)
-            .setMetadataServiceUri(null);
+            .setMetadataServiceUri(null)
+            .setJournalAdaptiveGroupWrites(false);
 
         JournalChannel jc = spy(new JournalChannel(journalDir, 1));
         whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);
@@ -321,6 +324,7 @@ public class BookieJournalForceTest {
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath());
+        conf.setJournalAdaptiveGroupWrites(false);
 
         JournalChannel jc = spy(new JournalChannel(journalDir, 1));
         whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);


### PR DESCRIPTION

Descriptions of the changes in this PR:

### Motivation

The test cases in BookieJournalForceTest check if the forceWriteQueue is empty after everything is flushed.
However if `adaptiveGroupWrites` is enabled, the forceWrite thread will insert a marker entry into force write queue,
this will fail the forceWriteQueue length checking.

### Changes

Disable `adaptiveGroupWrites` in BookieJournalForceTest

Master Issue: #1490 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [x] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [x] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [x] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [x] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [x] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [x] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [x] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---
