### PR TITLE
ISSUE #1527: Make ExplicitLAC persistent

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -244,6 +244,7 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
                     byte[] explicitLacBufArray = new byte[explicitLacBufLength];
                     bb.get(explicitLacBufArray);
                     explicitLac.put(explicitLacBufArray);
+                    explicitLac.rewind();
                 } else {
                     throw new IOException("ExplicitLacBufLength " + explicitLacBufLength
                             + " is invalid while reading header for " + lf);
@@ -309,8 +310,10 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
         bb.putInt(stateBits);
         if (this.headerVersion >= V1) {
             if (explicitLac != null) {
+                explicitLac.rewind();
                 bb.putInt(explicitLac.capacity());
                 bb.put(explicitLac);
+                explicitLac.rewind();
             } else {
                 bb.putInt(0);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -35,6 +35,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import org.apache.bookkeeper.common.util.Watchable;
 import org.apache.bookkeeper.common.util.Watcher;
+import org.apache.bookkeeper.proto.checksum.DigestManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +75,13 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
      * The fingerprint of a ledger index file.
      */
     public static final int SIGNATURE = ByteBuffer.wrap("BKLE".getBytes(UTF_8)).getInt();
-    public static final int HEADER_VERSION = 0;
+
+    // No explicitLac
+    static final int V0 = 0;
+    // Adding explicitLac
+    static final int V1 = 1;
+    // current version of FileInfo header is V1
+    public static final int CURRENT_HEADER_VERSION = V1;
 
     static final long START_OF_DATA = 1024;
     private long size;
@@ -91,12 +98,16 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
     // file access mode
     protected String mode;
 
+    // this FileInfo Header Version
+    private int headerVersion;
+
     public FileInfo(File lf, byte[] masterKey) throws IOException {
         super(WATCHER_RECYCLER);
 
         this.lf = lf;
         this.masterKey = masterKey;
         mode = "rw";
+        this.headerVersion = CURRENT_HEADER_VERSION;
     }
 
     synchronized Long getLastAddConfirmed() {
@@ -182,6 +193,7 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("fileInfo:SetLac: {}", explicitLac);
             }
+            needFlushHeader = true;
         }
         setLastAddConfirmed(explicitLacValue);
     }
@@ -206,9 +218,11 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
                 throw new IOException("Missing ledger signature while reading header for " + lf);
             }
             int version = bb.getInt();
