### PR TITLE
Move TimedOutTestsListener from dlog to bookkeeper-common

### DIFF
--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/util/TestTimedOutTestsListener.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/util/TestTimedOutTestsListener.java
@@ -7,15 +7,16 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-package org.apache.distributedlog.common.util;
+package org.apache.bookkeeper.common.testing.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/util/TimedOutTestsListener.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/util/TimedOutTestsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,15 +7,16 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-package org.apache.distributedlog.common.util;
+package org.apache.bookkeeper.common.testing.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/util/package-info.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/util/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Common testing related utils.
+ */
+package org.apache.bookkeeper.common.testing.util;

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -185,6 +185,24 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true</argLine>
+          <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
+          <reuseForks>false</reuseForks>
+          <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
+          <properties>
+            <property>
+              <name>listener</name>
+              <value>org.apache.bookkeeper.common.testing.util.TimedOutTestsListener</value>
+            </property>
+          </properties>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>

--- a/stream/distributedlog/core/pom.xml
+++ b/stream/distributedlog/core/pom.xml
@@ -104,7 +104,7 @@
           <properties>
             <property>
               <name>listener</name>
-              <value>org.apache.distributedlog.common.util.TimedOutTestsListener</value>
+              <value>org.apache.bookkeeper.common.testing.util.TimedOutTestsListener</value>
             </property>
           </properties>
         </configuration>


### PR DESCRIPTION

Descriptions of the changes in this PR:

This PR is to debug CI problems observed at #1516

### Motivation

dlog uses a `TimedOutTestsListener` to dump the jvm stack when a junit test timed out.
move this class to bookkeeper-common and built with `test-jar`, so it can be used across the project.

### Changes

relocate `TimedOutTestsListener` and its related classes from distributedlog-common to bookkeeper-common.

Related Issue: #1516 
