### PR TITLE
Issue #1511: Upgrade nokogiri to version 1.8.2

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 ruby '>=2.3.1'
 
 gem 'jekyll', '3.7.0'
-gem 'nokogiri'
+gem 'nokogiri', '1.8.2'
 gem 'jekyll-toc', '0.2.1'

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
     mini_portile2 (2.3.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
@@ -64,10 +64,10 @@ PLATFORMS
 DEPENDENCIES
   jekyll (= 3.7.0)
   jekyll-toc (= 0.2.1)
-  nokogiri
+  nokogiri (= 1.8.2)
 
 RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Version <1.8.2 contain a security vulnerability.