-            if (version != HEADER_VERSION) {
+            if (version > CURRENT_HEADER_VERSION) {
                 throw new IOException("Incompatible ledger version " + version + " while reading header for " + lf);
             }
+            this.headerVersion = version;
+
             int length = bb.getInt();
             if (length < 0) {
                 throw new IOException("Length " + length + " is invalid while reading header for " + lf);
@@ -218,6 +232,24 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
             masterKey = new byte[length];
             bb.get(masterKey);
             stateBits = bb.getInt();
+
+            if (this.headerVersion >= V1) {
+                int explicitLacBufLength = bb.getInt();
+                if (explicitLacBufLength == 0) {
+                    explicitLac = null;
+                } else if (explicitLacBufLength >= DigestManager.LAC_METADATA_LENGTH) {
+                    if (explicitLac == null) {
+                        explicitLac = ByteBuffer.allocate(explicitLacBufLength);
+                    }
+                    byte[] explicitLacBufArray = new byte[explicitLacBufLength];
+                    bb.get(explicitLacBufArray);
+                    explicitLac.put(explicitLacBufArray);
+                } else {
+                    throw new IOException("ExplicitLacBufLength " + explicitLacBufLength
+                            + " is invalid while reading header for " + lf);
+                }
+            }
+
             needFlushHeader = false;
         } else {
             throw new IOException("Ledger index file " + lf + " does not exist");
@@ -271,10 +303,18 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
     private void writeHeader() throws IOException {
         ByteBuffer bb = ByteBuffer.allocate((int) START_OF_DATA);
         bb.putInt(SIGNATURE);
-        bb.putInt(HEADER_VERSION);
+        bb.putInt(this.headerVersion);
         bb.putInt(masterKey.length);
         bb.put(masterKey);
         bb.putInt(stateBits);
+        if (this.headerVersion >= V1) {
+            if (explicitLac != null) {
+                bb.putInt(explicitLac.capacity());
+                bb.put(explicitLac);
+            } else {
+                bb.putInt(0);
+            }
+        }
         bb.rewind();
         fc.position(0);
         fc.write(bb);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -99,7 +99,7 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
     protected String mode;
 
     // this FileInfo Header Version
-    private int headerVersion;
+    int headerVersion;
 
     public FileInfo(File lf, byte[] masterKey) throws IOException {
         super(WATCHER_RECYCLER);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -101,13 +101,13 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
     // this FileInfo Header Version
     int headerVersion;
 
-    public FileInfo(File lf, byte[] masterKey) throws IOException {
+    public FileInfo(File lf, byte[] masterKey, int fileInfoVersionToWrite) throws IOException {
         super(WATCHER_RECYCLER);
 
         this.lf = lf;
         this.masterKey = masterKey;
         mode = "rw";
-        this.headerVersion = CURRENT_HEADER_VERSION;
+        this.headerVersion = fileInfoVersionToWrite;
     }
 
     synchronized Long getLastAddConfirmed() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfoBackingCache.java
@@ -35,9 +35,11 @@ class FileInfoBackingCache {
     final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     final ConcurrentLongHashMap<CachedFileInfo> fileInfos = new ConcurrentLongHashMap<>();
     final FileLoader fileLoader;
+    final int fileInfoVersionToWrite;
 
-    FileInfoBackingCache(FileLoader fileLoader) {
+    FileInfoBackingCache(FileLoader fileLoader, int fileInfoVersionToWrite) {
         this.fileLoader = fileLoader;
+        this.fileInfoVersionToWrite = fileInfoVersionToWrite;
     }
 
     /**
@@ -125,7 +127,7 @@ class FileInfoBackingCache {
         final AtomicInteger refCount;
 
         CachedFileInfo(long ledgerId, File lf, byte[] masterKey) throws IOException {
-            super(lf, masterKey);
+            super(lf, masterKey, fileInfoVersionToWrite);
             this.ledgerId = ledgerId;
             this.refCount = new AtomicInteger(0);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -110,7 +110,8 @@ public class IndexPersistenceMgr {
 
         // build the file info cache
         int concurrencyLevel = Math.max(1, Math.max(conf.getNumAddWorkerThreads(), conf.getNumReadWorkerThreads()));
-        fileInfoBackingCache = new FileInfoBackingCache(this::createFileInfoBackingFile);
+        fileInfoBackingCache = new FileInfoBackingCache(this::createFileInfoBackingFile,
+                conf.getFileInfoFormatVersionToWrite());
         RemovalListener<Long, CachedFileInfo> fileInfoEvictionListener = this::handleLedgerEviction;
         writeFileInfoCache = buildCache(
             concurrencyLevel,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -66,11 +66,13 @@ class JournalChannel implements Closeable {
     // 1) expanding header to 512
     // 2) Padding writes to align sector size
     static final int V5 = 5;
+    // Adding explicitlac entry
+    public static final int V6 = 6;
 
     static final int HEADER_SIZE = SECTOR_SIZE; // align header to sector size
     static final int VERSION_HEADER_SIZE = 8; // 4byte magic word, 4 byte version
     static final int MIN_COMPAT_JOURNAL_FORMAT_VERSION = V1;
-    static final int CURRENT_JOURNAL_FORMAT_VERSION = V5;
+    static final int CURRENT_JOURNAL_FORMAT_VERSION = V6;
 
     private final long preAllocSize;
     private final int journalAlignSize;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyFileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ReadOnlyFileInfo.java
@@ -30,7 +30,12 @@ import java.io.IOException;
 class ReadOnlyFileInfo extends FileInfo {
 
     public ReadOnlyFileInfo(File lf, byte[] masterKey) throws IOException {
-        super(lf, masterKey);
+        /*
+         * For ReadOnlyFile it is okay to initialize FileInfo with
+         * CURRENT_HEADER_VERSION, when fileinfo.readHeader is called it would
+         * read actual header version.
+         */
+        super(lf, masterKey, FileInfo.CURRENT_HEADER_VERSION);
         mode = "r";
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -66,6 +66,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String PAGE_SIZE = "pageSize";
     protected static final String FILEINFO_CACHE_INITIAL_CAPACITY = "fileInfoCacheInitialCapacity";
     protected static final String FILEINFO_MAX_IDLE_TIME = "fileInfoMaxIdleTime";
+    protected static final String FILEINFO_FORMAT_VERSION_TO_WRITE = "fileInfoFormatVersionToWrite";
     // Journal Parameters
     protected static final String MAX_JOURNAL_SIZE = "journalMaxSizeMB";
     protected static final String MAX_BACKUP_JOURNALS = "journalMaxBackups";
@@ -543,6 +544,27 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setFileInfoMaxIdleTime(long idleTime) {
         setProperty(FILEINFO_MAX_IDLE_TIME, idleTime);
+        return this;
+    }
+
+    /**
+     * Get fileinfo format version to write.
+     *
+     * @return fileinfo format version to write.
+     */
+    public int getFileInfoFormatVersionToWrite() {
+        return this.getInt(FILEINFO_FORMAT_VERSION_TO_WRITE, 0);
+    }
+
+    /**
+     * Set fileinfo format version to write.
+     *
+     * @param version
+     *            fileinfo format version to write.
+     * @return server configuration.
+     */
+    public ServerConfiguration setFileInfoFormatVersionToWrite(int version) {
+        this.setProperty(FILEINFO_FORMAT_VERSION_TO_WRITE, version);
         return this;
     }
 
@@ -2431,6 +2453,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
         if (isEntryLogPerLedgerEnabled() && getUseTransactionalCompaction()) {
             throw new ConfigurationException(
                     "When entryLogPerLedger is enabled , it is unnecessary to use transactional compaction");
+        }
+        if ((getJournalFormatVersionToWrite() >= 6) ^ (getFileInfoFormatVersionToWrite() >= 1)) {
+            throw new ConfigurationException("For persisiting explicitLac, journalFormatVersionToWrite should be >= 6"
+                    + "and FileInfoFormatVersionToWrite should be >= 1");
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.Response;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
@@ -66,12 +67,45 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             return writeLacResponse.build();
         }
 
+        BookkeeperInternalCallbacks.WriteCallback writeCallback = new BookkeeperInternalCallbacks.WriteCallback() {
+            @Override
+            public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx) {
+                if (BookieProtocol.EOK == rc) {
+                    requestProcessor.writeLacStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),
+                            TimeUnit.NANOSECONDS);
+                } else {
+                    requestProcessor.writeLacStats.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos),
+                            TimeUnit.NANOSECONDS);
+                }
+
+                StatusCode status;
+                switch (rc) {
+                case BookieProtocol.EOK:
+                    status = StatusCode.EOK;
+                    break;
+                case BookieProtocol.EIO:
+                    status = StatusCode.EIO;
+                    break;
+                default:
+                    status = StatusCode.EUA;
+                    break;
+                }
+                writeLacResponse.setStatus(status);
+                Response.Builder response = Response.newBuilder()
+                        .setHeader(getHeader())
+                        .setStatus(writeLacResponse.getStatus())
+                        .setWriteLacResponse(writeLacResponse);
+                Response resp = response.build();
+                sendResponse(status, resp, requestProcessor.writeLacStats);
+            }
+        };
+
         StatusCode status = null;
         ByteBuffer lacToAdd = writeLacRequest.getBody().asReadOnlyByteBuffer();
         byte[] masterKey = writeLacRequest.getMasterKey().toByteArray();
 
         try {
-            requestProcessor.bookie.setExplicitLac(Unpooled.wrappedBuffer(lacToAdd), channel, masterKey);
+            requestProcessor.bookie.setExplicitLac(Unpooled.wrappedBuffer(lacToAdd), writeCallback, channel, masterKey);
             status = StatusCode.EOK;
         } catch (IOException e) {
             logger.error("Error saving lac {} for ledger:{}",
@@ -90,15 +124,13 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
 
         // If everything is okay, we return null so that the calling function
         // dosn't return a response back to the caller.
-        if (status.equals(StatusCode.EOK)) {
-            requestProcessor.writeLacStats.registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos),
-                    TimeUnit.NANOSECONDS);
-        } else {
+        if (!status.equals(StatusCode.EOK)) {
             requestProcessor.writeLacStats.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos),
                     TimeUnit.NANOSECONDS);
+            writeLacResponse.setStatus(status);
+            return writeLacResponse.build();
         }
-        writeLacResponse.setStatus(status);
-        return writeLacResponse.build();
+        return null;
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -96,7 +96,7 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
                         .setStatus(writeLacResponse.getStatus())
                         .setWriteLacResponse(writeLacResponse);
                 Response resp = response.build();
-                sendResponse(status, resp, requestProcessor.writeLacStats);
+                sendResponse(status, resp, requestProcessor.writeLacRequestStats);
             }
         };
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -78,7 +78,7 @@ public class BookieJournalTest {
             throws Exception {
         File fn = new File(indexDir, IndexPersistenceMgr.getLedgerName(ledgerId));
         fn.getParentFile().mkdirs();
-        FileInfo fi = new FileInfo(fn, masterKey);
+        FileInfo fi = new FileInfo(fn, masterKey, FileInfo.CURRENT_HEADER_VERSION);
         // force creation of index file
         fi.write(new ByteBuffer[]{ ByteBuffer.allocate(0) }, 0);
         fi.close(true);
@@ -89,7 +89,7 @@ public class BookieJournalTest {
             throws Exception {
         File fn = new File(indexDir, IndexPersistenceMgr.getLedgerName(ledgerId));
         fn.getParentFile().mkdirs();
-        FileInfo fi = new FileInfo(fn, masterKey);
+        FileInfo fi = new FileInfo(fn, masterKey, FileInfo.CURRENT_HEADER_VERSION);
         // force creation of index file
         fi.write(new ByteBuffer[]{ ByteBuffer.allocate(0) }, 0);
         fi.close(true);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageTest.java
@@ -22,9 +22,19 @@ package org.apache.bookkeeper.bookie;
 
 import static org.junit.Assert.assertEquals;
 
+import io.netty.buffer.ByteBuf;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.proto.checksum.DigestManager;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.util.TestUtils;
 import org.junit.Test;
 
 /**
@@ -53,5 +63,162 @@ public class LedgerStorageTest extends BookKeeperClusterTestCase {
         ledgerStorage.deleteLedger(deletedLedgerId);
 
         counter.await();
+    }
+
+    @Test
+    public void testExplicitLacWriteToJournal() throws Exception {
+        ServerConfiguration bookieServerConfig = bsConfs.get(0);
+
+        ClientConfiguration confWithExplicitLAC = new ClientConfiguration();
+        confWithExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        /*
+         * enable explicitLacFlush by setting non-zero value for
+         * explictLacInterval
+         */
+        int explictLacInterval = 100;
+        BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
+        byte[] passwdBytes = "testPasswd".getBytes();
+        confWithExplicitLAC.setExplictLacInterval(explictLacInterval);
+
+        BookKeeper bkcWithExplicitLAC = new BookKeeper(confWithExplicitLAC);
+
+        LedgerHandle wlh = bkcWithExplicitLAC.createLedger(1, 1, 1, digestType, passwdBytes);
+        long ledgerId = wlh.getId();
+        int numOfEntries = 5;
+        for (int i = 0; i < numOfEntries; i++) {
+            wlh.addEntry(("foobar" + i).getBytes());
+        }
+
+        LedgerHandle rlh = bkcWithExplicitLAC.openLedgerNoRecovery(ledgerId, digestType, passwdBytes);
+
+        assertEquals("LAC of rlh", (long) numOfEntries - 2, rlh.getLastAddConfirmed());
+        assertEquals("Read explicit LAC of rlh", (long) numOfEntries - 2, rlh.readExplicitLastConfirmed());
+
+        /*
+         * we need to wait for atleast 2 explicitlacintervals, since in
+         * writehandle for the first call lh.getExplicitLastAddConfirmed() will
+         * be < lh.getPiggyBackedLastAddConfirmed(), so it wont make explicit
+         * writelac in the first run
+         */
+        long readExplicitLastConfirmed = TestUtils.waitUntilExplicitLacUpdated(rlh, numOfEntries - 1);
+        assertEquals("Read explicit LAC of rlh after wait for explicitlacflush", (numOfEntries - 1),
+                readExplicitLastConfirmed);
+
+        ServerConfiguration newBookieConf = new ServerConfiguration(bookieServerConfig);
+        /*
+         * by reusing bookieServerConfig and setting metadataServiceUri to null
+         * we can create/start new Bookie instance using the same data
+         * (journal/ledger/index) of the existing BookeieServer for our testing
+         * purpose.
+         */
+        newBookieConf.setMetadataServiceUri(null);
+        Bookie newbookie = new Bookie(newBookieConf);
+        /*
+         * since 'newbookie' uses the same data as original Bookie, it should be
+         * able to read journal of the original bookie and hence explicitLac buf
+         * entry written to Journal in the original bookie.
+         */
+        newbookie.readJournal();
+        ByteBuf explicitLacBuf = newbookie.getExplicitLac(ledgerId);
+
+        DigestManager digestManager = DigestManager.instantiate(ledgerId, passwdBytes,
+                BookKeeper.DigestType.toProtoDigestType(digestType), confWithExplicitLAC.getUseV2WireProtocol());
+        long explicitLacPersistedInJournal = digestManager.verifyDigestAndReturnLac(explicitLacBuf);
+        assertEquals("explicitLac persisted in journal", (numOfEntries - 1), explicitLacPersistedInJournal);
+
+        bkcWithExplicitLAC.close();
+    }
+
+    @Test
+    public void testExplicitLacWriteToFileInfo() throws Exception {
+        ServerConfiguration bookieServerConfig = bsConfs.get(0);
+
+        ClientConfiguration confWithExplicitLAC = new ClientConfiguration();
+        confWithExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        /*
+         * enable explicitLacFlush by setting non-zero value for
+         * explictLacInterval
+         */
+        int explictLacInterval = 100;
+        BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
+        byte[] passwdBytes = "testPasswd".getBytes();
+        confWithExplicitLAC.setExplictLacInterval(explictLacInterval);
+
+        BookKeeper bkcWithExplicitLAC = new BookKeeper(confWithExplicitLAC);
+
+        LedgerHandle wlh = bkcWithExplicitLAC.createLedger(1, 1, 1, digestType, passwdBytes);
+        long ledgerId = wlh.getId();
+        int numOfEntries = 5;
+        for (int i = 0; i < numOfEntries; i++) {
+            wlh.addEntry(("foobar" + i).getBytes());
+        }
+
+        LedgerHandle rlh = bkcWithExplicitLAC.openLedgerNoRecovery(ledgerId, digestType, passwdBytes);
+
+        assertEquals("LAC of rlh", (long) numOfEntries - 2, rlh.getLastAddConfirmed());
+        assertEquals("Read explicit LAC of rlh", (long) numOfEntries - 2, rlh.readExplicitLastConfirmed());
+
+        /*
+         * we need to wait for atleast 2 explicitlacintervals, since in
+         * writehandle for the first call lh.getExplicitLastAddConfirmed() will
+         * be < lh.getPiggyBackedLastAddConfirmed(), so it wont make explicit
+         * writelac in the first run
+         */
+        long readExplicitLastConfirmed = TestUtils.waitUntilExplicitLacUpdated(rlh, numOfEntries - 1);
+        assertEquals("Read explicit LAC of rlh after wait for explicitlacflush", (numOfEntries - 1),
+                readExplicitLastConfirmed);
+
+        /*
+         * flush ledgerStorage so that header of fileinfo is flushed.
+         */
+        bs.get(0).getBookie().ledgerStorage.flush();
+
+        ReadOnlyFileInfo fileInfo = getFileInfo(ledgerId, Bookie.getCurrentDirectories(bsConfs.get(0).getLedgerDirs()));
+        fileInfo.readHeader();
+        ByteBuf explicitLacBufReadFromFileInfo = fileInfo.getExplicitLac();
+
+        DigestManager digestManager = DigestManager.instantiate(ledgerId, passwdBytes,
+                BookKeeper.DigestType.toProtoDigestType(digestType), confWithExplicitLAC.getUseV2WireProtocol());
+        long explicitLacReadFromFileInfo = digestManager.verifyDigestAndReturnLac(explicitLacBufReadFromFileInfo);
+        assertEquals("explicitLac persisted in FileInfo", (numOfEntries - 1), explicitLacReadFromFileInfo);
+
+        bkcWithExplicitLAC.close();
+    }
+
+    /**
+     * Get the ledger file of a specified ledger.
+     *
+     * @param ledgerId Ledger Id
+     *
+     * @return file object.
+     */
+    private File getLedgerFile(long ledgerId, File[] indexDirectories) {
+        String ledgerName = IndexPersistenceMgr.getLedgerName(ledgerId);
+        File lf = null;
+        for (File d : indexDirectories) {
+            lf = new File(d, ledgerName);
+            if (lf.exists()) {
+                break;
+            }
+            lf = null;
+        }
+        return lf;
+    }
+
+    /**
+     * Get FileInfo for a specified ledger.
+     *
+     * @param ledgerId Ledger Id
+     * @return read only file info instance
+     */
+    ReadOnlyFileInfo getFileInfo(long ledgerId, File[] indexDirectories) throws IOException {
+        File ledgerFile = getLedgerFile(ledgerId, indexDirectories);
+        if (null == ledgerFile) {
+            throw new FileNotFoundException("No index file found for ledger " + ledgerId
+                    + ". It may be not flushed yet.");
+        }
+        ReadOnlyFileInfo fi = new ReadOnlyFileInfo(ledgerFile, null);
+        fi.readHeader();
+        return fi;
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestFileInfoBackingCache.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestFileInfoBackingCache.java
@@ -89,7 +89,7 @@ public class TestFileInfoBackingCache {
                     File f = new File(baseDir, String.valueOf(ledgerId));
                     f.deleteOnExit();
                     return f;
-                });
+                }, FileInfo.CURRENT_HEADER_VERSION);
         CachedFileInfo fi = cache.loadFileInfo(1, masterKey);
         Assert.assertEquals(fi.getRefCount(), 1);
         CachedFileInfo fi2 = cache.loadFileInfo(2, masterKey);
@@ -116,7 +116,7 @@ public class TestFileInfoBackingCache {
                 (ledgerId, createIfNotFound) -> {
                     Assert.assertFalse(createIfNotFound);
                     throw new Bookie.NoLedgerException(ledgerId);
-                });
+                }, FileInfo.CURRENT_HEADER_VERSION);
         cache.loadFileInfo(1, null);
     }
 
