### PR TITLE
LedgerManager should return the metadata just written

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * Encapsulates asynchronous ledger create operation.
  *
  */
-class LedgerCreateOp implements GenericCallback<Void> {
+class LedgerCreateOp implements GenericCallback<LedgerMetadata> {
 
     static final Logger LOG = LoggerFactory.getLogger(LedgerCreateOp.class);
 
@@ -189,7 +189,7 @@ class LedgerCreateOp implements GenericCallback<Void> {
      * Callback when created ledger.
      */
     @Override
-    public void operationComplete(int rc, Void result) {
+    public void operationComplete(int rc, LedgerMetadata writtenMetadata) {
         if (this.generateLedgerId && (BKException.Code.LedgerExistException == rc)) {
             // retry to generate a new ledger id
             generateLedgerIdAndCreateLedger();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -395,7 +395,7 @@ public class LedgerFragmentReplicator {
      * MetadataVersionException and update ensemble again. On successfull
      * updation, it will also notify to super call back
      */
-    private static class UpdateEnsembleCb implements GenericCallback<Void> {
+    private static class UpdateEnsembleCb implements GenericCallback<LedgerMetadata> {
         final AsyncCallback.VoidCallback ensembleUpdatedCb;
         final LedgerHandle lh;
         final long fragmentStartId;
@@ -411,7 +411,7 @@ public class LedgerFragmentReplicator {
         }
 
         @Override
-        public void operationComplete(int rc, Void result) {
+        public void operationComplete(int rc, LedgerMetadata writtenMetadata) {
             if (rc == BKException.Code.MetadataVersionException) {
                 LOG.warn("Two fragments attempted update at once; ledger id: "
                         + lh.getId() + " startid: " + fragmentStartId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -423,7 +423,7 @@ public class LedgerHandle implements WriteHandle {
         return bookiesHealthInfo;
     }
 
-    void writeLedgerConfig(GenericCallback<Void> writeCb) {
+    void writeLedgerConfig(GenericCallback<LedgerMetadata> writeCb) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Writing metadata to ledger manager: {}, {}", this.ledgerId, metadata.getVersion());
         }
@@ -560,13 +560,13 @@ public class LedgerHandle implements WriteHandle {
                               + metadata.getLastEntryId() + " with this many bytes: " + metadata.getLength());
                 }
 
-                final class CloseCb extends OrderedGenericCallback<Void> {
+                final class CloseCb extends OrderedGenericCallback<LedgerMetadata> {
                     CloseCb() {
                         super(bk.getMainWorkerPool(), ledgerId);
                     }
 
                     @Override
-                    public void safeOperationComplete(final int rc, Void result) {
+                    public void safeOperationComplete(final int rc, LedgerMetadata writtenMetadata) {
                         if (rc == BKException.Code.MetadataVersionException) {
                             rereadMetadata(new OrderedGenericCallback<LedgerMetadata>(bk.getMainWorkerPool(),
                                                                                           ledgerId) {
@@ -1974,7 +1974,7 @@ public class LedgerHandle implements WriteHandle {
      * reformed ensemble. On MetadataVersionException, will reread latest
      * ledgerMetadata and act upon.
      */
-    private final class ChangeEnsembleCb extends OrderedGenericCallback<Void> {
+    private final class ChangeEnsembleCb extends OrderedGenericCallback<LedgerMetadata> {
         private final EnsembleInfo ensembleInfo;
         private final int curBlockAddCompletions;
         private final int ensembleChangeIdx;
@@ -1992,7 +1992,7 @@ public class LedgerHandle implements WriteHandle {
         }
 
         @Override
-        public void safeOperationComplete(final int rc, Void result) {
+        public void safeOperationComplete(final int rc, LedgerMetadata writtenMetadata) {
             if (rc == BKException.Code.MetadataVersionException) {
                 // We changed the ensemble, but got a version exception. We
                 // should still consider this as an ensemble change
@@ -2300,9 +2300,9 @@ public class LedgerHandle implements WriteHandle {
             return;
         }
 
-        writeLedgerConfig(new OrderedGenericCallback<Void>(bk.getMainWorkerPool(), ledgerId) {
+        writeLedgerConfig(new OrderedGenericCallback<LedgerMetadata>(bk.getMainWorkerPool(), ledgerId) {
             @Override
-            public void safeOperationComplete(final int rc, Void result) {
+            public void safeOperationComplete(final int rc, LedgerMetadata writtenMetadata) {
                 if (rc == BKException.Code.MetadataVersionException) {
                     rereadMetadata(new OrderedGenericCallback<LedgerMetadata>(bk.getMainWorkerPool(),
                                                                                   ledgerId) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/UpdateLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/UpdateLedgerOp.java
@@ -232,9 +232,9 @@ public class UpdateLedgerOp {
                 future.set(null);
                 return; // ledger doesn't contains the given curBookieId
             }
-            final GenericCallback<Void> writeCb = new GenericCallback<Void>() {
+            final GenericCallback<LedgerMetadata> writeCb = new GenericCallback<LedgerMetadata>() {
                 @Override
-                public void operationComplete(int rc, Void result) {
+                public void operationComplete(int rc, LedgerMetadata result) {
                     if (rc != BKException.Code.OK) {
                         // metadata update failed
                         LOG.error("Ledger {} metadata update failed. Error code {}", ledgerId, rc);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -245,7 +245,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
 
     @Override
     public void createLedgerMetadata(final long ledgerId, final LedgerMetadata metadata,
-            final GenericCallback<Void> ledgerCb) {
+            final GenericCallback<LedgerMetadata> ledgerCb) {
         String ledgerPath = getLedgerPath(ledgerId);
         StringCallback scb = new StringCallback() {
             @Override
@@ -253,7 +253,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                 if (rc == Code.OK.intValue()) {
                     // update version
                     metadata.setVersion(new LongVersion(0));
-                    ledgerCb.operationComplete(BKException.Code.OK, null);
+                    ledgerCb.operationComplete(BKException.Code.OK, metadata);
                 } else if (rc == Code.NODEEXISTS.intValue()) {
                     LOG.warn("Failed to create ledger metadata for {} which already exist", ledgerId);
                     ledgerCb.operationComplete(BKException.Code.LedgerExistException, null);
@@ -425,7 +425,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
 
     @Override
     public void writeLedgerMetadata(final long ledgerId, final LedgerMetadata metadata,
-                                    final GenericCallback<Void> cb) {
+                                    final GenericCallback<LedgerMetadata> cb) {
         Version v = metadata.getVersion();
         if (!(v instanceof LongVersion)) {
             cb.operationComplete(BKException.Code.MetadataVersionException, null);
@@ -442,7 +442,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                 } else if (KeeperException.Code.OK.intValue() == rc) {
                     // update metadata version
                     metadata.setVersion(zv.setLongVersion(stat.getVersion()));
-                    cb.operationComplete(BKException.Code.OK, null);
+                    cb.operationComplete(BKException.Code.OK, metadata);
                 } else if (KeeperException.Code.NONODE.intValue() == rc) {
                     LOG.warn("Ledger node does not exist in ZooKeeper: ledgerId={}", ledgerId);
                     cb.operationComplete(BKException.Code.NoSuchLedgerExistsException, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
@@ -109,14 +109,14 @@ public class CleanupLedgerManager implements LedgerManager {
 
     @Override
     public void createLedgerMetadata(long lid, LedgerMetadata metadata,
-                                     GenericCallback<Void> cb) {
+                                     GenericCallback<LedgerMetadata> cb) {
         closeLock.readLock().lock();
         try {
             if (closed) {
                 cb.operationComplete(BKException.Code.ClientClosedException, null);
                 return;
             }
-            underlying.createLedgerMetadata(lid, metadata, new CleanupGenericCallback<Void>(cb));
+            underlying.createLedgerMetadata(lid, metadata, new CleanupGenericCallback<LedgerMetadata>(cb));
         } finally {
             closeLock.readLock().unlock();
         }
@@ -155,7 +155,7 @@ public class CleanupLedgerManager implements LedgerManager {
 
     @Override
     public void writeLedgerMetadata(long ledgerId, LedgerMetadata metadata,
-                                    GenericCallback<Void> cb) {
+                                    GenericCallback<LedgerMetadata> cb) {
         closeLock.readLock().lock();
         try {
             if (closed) {
@@ -163,7 +163,7 @@ public class CleanupLedgerManager implements LedgerManager {
                 return;
             }
             underlying.writeLedgerMetadata(ledgerId, metadata,
-                    new CleanupGenericCallback<Void>(cb));
+                    new CleanupGenericCallback<LedgerMetadata>(cb));
         } finally {
             closeLock.readLock().unlock();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
@@ -47,14 +47,15 @@ public interface LedgerManager extends Closeable {
      * @param metadata
      *            Metadata provided when creating the new ledger
      * @param cb
-     *            Callback when creating a new ledger. Return code:<ul>
+     *            Callback when creating a new ledger, returning the written metadata.
+     *            Return code:<ul>
      *            <li>{@link BKException.Code.OK} if success</li>
      *            <li>{@link BKException.Code.LedgerExistException} if given ledger id exist</li>
      *            <li>{@link BKException.Code.ZKException}/{@link BKException.Code.MetaStoreException}
      *                 for other issue</li>
      *            </ul>
      */
-    void createLedgerMetadata(long ledgerId, LedgerMetadata metadata, GenericCallback<Void> cb);
+    void createLedgerMetadata(long ledgerId, LedgerMetadata metadata, GenericCallback<LedgerMetadata> cb);
 
     /**
      * Remove a specified ledger metadata by ledgerId and version.
@@ -95,13 +96,14 @@ public interface LedgerManager extends Closeable {
      * @param metadata
      *          Ledger Metadata to write
      * @param cb
-     *          Callback when finished writing ledger metadata. Return code:<ul>
+     *          Callback when finished writing ledger metadata, returning the written metadata.
+     *          Return code:<ul>
      *          <li>{@link BKException.Code.OK} if success</li>
      *          <li>{@link BKException.Code.MetadataVersionException} if version in metadata doesn't match</li>
      *          <li>{@link BKException.Code.ZKException} for other issue</li>
      *          </ul>
      */
-    void writeLedgerMetadata(long ledgerId, LedgerMetadata metadata, GenericCallback<Void> cb);
+    void writeLedgerMetadata(long ledgerId, LedgerMetadata metadata, GenericCallback<LedgerMetadata> cb);
 
     /**
      * Register the ledger metadata <i>listener</i> on <i>ledgerId</i>.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
@@ -376,7 +376,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
 
         @Override
         public void createLedgerMetadata(final long lid, final LedgerMetadata metadata,
-                                         final GenericCallback<Void> ledgerCb) {
+                                         final GenericCallback<LedgerMetadata> ledgerCb) {
             MetastoreCallback<Version> msCallback = new MetastoreCallback<Version>() {
                 @Override
                 public void complete(int rc, Version version, Object ctx) {
@@ -393,7 +393,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
                     }
                     // update version
                     metadata.setVersion(version);
-                    ledgerCb.operationComplete(BKException.Code.OK, null);
+                    ledgerCb.operationComplete(BKException.Code.OK, metadata);
                 }
             };
 
@@ -457,7 +457,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
 
         @Override
         public void writeLedgerMetadata(final long ledgerId, final LedgerMetadata metadata,
-                final GenericCallback<Void> cb) {
+                final GenericCallback<LedgerMetadata> cb) {
             Value data = new Value().setField(META_FIELD, metadata.serialize());
 
             if (LOG.isDebugEnabled()) {
@@ -484,7 +484,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
                         bkRc = BKException.Code.MetaStoreException;
                     }
 
-                    cb.operationComplete(bkRc, null);
+                    cb.operationComplete(bkRc, metadata);
                 }
             };
             ledgerTable.put(key, data, metadata.getVersion(), msCallback, null);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -917,7 +917,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
     private LedgerManager getLedgerManager(final Set<Long> ledgers) {
         LedgerManager manager = new LedgerManager() {
                 @Override
-                public void createLedgerMetadata(long lid, LedgerMetadata metadata, GenericCallback<Void> cb) {
+                public void createLedgerMetadata(long lid, LedgerMetadata metadata,
+                                                 GenericCallback<LedgerMetadata> cb) {
                     unsupported();
                 }
                 @Override
@@ -931,7 +932,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
                 }
                 @Override
                 public void writeLedgerMetadata(long ledgerId, LedgerMetadata metadata,
-                        GenericCallback<Void> cb) {
+                        GenericCallback<LedgerMetadata> cb) {
                     unsupported();
                 }
                 @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
@@ -93,7 +93,7 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
         }
 
         @Override
-        public void createLedgerMetadata(long ledgerId, LedgerMetadata metadata, GenericCallback<Void> cb) {
+        public void createLedgerMetadata(long ledgerId, LedgerMetadata metadata, GenericCallback<LedgerMetadata> cb) {
             lm.createLedgerMetadata(ledgerId, metadata, cb);
         }
 
@@ -114,7 +114,7 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
 
         @Override
         public void writeLedgerMetadata(final long ledgerId, final LedgerMetadata metadata,
-                                        final GenericCallback<Void> cb) {
+                                        final GenericCallback<LedgerMetadata> cb) {
             final CountDownLatch cdl = waitLatch;
             if (null != cdl) {
                 executorService.submit(new Runnable() {
@@ -368,9 +368,9 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
                 newRecoverLh.getLedgerMetadata().markLedgerInRecovery();
                 final CountDownLatch updateLatch = new CountDownLatch(1);
                 final AtomicInteger updateResult = new AtomicInteger(0x12345);
-                newRecoverLh.writeLedgerConfig(new GenericCallback<Void>() {
+                newRecoverLh.writeLedgerConfig(new GenericCallback<LedgerMetadata>() {
                     @Override
-                    public void operationComplete(int rc, Void result) {
+                    public void operationComplete(int rc, LedgerMetadata result) {
                         updateResult.set(rc);
                         updateLatch.countDown();
                     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSequenceRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSequenceRead.java
@@ -68,9 +68,9 @@ public class TestSequenceRead extends BookKeeperClusterTestCase {
         // update the ledger metadata with duplicated bookies
         final CountDownLatch latch = new CountDownLatch(1);
         bkc.getLedgerManager().writeLedgerMetadata(lh.getId(), lh.getLedgerMetadata(),
-                new BookkeeperInternalCallbacks.GenericCallback<Void>() {
+                new BookkeeperInternalCallbacks.GenericCallback<LedgerMetadata>() {
             @Override
-            public void operationComplete(int rc, Void result) {
+            public void operationComplete(int rc, LedgerMetadata result) {
                 if (BKException.Code.OK == rc) {
                     latch.countDown();
                 } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWatchEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestWatchEnsembleChange.java
@@ -134,10 +134,10 @@ public class TestWatchEnsembleChange extends BookKeeperClusterTestCase {
             @Override
             public void operationComplete(int rc, final Long lid) {
                 manager.createLedgerMetadata(lid, new LedgerMetadata(4, 2, 2, digestType, "fpj was here".getBytes()),
-                         new BookkeeperInternalCallbacks.GenericCallback<Void>(){
+                         new BookkeeperInternalCallbacks.GenericCallback<LedgerMetadata>(){
 
                     @Override
-                    public void operationComplete(int rc, Void result) {
+                    public void operationComplete(int rc, LedgerMetadata result) {
                         bbLedgerId.putLong(lid);
                         bbLedgerId.flip();
                         createLatch.countDown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
@@ -156,7 +156,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         assertEquals(Version.NEW, metadata.getVersion());
 
-        GenericCallbackFuture<Void> callbackFuture = new GenericCallbackFuture<>();
+        GenericCallbackFuture<LedgerMetadata> callbackFuture = new GenericCallbackFuture<>();
         ledgerManager.createLedgerMetadata(ledgerId, metadata, callbackFuture);
         callbackFuture.get();
 
@@ -173,7 +173,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         assertEquals(Version.NEW, metadata.getVersion());
 
-        GenericCallbackFuture<Void> callbackFuture = new GenericCallbackFuture<>();
+        GenericCallbackFuture<LedgerMetadata> callbackFuture = new GenericCallbackFuture<>();
         ledgerManager.createLedgerMetadata(ledgerId, metadata, callbackFuture);
         try {
             result(callbackFuture);
@@ -198,7 +198,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         assertEquals(Version.NEW, metadata.getVersion());
 
-        GenericCallbackFuture<Void> callbackFuture = new GenericCallbackFuture<>();
+        GenericCallbackFuture<LedgerMetadata> callbackFuture = new GenericCallbackFuture<>();
         ledgerManager.createLedgerMetadata(ledgerId, metadata, callbackFuture);
         try {
             result(callbackFuture);
@@ -479,7 +479,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         assertEquals(new LongVersion(1234L), metadata.getVersion());
 
-        GenericCallbackFuture<Void> callbackFuture = new GenericCallbackFuture<>();
+        GenericCallbackFuture<LedgerMetadata> callbackFuture = new GenericCallbackFuture<>();
         ledgerManager.writeLedgerMetadata(ledgerId, metadata, callbackFuture);
         result(callbackFuture);
 
@@ -501,7 +501,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         assertEquals(new LongVersion(1234L), metadata.getVersion());
 
-        GenericCallbackFuture<Void> callbackFuture = new GenericCallbackFuture<>();
+        GenericCallbackFuture<LedgerMetadata> callbackFuture = new GenericCallbackFuture<>();
         ledgerManager.writeLedgerMetadata(ledgerId, metadata, callbackFuture);
         try {
             result(callbackFuture);
@@ -529,7 +529,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         assertEquals(new LongVersion(1234L), metadata.getVersion());
 
-        GenericCallbackFuture<Void> callbackFuture = new GenericCallbackFuture<>();
+        GenericCallbackFuture<LedgerMetadata> callbackFuture = new GenericCallbackFuture<>();
         ledgerManager.writeLedgerMetadata(ledgerId, metadata, callbackFuture);
         try {
             result(callbackFuture);
@@ -562,7 +562,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         metadata.setVersion(invalidVersion);
 
-        GenericCallbackFuture<Void> callbackFuture = new GenericCallbackFuture<>();
+        GenericCallbackFuture<LedgerMetadata> callbackFuture = new GenericCallbackFuture<>();
         ledgerManager.writeLedgerMetadata(ledgerId, metadata, callbackFuture);
         try {
             result(callbackFuture);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -106,9 +106,10 @@ public class GcLedgersTest extends LedgerManagerTestCase {
                     }
 
                     getLedgerManager().createLedgerMetadata(ledgerId,
-                            new LedgerMetadata(1, 1, 1, DigestType.MAC, "".getBytes()), new GenericCallback<Void>() {
+                            new LedgerMetadata(1, 1, 1, DigestType.MAC, "".getBytes()),
+                            new GenericCallback<LedgerMetadata>() {
                                 @Override
-                                public void operationComplete(int rc, Void result) {
+                                public void operationComplete(int rc, LedgerMetadata writtenMetadata) {
                                     if (rc == BKException.Code.OK) {
                                         activeLedgers.put(ledgerId, true);
                                         createdLedgers.add(ledgerId);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
@@ -109,7 +109,8 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
                 List<BookieSocketAddress> ensemble = md.getEnsembles().get(0L);
                 ensemble.set(0, new BookieSocketAddress("1.1.1.1", 1000));
 
-                TestCallbacks.GenericCallbackFuture<Void> cb = new TestCallbacks.GenericCallbackFuture<Void>();
+                TestCallbacks.GenericCallbackFuture<LedgerMetadata> cb =
+                    new TestCallbacks.GenericCallbackFuture<LedgerMetadata>();
                 ledgerManager.writeLedgerMetadata(lh.getId(), md, cb);
                 cb.get();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -674,7 +674,8 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         List<BookieSocketAddress> ensemble = md.getEnsembles().get(0L);
         ensemble.set(0, new BookieSocketAddress("1.1.1.1", 1000));
 
-        TestCallbacks.GenericCallbackFuture<Void> cb = new TestCallbacks.GenericCallbackFuture<Void>();
+        TestCallbacks.GenericCallbackFuture<LedgerMetadata> cb =
+            new TestCallbacks.GenericCallbackFuture<LedgerMetadata>();
         ledgerManager.writeLedgerMetadata(lh.getId(), md, cb);
         cb.get();
 


### PR DESCRIPTION
First part of changes to make ledger metadata immutable. The client
should only act on metadata which has been written to zookeeper. To
this end, we need to be able to get back from the ledger manager what
has been written to zookeeper (with the version number updated).

Master issue: #281
