### PR TITLE
Issue 1538: Expose MetricsServer in http server

### DIFF
--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
@@ -29,76 +29,76 @@ import java.util.Map;
  */
 public abstract class HttpRouter<Handler> {
 
-  // Define endpoints here.
-  public static final String HEARTBEAT                    = "/heartbeat";
-  public static final String SERVER_CONFIG                = "/api/v1/config/server_config";
-  public static final String METRICS                      = "/metrics";
-
-  // ledger
-  public static final String DELETE_LEDGER                = "/api/v1/ledger/delete";
-  public static final String LIST_LEDGER                  = "/api/v1/ledger/list";
-  public static final String GET_LEDGER_META              = "/api/v1/ledger/metadata";
-  public static final String READ_LEDGER_ENTRY            = "/api/v1/ledger/read";
-  // bookie
-  public static final String LIST_BOOKIES                 = "/api/v1/bookie/list_bookies";
-  public static final String LIST_BOOKIE_INFO             = "/api/v1/bookie/list_bookie_info";
-  public static final String LAST_LOG_MARK                = "/api/v1/bookie/last_log_mark";
-  public static final String LIST_DISK_FILE               = "/api/v1/bookie/list_disk_file";
-  public static final String EXPAND_STORAGE               = "/api/v1/bookie/expand_storage";
-  // autorecovery
-  public static final String RECOVERY_BOOKIE              = "/api/v1/autorecovery/bookie";
-  public static final String LIST_UNDER_REPLICATED_LEDGER = "/api/v1/autorecovery/list_under_replicated_ledger";
-  public static final String WHO_IS_AUDITOR               = "/api/v1/autorecovery/who_is_auditor";
-  public static final String TRIGGER_AUDIT                = "/api/v1/autorecovery/trigger_audit";
-  public static final String LOST_BOOKIE_RECOVERY_DELAY   = "/api/v1/autorecovery/lost_bookie_recovery_delay";
-  public static final String DECOMMISSION                 = "/api/v1/autorecovery/decommission";
-
-
-  private final Map<String, Handler> endpointHandlers = new HashMap<>();
-
-  public HttpRouter(AbstractHttpHandlerFactory<Handler> handlerFactory) {
-    this.endpointHandlers.put(HEARTBEAT, handlerFactory.newHandler(HttpServer.ApiType.HEARTBEAT));
-    this.endpointHandlers.put(SERVER_CONFIG, handlerFactory.newHandler(HttpServer.ApiType.SERVER_CONFIG));
-    this.endpointHandlers.put(METRICS, handlerFactory.newHandler(HttpServer.ApiType.METRICS));
+    // Define endpoints here.
+    public static final String HEARTBEAT                    = "/heartbeat";
+    public static final String SERVER_CONFIG                = "/api/v1/config/server_config";
+    public static final String METRICS                      = "/metrics";
 
     // ledger
-    this.endpointHandlers.put(DELETE_LEDGER, handlerFactory.newHandler(HttpServer.ApiType.DELETE_LEDGER));
-    this.endpointHandlers.put(LIST_LEDGER, handlerFactory.newHandler(HttpServer.ApiType.LIST_LEDGER));
-    this.endpointHandlers.put(GET_LEDGER_META, handlerFactory.newHandler(HttpServer.ApiType.GET_LEDGER_META));
-    this.endpointHandlers.put(READ_LEDGER_ENTRY, handlerFactory.newHandler(HttpServer.ApiType.READ_LEDGER_ENTRY));
-
+    public static final String DELETE_LEDGER                = "/api/v1/ledger/delete";
+    public static final String LIST_LEDGER                  = "/api/v1/ledger/list";
+    public static final String GET_LEDGER_META              = "/api/v1/ledger/metadata";
+    public static final String READ_LEDGER_ENTRY            = "/api/v1/ledger/read";
     // bookie
-    this.endpointHandlers.put(LIST_BOOKIES, handlerFactory.newHandler(HttpServer.ApiType.LIST_BOOKIES));
-    this.endpointHandlers.put(LIST_BOOKIE_INFO, handlerFactory.newHandler(HttpServer.ApiType.LIST_BOOKIE_INFO));
-    this.endpointHandlers.put(LAST_LOG_MARK, handlerFactory.newHandler(HttpServer.ApiType.LAST_LOG_MARK));
-    this.endpointHandlers.put(LIST_DISK_FILE, handlerFactory.newHandler(HttpServer.ApiType.LIST_DISK_FILE));
-    this.endpointHandlers.put(EXPAND_STORAGE, handlerFactory.newHandler(HttpServer.ApiType.EXPAND_STORAGE));
-
+    public static final String LIST_BOOKIES                 = "/api/v1/bookie/list_bookies";
+    public static final String LIST_BOOKIE_INFO             = "/api/v1/bookie/list_bookie_info";
+    public static final String LAST_LOG_MARK                = "/api/v1/bookie/last_log_mark";
+    public static final String LIST_DISK_FILE               = "/api/v1/bookie/list_disk_file";
+    public static final String EXPAND_STORAGE               = "/api/v1/bookie/expand_storage";
     // autorecovery
-    this.endpointHandlers.put(RECOVERY_BOOKIE, handlerFactory.newHandler(HttpServer.ApiType.RECOVERY_BOOKIE));
-    this.endpointHandlers.put(LIST_UNDER_REPLICATED_LEDGER,
-      handlerFactory.newHandler(HttpServer.ApiType.LIST_UNDER_REPLICATED_LEDGER));
-    this.endpointHandlers.put(WHO_IS_AUDITOR, handlerFactory.newHandler(HttpServer.ApiType.WHO_IS_AUDITOR));
-    this.endpointHandlers.put(TRIGGER_AUDIT, handlerFactory.newHandler(HttpServer.ApiType.TRIGGER_AUDIT));
-    this.endpointHandlers.put(LOST_BOOKIE_RECOVERY_DELAY,
-      handlerFactory.newHandler(HttpServer.ApiType.LOST_BOOKIE_RECOVERY_DELAY));
-    this.endpointHandlers.put(DECOMMISSION, handlerFactory.newHandler(HttpServer.ApiType.DECOMMISSION));
-  }
+    public static final String RECOVERY_BOOKIE              = "/api/v1/autorecovery/bookie";
+    public static final String LIST_UNDER_REPLICATED_LEDGER = "/api/v1/autorecovery/list_under_replicated_ledger";
+    public static final String WHO_IS_AUDITOR               = "/api/v1/autorecovery/who_is_auditor";
+    public static final String TRIGGER_AUDIT                = "/api/v1/autorecovery/trigger_audit";
+    public static final String LOST_BOOKIE_RECOVERY_DELAY   = "/api/v1/autorecovery/lost_bookie_recovery_delay";
+    public static final String DECOMMISSION                 = "/api/v1/autorecovery/decommission";
 
-  /**
-   * Bind all endpoints to corresponding handlers.
-   */
-  public void bindAll() {
-    for (Map.Entry<String, Handler> entry : endpointHandlers.entrySet()) {
-      bindHandler(entry.getKey(), entry.getValue());
+
+    private final Map<String, Handler> endpointHandlers = new HashMap<>();
+
+    public HttpRouter(AbstractHttpHandlerFactory<Handler> handlerFactory) {
+        this.endpointHandlers.put(HEARTBEAT, handlerFactory.newHandler(HttpServer.ApiType.HEARTBEAT));
+        this.endpointHandlers.put(SERVER_CONFIG, handlerFactory.newHandler(HttpServer.ApiType.SERVER_CONFIG));
+        this.endpointHandlers.put(METRICS, handlerFactory.newHandler(HttpServer.ApiType.METRICS));
+
+        // ledger
+        this.endpointHandlers.put(DELETE_LEDGER, handlerFactory.newHandler(HttpServer.ApiType.DELETE_LEDGER));
+        this.endpointHandlers.put(LIST_LEDGER, handlerFactory.newHandler(HttpServer.ApiType.LIST_LEDGER));
+        this.endpointHandlers.put(GET_LEDGER_META, handlerFactory.newHandler(HttpServer.ApiType.GET_LEDGER_META));
+        this.endpointHandlers.put(READ_LEDGER_ENTRY, handlerFactory.newHandler(HttpServer.ApiType.READ_LEDGER_ENTRY));
+
+        // bookie
+        this.endpointHandlers.put(LIST_BOOKIES, handlerFactory.newHandler(HttpServer.ApiType.LIST_BOOKIES));
+        this.endpointHandlers.put(LIST_BOOKIE_INFO, handlerFactory.newHandler(HttpServer.ApiType.LIST_BOOKIE_INFO));
+        this.endpointHandlers.put(LAST_LOG_MARK, handlerFactory.newHandler(HttpServer.ApiType.LAST_LOG_MARK));
+        this.endpointHandlers.put(LIST_DISK_FILE, handlerFactory.newHandler(HttpServer.ApiType.LIST_DISK_FILE));
+        this.endpointHandlers.put(EXPAND_STORAGE, handlerFactory.newHandler(HttpServer.ApiType.EXPAND_STORAGE));
+
+        // autorecovery
+        this.endpointHandlers.put(RECOVERY_BOOKIE, handlerFactory.newHandler(HttpServer.ApiType.RECOVERY_BOOKIE));
+        this.endpointHandlers.put(LIST_UNDER_REPLICATED_LEDGER,
+            handlerFactory.newHandler(HttpServer.ApiType.LIST_UNDER_REPLICATED_LEDGER));
+        this.endpointHandlers.put(WHO_IS_AUDITOR, handlerFactory.newHandler(HttpServer.ApiType.WHO_IS_AUDITOR));
+        this.endpointHandlers.put(TRIGGER_AUDIT, handlerFactory.newHandler(HttpServer.ApiType.TRIGGER_AUDIT));
+        this.endpointHandlers.put(LOST_BOOKIE_RECOVERY_DELAY,
+            handlerFactory.newHandler(HttpServer.ApiType.LOST_BOOKIE_RECOVERY_DELAY));
+        this.endpointHandlers.put(DECOMMISSION, handlerFactory.newHandler(HttpServer.ApiType.DECOMMISSION));
     }
-  }
 
-  /**
-   * Bind the given endpoint to its corresponding handlers.
-   * @param endpoint http endpoint
-   * @param handler http handler
-   */
-  public abstract void bindHandler(String endpoint, Handler handler);
+    /**
+     * Bind all endpoints to corresponding handlers.
+     */
+    public void bindAll() {
+        for (Map.Entry<String, Handler> entry : endpointHandlers.entrySet()) {
+            bindHandler(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Bind the given endpoint to its corresponding handlers.
+     * @param endpoint http endpoint
+     * @param handler http handler
+     */
+    public abstract void bindHandler(String endpoint, Handler handler);
 
 }

--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
@@ -32,7 +32,7 @@ public abstract class HttpRouter<Handler> {
   // Define endpoints here.
   public static final String HEARTBEAT                    = "/heartbeat";
   public static final String SERVER_CONFIG                = "/api/v1/config/server_config";
-  public static final String METRICS                      = "/api/v1/metrics";
+  public static final String METRICS                      = "/metrics";
 
   // ledger
   public static final String DELETE_LEDGER                = "/api/v1/ledger/delete";

--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
@@ -32,6 +32,7 @@ public abstract class HttpRouter<Handler> {
   // Define endpoints here.
   public static final String HEARTBEAT                    = "/heartbeat";
   public static final String SERVER_CONFIG                = "/api/v1/config/server_config";
+  public static final String METRICS                      = "/api/v1/metrics";
 
   // ledger
   public static final String DELETE_LEDGER                = "/api/v1/ledger/delete";
@@ -58,6 +59,7 @@ public abstract class HttpRouter<Handler> {
   public HttpRouter(AbstractHttpHandlerFactory<Handler> handlerFactory) {
     this.endpointHandlers.put(HEARTBEAT, handlerFactory.newHandler(HttpServer.ApiType.HEARTBEAT));
     this.endpointHandlers.put(SERVER_CONFIG, handlerFactory.newHandler(HttpServer.ApiType.SERVER_CONFIG));
+    this.endpointHandlers.put(METRICS, handlerFactory.newHandler(HttpServer.ApiType.METRICS));
 
     // ledger
     this.endpointHandlers.put(DELETE_LEDGER, handlerFactory.newHandler(HttpServer.ApiType.DELETE_LEDGER));

--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/service/NullHttpService.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/service/NullHttpService.java
@@ -20,12 +20,16 @@
  */
 package org.apache.bookkeeper.http.service;
 
+import org.apache.bookkeeper.http.HttpServer;
+
 /**
- * HttpEndpointService that return empty content.
+ * HttpEndpointService that return fixed content.
  */
 public class NullHttpService implements HttpEndpointService {
+    public static final String CONTENT = "NullHttpService\n";
+
     @Override
     public HttpServiceResponse handle(HttpServiceRequest request) {
-        return new HttpServiceResponse();
+        return new HttpServiceResponse(CONTENT, HttpServer.StatusCode.OK);
     }
 }

--- a/bookkeeper-http/vertx-http-server/src/test/java/org/apache/bookkeeper/http/vertx/TestVertxHttpServer.java
+++ b/bookkeeper-http/vertx-http-server/src/test/java/org/apache/bookkeeper/http/vertx/TestVertxHttpServer.java
@@ -58,6 +58,21 @@ public class TestVertxHttpServer {
         httpServer.stopServer();
     }
 
+    @Test
+    public void testStartMetricsServiceOnRouterPath() throws Exception {
+        VertxHttpServer httpServer = new VertxHttpServer();
+        HttpServiceProvider httpServiceProvider = NullHttpServiceProvider.getInstance();
+        httpServer.initialize(httpServiceProvider);
+        int port = getNextPort();
+        while (!httpServer.startServer(port)) {
+            httpServer.stopServer();
+            port = getNextPort();
+        }
+        HttpResponse httpResponse = sendGet(getUrl(port, HttpRouter.METRICS));
+        assertEquals(HttpServer.StatusCode.OK.getValue(), httpResponse.responseCode);
+        httpServer.stopServer();
+    }
+
     // HTTP GET request
     private HttpResponse sendGet(String url) throws IOException {
         URL obj = new URL(url);

--- a/site/docs/latest/admin/http.md
+++ b/site/docs/latest/admin/http.md
@@ -60,6 +60,19 @@ Currently all the HTTP endpoints could be divided into these 4 components:
         |403 | Permission denied |
         |404 | Not found |
 
+## Config
+
+### Endpoint: /api/v1/metrics
+1. Method: GET
+    * Description: Get all metrics by calling `writeAllMetrics()` of `statsProvider` internally
+    * Response:  
+    
+        | Code   | Description |
+        |:-------|:------------|
+        |200 | Successful operation |
+        |403 | Permission denied |
+        |404 | Not found |
+
 ## Ledger
 
 ### Endpoint: /api/v1/ledger/delete/?ledger_id=&lt;ledger_id&gt;

--- a/site/docs/latest/admin/http.md
+++ b/site/docs/latest/admin/http.md
@@ -62,7 +62,7 @@ Currently all the HTTP endpoints could be divided into these 4 components:
 
 ## Config
 
-### Endpoint: /api/v1/metrics
+### Endpoint: /metrics
 1. Method: GET
     * Description: Get all metrics by calling `writeAllMetrics()` of `statsProvider` internally
     * Response:  


### PR DESCRIPTION
Descriptions of the changes in this PR:

Expose MetricsServer in  http server under `/metrics`


> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [X] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [X] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [X] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [X] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [X] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---