@@ -135,7 +135,7 @@ public class TestFileInfoBackingCache {
                     File f = new File(baseDir, String.valueOf(ledgerId));
                     f.deleteOnExit();
                     return f;
-                });
+                }, FileInfo.CURRENT_HEADER_VERSION);
         Iterable<Future<Set<CachedFileInfo>>> futures =
             IntStream.range(0, numRunners).mapToObj(
                     (i) -> {
@@ -194,7 +194,7 @@ public class TestFileInfoBackingCache {
                     File f = new File(baseDir, String.valueOf(ledgerId));
                     f.deleteOnExit();
                     return f;
-                });
+                }, FileInfo.CURRENT_HEADER_VERSION);
 
         Iterable<Future<Set<CachedFileInfo>>> futures =
             IntStream.range(0, 2).mapToObj(
@@ -239,7 +239,7 @@ public class TestFileInfoBackingCache {
                     File f = new File(baseDir, String.valueOf(ledgerId));
                     f.deleteOnExit();
                     return f;
-                });
+                }, FileInfo.CURRENT_HEADER_VERSION);
 
         Cache<Long, CachedFileInfo> guavaCache = CacheBuilder.newBuilder()
             .maximumSize(1)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
@@ -67,7 +67,7 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
 
         File fn = new File(dir, IndexPersistenceMgr.getLedgerName(ledgerId));
         fn.getParentFile().mkdirs();
