### PR TITLE
WIP - Add JaCoco agent in stream module when using code-coverage profile

### DIFF
--- a/stream/pom.xml
+++ b/stream/pom.xml
@@ -85,7 +85,25 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <!-- profile used by jenkins CI -->
+      <id>code-coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <!-- @{argLine} is a variable injected by JaCoCo-->
+              <argLine>@{argLine} -Xmx2G -Djava.net.preferIPv4Stack=true</argLine>
+              <reuseForks>false</reuseForks>
+              <!-- we want build to complete even in case of failures -->
+              <testFailureIgnore>true</testFailureIgnore>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+   </profile>
   </profiles>
-
 </project>
 


### PR DESCRIPTION
This is a WIP patch to force executing JaCoCo agent on 'stream' module.
Stream module pom.xml overrides surefire configuration from parent pom and so it is hiding special configuration parameters activated usually by the code-coverage profile.