### PR TITLE
Issue 1540: Bookie/BookieServer components shutdown will fail to end exit the BookieProcess

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/AbstractLifecycleComponent.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/AbstractLifecycleComponent.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.common.component;
 
 import java.io.IOException;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import lombok.extern.slf4j.Slf4j;
@@ -35,12 +36,18 @@ public abstract class AbstractLifecycleComponent<ConfT extends ComponentConfigur
     protected final Lifecycle lifecycle = new Lifecycle();
     private final Set<LifecycleListener> listeners = new CopyOnWriteArraySet<>();
     protected final StatsLogger statsLogger;
+    protected volatile UncaughtExceptionHandler uncaughtExceptionHandler;
 
     protected AbstractLifecycleComponent(String componentName,
                                          ConfT conf,
                                          StatsLogger statsLogger) {
         super(componentName, conf);
         this.statsLogger = statsLogger;
+    }
+
+    @Override
+    public void setExceptionHandler(UncaughtExceptionHandler handler) {
+        this.uncaughtExceptionHandler = handler;
     }
 
     protected StatsLogger getStatsLogger() {

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/LifecycleComponent.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/LifecycleComponent.java
@@ -18,6 +18,8 @@
 
 package org.apache.bookkeeper.common.component;
 
+import java.lang.Thread.UncaughtExceptionHandler;
+
 /**
  * A component based on lifecycle management.
  */
@@ -36,4 +38,13 @@ public interface LifecycleComponent extends AutoCloseable {
     void stop();
 
     void close();
+
+    /**
+     * Set the default handler invoked when a lifecycle component
+     * abruptly terminates due an uncaught exception.
+     *
+     * @param handler handler invoked when an uncaught exception happens
+     *                in the lifecycle component.
+     */
+    void setExceptionHandler(UncaughtExceptionHandler handler);
 }

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/LifecycleComponentStack.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/LifecycleComponentStack.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.List;
 
 /**
@@ -120,5 +121,10 @@ public class LifecycleComponentStack implements LifecycleComponent {
     @Override
     public void close() {
         components.reverse().forEach(component -> component.close());
+    }
+
+    @Override
+    public void setExceptionHandler(UncaughtExceptionHandler handler) {
+        components.forEach(component -> component.setExceptionHandler(handler));
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
@@ -27,21 +27,26 @@ package org.apache.bookkeeper.bookie;
 @SuppressWarnings("serial")
 public abstract class BookieException extends Exception {
 
-    private int code;
+    private final int code;
+
     public BookieException(int code) {
+        super();
         this.code = code;
     }
 
     public BookieException(int code, Throwable t) {
         super(t);
+        this.code = code;
     }
 
     public BookieException(int code, String reason) {
         super(reason);
+        this.code = code;
     }
 
     public BookieException(int code, String reason, Throwable t) {
         super(reason, t);
+        this.code = code;
     }
 
     public static BookieException create(int code) {
@@ -62,8 +67,6 @@ public abstract class BookieException extends Exception {
             return new MetadataStoreException();
         case Code.UnknownBookieIdException:
             return new UnknownBookieIdException();
-        case Code.BookieDeadException:
-            return new BookieDeadException();
         default:
             return new BookieIllegalOpException();
         }
@@ -85,11 +88,6 @@ public abstract class BookieException extends Exception {
         int MetadataStoreException = -106;
         int UnknownBookieIdException = -107;
         int OperationRejectedException = -108;
-        int BookieDeadException = -109;
-    }
-
-    public void setCode(int code) {
-        this.code = code;
     }
 
     public int getCode() {
@@ -303,17 +301,4 @@ public abstract class BookieException extends Exception {
         }
     }
 
-    /**
-     * Signal when bookie is not running any more.
-     */
-    public static class BookieDeadException extends BookieException {
-
-        public BookieDeadException() {
-            super(Code.BookieDeadException);
-        }
-
-        public BookieDeadException(String msg) {
-            super(Code.BookieDeadException, msg);
-        }
-    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
@@ -62,6 +62,8 @@ public abstract class BookieException extends Exception {
             return new MetadataStoreException();
         case Code.UnknownBookieIdException:
             return new UnknownBookieIdException();
+        case Code.BookieDeadException:
+            return new BookieDeadException();
         default:
             return new BookieIllegalOpException();
         }
@@ -83,6 +85,7 @@ public abstract class BookieException extends Exception {
         int MetadataStoreException = -106;
         int UnknownBookieIdException = -107;
         int OperationRejectedException = -108;
+        int BookieDeadException = -109;
     }
 
     public void setCode(int code) {
@@ -297,6 +300,20 @@ public abstract class BookieException extends Exception {
 
         public UnknownBookieIdException(Throwable cause) {
             super(Code.UnknownBookieIdException, cause);
+        }
+    }
+
+    /**
+     * Signal when bookie is not running any more.
+     */
+    public static class BookieDeadException extends BookieException {
+
+        public BookieDeadException() {
+            super(Code.BookieDeadException);
+        }
+
+        public BookieDeadException(String msg) {
+            super(Code.BookieDeadException, msg);
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -255,6 +255,12 @@ public class BookieServer {
         DeathWatcher(ServerConfiguration conf) {
             super("BookieDeathWatcher-" + conf.getBookiePort());
             watchInterval = conf.getDeathWatchInterval();
+            // set a default uncaught exception handler to shutdown the bookie server
+            // when it notices the bookie is not running any more.
+            setUncaughtExceptionHandler((thread, cause) -> {
+                shutdown();
+                LOG.info("BookieDeathWatcher exited loop!");
+            });
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -258,8 +258,9 @@ public class BookieServer {
             // set a default uncaught exception handler to shutdown the bookie server
             // when it notices the bookie is not running any more.
             setUncaughtExceptionHandler((thread, cause) -> {
+                LOG.info("BookieDeathWatcher exited loop due to uncaught exception from thread {}",
+                    thread.getName(), cause);
                 shutdown();
-                LOG.info("BookieDeathWatcher exited loop!");
             });
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/BookieService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/BookieService.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.server.service;
 
 import java.io.IOException;
+import java.lang.Thread.UncaughtExceptionHandler;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
@@ -40,6 +41,11 @@ public class BookieService extends ServerLifecycleComponent {
             throws Exception {
         super(NAME, conf, statsLogger);
         this.server = new BookieServer(conf.getServerConf(), statsLogger);
+    }
+
+    @Override
+    public void setExceptionHandler(UncaughtExceptionHandler handler) {
+        server.setExceptionHandler(handler);
     }
 
     public BookieServer getServer() {


### PR DESCRIPTION
Descriptions of the changes in this PR:

 ### Motivation

Fixes the issue at #1540.

If Bookie/BookieServer components are shutdown internally because of any fatal errors
(ExitCode - INVALID_CONF, SERVER_EXCEPTION, ZK_EXPIRED, ZK_REG_FAIL, BOOKIE_EXCEPTION) then
it will go through shutdown method logic and shutdowns components internal to Bookie/BookieServer
but it will not succeed in bringing down the bookie process.

This is because in BookieServer.main / server.Main.doMain it would wait for the startComponent
future to complete
http://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java#L227 .
The startComponent future will be market complete only in runtime shutdownhook -
https://github.com/apache/bookkeeper/blob/master/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java#L66.

But the problem is nowhere in Bookie/BookieProcess shutdown we are calling System.exit() and hence
the runtime shutdownhook is not executed to mark the startComponent future to complete. Hence
Main.doMain will wait forever on this future though Bookie/BookieServer components are shutdown
because of known fatal errors.

 ### Regression

Issue #508 introduced this regression. Before this change, the main thread is blocking using `BookieServer#join()`.
When bookie is dead for any reason, the DeathWatchThread will kill the bookie and bookie server. so the main thread will quite.
However after #508 is introduced, the lifecycle management is disconnected from the bookie and bookie server. so when they are dead,
lifecycle management is unaware of the situation and the main thread doesn't quite.

 ### Changes

- Add `UncaughtExceptionHandler` to lifecycle components
- When a lifecycle component hits an error, it can use `UncaughtExceptionHandler` to notify lifecycle component stack to shutdown the whole stack



Master Issue: #1540 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