-        FileInfo fi = new FileInfo(fn, masterKey);
+        FileInfo fi = new FileInfo(fn, masterKey, FileInfo.CURRENT_HEADER_VERSION);
         // force creation of index file
         fi.write(new ByteBuffer[]{ ByteBuffer.allocate(0) }, 0);
         fi.close(true);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
@@ -53,6 +53,12 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
         super(1);
         this.digestType = DigestType.CRC32;
         baseConf.setLedgerStorageClass(storageClass.getName());
+        /*
+         * to persist explicitLac, journalFormatVersionToWrite should be atleast
+         * V6 and fileInfoFormatVersionToWrite should be atleast V1
+         */
+        baseConf.setJournalFormatVersionToWrite(6);
+        baseConf.setFileInfoFormatVersionToWrite(1);
     }
 
     @Parameters

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
@@ -83,4 +83,32 @@ public class TestServerConfiguration {
         assertArrayEquals(components, serverConf.getExtraServerComponents());
     }
 
+    @Test(expected = ConfigurationException.class)
+    public void testMismatchofJournalAndFileInfoVersionsOlderJournalVersion() throws ConfigurationException {
+        ServerConfiguration conf = new ServerConfiguration();
+        conf.setJournalFormatVersionToWrite(5);
+        conf.setFileInfoFormatVersionToWrite(1);
+        conf.validate();
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testMismatchofJournalAndFileInfoVersionsOlderFileInfoVersion() throws ConfigurationException {
+        ServerConfiguration conf = new ServerConfiguration();
+        conf.setJournalFormatVersionToWrite(6);
+        conf.setFileInfoFormatVersionToWrite(0);
+        conf.validate();
+    }
+
+    @Test
+    public void testValidityOfJournalAndFileInfoVersions() throws ConfigurationException {
+        ServerConfiguration conf = new ServerConfiguration();
+        conf.setJournalFormatVersionToWrite(5);
+        conf.setFileInfoFormatVersionToWrite(0);
+        conf.validate();
+
+        conf = new ServerConfiguration();
+        conf.setJournalFormatVersionToWrite(6);
+        conf.setFileInfoFormatVersionToWrite(1);
+        conf.validate();
+    }
 }

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -278,9 +278,13 @@ journalDirectories=/tmp/bk-txn
 # 3: ledger key was introduced
 # 4: fencing key was introduced
 # 5: expanding header to 512 and padding writes to align sector size configured by `journalAlignmentSize`
