### PR TITLE
Issue-1563 Spammy logs on Bookie in ReadEntryProcessorV3 in case of tailing reader on empty ledger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -221,8 +221,8 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
         } catch (Bookie.NoLedgerException e) {
             if (RequestUtils.isFenceRequest(readRequest)) {
                 LOG.info("No ledger found reading entry {} when fencing ledger {}", entryId, ledgerId);
-            } else {
-                LOG.info("No ledger found while reading entry: {} from ledger: {}", entryId, ledgerId);
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug("No ledger found while reading entry: {} from ledger: {}", entryId, ledgerId);
             }
             return buildResponse(readResponse, StatusCode.ENOLEDGER, startTimeSw);
         } catch (Bookie.NoEntryException e) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -221,7 +221,10 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
         } catch (Bookie.NoLedgerException e) {
             if (RequestUtils.isFenceRequest(readRequest)) {
                 LOG.info("No ledger found reading entry {} when fencing ledger {}", entryId, ledgerId);
+            } else if (entryId != BookieProtocol.LAST_ADD_CONFIRMED) {
+                LOG.info("No ledger found while reading entry: {} from ledger: {}", entryId, ledgerId);
             } else if (LOG.isDebugEnabled()) {
+                // this is the case of a reader which is calling readLastAddConfirmed and the ledger is empty
                 LOG.debug("No ledger found while reading entry: {} from ledger: {}", entryId, ledgerId);
             }
             return buildResponse(readResponse, StatusCode.ENOLEDGER, startTimeSw);


### PR DESCRIPTION
Descriptions of the changes in this PR:
### Motivation

In case of an empty ledger the bookie floods the disk with an useless message.

### Changes

Make that line "No ledger found while reading entry" to be logged at 'debug' level.

Master issue #1563 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [x] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [x] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [x] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [x] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [x] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [x] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

