### PR TITLE
Make LedgerHandle injectable

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -24,7 +24,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.WATCHER_SCOPE;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -60,7 +59,6 @@ import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.feature.Feature;
 import org.apache.bookkeeper.feature.FeatureProvider;
 import org.apache.bookkeeper.feature.SettableFeatureProvider;
 import org.apache.bookkeeper.meta.CleanupLedgerManager;
@@ -76,9 +74,7 @@ import org.apache.bookkeeper.net.DNSToSwitchMapping;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.DataFormats;
-import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.NullStatsLogger;
-import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.ReflectionUtils;
 import org.apache.bookkeeper.util.SafeRunnable;
@@ -109,24 +105,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
     // The stats logger for this client.
     private final StatsLogger statsLogger;
-    private OpStatsLogger createOpLogger;
-    private OpStatsLogger openOpLogger;
-    private OpStatsLogger deleteOpLogger;
-    private OpStatsLogger recoverOpLogger;
-    private OpStatsLogger readOpLogger;
-    private OpStatsLogger readLacAndEntryOpLogger;
-    private OpStatsLogger readLacAndEntryRespLogger;
-    private OpStatsLogger addOpLogger;
-    private OpStatsLogger forceOpLogger;
-    private OpStatsLogger writeLacOpLogger;
-    private OpStatsLogger readLacOpLogger;
-    private OpStatsLogger recoverAddEntriesStats;
-    private OpStatsLogger recoverReadEntriesStats;
-
-    private Counter speculativeReadCounter;
-    private Counter readOpDmCounter;
-    private Counter addOpUrCounter;
-
+    private final BookKeeperClientStats clientStats;
 
     // whether the event loop group is one we created, or is owned by whoever
     // instantiated us
@@ -142,9 +121,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     final FeatureProvider featureProvider;
     final ScheduledExecutorService bookieInfoScheduler;
 
-    // Features
-    final Feature disableEnsembleChangeFeature;
-
     final MetadataClientDriver metadataDriver;
     // Ledger manager responsible for how to store ledger meta data
     final LedgerManagerFactory ledgerManagerFactory;
@@ -156,13 +132,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     BookieInfoReader bookieInfoReader;
 
     final ClientConfiguration conf;
-    final int explicitLacInterval;
-    final boolean delayEnsembleChange;
-    final boolean reorderReadSequence;
-    final long addEntryQuorumTimeoutNanos;
-
-    final Optional<SpeculativeRequestExecutionPolicy> readSpeculativeRequestPolicy;
-    final Optional<SpeculativeRequestExecutionPolicy> readLACSpeculativeRequestPolicy;
+    final ClientInternalConf internalConf;
 
     // Close State
     boolean closed = false;
@@ -409,37 +379,34 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     BookKeeper(ClientConfiguration conf,
                        ZooKeeper zkc,
                        EventLoopGroup eventLoopGroup,
-                       StatsLogger statsLogger,
+                       StatsLogger rootStatsLogger,
                        DNSToSwitchMapping dnsResolver,
                        HashedWheelTimer requestTimer,
                        FeatureProvider featureProvider)
             throws IOException, InterruptedException, BKException {
         this.conf = conf;
-        this.delayEnsembleChange = conf.getDelayEnsembleChange();
-        this.reorderReadSequence = conf.isReorderReadSequenceEnabled();
-
-        // initialize resources
-        this.scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperClientScheduler").build();
-        this.mainWorkerPool = OrderedExecutor.newBuilder()
-                .name("BookKeeperClientWorker")
-                .numThreads(conf.getNumWorkerThreads())
-                .statsLogger(statsLogger)
-                .traceTaskExecution(conf.getEnableTaskExecutionStats())
-                .traceTaskWarnTimeMicroSec(conf.getTaskExecutionWarnTimeMicros())
-                .build();
-
-        // initialize stats logger
-        this.statsLogger = statsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE);
-        initOpLoggers(this.statsLogger);
-
         // initialize feature provider
         if (null == featureProvider) {
             this.featureProvider = SettableFeatureProvider.DISABLE_ALL;
         } else {
             this.featureProvider = featureProvider;
         }
-        this.disableEnsembleChangeFeature =
-            this.featureProvider.getFeature(conf.getDisableEnsembleChangeFeatureName());
+
+        this.internalConf = ClientInternalConf.fromConfigAndFeatureProvider(conf, this.featureProvider);
+
+        // initialize resources
+        this.scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperClientScheduler").build();
+        this.mainWorkerPool = OrderedExecutor.newBuilder()
+                .name("BookKeeperClientWorker")
+                .numThreads(conf.getNumWorkerThreads())
+                .statsLogger(rootStatsLogger)
+                .traceTaskExecution(conf.getEnableTaskExecutionStats())
+                .traceTaskWarnTimeMicroSec(conf.getTaskExecutionWarnTimeMicros())
+                .build();
+
+        // initialize stats logger
+        this.statsLogger = rootStatsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE);
+        this.clientStats = BookKeeperClientStats.newInstance(this.statsLogger);
 
         // initialize metadata driver
         try {
@@ -453,7 +420,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             this.metadataDriver.initialize(
                 conf,
                 scheduler,
-                statsLogger,
+                rootStatsLogger,
                 java.util.Optional.ofNullable(zkc));
         } catch (ConfigurationException ce) {
             LOG.error("Failed to initialize metadata client driver using invalid metadata service uri", ce);
@@ -487,28 +454,9 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         this.placementPolicy = initializeEnsemblePlacementPolicy(conf,
                 dnsResolver, this.requestTimer, this.featureProvider, this.statsLogger);
 
-        if (conf.getFirstSpeculativeReadTimeout() > 0) {
-            this.readSpeculativeRequestPolicy =
-                    Optional.of(new DefaultSpeculativeRequestExecutionPolicy(
-                        conf.getFirstSpeculativeReadTimeout(),
-                        conf.getMaxSpeculativeReadTimeout(),
-                        conf.getSpeculativeReadTimeoutBackoffMultiplier()));
-        } else {
-            this.readSpeculativeRequestPolicy = Optional.<SpeculativeRequestExecutionPolicy>absent();
-        }
-
-        if (conf.getFirstSpeculativeReadLACTimeout() > 0) {
-            this.readLACSpeculativeRequestPolicy =
-                    Optional.of((SpeculativeRequestExecutionPolicy) (new DefaultSpeculativeRequestExecutionPolicy(
-                        conf.getFirstSpeculativeReadLACTimeout(),
-                        conf.getMaxSpeculativeReadLACTimeout(),
-                        conf.getSpeculativeReadLACTimeoutBackoffMultiplier())));
-        } else {
-            this.readLACSpeculativeRequestPolicy = Optional.<SpeculativeRequestExecutionPolicy>absent();
-        }
         // initialize bookie client
         this.bookieClient = new BookieClient(conf, this.eventLoopGroup, this.mainWorkerPool,
-                                             scheduler, statsLogger);
+                                             scheduler, rootStatsLogger);
         this.bookieWatcher = new BookieWatcher(
                 conf, this.placementPolicy, metadataDriver.getRegistrationClient(),
                 this.statsLogger.scope(WATCHER_SCOPE));
@@ -536,13 +484,8 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         }
         this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
         this.ledgerIdGenerator = ledgerManagerFactory.newLedgerIdGenerator();
-        this.explicitLacInterval = conf.getExplictLacInterval();
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Explicit LAC Interval : {}", this.explicitLacInterval);
-        }
 
