### PR TITLE
Issue 1537: fix distributedlog incubator link

### DIFF
--- a/site/docs/4.5.0/api/distributedlog-api.md
+++ b/site/docs/4.5.0/api/distributedlog-api.md
@@ -81,7 +81,7 @@ The DistributedLog API for BookKeeper provides a number of guarantees for applic
 
 ## API
 
-Documentation for the DistributedLog API can be found [here](https://distributedlog.incubator.apache.org/docs/latest/user_guide/api/core).
+Documentation for the DistributedLog API can be found [here](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/api/core).
 
 > At a later date, the DistributedLog API docs will be added here.
 

--- a/site/docs/4.5.0/overview/releaseNotes.md
+++ b/site/docs/4.5.0/overview/releaseNotes.md
@@ -79,7 +79,7 @@ The second change provides a new `long poll` read API, allowing tailing-reads wi
 Although `long poll` API brings great latency improvements on tailing reads, it is still a very low-level primitive.
 It is still recommended to use high level API (e.g. [DistributedLog API](../../api/distributedlog-api)) for tailing and streaming use cases.
 
-See [Streaming Reads](https://distributedlog.incubator.apache.org/docs/latest/user_guide/design/main.html#streaming-reads) for more details.
+See [Streaming Reads](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/design/main.html#streaming-reads) for more details.
 
 #### Explicit LAC
 

--- a/site/docs/4.5.1/api/distributedlog-api.md
+++ b/site/docs/4.5.1/api/distributedlog-api.md
@@ -81,7 +81,7 @@ The DistributedLog API for BookKeeper provides a number of guarantees for applic
 
 ## API
 
-Documentation for the DistributedLog API can be found [here](https://distributedlog.incubator.apache.org/docs/latest/user_guide/api/core).
+Documentation for the DistributedLog API can be found [here](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/api/core).
 
 > At a later date, the DistributedLog API docs will be added here.
 

--- a/site/docs/4.6.0/api/distributedlog-api.md
+++ b/site/docs/4.6.0/api/distributedlog-api.md
@@ -81,7 +81,7 @@ The DistributedLog API for BookKeeper provides a number of guarantees for applic
 
 ## API
 
-Documentation for the DistributedLog API can be found [here](https://distributedlog.incubator.apache.org/docs/latest/user_guide/api/core).
+Documentation for the DistributedLog API can be found [here](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/api/core).
 
 > At a later date, the DistributedLog API docs will be added here.
 

--- a/site/docs/4.6.1/api/distributedlog-api.md
+++ b/site/docs/4.6.1/api/distributedlog-api.md
@@ -81,7 +81,7 @@ The DistributedLog API for BookKeeper provides a number of guarantees for applic
 
 ## API
 
-Documentation for the DistributedLog API can be found [here](https://distributedlog.incubator.apache.org/docs/latest/user_guide/api/core).
+Documentation for the DistributedLog API can be found [here](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/api/core).
 
 > At a later date, the DistributedLog API docs will be added here.
 

--- a/site/docs/4.6.2/api/distributedlog-api.md
+++ b/site/docs/4.6.2/api/distributedlog-api.md
@@ -81,7 +81,7 @@ The DistributedLog API for BookKeeper provides a number of guarantees for applic
 
 ## API
 
-Documentation for the DistributedLog API can be found [here](https://distributedlog.incubator.apache.org/docs/latest/user_guide/api/core).
+Documentation for the DistributedLog API can be found [here](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/api/core).
 
 > At a later date, the DistributedLog API docs will be added here.
 

--- a/site/docs/4.7.0/api/distributedlog-api.md
+++ b/site/docs/4.7.0/api/distributedlog-api.md
@@ -81,7 +81,7 @@ The DistributedLog API for BookKeeper provides a number of guarantees for applic
 
 ## API
 
-Documentation for the DistributedLog API can be found [here](https://distributedlog.incubator.apache.org/docs/latest/user_guide/api/core).
+Documentation for the DistributedLog API can be found [here](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/api/core).
 
 > At a later date, the DistributedLog API docs will be added here.
 

--- a/site/docs/4.7.1/api/distributedlog-api.md
+++ b/site/docs/4.7.1/api/distributedlog-api.md
@@ -81,7 +81,7 @@ The DistributedLog API for BookKeeper provides a number of guarantees for applic
 
 ## API
 
-Documentation for the DistributedLog API can be found [here](https://distributedlog.incubator.apache.org/docs/latest/user_guide/api/core).
+Documentation for the DistributedLog API can be found [here](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/api/core).
 
 > At a later date, the DistributedLog API docs will be added here.
 

--- a/site/docs/latest/api/distributedlog-api.md
+++ b/site/docs/latest/api/distributedlog-api.md
@@ -81,7 +81,7 @@ The DistributedLog API for BookKeeper provides a number of guarantees for applic
 
 ## API
 
-Documentation for the DistributedLog API can be found [here](https://distributedlog.incubator.apache.org/docs/latest/user_guide/api/core).
+Documentation for the DistributedLog API can be found [here](https://bookkeeper.apache.org/distributedlog/docs/latest/user_guide/api/core).
 
 > At a later date, the DistributedLog API docs will be added here.
 


### PR DESCRIPTION
Descriptions of the changes in this PR:
### Motivation

In bookkeeper website, we are still using incubator locations for dlog references. we should change it to http://bookkeeper.apache.org/distributedlog

### Changes
change links from
`https://distributedlog.incubator.apache.org`
to
`https://bookkeeper.apache.org/distributedlog`

Master Issue: #1537 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [x] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [x] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [x] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [x] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [x] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [x] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [x] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [x] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.

