### PR TITLE
Fix master versions (4.8.0-SNAPSHOT->4.9.0-SNAPSHOT)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -699,15 +699,10 @@
               <artifactId>checkstyle</artifactId>
               <version>${puppycrawl.checkstyle.version}</version>
             </dependency>
-            <dependency>
-              <groupId>org.apache.bookkeeper</groupId>
-              <artifactId>buildtools</artifactId>
-              <version>${project.version}</version>
-            </dependency>
           </dependencies>
           <configuration>
-            <configLocation>bookkeeper/checkstyle.xml</configLocation>
-            <suppressionsLocation>bookkeeper/suppressions.xml</suppressionsLocation>
+            <configLocation>buildtools/src/main/resources/bookkeeper/checkstyle.xml</configLocation>
+            <suppressionsLocation>buildtools/src/main/resources/bookkeeper/suppressions.xml</suppressionsLocation>
             <encoding>UTF-8</encoding>
             <consoleOutput>true</consoleOutput>
             <failOnViolation>true</failOnViolation>

--- a/stream/api/pom.xml
+++ b/stream/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>stream-storage-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/clients/java/all/pom.xml
+++ b/stream/clients/java/all/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-java-client</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Clients :: Java Client </name>

--- a/stream/clients/java/base/pom.xml
+++ b/stream/clients/java/base/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-java-client-base</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Clients :: Java Client :: Base</name>

--- a/stream/clients/java/kv/pom.xml
+++ b/stream/clients/java/kv/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-java-kv-client</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Clients :: Java Client :: KV</name>

--- a/stream/clients/java/pom.xml
+++ b/stream/clients/java/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-clients-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-java-client-parent</artifactId>

--- a/stream/clients/pom.xml
+++ b/stream/clients/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-clients-parent</artifactId>

--- a/stream/common/pom.xml
+++ b/stream/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>stream-storage-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/distributedlog/core/pom.xml
+++ b/stream/distributedlog/core/pom.xml
@@ -146,7 +146,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <suppressionsLocation>distributedlog/suppressions.xml</suppressionsLocation>
+          <suppressionsLocation>buildtools/src/main/resources/distributedlog/suppressions.xml</suppressionsLocation>
           <excludes>**/thrift/**/*</excludes>
         </configuration>
       </plugin>

--- a/stream/pom.xml
+++ b/stream/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <packaging>pom</packaging>

--- a/stream/proto/pom.xml
+++ b/stream/proto/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/server/pom.xml
+++ b/stream/server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-server</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Server</name>

--- a/stream/statelib/pom.xml
+++ b/stream/statelib/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>stream-storage-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/storage/api/pom.xml
+++ b/stream/storage/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-service-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-service-api</artifactId>

--- a/stream/storage/impl/pom.xml
+++ b/stream/storage/impl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-service-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-service-impl</artifactId>

--- a/stream/storage/pom.xml
+++ b/stream/storage/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-service-parent</artifactId>

--- a/stream/tests-common/pom.xml
+++ b/stream/tests-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/integration/cluster/pom.xml
+++ b/tests/integration/cluster/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests.integration</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.bookkeeper.tests.integration</groupId>

--- a/tests/scripts/src/test/bash/bk_test_bin_common.sh
+++ b/tests/scripts/src/test/bash/bk_test_bin_common.sh
@@ -32,7 +32,8 @@ testDefaultVariables() {
   assertEquals "BINDIR is not set correctly" "${BK_BINDIR}" "${BINDIR}"
   assertEquals "BK_HOME is not set correctly" "${BK_HOMEDIR}" "${BK_HOME}"
   assertEquals "DEFAULT_LOG_CONF is not set correctly" "${BK_CONFDIR}/log4j.properties" "${DEFAULT_LOG_CONF}"
-  assertEquals "NETTY_LEAK_DETECTION_LEVEL is not set correctly" "disabled" "${NETTY_LEAK_DETECTION_LEVEL}"
+  assertEquals "NETTY_LEAK_DETECTION_LEVEL is not set correctly" "disabled" "${NETTY_LEAK
+_DETECTION_LEVEL}"
   assertEquals "NETTY_RECYCLER_MAXCAPACITY is not set correctly" "1000" "${NETTY_RECYCLER_MAXCAPACITY}"
   assertEquals "NETTY_RECYCLER_LINKCAPACITY is not set correctly" "1024" "${NETTY_RECYCLER_LINKCAPACITY}"
   assertEquals "BOOKIE_MAX_HEAP_MEMORY is not set correctly" "1g" "${BOOKIE_MAX_HEAP_MEMORY}"
