### PR TITLE
ISSUE #1534: LedgerCache should be flushed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
@@ -114,6 +114,7 @@ public class EntryLogCompactor extends AbstractLogCompactor {
             try {
                 entryLogger.flush();
                 ledgerStorage.updateEntriesLocations(offsets);
+                ledgerStorage.flushEntriesLocationsIndex();
             } finally {
                 offsets.clear();
             }


### PR DESCRIPTION

Descriptions of the changes in this PR:

### Motivation

EntryLogComparator.CompactionScannerFactory.flush just calls "ledgerStorage.updateEntriesLocations(offsets);" but not "ledgerStorage.flushEntriesLocationsIndex()".

Because of this, EntryLogCompactor.compact method would remove compacted entryLog without updated offsets/locations getting flushed/persisted/fsynced to LedgerCache (Index/FileInfo files). This could lead to data corruption/loss if Bookie is broughtdown/killed before those updated offsets/locations are flushed/persisted/fsynced.
### Changes

In EntryLogComparator, before removing compacted entryLog, LedgerCache (IndexInMemPageMgr and Index files) should be flushed, just like EntryLogger.

Master Issue: #1534
