### PR TITLE
ISSUE #1559: Fix for moveLedgerIndexFile logic in relocateIndexFileAndFlushHeader

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -317,13 +317,8 @@ public class LedgerDirsManager {
     }
 
     boolean isDirWritableForNewIndexFile(File indexDir) {
-        List<File> writableDirsForNewIndexFile;
-        try {
-            writableDirsForNewIndexFile = getDirsAboveUsableThresholdSize(minUsableSizeForIndexFileCreation, true);
-        } catch (NoWritableLedgerDirException nwe) {
-            return false;
-        }
-        return writableDirsForNewIndexFile.contains(indexDir);
+        return (ledgerDirectories.contains(indexDir)
+                && (indexDir.getUsableSpace() > minUsableSizeForIndexFileCreation));
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -316,6 +316,16 @@ public class LedgerDirsManager {
         return pickRandomDir(writableDirsForNewIndexFile, excludedDir);
     }
 
+    boolean isDirWritableForNewIndexFile(File indexDir) {
+        List<File> writableDirsForNewIndexFile;
+        try {
+            writableDirsForNewIndexFile = getDirsAboveUsableThresholdSize(minUsableSizeForIndexFileCreation, true);
+        } catch (NoWritableLedgerDirException nwe) {
+            return false;
+        }
+        return writableDirsForNewIndexFile.contains(indexDir);
+    }
+
     /**
      * Return one dir from all dirs, regardless writable or not.
      */


### PR DESCRIPTION
Descriptions of the changes in this PR:

- In IndexPersistenceMgr.relocateIndexFileAndFlushHeader, if the
currentDir is full and if it is the only indexDir which is
eligible for newIndexFile creation then instead of failing with
NoWritableLedgerDirException it should flushHeader without trying
to move LedgerIndexFile.

Master Issue: #1559 