@@ -62,13 +63,13 @@ testFindModuleJarAt() {
   # case 2: SNAPSHOT jar
   TEST_FILES=(
     "invalid-${MODULE}.jar"
-    "invalid-${MODULE}-4.8.0.jar"
-    "invalid-${MODULE}-4.8.0-SNAPSHOT.jar"
+    "invalid-${MODULE}-4.9.0.jar"
+    "invalid-${MODULE}-4.9.0-SNAPSHOT.jar"
     "${MODULE}.jar.invalid"
-    "${MODULE}-4.8.0.jar.invalid"
-    "${MODULE}-4.8.0-SNAPSHOT.jar.invalid"
+    "${MODULE}-4.9.0.jar.invalid"
+    "${MODULE}-4.9.0-SNAPSHOT.jar.invalid"
     "${MODULE}.jar"
-    "${MODULE}-4.8.0-SNAPSHOT.jar"
+    "${MODULE}-4.9.0-SNAPSHOT.jar"
   )
 
   TEST_DIR2=${BK_TMPDIR}/testdir2
@@ -80,18 +81,18 @@ testFindModuleJarAt() {
     count=$(( $count + 1 ))
   done
   MODULE_JAR2=$(find_module_jar_at ${TEST_DIR2} ${MODULE})
-  assertEquals "${MODULE}-4.8.0-SNAPSHOT.jar is not found" "${TEST_DIR2}/${MODULE}-4.8.0-SNAPSHOT.jar" "${MODULE_JAR2}"
+  assertEquals "${MODULE}-4.9.0-SNAPSHOT.jar is not found" "${TEST_DIR2}/${MODULE}-4.9.0-SNAPSHOT.jar" "${MODULE_JAR2}"
 
   # case 3: release jar
   TEST_FILES=(
     "invalid-${MODULE}.jar"
-    "invalid-${MODULE}-4.8.0.jar"
-    "invalid-${MODULE}-4.8.0-SNAPSHOT.jar"
+    "invalid-${MODULE}-4.9.0.jar"
+    "invalid-${MODULE}-4.9.0-SNAPSHOT.jar"
     "${MODULE}.jar.invalid"
-    "${MODULE}-4.8.0.jar.invalid"
-    "${MODULE}-4.8.0-SNAPSHOT.jar.invalid"
+    "${MODULE}-4.9.0.jar.invalid"
+    "${MODULE}-4.9.0-SNAPSHOT.jar.invalid"
     "${MODULE}.jar"
-    "${MODULE}-4.8.0.jar"
+    "${MODULE}-4.9.0.jar"
   )
 
   TEST_DIR3=${BK_TMPDIR}/testdir3
@@ -103,7 +104,7 @@ testFindModuleJarAt() {
     count=$(( $count + 1 ))
   done
   MODULE_JAR3=$(find_module_jar_at ${TEST_DIR3} ${MODULE})
-  assertEquals "${MODULE}-4.8.0.jar is not found" "${TEST_DIR3}/${MODULE}-4.8.0.jar" "${MODULE_JAR3}"
+  assertEquals "${MODULE}-4.9.0.jar is not found" "${TEST_DIR3}/${MODULE}-4.9.0.jar" "${MODULE_JAR3}"
 }
 
 testFindModuleJar() {
@@ -118,7 +119,7 @@ testFindModuleJar() {
 
   MODULE="test-module"
   MODULE_PATH="testmodule"
-  VERSION="4.8.0"
+  VERSION="4.9.0"
 
   TEST_FILES=(
     "${MODULE}-${VERSION}.jar"

--- a/tests/scripts/src/test/bash/bk_test_bin_common.sh
+++ b/tests/scripts/src/test/bash/bk_test_bin_common.sh
@@ -32,8 +32,7 @@ testDefaultVariables() {
   assertEquals "BINDIR is not set correctly" "${BK_BINDIR}" "${BINDIR}"
   assertEquals "BK_HOME is not set correctly" "${BK_HOMEDIR}" "${BK_HOME}"
   assertEquals "DEFAULT_LOG_CONF is not set correctly" "${BK_CONFDIR}/log4j.properties" "${DEFAULT_LOG_CONF}"
-  assertEquals "NETTY_LEAK_DETECTION_LEVEL is not set correctly" "disabled" "${NETTY_LEAK
-_DETECTION_LEVEL}"
+  assertEquals "NETTY_LEAK_DETECTION_LEVEL is not set correctly" "disabled" "${NETTY_LEAK_DETECTION_LEVEL}"
   assertEquals "NETTY_RECYCLER_MAXCAPACITY is not set correctly" "1000" "${NETTY_RECYCLER_MAXCAPACITY}"
   assertEquals "NETTY_RECYCLER_LINKCAPACITY is not set correctly" "1024" "${NETTY_RECYCLER_LINKCAPACITY}"
   assertEquals "BOOKIE_MAX_HEAP_MEMORY is not set correctly" "1g" "${BOOKIE_MAX_HEAP_MEMORY}"
@@ -63,13 +62,13 @@ testFindModuleJarAt() {
   # case 2: SNAPSHOT jar
   TEST_FILES=(
     "invalid-${MODULE}.jar"
-    "invalid-${MODULE}-4.9.0.jar"
-    "invalid-${MODULE}-4.9.0-SNAPSHOT.jar"
+    "invalid-${MODULE}-4.8.0.jar"
+    "invalid-${MODULE}-4.8.0-SNAPSHOT.jar"
     "${MODULE}.jar.invalid"
-    "${MODULE}-4.9.0.jar.invalid"
-    "${MODULE}-4.9.0-SNAPSHOT.jar.invalid"
+    "${MODULE}-4.8.0.jar.invalid"
+    "${MODULE}-4.8.0-SNAPSHOT.jar.invalid"
     "${MODULE}.jar"
-    "${MODULE}-4.9.0-SNAPSHOT.jar"
+    "${MODULE}-4.8.0-SNAPSHOT.jar"
   )
 
   TEST_DIR2=${BK_TMPDIR}/testdir2
@@ -81,18 +80,18 @@ testFindModuleJarAt() {
     count=$(( $count + 1 ))
   done
   MODULE_JAR2=$(find_module_jar_at ${TEST_DIR2} ${MODULE})
-  assertEquals "${MODULE}-4.9.0-SNAPSHOT.jar is not found" "${TEST_DIR2}/${MODULE}-4.9.0-SNAPSHOT.jar" "${MODULE_JAR2}"
+  assertEquals "${MODULE}-4.8.0-SNAPSHOT.jar is not found" "${TEST_DIR2}/${MODULE}-4.8.0-SNAPSHOT.jar" "${MODULE_JAR2}"
 
   # case 3: release jar
   TEST_FILES=(
     "invalid-${MODULE}.jar"
-    "invalid-${MODULE}-4.9.0.jar"
-    "invalid-${MODULE}-4.9.0-SNAPSHOT.jar"
+    "invalid-${MODULE}-4.8.0.jar"
+    "invalid-${MODULE}-4.8.0-SNAPSHOT.jar"
     "${MODULE}.jar.invalid"
-    "${MODULE}-4.9.0.jar.invalid"
-    "${MODULE}-4.9.0-SNAPSHOT.jar.invalid"
+    "${MODULE}-4.8.0.jar.invalid"
+    "${MODULE}-4.8.0-SNAPSHOT.jar.invalid"
     "${MODULE}.jar"
-    "${MODULE}-4.9.0.jar"
+    "${MODULE}-4.8.0.jar"
   )
 
   TEST_DIR3=${BK_TMPDIR}/testdir3
@@ -104,7 +103,7 @@ testFindModuleJarAt() {
     count=$(( $count + 1 ))
   done
   MODULE_JAR3=$(find_module_jar_at ${TEST_DIR3} ${MODULE})
-  assertEquals "${MODULE}-4.9.0.jar is not found" "${TEST_DIR3}/${MODULE}-4.9.0.jar" "${MODULE_JAR3}"
+  assertEquals "${MODULE}-4.8.0.jar is not found" "${TEST_DIR3}/${MODULE}-4.8.0.jar" "${MODULE_JAR3}"
 }
 
 testFindModuleJar() {
@@ -119,7 +118,7 @@ testFindModuleJar() {
 
   MODULE="test-module"
   MODULE_PATH="testmodule"
-  VERSION="4.9.0"
+  VERSION="4.8.0"
 
   TEST_FILES=(
     "${MODULE}-${VERSION}.jar"

--- a/tools/stream/pom.xml
+++ b/tools/stream/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper-tools-parent</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>4.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-cli</artifactId>
   <name>Apache BookKeeper :: Tools :: Stream</name>


### PR DESCRIPTION
Some pom versions and the versions in bk_test_bin_common.sh were
missed when the version was bumped to 4.9.0-SNAPSHOT, which is killing
all builds.