-        this.addEntryQuorumTimeoutNanos = TimeUnit.SECONDS.toNanos(conf.getAddEntryQuorumTimeout());
-        scheduleBookieHealthCheckIfEnabled();
+        scheduleBookieHealthCheckIfEnabled(conf);
     }
 
     /**
@@ -550,13 +493,13 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
      */
     @VisibleForTesting
     BookKeeper() {
+        conf = new ClientConfiguration();
+        internalConf = ClientInternalConf.defaultValues();
         statsLogger = NullStatsLogger.INSTANCE;
+        clientStats = BookKeeperClientStats.newInstance(statsLogger);
         scheduler = null;
         requestTimer = null;
-        reorderReadSequence = false;
         metadataDriver = null;
-        readSpeculativeRequestPolicy = Optional.absent();
-        readLACSpeculativeRequestPolicy = Optional.absent();
         placementPolicy = null;
         ownTimer = false;
         mainWorkerPool = null;
@@ -564,24 +507,10 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         ledgerManager = null;
         ledgerIdGenerator = null;
         featureProvider = null;
-        explicitLacInterval = 0;
         eventLoopGroup = null;
-        disableEnsembleChangeFeature = null;
-        delayEnsembleChange = false;
-        conf = new ClientConfiguration();
         bookieWatcher = null;
         bookieInfoScheduler = null;
         bookieClient = null;
-        addEntryQuorumTimeoutNanos = 0;
-    }
-
-    long getAddEntryQuorumTimeoutNanos() {
-        return addEntryQuorumTimeoutNanos;
-    }
-
-
-    public int getExplicitLacInterval() {
-        return explicitLacInterval;
     }
 
     private EnsemblePlacementPolicy initializeEnsemblePlacementPolicy(ClientConfiguration conf,
@@ -600,6 +529,10 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     }
 
     int getReturnRc(int rc) {
+        return getReturnRc(bookieClient, rc);
+    }
+
+    static int getReturnRc(BookieClient bookieClient, int rc) {
         if (BKException.Code.OK == rc) {
             return rc;
         } else {
@@ -611,7 +544,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         }
     }
 
