### PR TITLE
Use readExplicitLAC instead of readEntry in order to get current LastAddConfirmed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
@@ -48,6 +48,7 @@ class ClientInternalConf {
     final long timeoutMonitorIntervalSec;
     final boolean enableBookieFailureTracking;
     final boolean useV2WireProtocol;
+    final boolean useExplicitLacForReads;
 
     static ClientInternalConf defaultValues() {
         return fromConfig(new ClientConfiguration());
@@ -79,6 +80,7 @@ class ClientInternalConf {
         this.maxAllowedEnsembleChanges = conf.getMaxAllowedEnsembleChanges();
         this.timeoutMonitorIntervalSec = conf.getTimeoutMonitorIntervalSec();
         this.enableBookieFailureTracking = conf.getEnableBookieFailureTracking();
+        this.useExplicitLacForReads = conf.isUseExplicitLacForReads();
         this.useV2WireProtocol = conf.getUseV2WireProtocol();
 
         if (conf.getFirstSpeculativeReadTimeout() > 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1338,11 +1338,11 @@ public class LedgerHandle implements WriteHandle {
         if (clientCtx.getConf().useExplicitLacForReads) {
             asyncReadExplicitLastConfirmed(cb, ctx);
         } else {
-            asyncReadLastConfirmedInternal(cb, ctx);
+            asyncReadPiggybackLastConfirmed(cb, ctx);
         }
     }
 
-    private void asyncReadLastConfirmedInternal(final ReadLastConfirmedCallback cb, final Object ctx) {
+    private void asyncReadPiggybackLastConfirmed(final ReadLastConfirmedCallback cb, final Object ctx) {
         boolean isClosed;
         long lastEntryId;
         synchronized (this) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1388,11 +1388,11 @@ public class LedgerHandle implements WriteHandle {
         if (clientCtx.getConf().useExplicitLacForReads) {
             asyncTryReadExplicitLastConfirmed(cb, ctx);
         } else {
-            asyncTryReadLastConfirmedInternal(cb, ctx);
+            asyncTryReadPiggybackLastConfirmed(cb, ctx);
         }
     }
 
-    private void asyncTryReadLastConfirmedInternal(final ReadLastConfirmedCallback cb, final Object ctx) {
+    private void asyncTryReadPiggybackLastConfirmed(final ReadLastConfirmedCallback cb, final Object ctx) {
         boolean isClosed;
         long lastEntryId;
         synchronized (this) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryPendingReadLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryPendingReadLacOp.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This op is try to read last confirmed without involving quorum coverage checking.
- * Use {@link PendingLacOp} if you need quorum coverage checking.
+ * Use {@link PendingReadLacOp} if you need quorum coverage checking.
  */
 
 class TryPendingReadLacOp implements ReadLacCallback {
@@ -104,9 +104,9 @@ class TryPendingReadLacOp implements ReadLacCallback {
                 // Extract lac from last entry on the disk
                 if (lastEntryBuffer != null && lastEntryBuffer.readableBytes() > 0) {
                     RecoveryData recoveryData = lh.macManager.verifyDigestAndReturnLastConfirmed(lastEntryBuffer);
-                    long recoveredLac = recoveryData.getLastAddConfirmed();
-                    if (recoveredLac > maxLac) {
-                        newLac = recoveredLac;
+                    long piggyBackedLAC = recoveryData.getLastAddConfirmed();
+                    if (piggyBackedLAC > newLac) {
+                        newLac = piggyBackedLAC;
                     }
                 }
                 if (newLac > maxLac) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryPendingReadLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryPendingReadLacOp.java
@@ -67,7 +67,6 @@ class TryPendingReadLacOp implements ReadLacCallback {
     public void readLacComplete(int rc, long ledgerId, final ByteBuf lacBuffer, final ByteBuf lastEntryBuffer,
             Object ctx) {
         int bookieIndex = (Integer) ctx;
-        LOG.info("readLacComplete "+rc+", "+ledgerId+" index "+bookieIndex+", numResponsesPending "+numResponsesPending+", completed:"+completed);
 
         numResponsesPending--;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryPendingReadLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryPendingReadLacOp.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client;
+
+import io.netty.buffer.ByteBuf;
+
+import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadLacCallback;
+import org.apache.bookkeeper.proto.checksum.DigestManager.RecoveryData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This op is try to read last confirmed without involving quorum coverage checking.
+ * Use {@link PendingLacOp} if you need quorum coverage checking.
+ */
+
+class TryPendingReadLacOp implements ReadLacCallback {
+    static final Logger LOG = LoggerFactory.getLogger(TryPendingReadLacOp.class);
+    LedgerHandle lh;
+    LacCallback cb;
+    int numResponsesPending;
+    volatile boolean completed = false;
+    volatile boolean hasValidResponse = false;
+    int lastSeenError = BKException.Code.ReadException;
+    RecoveryData maxRecoveredData;
+    long maxLac;
+
+    /*
+     * Wrapper to get Lac from the request
+     */
+    interface LacCallback {
+        void getLacComplete(int rc, long lac);
+    }
+
+    TryPendingReadLacOp(LedgerHandle lh, LacCallback cb) {
+        this.lh = lh;
+        this.cb = cb;
+        this.maxLac = lh.getLastAddConfirmed();
+        this.numResponsesPending = lh.metadata.getEnsembleSize();
+        this.maxRecoveredData = new RecoveryData(maxLac, 0);
+    }
+
+    public void initiate() {
+        for (int i = 0; i < lh.metadata.currentEnsemble.size(); i++) {
+            lh.bk.getBookieClient().readLac(lh.metadata.currentEnsemble.get(i),
+                    lh.ledgerId, this, i);
+        }
+    }
+
+    @Override
+    public void readLacComplete(int rc, long ledgerId, final ByteBuf lacBuffer, final ByteBuf lastEntryBuffer,
+            Object ctx) {
+        int bookieIndex = (Integer) ctx;
+        LOG.info("readLacComplete "+rc+", "+ledgerId+" index "+bookieIndex+", numResponsesPending "+numResponsesPending+", completed:"+completed);
+
+        numResponsesPending--;
+
+        if (completed) {
+            return;
+        }
+
+
+        if (rc == BKException.Code.OK) {
+            try {
+                // Each bookie may have two store LAC in two places.
+                // One is in-memory copy in FileInfo and other is
+                // piggy-backed LAC on the last entry.
+                // This routine picks both of them and compares to return
+                // the latest Lac.
+
+                // lacBuffer and lastEntryBuffer are optional in the protocol.
+                // So check if they exist before processing them.
+                long newLac = LedgerHandle.INVALID_ENTRY_ID;
+                // Extract lac from FileInfo on the ledger.
+                if (lacBuffer != null && lacBuffer.readableBytes() > 0) {
+                    long lac = lh.macManager.verifyDigestAndReturnLac(lacBuffer);
+                    if (lac > maxLac) {
+                        newLac = lac;
+                    }
+                }
+                // Extract lac from last entry on the disk
+                if (lastEntryBuffer != null && lastEntryBuffer.readableBytes() > 0) {
+                    RecoveryData recoveryData = lh.macManager.verifyDigestAndReturnLastConfirmed(lastEntryBuffer);
+                    long recoveredLac = recoveryData.getLastAddConfirmed();
+                    if (recoveredLac > maxLac) {
+                        newLac = recoveredLac;
+                    }
+                }
+                if (newLac > maxLac) {
+                    // as for TryReadLastConfirmedOp we will call the callback as soon as possible
+                    cb.getLacComplete(rc, newLac);
+                    completed = true;
+                }
+                maxLac = newLac;
+
+                hasValidResponse = true;
+            } catch (BKDigestMatchException e) {
+                // Too bad, this bookie did not give us a valid answer, we
+                // still might be able to recover. So, continue
+                LOG.error("Mac mismatch while reading  ledger: " + ledgerId + " LAC from bookie: "
+                        + lh.metadata.currentEnsemble.get(bookieIndex));
+                rc = BKException.Code.DigestMatchException;
+            }
+        }
+
+        if (rc == BKException.Code.NoSuchLedgerExistsException || rc == BKException.Code.NoSuchEntryException) {
+            hasValidResponse = true;
+        }
+
+        if (rc == BKException.Code.UnauthorizedAccessException && !completed) {
+            cb.getLacComplete(rc, maxLac);
+            completed = true;
+            return;
+        }
+
+        if (!hasValidResponse && BKException.Code.OK != rc) {
+            lastSeenError = rc;
+        }
+
+        if (numResponsesPending == 0 && !completed) {
+            if (!hasValidResponse) {
+                cb.getLacComplete(lastSeenError, maxLac);
+            } else {
+                cb.getLacComplete(BKException.Code.OK, maxLac);
+            }
+            completed = true;
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -121,6 +121,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     protected static final String TIMEOUT_MONITOR_INTERVAL_SEC = "timeoutMonitorIntervalSec";
     protected static final String TIMEOUT_TASK_INTERVAL_MILLIS = "timeoutTaskIntervalMillis";
     protected static final String EXPLICIT_LAC_INTERVAL = "explicitLacInterval";
+    protected static final String USE_EXPLICIT_LAC_FOR_READS = "useExplicitLacForReads";
     protected static final String PCBC_TIMEOUT_TIMER_TICK_DURATION_MS = "pcbcTimeoutTimerTickDurationMs";
     protected static final String PCBC_TIMEOUT_TIMER_NUM_TICKS = "pcbcTimeoutTimerNumTicks";
     protected static final String TIMEOUT_TIMER_TICK_DURATION_MS = "timeoutTimerTickDurationMs";
@@ -730,6 +731,28 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
      */
     public ClientConfiguration setExplictLacInterval(int interval) {
         setProperty(EXPLICIT_LAC_INTERVAL, interval);
+        return this;
+    }
+
+    /**
+     * Whether to enable reads of LastAddConfirmed using ExplicitLAC support.
+     *
+     * @return true if enable reads of LastAddConfirmed using ExplicitLAC support. otherwise, return false.
+     */
+    public boolean isUseExplicitLacForReads() {
+        return getBoolean(USE_EXPLICIT_LAC_FOR_READS, false);
+    }
+
+    /**
+     * Enable/Disable reads of LastAddConfirmed using ExplicitLAC support.
+     *
+     * @param value if true the client will consider ExplicitLAC while reading LastAddConfirmed
+     *              from Bookies.
+     *
+     * @return Client configuration.
+     */
+    public ClientConfiguration setUseExplicitLacForReads(boolean value) {
+        setProperty(USE_EXPLICIT_LAC_FOR_READS, value);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestTryReadLastConfirmed.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestTryReadLastConfirmed.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import java.util.Arrays;
+import java.util.Collection;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -25,26 +27,41 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
+import org.apache.bookkeeper.bookie.SortedLedgerStorage;
+import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Test try read last confirmed.
  */
+@RunWith(Parameterized.class)
 public class TestTryReadLastConfirmed extends BookKeeperClusterTestCase {
 
     private static final Logger logger = LoggerFactory.getLogger(TestTryReadLastConfirmed.class);
 
     final DigestType digestType;
 
-    public TestTryReadLastConfirmed() {
+    public TestTryReadLastConfirmed(boolean useExplicitLacForReads) {
         super(6);
         this.digestType = DigestType.CRC32;
+        this.baseClientConf.setUseExplicitLacForReads(useExplicitLacForReads);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> configs() {
+        return Arrays.asList(new Object[][] {
+            { true },
+            { false }
+        });
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestTryReadLastConfirmed.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestTryReadLastConfirmed.java
@@ -17,23 +17,22 @@
  */
 package org.apache.bookkeeper.client;
 
-import java.util.Arrays;
-import java.util.Collection;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
-import org.apache.bookkeeper.bookie.SortedLedgerStorage;
-import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;


### PR DESCRIPTION
### Motivation

Readers have to explicitly call readExplicitLastConfirmed in order to leverage ExplicitLAC.
I would like to have a unified way to read LastAddConfirmed.


### Changes
This change makes the client use internally readExplicitLastConfirmed instead of using readLastAddConfirmed.
We need to introduce something similar to tryReadLastAddConfirmed in order to make it consistent  with readLastAddConfirmed.

It lacks support for Long Poll Reads, notably we would have to listen on ExplicitLAC modifications on the bookie side in order to wake up the readers even in case of setExplicitLAC from the writer and we would need to change protocol for readLastAddConfirmedAndEntry in order to return the ExplicitLAC.

We cannot support v2 clients.