### PR TITLE
Issue 1542: Unable to run 'bookkeeper' shell script from /bookkeeper/bin folder

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -181,9 +181,9 @@ add_maven_deps_to_classpath() {
   # Need to generate classpath from maven pom. This is costly so generate it
   # and cache it. Save the file into our target dir so a mvn clean will get
   # clean it up and force us create a new one.
-  f="${MODULE_PATH}/target/cached_classpath.txt"
+  f="${BK_HOME}/${MODULE_PATH}/target/cached_classpath.txt"
   if [ ! -f ${f} ]; then
-    ${MVN} -f "${MODULE_PATH}/pom.xml" -Dstream dependency:build-classpath -Dmdep.outputFile="target/cached_classpath.txt" &> /dev/null
+    ${MVN} -f "${BK_HOME}/${MODULE_PATH}/pom.xml" -Dstream dependency:build-classpath -Dmdep.outputFile="target/cached_classpath.txt" &> /dev/null
   fi
 }
 
@@ -197,7 +197,7 @@ set_module_classpath() {
     echo ${BK_CLASSPATH}
   else
     add_maven_deps_to_classpath ${MODULE_PATH} >&2
-    cat ${MODULE_PATH}/target/cached_classpath.txt
+    cat ${BK_HOME}/${MODULE_PATH}/target/cached_classpath.txt
   fi
   return
 }

--- a/tests/scripts/src/test/bash/bk_test_bin_common.sh
+++ b/tests/scripts/src/test/bash/bk_test_bin_common.sh
@@ -172,6 +172,28 @@ testLoadEnvfiles() {
   unset BK_HOME
 }
 
+testSetModuleClasspath() {
+  TEST_DIR=${BK_TMPDIR}/test_set_module_classpath
+  mkdir -p ${TEST_DIR}
+  BK_HOME=${TEST_DIR}
+
+  # prepare the env files
+  mkdir -p ${BK_HOME}/conf
+  echo "" > ${BK_HOME}/conf/nettyenv.sh
+  echo "" > ${BK_HOME}/conf/bkenv.sh
+  echo "" > ${BK_HOME}/conf/bk_cli_env.sh
+
+  source ${BK_BINDIR}/common.sh
+
+  MODULE_PATH="testmodule"
+
+  mkdir -p ${BK_HOME}/${MODULE_PATH}/target
+  echo "test-classpath" > ${BK_HOME}/${MODULE_PATH}/target/cached_classpath.txt
+
+  local result=$(set_module_classpath ${MODULE_PATH})
+  assertEquals "test-classpath" ${result}
+}
+
 testBuildBookieJVMOpts() {
   source ${BK_BINDIR}/common.sh
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

*Bug*

```
Getting NoClassDefFoundError while trying to run 'bookkeeper' shell script from 'bin' folder. Issue seems to be related with classpath (cached classpath file - cached_classpath.txt)

~/Workspace/Community/bookkeeper/bin$ ./bookkeeper shell
JAVA_HOME not set, using java from PATH. (/usr/bin/java)
cat: bookkeeper-server/target/cached_classpath.txt: No such file or directory
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/configuration/Configuration
at java.lang.Class.getDeclaredMethods0(Native Method)
at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
at java.lang.Class.getMethod0(Class.java:3018)
at java.lang.Class.getMethod(Class.java:1784)
at sun.launcher.LauncherHelper.validateMainClass(LauncherHelper.java:544)
at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:526)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.configuration.Configuration
at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
... 7 more
```

*Motivation*

Fixes #1542

*Problem*

`bin/common.sh` uses a relative path for caching classpath and locating the pom file.

*Changes*

- change to use full path for cached classpath file and the module pom file
- add a test case to cover this problem

Master Issue: #1542 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [x] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [x] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [x] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [x] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [x] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [x] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [x] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [x] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
