### PR TITLE
Issue #1584: LedgerHandleAdv should expose asyncAddEntry variant that takes ByteBuf (LedgerHandle exposes it as public)

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1126,6 +1126,26 @@ public class LedgerHandle implements WriteHandle {
     }
 
     /**
+     * Add entry asynchronously to an open ledger, using an offset and range.
+     * This can be used only with {@link LedgerHandleAdv} returned through
+     * ledgers created with {@link createLedgerAdv(int, int, int, DigestType, byte[])}.
+     *
+     * @param entryId
+     *            entryId of the entry to add.
+     * @param data
+     *            io.netty.buffer.ByteBuf of bytes to be written
+     * @param cb
+     *            object implementing callbackinterface
+     * @param ctx
+     *            some control object
+     */
+    public void asyncAddEntry(final long entryId, ByteBuf data,
+                              final AddCallbackWithLatency cb, final Object ctx) {
+        LOG.error("To use this feature Ledger must be created with createLedgerAdv() interface.");
+        cb.addCompleteWithLatency(BKException.Code.IllegalOpException, LedgerHandle.this, entryId, 0, ctx);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1067,7 +1067,6 @@ public class LedgerHandle implements WriteHandle {
     }
 
     public void asyncAddEntry(ByteBuf data, final AddCallback cb, final Object ctx) {
-        data.retain();
         PendingAddOp op = PendingAddOp.create(this, data, writeFlags, cb, ctx);
         doAsyncAddEntry(op);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -177,8 +177,23 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
         asyncAddEntry(entryId, Unpooled.wrappedBuffer(data, offset, length), cb, ctx);
     }
 
-    private void asyncAddEntry(final long entryId, ByteBuf data,
-            final AddCallbackWithLatency cb, final Object ctx) {
+    /**
+     * Add entry asynchronously to an open ledger, using an offset and range.
+     * This can be used only with {@link LedgerHandleAdv} returned through
+     * ledgers created with {@link createLedgerAdv(int, int, int, DigestType, byte[])}.
+     *
+     * @param entryId
+     *            entryId of the entry to add.
+     * @param data
+     *            io.netty.buffer.ByteBuf of bytes to be written
+     * @param cb
+     *            object implementing callbackinterface
+     * @param ctx
+     *            some control object
+     */
+    @Override
+    public void asyncAddEntry(final long entryId, ByteBuf data,
+                              final AddCallbackWithLatency cb, final Object ctx) {
         PendingAddOp op = PendingAddOp.create(this, data, writeFlags, cb, ctx);
         op.setEntryId(entryId);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -92,7 +92,6 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         op.entryId = LedgerHandle.INVALID_ENTRY_ID;
         op.currentLedgerLength = -1;
         op.payload = payload;
-        op.payload.retain();
         op.entryLength = payload.readableBytes();
 
         op.completed = false;
@@ -244,6 +243,8 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         this.toSend = lh.macManager.computeDigestAndPackageForSending(
                 entryId, lh.lastAddConfirmed, currentLedgerLength,
                 payload);
+        // ownership of RefCounted ByteBuf was passed to computeDigestAndPackageForSending
+        payload = null;
 
         // We are about to send. Check if we need to make an ensemble change
         // becasue of delayed write errors
@@ -457,8 +458,10 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
     private void recyclePendAddOpObject() {
         entryId = LedgerHandle.INVALID_ENTRY_ID;
         currentLedgerLength = -1;
-        ReferenceCountUtil.release(payload);
-        payload = null;
+        if (payload != null) {
+            ReferenceCountUtil.release(payload);
+            payload = null;
+        }
         cb = null;
         ctx = null;
         ackSet.recycle();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -92,6 +92,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         op.entryId = LedgerHandle.INVALID_ENTRY_ID;
         op.currentLedgerLength = -1;
         op.payload = payload;
+        op.payload.retain();
         op.entryLength = payload.readableBytes();
 
         op.completed = false;
@@ -456,6 +457,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
     private void recyclePendAddOpObject() {
         entryId = LedgerHandle.INVALID_ENTRY_ID;
         currentLedgerLength = -1;
+        ReferenceCountUtil.release(payload);
         payload = null;
         cb = null;
         ctx = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -23,6 +23,7 @@ import io.netty.buffer.Unpooled;
 
 import java.security.GeneralSecurityException;
 
+import io.netty.util.ReferenceCountUtil;
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType;
@@ -127,6 +128,7 @@ public abstract class DigestManager {
             populateValueAndReset(sendBuffer);
 
             sendBuffer.writeBytes(data, data.readerIndex(), data.readableBytes());
+            ReferenceCountUtil.release(data);
 
             return ByteBufList.get(sendBuffer);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -20,10 +20,10 @@ package org.apache.bookkeeper.proto.checksum;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 
 import java.security.GeneralSecurityException;
 
-import io.netty.util.ReferenceCountUtil;
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -1335,7 +1335,12 @@ public class BookieWriteLedgerTest extends
             int rc = cf.get();
             assertEquals("rc code is OK", BKException.Code.OK, rc);
 
-            TimeUnit.MILLISECONDS.sleep(250); // recycler runs asynchronously
+            for (int i =0; i < 10; i++) {
+                if (data.refCnt() == 0) {
+                    break;
+                }
+                TimeUnit.MILLISECONDS.sleep(250); // recycler runs asynchronously
+            }
             assertEquals("writing entry with id " + entryId + ", ref count on ByteBuf should be 0 ",
                     0, data.refCnt());
 
@@ -1373,7 +1378,12 @@ public class BookieWriteLedgerTest extends
             int rc = cf.get();
             assertEquals("rc code is OK", BKException.Code.OK, rc);
 
-            TimeUnit.MILLISECONDS.sleep(250); // recycler runs asynchronously
+            for (int i =0; i < 10; i++) {
+                if (data.refCnt() == 0) {
+                    break;
+                }
+                TimeUnit.MILLISECONDS.sleep(250); // recycler runs asynchronously
+            }
             assertEquals("writing entry with id " + entryId + ", ref count on ByteBuf should be 0 ",
                     0, data.refCnt());
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -34,6 +34,7 @@ import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -50,7 +51,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
@@ -1350,7 +1350,7 @@ public class BookieWriteLedgerTest extends
     @Test
     @SuppressWarnings("unchecked")
     public void testLedgerCreateByteBufRefCnt() throws Exception {
-        final LedgerHandle lh = bkc.createLedger(5, 3, 2, digestType, ledgerPassword, null);;
+        final LedgerHandle lh = bkc.createLedger(5, 3, 2, digestType, ledgerPassword, null);
 
         final List<AbstractByteBufAllocator> allocs = Lists.newArrayList(
                 new PooledByteBufAllocator(true),

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -28,7 +28,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import com.google.common.collect.Lists;
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 
 import java.io.IOException;
@@ -43,8 +47,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
@@ -1292,6 +1298,91 @@ public class BookieWriteLedgerTest extends
         }
         // Close the ledger
         lh.close();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLedgerCreateAdvByteBufRefCnt() throws Exception {
+        long ledgerId = rng.nextLong();
+        ledgerId &= Long.MAX_VALUE;
+        if (!baseConf.getLedgerManagerFactoryClass().equals(LongHierarchicalLedgerManagerFactory.class)) {
+            // since LongHierarchicalLedgerManager supports ledgerIds of
+            // decimal length upto 19 digits but other
+            // LedgerManagers only upto 10 decimals
+            ledgerId %= 9999999999L;
+        }
+
+        final LedgerHandle lh = bkc.createLedgerAdv(ledgerId, 5, 3, 2, digestType, ledgerPassword, null);
+
+        final List<AbstractByteBufAllocator> allocs = Lists.newArrayList(
+                new PooledByteBufAllocator(true),
+                new PooledByteBufAllocator(false),
+                new UnpooledByteBufAllocator(true),
+                new UnpooledByteBufAllocator(false));
+
+        long entryId = 0;
+        for (AbstractByteBufAllocator alloc: allocs) {
+            final ByteBuf data = alloc.buffer(10);
+            data.writeBytes(("fragment0" + entryId).getBytes());
+            assertEquals("ref count on ByteBuf should be 1", 1, data.refCnt());
+
+            CompletableFuture<Integer> cf = new CompletableFuture<>();
+            lh.asyncAddEntry(entryId, data, (rc, handle, eId, qwcLatency, ctx) -> {
+                CompletableFuture<Integer> future = (CompletableFuture<Integer>) ctx;
+                future.complete(rc);
+            }, cf);
+
+            int rc = cf.get();
+            assertEquals("rc code is OK", BKException.Code.OK, rc);
+
+            TimeUnit.MILLISECONDS.sleep(250); // recycler runs asynchronously
+            assertEquals("writing entry with id " + entryId + ", ref count on ByteBuf should be 0 ",
+                    0, data.refCnt());
+
+            org.apache.bookkeeper.client.api.LedgerEntry e = lh.read(entryId, entryId).getEntry(entryId);
+            assertEquals("entry data is correct", "fragment0" + entryId, new String(e.getEntryBytes()));
+            entryId++;
+        }
+
+        bkc.deleteLedger(lh.ledgerId);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLedgerCreateByteBufRefCnt() throws Exception {
+        final LedgerHandle lh = bkc.createLedger(5, 3, 2, digestType, ledgerPassword, null);;
+
+        final List<AbstractByteBufAllocator> allocs = Lists.newArrayList(
+                new PooledByteBufAllocator(true),
+                new PooledByteBufAllocator(false),
+                new UnpooledByteBufAllocator(true),
+                new UnpooledByteBufAllocator(false));
+
+        int entryId = 0;
+        for (AbstractByteBufAllocator alloc: allocs) {
+            final ByteBuf data = alloc.buffer(10);
+            data.writeBytes(("fragment0" + entryId).getBytes());
+            assertEquals("ref count on ByteBuf should be 1", 1, data.refCnt());
+
+            CompletableFuture<Integer> cf = new CompletableFuture<>();
+            lh.asyncAddEntry(data, (rc, handle, eId, ctx) -> {
+                CompletableFuture<Integer> future = (CompletableFuture<Integer>) ctx;
+                future.complete(rc);
+            }, cf);
+
+            int rc = cf.get();
+            assertEquals("rc code is OK", BKException.Code.OK, rc);
+
+            TimeUnit.MILLISECONDS.sleep(250); // recycler runs asynchronously
+            assertEquals("writing entry with id " + entryId + ", ref count on ByteBuf should be 0 ",
+                    0, data.refCnt());
+
+            org.apache.bookkeeper.client.api.LedgerEntry e = lh.read(entryId, entryId).getEntry(entryId);
+            assertEquals("entry data is correct", "fragment0" + entryId, new String(e.getEntryBytes()));
+            entryId++;
+        }
+
+        bkc.deleteLedger(lh.ledgerId);
     }
 
     private void readEntries(LedgerHandle lh, List<byte[]> entries) throws InterruptedException, BKException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -1335,7 +1335,7 @@ public class BookieWriteLedgerTest extends
             int rc = cf.get();
             assertEquals("rc code is OK", BKException.Code.OK, rc);
 
-            for (int i =0; i < 10; i++) {
+            for (int i = 0; i < 10; i++) {
                 if (data.refCnt() == 0) {
                     break;
                 }
@@ -1378,7 +1378,7 @@ public class BookieWriteLedgerTest extends
             int rc = cf.get();
             assertEquals("rc code is OK", BKException.Code.OK, rc);
 
-            for (int i =0; i < 10; i++) {
+            for (int i = 0; i < 10; i++) {
                 if (data.refCnt() == 0) {
                     break;
                 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/DeferredSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/DeferredSyncTest.java
@@ -50,9 +50,9 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
                 .withWriteFlags(WriteFlag.DEFERRED_SYNC)
                 .execute())) {
             for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-                result(wh.appendAsync(DATA));
+                result(wh.appendAsync(DATA.retainedDuplicate()));
             }
-            long lastEntryID = result(wh.appendAsync(DATA));
+            long lastEntryID = result(wh.appendAsync(DATA.retainedDuplicate()));
             assertEquals(NUM_ENTRIES - 1, lastEntryID);
             assertEquals(NUM_ENTRIES - 1, wh.getLastAddPushed());
             assertEquals(-1, wh.getLastAddConfirmed());
@@ -69,9 +69,9 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
                 .withWriteFlags(WriteFlag.DEFERRED_SYNC)
                 .execute())) {
             for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-                result(wh.appendAsync(DATA));
+                result(wh.appendAsync(DATA.retainedDuplicate()));
             }
-            long lastEntryID = result(wh.appendAsync(DATA));
+            long lastEntryID = result(wh.appendAsync(DATA.retainedDuplicate()));
             assertEquals(NUM_ENTRIES - 1, lastEntryID);
             assertEquals(NUM_ENTRIES - 1, wh.getLastAddPushed());
             assertEquals(-1, wh.getLastAddConfirmed());
@@ -90,20 +90,20 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
                 .withWriteFlags(WriteFlag.DEFERRED_SYNC)
                 .makeAdv()
                 .execute())) {
-            CompletableFuture<Long> w0 = wh.writeAsync(0, DATA);
-            CompletableFuture<Long> w2 = wh.writeAsync(2, DATA);
-            CompletableFuture<Long> w3 = wh.writeAsync(3, DATA);
+            CompletableFuture<Long> w0 = wh.writeAsync(0, DATA.retainedDuplicate());
+            CompletableFuture<Long> w2 = wh.writeAsync(2, DATA.retainedDuplicate());
+            CompletableFuture<Long> w3 = wh.writeAsync(3, DATA.retainedDuplicate());
             result(w0);
             result(wh.force());
             assertEquals(0, wh.getLastAddConfirmed());
-            CompletableFuture<Long> w1 = wh.writeAsync(1, DATA);
+            CompletableFuture<Long> w1 = wh.writeAsync(1, DATA.retainedDuplicate());
             result(w3);
             assertTrue(w1.isDone());
             assertTrue(w2.isDone());
-            CompletableFuture<Long> w5 = wh.writeAsync(5, DATA);
+            CompletableFuture<Long> w5 = wh.writeAsync(5, DATA.retainedDuplicate());
             result(wh.force());
             assertEquals(3, wh.getLastAddConfirmed());
-            wh.writeAsync(4, DATA);
+            wh.writeAsync(4, DATA.retainedDuplicate());
             result(w5);
             result(wh.force());
             assertEquals(5, wh.getLastAddConfirmed());
@@ -120,9 +120,9 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
                 .withWriteFlags(WriteFlag.DEFERRED_SYNC)
                 .execute())) {
             for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-                result(wh.appendAsync(DATA));
+                result(wh.appendAsync(DATA.retainedDuplicate()));
             }
-            long lastEntryID = result(wh.appendAsync(DATA));
+            long lastEntryID = result(wh.appendAsync(DATA.retainedDuplicate()));
             assertEquals(NUM_ENTRIES - 1, lastEntryID);
             assertEquals(NUM_ENTRIES - 1, wh.getLastAddPushed());
             assertEquals(-1, wh.getLastAddConfirmed());
@@ -131,7 +131,7 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
             killBookie(bookieAddress);
 
             // write should succeed (we still have 2 bookies out of 3)
-            result(wh.appendAsync(DATA));
+            result(wh.appendAsync(DATA.retainedDuplicate()));
 
             // force cannot go, it must be acknowledged by all of the bookies in the ensamble
             try {
@@ -154,9 +154,9 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
                 .withWriteFlags(WriteFlag.DEFERRED_SYNC)
                 .execute())) {
             for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-                result(wh.appendAsync(DATA));
+                result(wh.appendAsync(DATA.retainedDuplicate()));
             }
-            long lastEntryIdBeforeSuspend = result(wh.appendAsync(DATA));
+            long lastEntryIdBeforeSuspend = result(wh.appendAsync(DATA.retainedDuplicate()));
             assertEquals(NUM_ENTRIES - 1, lastEntryIdBeforeSuspend);
             assertEquals(-1, wh.getLastAddConfirmed());
 
@@ -170,7 +170,7 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
             assertEquals(-1, wh.getLastAddConfirmed());
 
             // send an entry and receive ack
-            long lastEntry = wh.append(DATA);
+            long lastEntry = wh.append(DATA.retainedDuplicate());
 
             // receive the ack for forceLedger
             resumeBookieWriteAcks(bookieAddress);
@@ -195,7 +195,7 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
                 .withWriteFlags(WriteFlag.DEFERRED_SYNC)
                 .execute())) {
             for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-                wh.append(DATA);
+                wh.append(DATA.retainedDuplicate());
             }
 
             assertEquals(1, availableBookies.size());
@@ -207,7 +207,7 @@ public class DeferredSyncTest extends MockBookKeeperTestCase {
 
             try {
                 // we cannot switch to the new bookie with DEFERRED_SYNC
-                wh.append(DATA);
+                wh.append(DATA.retainedDuplicate());
                 fail("since ensemble change is disable we cannot be able to write any more");
             } catch (BKException.BKWriteException ex) {
                 // expected

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryWriter.java
@@ -165,7 +165,7 @@ class EnvelopedEntryWriter implements Writer {
         if (null == finalizedBuffer) {
             finalizedBuffer = finalizeBuffer();
         }
-        return finalizedBuffer.slice();
+        return finalizedBuffer.retainedSlice();
     }
 
     private ByteBuf finalizeBuffer() {


### PR DESCRIPTION
Descriptions of the changes in this PR:

- exposed asyncAddEntry as public, similarly to other variants.
- fixed ByteBuf retention

### Motivation

It's useful to have this exposed as public for clients to make use of netty's allocator and pass ByteBuf directly.

### Changes

exposed asyncAddEntry as public, similarly to other variants.

Master Issue: #1584 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