+# 6: persisting explicitLac is introduced
 # By default, it is `4`. If you'd like to enable `padding-writes` feature, you can set journal version to `5`.
 # You can disable `padding-writes` by setting journal version back to `4`. This feature is available in 4.5.0
 # and onward versions.
+# If you'd like to enable persisting ExplicitLac, you can set this config to 6 and also 
+# fileInfoFormatVersionToWrite should be atleast 1. If there is mismatch then the serverconfig is considered 
+# invalid.
 # journalFormatVersionToWrite=4
 
 # Max file size of journal file, in mega bytes
@@ -591,6 +595,15 @@ ledgerDirectories=/tmp/bk-data
 # will be evicted and closed. If the value is zero or negative, the file info is evicted
 # only when opened files reached openFileLimit. The default value is 0.
 # fileInfoMaxIdleTime=0
+
+# The fileinfo format version to write.
+#  Available formats are 0-1:
+#   0: Initial version
+#   1: persisting explicitLac is introduced
+#  By default, it is `0`. If you'd like to enable persisting ExplicitLac, you can set
+#  this config to 1 and also journalFormatVersionToWrite should be atleast 6. If 
+#  there is mismatch then the serverconfig is considered invalid.
+# fileInfoFormatVersionToWrite = 0
 
 # Size of a index page in ledger cache, in bytes
 # A larger index page can improve performance writing page to disk,

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -198,9 +198,11 @@ groups:
        3: ledger key was introduced
        4: fencing key was introduced
        5: expanding header to 512 and padding writes to align sector size configured by `journalAlignmentSize`