-    void scheduleBookieHealthCheckIfEnabled() {
+    void scheduleBookieHealthCheckIfEnabled(ClientConfiguration conf) {
         if (conf.isBookieHealthCheckEnabled()) {
             scheduler.scheduleAtFixedRate(new SafeRunnable() {
 
@@ -634,10 +567,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     /**
      * Returns ref to speculative read counter, needed in PendingReadOp.
      */
-    Counter getSpeculativeReadCounter() {
-        return speculativeReadCounter;
-    }
-
     @VisibleForTesting
     public LedgerManager getLedgerManager() {
         return ledgerManager;
@@ -681,11 +610,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     @VisibleForTesting
     EnsemblePlacementPolicy getPlacementPolicy() {
         return placementPolicy;
-    }
-
-    @VisibleForTesting
-    boolean isReorderReadSequence() {
-        return reorderReadSequence;
     }
 
     @VisibleForTesting
@@ -753,10 +677,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         }
     }
 
-    boolean shouldReorderReadSequence() {
-        return reorderReadSequence;
-    }
-
     ZooKeeper getZkHandle() {
         return ((ZKMetadataClientDriver) metadataDriver).getZk();
     }
@@ -765,25 +685,16 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         return conf;
     }
 
+    ClientInternalConf getInternalConf() {
+        return internalConf;
+    }
+
     StatsLogger getStatsLogger() {
         return statsLogger;
     }
 
-    public Optional<SpeculativeRequestExecutionPolicy> getReadSpeculativeRequestPolicy() {
-        return readSpeculativeRequestPolicy;
-    }
-
-    public Optional<SpeculativeRequestExecutionPolicy> getReadLACSpeculativeRequestPolicy() {
-        return readLACSpeculativeRequestPolicy;
-    }
-
-    /**
-     * Get the disableEnsembleChangeFeature.
-     *
-     * @return disableEnsembleChangeFeature for the BookKeeper instance.
-     */
-    Feature getDisableEnsembleChangeFeature() {
-        return disableEnsembleChangeFeature;
+    BookKeeperClientStats getClientStats() {
+        return clientStats;
     }
 
     /**
@@ -886,7 +797,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             }
             new LedgerCreateOp(BookKeeper.this, ensSize, writeQuorumSize,
                                ackQuorumSize, digestType, passwd, cb, ctx,
-                               customMetadata, WriteFlag.NONE, getStatsLogger())
+                               customMetadata, WriteFlag.NONE, clientStats)
                 .initiate();
         } finally {
             closeLock.readLock().unlock();
@@ -1084,7 +995,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             }
             new LedgerCreateOp(BookKeeper.this, ensSize, writeQuorumSize,
                                ackQuorumSize, digestType, passwd, cb, ctx,
-                               customMetadata, WriteFlag.NONE, getStatsLogger())
+                               customMetadata, WriteFlag.NONE, clientStats)
                                        .initiateAdv(-1L);
         } finally {
             closeLock.readLock().unlock();
@@ -1192,7 +1103,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             }
             new LedgerCreateOp(BookKeeper.this, ensSize, writeQuorumSize,
                                ackQuorumSize, digestType, passwd, cb, ctx,
-                               customMetadata, WriteFlag.NONE, getStatsLogger())
+                               customMetadata, WriteFlag.NONE, clientStats)
                     .initiateAdv(ledgerId);
         } finally {
             closeLock.readLock().unlock();
@@ -1233,7 +1144,8 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                 cb.openComplete(BKException.Code.ClientClosedException, null, ctx);
                 return;
             }
-            new LedgerOpenOp(BookKeeper.this, lId, digestType, passwd, cb, ctx).initiate();
+            new LedgerOpenOp(BookKeeper.this, clientStats,
+                             lId, digestType, passwd, cb, ctx).initiate();
         } finally {
             closeLock.readLock().unlock();
         }
@@ -1277,7 +1189,8 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                 cb.openComplete(BKException.Code.ClientClosedException, null, ctx);
                 return;
             }
-            new LedgerOpenOp(BookKeeper.this, lId, digestType, passwd, cb, ctx).initiateWithoutRecovery();
+            new LedgerOpenOp(BookKeeper.this, clientStats,
+                             lId, digestType, passwd, cb, ctx).initiateWithoutRecovery();
         } finally {
             closeLock.readLock().unlock();
         }
@@ -1356,7 +1269,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                 cb.deleteComplete(BKException.Code.ClientClosedException, ctx);
                 return;
             }
-            new LedgerDeleteOp(BookKeeper.this, lId, cb, ctx).initiate();
+            new LedgerDeleteOp(BookKeeper.this, clientStats, lId, cb, ctx).initiate();
         } finally {
             closeLock.readLock().unlock();
         }
@@ -1497,72 +1410,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         this.metadataDriver.close();
     }
 
-    private void initOpLoggers(StatsLogger stats) {
-        createOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.CREATE_OP);
-        deleteOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.DELETE_OP);
-        openOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.OPEN_OP);
-        recoverOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.RECOVER_OP);
-        readOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_OP);
-        readOpDmCounter = stats.getCounter(BookKeeperClientStats.READ_OP_DM);
-        readLacAndEntryOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY);
-        readLacAndEntryRespLogger = stats.getOpStatsLogger(
-                BookKeeperClientStats.READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE);
-        addOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.ADD_OP);
-        forceOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.FORCE_OP);
-        addOpUrCounter = stats.getCounter(BookKeeperClientStats.ADD_OP_UR);
-        writeLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.WRITE_LAC_OP);
-        readLacOpLogger = stats.getOpStatsLogger(BookKeeperClientStats.READ_LAC_OP);
-        recoverAddEntriesStats = stats.getOpStatsLogger(BookKeeperClientStats.LEDGER_RECOVER_ADD_ENTRIES);
-        recoverReadEntriesStats = stats.getOpStatsLogger(BookKeeperClientStats.LEDGER_RECOVER_READ_ENTRIES);
-
-        speculativeReadCounter = stats.getCounter(BookKeeperClientStats.SPECULATIVE_READ_COUNT);
-    }
-
-    OpStatsLogger getCreateOpLogger() {
-        return createOpLogger;
-    }
-    OpStatsLogger getOpenOpLogger() {
-        return openOpLogger;
-    }
-    OpStatsLogger getDeleteOpLogger() {
-        return deleteOpLogger;
-    }
-    OpStatsLogger getRecoverOpLogger() {
-        return recoverOpLogger;
-    }
-    OpStatsLogger getReadOpLogger() {
-        return readOpLogger;
-    }
-    OpStatsLogger getReadLacAndEntryOpLogger() {
-        return readLacAndEntryOpLogger;
-    }
-    OpStatsLogger getReadLacAndEntryRespLogger() {
-        return readLacAndEntryRespLogger;
-    }
-    OpStatsLogger getAddOpLogger() {
-        return addOpLogger;
-    }
-    OpStatsLogger getForceOpLogger() {
-        return forceOpLogger;
-    }
-    OpStatsLogger getWriteLacOpLogger() {
-        return writeLacOpLogger;
-    }
-    OpStatsLogger getReadLacOpLogger() {
-        return readLacOpLogger;
-    }
-    OpStatsLogger getRecoverAddCountLogger() {
-        return recoverAddEntriesStats;
-    }
-    OpStatsLogger getRecoverReadCountLogger() {
-        return recoverReadEntriesStats;
-    }
-    Counter getReadOpDmCounter() {
-        return readOpDmCounter;
-    }
-    Counter getAddOpUrCounter() {
-        return addOpUrCounter;
-    }
     static EventLoopGroup getDefaultEventLoopGroup() {
         ThreadFactory threadFactory = new DefaultThreadFactory("bookkeeper-io");
         final int numThreads = Runtime.getRuntime().availableProcessors() * 2;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -267,7 +267,7 @@ public class BookKeeperAdmin implements AutoCloseable {
      * @see BookKeeper#asyncOpenLedger
      */
     public void asyncOpenLedger(final long lId, final OpenCallback cb, final Object ctx) {
-        new LedgerOpenOp(bkc, lId, cb, ctx).initiate();
+        new LedgerOpenOp(bkc, bkc.getClientStats(), lId, cb, ctx).initiate();
     }
 
     /**
@@ -284,7 +284,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         CompletableFuture<LedgerHandle> future = new CompletableFuture<>();
         SyncOpenCallback result = new SyncOpenCallback(future);
 
-        new LedgerOpenOp(bkc, lId, result, null).initiate();
+        new LedgerOpenOp(bkc, bkc.getClientStats(), lId, result, null).initiate();
 
         return SyncCallbackUtils.waitForResult(future);
     }
@@ -304,7 +304,7 @@ public class BookKeeperAdmin implements AutoCloseable {
      * @see BookKeeper#asyncOpenLedgerNoRecovery
      */
     public void asyncOpenLedgerNoRecovery(final long lId, final OpenCallback cb, final Object ctx) {
-        new LedgerOpenOp(bkc, lId, cb, ctx).initiateWithoutRecovery();
+        new LedgerOpenOp(bkc, bkc.getClientStats(), lId, cb, ctx).initiateWithoutRecovery();
     }
 
     /**
@@ -322,7 +322,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         CompletableFuture<LedgerHandle> future = new CompletableFuture<>();
         SyncOpenCallback result = new SyncOpenCallback(future);
 
-        new LedgerOpenOp(bkc, lId, result, null)
+        new LedgerOpenOp(bkc, bkc.getClientStats(), lId, result, null)
                 .initiateWithoutRecovery();
 
         return SyncCallbackUtils.waitForResult(future);
@@ -893,6 +893,7 @@ public class BookKeeperAdmin implements AutoCloseable {
                         try {
                             LedgerFragmentReplicator.SingleFragmentCallback cb =
                                 new LedgerFragmentReplicator.SingleFragmentCallback(ledgerFragmentsMcb, lh,
+                                                                                    bkc.getMainWorkerPool(),
                                         startEntryId, getReplacementBookiesMap(ensemble, targetBookieAddresses));
                             LedgerFragment ledgerFragment = new LedgerFragment(lh,
                                 startEntryId, endEntryId, targetBookieAddresses.keySet());
@@ -1046,6 +1047,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         SingleFragmentCallback cb = new SingleFragmentCallback(
             resultCallBack,
             lh,
+            bkc.getMainWorkerPool(),
             ledgerFragment.getFirstEntryId(),
             getReplacementBookiesMap(ledgerFragment, targetBookieAddresses));
 
@@ -1423,7 +1425,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         }
 
         BookieSocketAddress auditorId =
-            AuditorElector.getCurrentAuditor(new ServerConfiguration(bkc.conf), bkc.getZkHandle());
+            AuditorElector.getCurrentAuditor(new ServerConfiguration(bkc.getConf()), bkc.getZkHandle());
         if (auditorId == null) {
             LOG.error("No auditor elected, though Autorecovery is enabled. So giving up.");
             throw new UnavailableException("No auditor elected, though Autorecovery is enabled. So giving up.");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -21,6 +21,11 @@
 
 package org.apache.bookkeeper.client;
 
+import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.Gauge;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
+
 /**
  * List of constants for defining client stats names.
  */
@@ -84,4 +89,144 @@ public interface BookKeeperClientStats {
     String ACTIVE_TLS_CHANNEL_COUNTER = "ACTIVE_TLS_CHANNEL_COUNTER";
     String FAILED_CONNECTION_COUNTER = "FAILED_CONNECTION_COUNTER";
     String FAILED_TLS_HANDSHAKE_COUNTER = "FAILED_TLS_HANDSHAKE_COUNTER";
+
+    OpStatsLogger getCreateOpLogger();
+    OpStatsLogger getOpenOpLogger();
+    OpStatsLogger getDeleteOpLogger();
+    OpStatsLogger getRecoverOpLogger();
+    OpStatsLogger getReadOpLogger();
+    OpStatsLogger getReadLacAndEntryOpLogger();
+    OpStatsLogger getReadLacAndEntryRespLogger();
+    OpStatsLogger getAddOpLogger();
+    OpStatsLogger getForceOpLogger();
+    OpStatsLogger getWriteLacOpLogger();
+    OpStatsLogger getReadLacOpLogger();
+    OpStatsLogger getRecoverAddCountLogger();
+    OpStatsLogger getRecoverReadCountLogger();
+    Counter getReadOpDmCounter();
+    Counter getAddOpUrCounter();
+    Counter getSpeculativeReadCounter();
+    Counter getEnsembleBookieDistributionCounter(String bookie);
+    Counter getEnsembleChangeCounter();
+    Counter getLacUpdateHitsCounter();
+    Counter getLacUpdateMissesCounter();
+    OpStatsLogger getClientChannelWriteWaitLogger();
+    void registerPendingAddsGauge(Gauge<Integer> gauge);
+
+    static BookKeeperClientStats newInstance(StatsLogger stats) {
+        OpStatsLogger createOpLogger = stats.getOpStatsLogger(CREATE_OP);
+        OpStatsLogger deleteOpLogger = stats.getOpStatsLogger(DELETE_OP);
+        OpStatsLogger openOpLogger = stats.getOpStatsLogger(OPEN_OP);
+        OpStatsLogger recoverOpLogger = stats.getOpStatsLogger(RECOVER_OP);
+        OpStatsLogger readOpLogger = stats.getOpStatsLogger(READ_OP);
+        Counter readOpDmCounter = stats.getCounter(READ_OP_DM);
+        OpStatsLogger readLacAndEntryOpLogger = stats.getOpStatsLogger(READ_LAST_CONFIRMED_AND_ENTRY);
+        OpStatsLogger readLacAndEntryRespLogger = stats.getOpStatsLogger(READ_LAST_CONFIRMED_AND_ENTRY_RESPONSE);
+        OpStatsLogger addOpLogger = stats.getOpStatsLogger(ADD_OP);
+        OpStatsLogger forceOpLogger = stats.getOpStatsLogger(FORCE_OP);
+        Counter addOpUrCounter = stats.getCounter(ADD_OP_UR);
+        OpStatsLogger writeLacOpLogger = stats.getOpStatsLogger(WRITE_LAC_OP);
+        OpStatsLogger readLacOpLogger = stats.getOpStatsLogger(READ_LAC_OP);
+        OpStatsLogger recoverAddEntriesStats = stats.getOpStatsLogger(LEDGER_RECOVER_ADD_ENTRIES);
+        OpStatsLogger recoverReadEntriesStats = stats.getOpStatsLogger(LEDGER_RECOVER_READ_ENTRIES);
+
+        Counter ensembleChangeCounter = stats.getCounter(ENSEMBLE_CHANGES);
+        Counter lacUpdateHitsCounter = stats.getCounter(LAC_UPDATE_HITS);
+        Counter lacUpdateMissesCounter = stats.getCounter(LAC_UPDATE_MISSES);
+        OpStatsLogger clientChannelWriteWaitStats = stats.getOpStatsLogger(CLIENT_CHANNEL_WRITE_WAIT);
+
+        Counter speculativeReadCounter = stats.getCounter(SPECULATIVE_READ_COUNT);
+
+        return new BookKeeperClientStats() {
+            @Override
+            public OpStatsLogger getCreateOpLogger() {
+                return createOpLogger;
+            }
+            @Override
+            public OpStatsLogger getOpenOpLogger() {
+                return openOpLogger;
+            }
+            @Override
+            public OpStatsLogger getDeleteOpLogger() {
+                return deleteOpLogger;
+            }
+            @Override
+            public OpStatsLogger getRecoverOpLogger() {
+                return recoverOpLogger;
+            }
+            @Override
+            public OpStatsLogger getReadOpLogger() {
+                return readOpLogger;
+            }
+            @Override
+            public OpStatsLogger getReadLacAndEntryOpLogger() {
+                return readLacAndEntryOpLogger;
+            }
+            @Override
+            public OpStatsLogger getReadLacAndEntryRespLogger() {
+                return readLacAndEntryRespLogger;
+            }
+            @Override
+            public OpStatsLogger getAddOpLogger() {
+                return addOpLogger;
+            }
+            @Override
+            public OpStatsLogger getForceOpLogger() {
+                return forceOpLogger;
+            }
+            @Override
+            public OpStatsLogger getWriteLacOpLogger() {
+                return writeLacOpLogger;
+            }
+            @Override
+            public OpStatsLogger getReadLacOpLogger() {
+                return readLacOpLogger;
+            }
+            @Override
+            public OpStatsLogger getRecoverAddCountLogger() {
+                return recoverAddEntriesStats;
+            }
+            @Override
+            public OpStatsLogger getRecoverReadCountLogger() {
+                return recoverReadEntriesStats;
+            }
+            @Override
+            public Counter getReadOpDmCounter() {
+                return readOpDmCounter;
+            }
+            @Override
+            public Counter getAddOpUrCounter() {
+                return addOpUrCounter;
+            }
+            @Override
+            public Counter getSpeculativeReadCounter() {
+                return speculativeReadCounter;
+            }
+            @Override
+            public Counter getEnsembleChangeCounter() {
+                return ensembleChangeCounter;
+            }
+            @Override
+            public Counter getLacUpdateHitsCounter() {
+                return lacUpdateHitsCounter;
+            }
+            @Override
+            public Counter getLacUpdateMissesCounter() {
+                return lacUpdateMissesCounter;
+            }
+            @Override
+            public OpStatsLogger getClientChannelWriteWaitLogger() {
+                return clientChannelWriteWaitStats;
+            }
+            @Override
+            public Counter getEnsembleBookieDistributionCounter(String bookie) {
+                return stats.getCounter(LEDGER_ENSEMBLE_BOOKIE_DISTRIBUTION + "-" + bookie);
+            }
+            @Override
+            public void registerPendingAddsGauge(Gauge<Integer> gauge) {
+                stats.registerGauge(PENDING_ADDS, gauge);
+            }
+        };
+    }
+
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
@@ -1,0 +1,103 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import com.google.common.base.Optional;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.feature.Feature;
+import org.apache.bookkeeper.feature.FeatureProvider;
+import org.apache.bookkeeper.feature.SettableFeatureProvider;
+
+class ClientInternalConf {
+    final Feature disableEnsembleChangeFeature;
+    final boolean delayEnsembleChange;
+
+    final Optional<SpeculativeRequestExecutionPolicy> readSpeculativeRequestPolicy;
+    final Optional<SpeculativeRequestExecutionPolicy> readLACSpeculativeRequestPolicy;
+
+    final int explicitLacInterval;
+    final long waitForWriteSetMs;
+    final long addEntryQuorumTimeoutNanos;
+    final boolean enableParallelRecoveryRead;
+    final boolean enableReorderReadSequence;
+    final int recoveryReadBatchSize;
+    final int throttleValue;
+    final int bookieFailureHistoryExpirationMSec;
+    final int maxAllowedEnsembleChanges;
+    final long timeoutMonitorIntervalSec;
+    final boolean enableBookieFailureTracking;
+    final boolean useV2WireProtocol;
+
+    static ClientInternalConf defaultValues() {
+        return fromConfig(new ClientConfiguration());
+    }
+
+    static ClientInternalConf fromConfig(ClientConfiguration conf) {
+        return fromConfigAndFeatureProvider(conf, SettableFeatureProvider.DISABLE_ALL);
+    }
+
+    static ClientInternalConf fromConfigAndFeatureProvider(ClientConfiguration conf,
+                                                           FeatureProvider featureProvider) {
+        return new ClientInternalConf(conf, featureProvider);
+    }
+
+    private ClientInternalConf(ClientConfiguration conf,
+                               FeatureProvider featureProvider) {
+        this.explicitLacInterval = conf.getExplictLacInterval();
+        this.enableReorderReadSequence = conf.isReorderReadSequenceEnabled();
+        this.enableParallelRecoveryRead = conf.getEnableParallelRecoveryRead();
+        this.recoveryReadBatchSize = conf.getRecoveryReadBatchSize();
+        this.waitForWriteSetMs = conf.getWaitTimeoutOnBackpressureMillis();
+        this.addEntryQuorumTimeoutNanos = TimeUnit.SECONDS.toNanos(conf.getAddEntryQuorumTimeout());
+        this.throttleValue = conf.getThrottleValue();
+        this.bookieFailureHistoryExpirationMSec = conf.getBookieFailureHistoryExpirationMSec();
+
+        this.disableEnsembleChangeFeature = featureProvider.getFeature(conf.getDisableEnsembleChangeFeatureName());
+
+        this.delayEnsembleChange = conf.getDelayEnsembleChange();
+        this.maxAllowedEnsembleChanges = conf.getMaxAllowedEnsembleChanges();
+        this.timeoutMonitorIntervalSec = conf.getTimeoutMonitorIntervalSec();
+        this.enableBookieFailureTracking = conf.getEnableBookieFailureTracking();
+        this.useV2WireProtocol = conf.getUseV2WireProtocol();
+
+        if (conf.getFirstSpeculativeReadTimeout() > 0) {
+            this.readSpeculativeRequestPolicy =
+                    Optional.of(new DefaultSpeculativeRequestExecutionPolicy(
+                                        conf.getFirstSpeculativeReadTimeout(),
+                                        conf.getMaxSpeculativeReadTimeout(),
+                                        conf.getSpeculativeReadTimeoutBackoffMultiplier()));
+        } else {
+            this.readSpeculativeRequestPolicy = Optional.<SpeculativeRequestExecutionPolicy>absent();
+        }
+        if (conf.getFirstSpeculativeReadLACTimeout() > 0) {
+            this.readLACSpeculativeRequestPolicy =
+                    Optional.of(new DefaultSpeculativeRequestExecutionPolicy(
+                        conf.getFirstSpeculativeReadLACTimeout(),
+                        conf.getMaxSpeculativeReadLACTimeout(),
+                        conf.getSpeculativeReadLACTimeoutBackoffMultiplier()));
+        } else {
+            this.readLACSpeculativeRequestPolicy = Optional.<SpeculativeRequestExecutionPolicy>absent();
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ForceLedgerCallback;
 import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
@@ -44,14 +45,17 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
     long currentNonDurableLastAddConfirmed = LedgerHandle.INVALID_ENTRY_ID;
 
     final LedgerHandle lh;
+    final BookieClient bookieClient;
 
-    ForceLedgerOp(LedgerHandle lh, CompletableFuture<Void> cb) {
+    ForceLedgerOp(LedgerHandle lh, BookieClient bookieClient,
+                  CompletableFuture<Void> cb) {
         this.lh = lh;
+        this.bookieClient = bookieClient;
         this.cb = cb;
     }
 
     void sendForceLedgerRequest(int bookieIndex) {
-        lh.bk.getBookieClient().forceLedger(currentEnsemble.get(bookieIndex), lh.ledgerId, this, bookieIndex);
+        bookieClient.forceLedger(currentEnsemble.get(bookieIndex), lh.ledgerId, this, bookieIndex);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -45,7 +45,6 @@ import org.apache.bookkeeper.meta.LedgerIdGenerator;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.stats.OpStatsLogger;
-import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,9 +68,9 @@ class LedgerCreateOp implements GenericCallback<LedgerMetadata> {
     final EnumSet<WriteFlag> writeFlags;
     final long startTime;
     final OpStatsLogger createOpLogger;
+    final BookKeeperClientStats clientStats;
     boolean adv = false;
     boolean generateLedgerId = true;
-    private final StatsLogger statsLogger;
 
     /**
      * Constructor.
@@ -100,7 +99,7 @@ class LedgerCreateOp implements GenericCallback<LedgerMetadata> {
             BookKeeper bk, int ensembleSize, int writeQuorumSize, int ackQuorumSize, DigestType digestType,
             byte[] passwd, CreateCallback cb, Object ctx, final Map<String, byte[]> customMetadata,
             EnumSet<WriteFlag> writeFlags,
-            StatsLogger statsLogger) {
+            BookKeeperClientStats clientStats) {
         this.bk = bk;
         this.metadata = new LedgerMetadata(
             ensembleSize,
@@ -116,8 +115,8 @@ class LedgerCreateOp implements GenericCallback<LedgerMetadata> {
         this.cb = cb;
         this.ctx = ctx;
         this.startTime = MathUtils.nowInNano();
-        this.createOpLogger = bk.getCreateOpLogger();
-        this.statsLogger = statsLogger;
+        this.createOpLogger = clientStats.getCreateOpLogger();
+        this.clientStats = clientStats;
     }
 
     /**
@@ -200,11 +199,19 @@ class LedgerCreateOp implements GenericCallback<LedgerMetadata> {
 
         try {
             if (adv) {
-                lh = new LedgerHandleAdv(bk, ledgerId, metadata, digestType,
-                        passwd, writeFlags);
+                lh = new LedgerHandleAdv(bk.getInternalConf(), bk.getLedgerManager(),
+                                         bk.getBookieWatcher(), bk.getPlacementPolicy(),
+                                         bk.getBookieClient(), bk.getMainWorkerPool(),
+                                         bk.getScheduler(), () -> bk.isClosed(),
+                                         bk.getClientStats(), ledgerId, metadata, digestType,
+                                         passwd, writeFlags);
             } else {
-                lh = new LedgerHandle(bk, ledgerId, metadata, digestType,
-                        passwd, writeFlags);
+                lh = new LedgerHandle(bk.getInternalConf(), bk.getLedgerManager(),
+                                      bk.getBookieWatcher(), bk.getPlacementPolicy(),
+                                      bk.getBookieClient(), bk.getMainWorkerPool(),
+                                      bk.getScheduler(), () -> bk.isClosed(),
+                                      bk.getClientStats(), ledgerId, metadata, digestType,
+                                      passwd, writeFlags);
             }
         } catch (GeneralSecurityException e) {
             LOG.error("Security exception while creating ledger: " + ledgerId, e);
@@ -220,8 +227,7 @@ class LedgerCreateOp implements GenericCallback<LedgerMetadata> {
         LOG.info("Ensemble: {} for ledger: {}", curEns, lh.getId());
 
         for (BookieSocketAddress bsa : curEns) {
-            String ensSpread = BookKeeperClientStats.LEDGER_ENSEMBLE_BOOKIE_DISTRIBUTION + "-" + bsa;
-            statsLogger.getCounter(ensSpread).inc();
+            clientStats.getEnsembleBookieDistributionCounter(bsa.toString()).inc();
         }
 
         // return the ledger handle back
@@ -357,7 +363,7 @@ class LedgerCreateOp implements GenericCallback<LedgerMetadata> {
             }
             LedgerCreateOp op = new LedgerCreateOp(bk, builderEnsembleSize,
                 builderWriteQuorumSize, builderAckQuorumSize, DigestType.fromApiDigestType(builderDigestType),
-                builderPassword, cb, null, builderCustomMetadata, builderWriteFlags, bk.getStatsLogger());
+                builderPassword, cb, null, builderCustomMetadata, builderWriteFlags, bk.getClientStats());
             ReentrantReadWriteLock closeLock = bk.getCloseLock();
             closeLock.readLock().lock();
             try {
@@ -417,7 +423,7 @@ class LedgerCreateOp implements GenericCallback<LedgerMetadata> {
                     DigestType.fromApiDigestType(parent.builderDigestType),
                     parent.builderPassword, cb, null, parent.builderCustomMetadata,
                     parent.builderWriteFlags,
-                    parent.bk.getStatsLogger());
+                    parent.bk.getClientStats());
             ReentrantReadWriteLock closeLock = parent.bk.getCloseLock();
             closeLock.readLock().lock();
             try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerDeleteOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerDeleteOp.java
@@ -62,14 +62,15 @@ class LedgerDeleteOp extends OrderedGenericCallback<Void> {
      * @param ctx
      *            optional control object
      */
-    LedgerDeleteOp(BookKeeper bk, long ledgerId, DeleteCallback cb, Object ctx) {
+    LedgerDeleteOp(BookKeeper bk, BookKeeperClientStats clientStats,
+                   long ledgerId, DeleteCallback cb, Object ctx) {
         super(bk.getMainWorkerPool(), ledgerId);
         this.bk = bk;
         this.ledgerId = ledgerId;
         this.cb = cb;
         this.ctx = ctx;
         this.startTime = MathUtils.nowInNano();
-        this.deleteOpLogger = bk.getDeleteOpLogger();
+        this.deleteOpLogger = clientStats.getDeleteOpLogger();
     }
 
     /**
@@ -135,7 +136,7 @@ class LedgerDeleteOp extends OrderedGenericCallback<Void> {
                 cb.deleteComplete(BKException.Code.IncorrectParameterException, null);
                 return;
             }
-            LedgerDeleteOp op = new LedgerDeleteOp(bk, ledgerId, cb, null);
+            LedgerDeleteOp op = new LedgerDeleteOp(bk, bk.getClientStats(), ledgerId, cb, null);
             ReentrantReadWriteLock closeLock = bk.getCloseLock();
             closeLock.readLock().lock();
             try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -73,7 +73,8 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
      * @param cb
      * @param ctx
      */
-    public LedgerOpenOp(BookKeeper bk, long ledgerId, DigestType digestType, byte[] passwd,
+    public LedgerOpenOp(BookKeeper bk, BookKeeperClientStats clientStats,
+                        long ledgerId, DigestType digestType, byte[] passwd,
                         OpenCallback cb, Object ctx) {
         this.bk = bk;
         this.ledgerId = ledgerId;
@@ -82,10 +83,11 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
         this.ctx = ctx;
         this.enableDigestAutodetection = bk.getConf().getEnableDigestTypeAutodetection();
         this.suggestedDigestType = digestType;
-        this.openOpLogger = bk.getOpenOpLogger();
+        this.openOpLogger = clientStats.getOpenOpLogger();
     }
 
-    public LedgerOpenOp(BookKeeper bk, long ledgerId, OpenCallback cb, Object ctx) {
+    public LedgerOpenOp(BookKeeper bk, BookKeeperClientStats clientStats,
+                        long ledgerId, OpenCallback cb, Object ctx) {
         this.bk = bk;
         this.ledgerId = ledgerId;
         this.cb = cb;
@@ -95,7 +97,7 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
         this.administrativeOpen = true;
         this.enableDigestAutodetection = false;
         this.suggestedDigestType = bk.conf.getBookieRecoveryDigestType();
-        this.openOpLogger = bk.getOpenOpLogger();
+        this.openOpLogger = clientStats.getOpenOpLogger();
     }
 
     /**
@@ -165,7 +167,13 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
 
         // get the ledger metadata back
         try {
-            lh = new ReadOnlyLedgerHandle(bk, ledgerId, metadata, digestType, passwd, !doRecovery);
+            lh = new ReadOnlyLedgerHandle(bk.getInternalConf(), bk.getLedgerManager(),
+                                          bk.getBookieWatcher(), bk.getPlacementPolicy(),
+                                          bk.getBookieClient(),
+                                          bk.getMainWorkerPool(), bk.getScheduler(),
+                                          () -> bk.isClosed(), bk.getClientStats(),
+                                          ledgerId, metadata, digestType,
+                                          passwd, !doRecovery);
         } catch (GeneralSecurityException e) {
             LOG.error("Security exception while opening ledger: " + ledgerId, e);
             openComplete(BKException.Code.DigestNotInitializedException, null);
@@ -247,7 +255,8 @@ class LedgerOpenOp implements GenericCallback<LedgerMetadata> {
                 return;
             }
 
-            LedgerOpenOp op = new LedgerOpenOp(bk, ledgerId, fromApiDigestType(digestType),
+            LedgerOpenOp op = new LedgerOpenOp(bk, bk.getClientStats(),
+                                               ledgerId, fromApiDigestType(digestType),
                                                password, cb, null);
             ReentrantReadWriteLock closeLock = bk.getCloseLock();
             closeLock.readLock().lock();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ListenerBasedPendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ListenerBasedPendingReadOp.java
@@ -23,6 +23,8 @@ package org.apache.bookkeeper.client;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryListener;
 import org.apache.bookkeeper.util.MathUtils;
 
@@ -33,29 +35,20 @@ class ListenerBasedPendingReadOp extends PendingReadOp {
     final Object ctx;
 
     ListenerBasedPendingReadOp(LedgerHandle lh,
+                               ClientInternalConf conf,
+                               EnsemblePlacementPolicy placementPolicy,
+                               BookieClient bookieClient,
+                               OrderedExecutor mainWorkerPool,
                                ScheduledExecutorService scheduler,
-                               long startEntryId,
-                               long endEntryId,
-                               ReadEntryListener listener,
-                               Object ctx) {
-        this(
-            lh,
-            scheduler,
-            startEntryId,
-            endEntryId,
-            listener,
-            ctx,
-            false);
-    }
-
-    ListenerBasedPendingReadOp(LedgerHandle lh,
-                               ScheduledExecutorService scheduler,
+                               BookKeeperClientStats clientStats,
                                long startEntryId,
                                long endEntryId,
                                ReadEntryListener listener,
                                Object ctx,
                                boolean isRecoveryRead) {
-        super(lh, scheduler, startEntryId, endEntryId, isRecoveryRead);
+        super(lh, conf, placementPolicy, bookieClient,
+              mainWorkerPool, scheduler, clientStats,
+              startEntryId, endEntryId, isRecoveryRead);
         this.listener = listener;
         this.ctx = ctx;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
@@ -441,6 +441,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
         ClientConfiguration newConf = new ClientConfiguration()
             .setReadEntryTimeout(60000)
             .setAddEntryTimeout(60000)
+            .setEnableParallelRecoveryRead(true)
             .setRecoveryReadBatchSize(batchSize);
 
         newConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
@@ -480,14 +481,17 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
 
         final CountDownLatch recoverLatch = new CountDownLatch(1);
         final AtomicBoolean success = new AtomicBoolean(false);
-        LedgerRecoveryOp recoveryOp = new LedgerRecoveryOp(recoverLh,
+        LedgerRecoveryOp recoveryOp = new LedgerRecoveryOp(
+                recoverLh, bkc.getInternalConf(), bkc.getPlacementPolicy(),
+                bkc.getBookieClient(), bkc.getMainWorkerPool(), bkc.getScheduler(),
+                bkc.getClientStats(),
                 new BookkeeperInternalCallbacks.GenericCallback<Void>() {
-            @Override
-            public void operationComplete(int rc, Void result) {
-                success.set(BKException.Code.OK == rc);
-                recoverLatch.countDown();
-            }
-        }).parallelRead(true).readBatchSize(newConf.getRecoveryReadBatchSize());
+                    @Override
+                    public void operationComplete(int rc, Void result) {
+                        success.set(BKException.Code.OK == rc);
+                        recoverLatch.countDown();
+                    }
+                });
         recoveryOp.initiate();
         recoverLatch.await(10, TimeUnit.SECONDS);
         assertTrue(success.get());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -30,8 +30,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Optional;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
@@ -58,7 +56,6 @@ import org.apache.bookkeeper.client.api.OpenBuilder;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.feature.Feature;
 import org.apache.bookkeeper.meta.LedgerIdGenerator;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -150,22 +147,20 @@ public abstract class MockBookKeeperTestCase {
 
         bk = mock(BookKeeper.class);
 
-        NullStatsLogger nullStatsLogger = setupLoggers();
-
         failedBookies = new ArrayList<>();
         availableBookies = new HashSet<>();
 
         when(bk.getCloseLock()).thenReturn(new ReentrantReadWriteLock());
         when(bk.isClosed()).thenReturn(false);
         when(bk.getBookieWatcher()).thenReturn(bookieWatcher);
-        when(bk.getDisableEnsembleChangeFeature()).thenReturn(mock(Feature.class));
-        when(bk.getExplicitLacInterval()).thenReturn(0);
         when(bk.getMainWorkerPool()).thenReturn(executor);
         when(bk.getBookieClient()).thenReturn(bookieClient);
         when(bk.getScheduler()).thenReturn(scheduler);
-        when(bk.getReadSpeculativeRequestPolicy()).thenReturn(Optional.absent());
-        mockBookKeeperGetConf(new ClientConfiguration());
-        when(bk.getStatsLogger()).thenReturn(nullStatsLogger);
+
+        setBookKeeperConfig(new ClientConfiguration());
+        when(bk.getStatsLogger()).thenReturn(NullStatsLogger.INSTANCE);
+        BookKeeperClientStats clientStats = BookKeeperClientStats.newInstance(NullStatsLogger.INSTANCE);
+        when(bk.getClientStats()).thenReturn(clientStats);
         when(bk.getLedgerManager()).thenReturn(ledgerManager);
         when(bk.getLedgerIdGenerator()).thenReturn(ledgerIdGenerator);
         when(bk.getReturnRc(anyInt())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
@@ -184,22 +179,10 @@ public abstract class MockBookKeeperTestCase {
         setupBookieClientForceLedger();
     }
 
-    protected void mockBookKeeperGetConf(ClientConfiguration conf) {
+    protected void setBookKeeperConfig(ClientConfiguration conf) {
         when(bk.getConf()).thenReturn(conf);
-    }
-
-    protected NullStatsLogger setupLoggers() {
-        NullStatsLogger nullStatsLogger = NullStatsLogger.INSTANCE;
-        when(bk.getOpenOpLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
-        when(bk.getRecoverOpLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
-        when(bk.getAddOpLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
-        when(bk.getReadOpLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
-        when(bk.getDeleteOpLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
-        when(bk.getCreateOpLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
-        when(bk.getRecoverAddCountLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
-        when(bk.getRecoverReadCountLogger()).thenReturn(nullStatsLogger.getOpStatsLogger("mock"));
-        when(bk.getAddOpUrCounter()).thenReturn(nullStatsLogger.getCounter("mock"));
-        return nullStatsLogger;
+        ClientInternalConf internalConf = ClientInternalConf.fromConfig(conf);
+        when(bk.getInternalConf()).thenReturn(internalConf);
     }
 
     private DigestManager getDigestType(long ledgerId) throws GeneralSecurityException {
@@ -216,10 +199,6 @@ public abstract class MockBookKeeperTestCase {
     public void tearDown() {
         scheduler.shutdown();
         executor.shutdown();
-    }
-
-    protected void setBookkeeperConfig(ClientConfiguration config) {
-        when(bk.getConf()).thenReturn(config);
     }
 
     protected CreateBuilder newCreateLedgerOp() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -59,8 +59,12 @@ public class MockLedgerHandle extends LedgerHandle {
     boolean fenced = false;
 
     MockLedgerHandle(MockBookKeeper bk, long id, DigestType digest, byte[] passwd) throws GeneralSecurityException {
-        super(bk, id, new LedgerMetadata(3, 3, 2, DigestType.MAC, "".getBytes()), DigestType.MAC, "".getBytes(),
-                WriteFlag.NONE);
+        super(bk.getInternalConf(), bk.getLedgerManager(),
+              bk.getBookieWatcher(), bk.getPlacementPolicy(), bk.getBookieClient(),
+              bk.getMainWorkerPool(), bk.getScheduler(),
+              () -> bk.isClosed(), bk.getClientStats(), id,
+              new LedgerMetadata(3, 3, 2, DigestType.MAC, "".getBytes()), DigestType.MAC, "".getBytes(),
+              WriteFlag.NONE);
         this.bk = bk;
         this.id = id;
         this.digest = digest;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
@@ -428,7 +428,7 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
         final CountDownLatch addLatch = new CountDownLatch(1);
         final AtomicBoolean addSuccess = new AtomicBoolean(false);
         LOG.info("Add entry {} with lac = {}", entryId, lac);
-        lh.bk.getBookieClient().addEntry(lh.getLedgerMetadata().currentEnsemble.get(0),
+        bkc.getBookieClient().addEntry(lh.getLedgerMetadata().currentEnsemble.get(0),
                                          lh.getId(), lh.ledgerKey, entryId, toSend,
                                          new WriteCallback() {
                                              @Override
@@ -667,7 +667,7 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
         final AtomicLong lacHolder = new AtomicLong(-1234L);
         final AtomicInteger rcHolder = new AtomicInteger(-1234);
         final CountDownLatch doneLatch = new CountDownLatch(1);
-        new ReadLastConfirmedOp(readLh, new ReadLastConfirmedOp.LastConfirmedDataCallback() {
+        new ReadLastConfirmedOp(readLh, bkc.getBookieClient(), new ReadLastConfirmedOp.LastConfirmedDataCallback() {
             @Override
             public void readLastConfirmedDataComplete(int rc, DigestManager.RecoveryData data) {
                 rcHolder.set(rc);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingAddOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingAddOpTest.java
@@ -30,6 +30,8 @@ import io.netty.buffer.Unpooled;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.api.WriteFlag;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,18 +41,19 @@ import org.junit.Test;
  */
 public class PendingAddOpTest {
 
-    private BookKeeper bk;
     private LedgerHandle lh;
+    private BookieClient bookieClient;
+    private OrderedExecutor mainWorkerPool;
+    private BookKeeperClientStats clientStats;
     private ByteBuf payload;
 
     @Before
     public void setup() {
-        bk = mock(BookKeeper.class);
-        when(bk.getAddEntryQuorumTimeoutNanos()).thenReturn(1000L);
-        when(bk.getAddOpLogger()).thenReturn(NullStatsLogger.INSTANCE.getOpStatsLogger("test"));
-        when(bk.getAddOpUrCounter()).thenReturn(NullStatsLogger.INSTANCE.getCounter("test"));
+        clientStats = BookKeeperClientStats.newInstance(NullStatsLogger.INSTANCE);
+        bookieClient = mock(BookieClient.class);
+        mainWorkerPool = mock(OrderedExecutor.class);
+
         lh = mock(LedgerHandle.class);
-        when(lh.getBk()).thenReturn(bk);
         when(lh.getDistributionSchedule())
             .thenReturn(new RoundRobinDistributionSchedule(3, 3, 2));
         byte[] data = "test-pending-add-op".getBytes(UTF_8);
@@ -62,9 +65,12 @@ public class PendingAddOpTest {
     public void testExecuteAfterCancelled() {
         AtomicInteger rcHolder = new AtomicInteger(-0xdead);
         PendingAddOp op = PendingAddOp.create(
-            lh, payload, WriteFlag.NONE, (rc, handle, entryId, qwcLatency, ctx) -> {
-                rcHolder.set(rc);
-            }, null);
+                lh, ClientInternalConf.defaultValues(),
+                bookieClient, mainWorkerPool, clientStats,
+                payload, WriteFlag.NONE,
+                (rc, handle, entryId, qwcLatency, ctx) -> {
+                    rcHolder.set(rc);
+                }, null);
         assertSame(lh, op.lh);
 
         // cancel the op.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
@@ -244,8 +244,12 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
                 return true;
             }
         };
-        LedgerHandle lh = new LedgerHandle(bkc, 0, metadata, TEST_DIGEST_TYPE,
-                TEST_PSSWD, WriteFlag.NONE);
+        LedgerHandle lh = new LedgerHandle(bkc.getInternalConf(), bkc.getLedgerManager(),
+                                           bkc.getBookieWatcher(), bkc.getPlacementPolicy(),
+                                           bkc.getBookieClient(), bkc.getMainWorkerPool(),
+                                           bkc.getScheduler(), () -> bkc.isClosed(),
+                                           bkc.getClientStats(), 0, metadata, TEST_DIGEST_TYPE,
+                                           TEST_PSSWD, WriteFlag.NONE);
         testSplitIntoSubFragments(10, 21, -1, 1, lh);
         testSplitIntoSubFragments(10, 21, 20, 1, lh);
         testSplitIntoSubFragments(0, 0, 10, 1, lh);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestMaxEnsembleChangeNum.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestMaxEnsembleChangeNum.java
@@ -43,7 +43,7 @@ public class TestMaxEnsembleChangeNum extends MockBookKeeperTestCase {
         long lId;
         int numEntries = 5;
         int changeNum = 5;
-        setBookkeeperConfig(new ClientConfiguration().setDelayEnsembleChange(false).setMaxAllowedEnsembleChanges(5));
+        setBookKeeperConfig(new ClientConfiguration().setDelayEnsembleChange(false).setMaxAllowedEnsembleChanges(5));
         try (WriteHandle writer = result(newCreateLedgerOp()
                 .withAckQuorumSize(3)
                 .withWriteQuorumSize(3)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestPendingReadLacOp.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestPendingReadLacOp.java
@@ -51,7 +51,8 @@ public class TestPendingReadLacOp extends BookKeeperClusterTestCase {
         lh.append(data);
 
         final CompletableFuture<Long> result = new CompletableFuture<>();
-        PendingReadLacOp pro = new PendingReadLacOp(lh, (rc, lac) -> result.complete(lac)) {
+        PendingReadLacOp pro = new PendingReadLacOp(lh, bkc.getBookieClient(),
+                                                    (rc, lac) -> result.complete(lac)) {
             @Override
             public void initiate() {
                 for (int i = 0; i < lh.getLedgerMetadata().currentEnsemble.size(); i++) {
@@ -70,7 +71,7 @@ public class TestPendingReadLacOp extends BookKeeperClusterTestCase {
                                 index);
 
                     }, 0, TimeUnit.SECONDS);
-                    lh.bk.getBookieClient().readLac(lh.getLedgerMetadata().currentEnsemble.get(i),
+                    bookieClient.readLac(lh.getLedgerMetadata().currentEnsemble.get(i),
                             lh.ledgerId, this, i);
                 }
             }
@@ -87,7 +88,7 @@ public class TestPendingReadLacOp extends BookKeeperClusterTestCase {
         lh.append(data);
 
         final CompletableFuture<Long> result = new CompletableFuture<>();
-        PendingReadLacOp pro = new PendingReadLacOp(lh, (rc, lac) -> result.complete(lac)) {
+        PendingReadLacOp pro = new PendingReadLacOp(lh, bkc.getBookieClient(), (rc, lac) -> result.complete(lac)) {
             @Override
             public void initiate() {
                 for (int i = 0; i < lh.getLedgerMetadata().currentEnsemble.size(); i++) {
@@ -101,7 +102,7 @@ public class TestPendingReadLacOp extends BookKeeperClusterTestCase {
                                 null,
                                 index);
                     }, 0, TimeUnit.SECONDS);
-                    lh.bk.getBookieClient().readLac(lh.getLedgerMetadata().currentEnsemble.get(i),
+                    bookieClient.readLac(lh.getLedgerMetadata().currentEnsemble.get(i),
                             lh.ledgerId, this, i);
                 }
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadEntryListener.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadEntryListener.java
@@ -109,6 +109,13 @@ public class TestReadEntryListener extends BookKeeperClusterTestCase {
         }
     }
 
+    ListenerBasedPendingReadOp createReadOp(LedgerHandle lh, long from, long to, ReadEntryListener listener) {
+        return new ListenerBasedPendingReadOp(lh, bkc.getInternalConf(),
+                                              bkc.getPlacementPolicy(), bkc.getBookieClient(),
+                                              bkc.getMainWorkerPool(), bkc.getScheduler(),
+                                              bkc.getClientStats(), from, to, listener, null, false);
+    }
+
     void basicReadTest(boolean parallelRead) throws Exception {
         int numEntries = 10;
 
@@ -118,8 +125,7 @@ public class TestReadEntryListener extends BookKeeperClusterTestCase {
         // read single entry
         for (int i = 0; i < numEntries; i++) {
             LatchListener listener = new LatchListener(i, 1);
-            ListenerBasedPendingReadOp readOp =
-                    new ListenerBasedPendingReadOp(lh, lh.bk.scheduler, i, i, listener, null);
+            ListenerBasedPendingReadOp readOp = createReadOp(lh, i, i, listener);
             readOp.parallelRead(parallelRead).submit();
             listener.expectComplete();
             assertEquals(1, listener.resultCodes.size());
@@ -132,8 +138,7 @@ public class TestReadEntryListener extends BookKeeperClusterTestCase {
 
         // read multiple entries
         LatchListener listener = new LatchListener(0L, numEntries);
-        ListenerBasedPendingReadOp readOp =
-                new ListenerBasedPendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, listener, null);
+        ListenerBasedPendingReadOp readOp = createReadOp(lh, 0, numEntries - 1, listener);
         readOp.parallelRead(parallelRead).submit();
         listener.expectComplete();
         assertEquals(numEntries, listener.resultCodes.size());
@@ -166,8 +171,7 @@ public class TestReadEntryListener extends BookKeeperClusterTestCase {
 
         // read single entry
         LatchListener listener = new LatchListener(11L, 1);
-        ListenerBasedPendingReadOp readOp =
-                new ListenerBasedPendingReadOp(lh, lh.bk.scheduler, 11, 11, listener, null);
+        ListenerBasedPendingReadOp readOp = createReadOp(lh, 11, 11, listener);
         readOp.parallelRead(parallelRead).submit();
         listener.expectComplete();
         assertEquals(1, listener.resultCodes.size());
@@ -178,7 +182,7 @@ public class TestReadEntryListener extends BookKeeperClusterTestCase {
 
         // read multiple missing entries
         listener = new LatchListener(11L, 3);
-        readOp = new ListenerBasedPendingReadOp(lh, lh.bk.scheduler, 11, 13, listener, null);
+        readOp = createReadOp(lh, 11, 13, listener);
         readOp.parallelRead(parallelRead).submit();
         listener.expectComplete();
         assertEquals(3, listener.resultCodes.size());
@@ -192,7 +196,7 @@ public class TestReadEntryListener extends BookKeeperClusterTestCase {
 
         // read multiple entries with missing entries
         listener = new LatchListener(5L, 10);
-        readOp = new ListenerBasedPendingReadOp(lh, lh.bk.scheduler, 5L, 14L, listener, null);
+        readOp = createReadOp(lh, 5L, 14L, listener);
         readOp.parallelRead(parallelRead).submit();
         listener.expectComplete();
         assertEquals(10, listener.resultCodes.size());
@@ -237,8 +241,7 @@ public class TestReadEntryListener extends BookKeeperClusterTestCase {
 
         // read multiple entries
         LatchListener listener = new LatchListener(0L, numEntries);
-        ListenerBasedPendingReadOp readOp =
-                new ListenerBasedPendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, listener, null);
+        ListenerBasedPendingReadOp readOp = createReadOp(lh, 0, numEntries - 1, listener);
         readOp.parallelRead(parallelRead).submit();
         listener.expectComplete();
         assertEquals(numEntries, listener.resultCodes.size());
@@ -278,8 +281,7 @@ public class TestReadEntryListener extends BookKeeperClusterTestCase {
 
         // read multiple entries
         LatchListener listener = new LatchListener(0L, numEntries);
-        ListenerBasedPendingReadOp readOp =
-            new ListenerBasedPendingReadOp(lh, lh.bk.scheduler, 0, numEntries - 1, listener, null);
+        ListenerBasedPendingReadOp readOp = createReadOp(lh, 0, numEntries - 1, listener);
         readOp.parallelRead(parallelRead).submit();
         listener.expectComplete();
         assertEquals(numEntries, listener.resultCodes.size());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
@@ -159,7 +159,7 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
             speccb.expectSuccess(4000);
             nospeccb.expectTimeout(4000);
             // Check that the second bookie is registered as slow at entryId 1
-            RackawareEnsemblePlacementPolicy rep = (RackawareEnsemblePlacementPolicy) lspec.bk.placementPolicy;
+            RackawareEnsemblePlacementPolicy rep = (RackawareEnsemblePlacementPolicy) bkspec.getPlacementPolicy();
             assertTrue(rep.slowBookies.asMap().size() == 1);
 
             assertTrue(
@@ -220,7 +220,7 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
             Set<BookieSocketAddress> expectedSlowBookies = new HashSet<>();
             expectedSlowBookies.add(l.getLedgerMetadata().getEnsembles().get(0L).get(1));
             expectedSlowBookies.add(l.getLedgerMetadata().getEnsembles().get(0L).get(2));
-            assertEquals(((RackawareEnsemblePlacementPolicy) l.bk.placementPolicy).slowBookies.asMap().keySet(),
+            assertEquals(((RackawareEnsemblePlacementPolicy) bkspec.getPlacementPolicy()).slowBookies.asMap().keySet(),
                 expectedSlowBookies);
 
             // third should not hit timeouts since bookies 1 & 2 are registered as slow
@@ -318,8 +318,13 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
         secondHostOnly.set(1, true);
         PendingReadOp.LedgerEntryRequest req0 = null, req2 = null, req4 = null;
         try {
-            PendingReadOp op = new PendingReadOp(l, bkspec.scheduler, 0, 5);
-
+            PendingReadOp op = new PendingReadOp(l, bkspec.getInternalConf(),
+                                                 bkspec.getPlacementPolicy(),
+                                                 bkspec.getBookieClient(),
+                                                 bkspec.getMainWorkerPool(),
+                                                 bkspec.getScheduler(),
+                                                 bkspec.getClientStats(), 0, 5,
+                                                 false);
             // if we've already heard from all hosts,
             // we only send the initial read
             req0 = op.new SequenceReadRequest(ensemble, l.getId(), 0);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
@@ -212,7 +212,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
     private void testOpenLedgerDigestUnmatched(boolean autodetection) throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
         conf.setEnableDigestTypeAutodetection(autodetection);
-        mockBookKeeperGetConf(conf);
+        setBookKeeperConfig(conf);
 
         long lId;
         try (WriteHandle writer = result(newCreateLedgerOp()

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
@@ -152,7 +152,7 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
     public void testFailDigestTypeNullAndAutodetectionTrue() throws Exception {
         ClientConfiguration config = new ClientConfiguration();
         config.setEnableDigestTypeAutodetection(true);
-        setBookkeeperConfig(config);
+        setBookKeeperConfig(config);
         result(newCreateLedgerOp()
             .withDigestType(null)
             .withPassword(password)
@@ -163,7 +163,7 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
     public void testFailDigestTypeNullAndAutodetectionFalse() throws Exception {
         ClientConfiguration config = new ClientConfiguration();
         config.setEnableDigestTypeAutodetection(false);
-        setBookkeeperConfig(config);
+        setBookKeeperConfig(config);
         result(newCreateLedgerOp()
             .withDigestType(null)
             .withPassword(password)


### PR DESCRIPTION
This patch removes the hard dependency of LedgerHandle on BookKeeper.
This allows us to create an instance of LedgerHandle independently,
with a fully mocked BookieClient or LedgerManager and be clear on
where the objects used by the LedgerHandle are coming from.
