### PR TITLE
Restore JaCoCo configuration on bookkeeper-server module

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -185,24 +185,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
-        <configuration>
-          <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true</argLine>
-          <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
-          <reuseForks>false</reuseForks>
-          <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
-          <rerunFailingTestsCount>2</rerunFailingTestsCount>
-          <properties>
-            <property>
-              <name>listener</name>
-              <value>org.apache.bookkeeper.common.testing.util.TimedOutTestsListener</value>
-            </property>
-          </properties>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>


### PR DESCRIPTION
With commit  c5a3621 - Sijie Guo <sijie@apache.org>
Move TimedOutTestsListener from dlog to bookkeeper-common

We had overwritten surefire configuration on mostly every profile in bookkeeper-server module and this disabled JaCoCo agent which is activated using 'code-coverage' Maven profile.

This change forces surefire configuration in case of 'code-coverage' profile