+       6: persisting explicitLac is introduced
 
       By default, it is `4`. If you'd like to enable `padding-writes` feature, you can set journal version to `5`.
       You can disable `padding-writes` by setting journal version back to `4`. This feature is available in 4.5.0 and onward versions.
+      If you'd like to enable persisting ExplicitLac, you can set this config to 6 and also fileInfoFormatVersionToWrite should be atleast 1. If there is mismatch then the serverconfig is considered invalid.
     default: 4
   - param: journalMaxSizeMB
     description: Max file size of journal file, in mega bytes. A new journal file will be created when the old one reaches the file size limitation.
@@ -412,6 +414,15 @@ groups:
     description: |
       The max idle time allowed for an open file info existed in the file info cache. If the file info is idle for a long time, exceed the given time period. The file info will be
       evicted and closed. If the value is zero or negative, the file info is evicted only when opened files reached `openFileLimit`.
+    default: 0
+  - param: fileInfoFormatVersionToWrite
+    description: |
+      The fileinfo format version to write.
+      Available formats are 0-1:
+       0: Initial version
+       1: persisting explicitLac is introduced
+
+      By default, it is `0`. If you'd like to enable persisting ExplicitLac, you can set this config to 1 and also journalFormatVersionToWrite should be atleast 6. If there is mismatch then the serverconfig is considered invalid.
     default: 0
   - param: pageSize
     description: |


### PR DESCRIPTION


Descriptions of the changes in this PR:

For persisting explicitLAC, we can follow the
same approach as followed in persisting
fencing information / stateBits (d69986c)
in FileInfo file and special marker entry
in Journal.

### Motivation

ExplicitLAC is kept in the memory and it can be lost in bookie reboot.
Though it is an extreme corner case scenario, it can break one of the BK guarantees.
" If you read once you can always read it".
If all the bookies of the Write stripe were rebooted, it can loose its explicitLAC value and the client
which was able to read the entry before the reboot, can't read it anymore.

Master Issue: #1527
