### PR TITLE
Provide consistent locking mechanism in EntryLogManagerForEntryLogPerLedger

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -1003,10 +1003,17 @@ public class EntryLogTest {
         latchToStart.countDown();
         Thread.sleep(1000);
         /*
-         * since there are only "numOfLedgers" ledgers, only "numOfLedgers" threads should have been able to acquire
-         * lock. After acquiring the lock there must be waiting on 'latchToWait' latch
+         * since there are only "numOfLedgers" ledgers, only < "numOfLedgers"
+         * threads should have been able to acquire lock, because multiple
+         * ledgers can end up getting same lock because their hashcode might
+         * fall in the same bucket.
+         *
+         *
+         * After acquiring the lock there must be waiting on 'latchToWait' latch
          */
-        assertEquals("Number Of Threads acquired Lock", numOfLedgers, numberOfThreadsAcquiredLock.get());
+        int currentNumberOfThreadsAcquiredLock = numberOfThreadsAcquiredLock.get();
+        assertTrue("Number Of Threads acquired Lock " + currentNumberOfThreadsAcquiredLock,
+                (currentNumberOfThreadsAcquiredLock > 0) && (currentNumberOfThreadsAcquiredLock <= numOfLedgers));
         latchToWait.countDown();
         Thread.sleep(2000);
         assertEquals("Number Of Threads acquired Lock", numOfLedgers * numOfThreadsPerLedger,


### PR DESCRIPTION
Descriptions of the changes in this PR:

Assumption: The lock stored alongside the EntryLog in this map is meant
to be used to ensure that no two threads can be writing to the same
ledger at the same time.

The above invariant can be violated if the EntryLogAndLockTuple
object is evicted from the cache while in a critical section nominally
protected by the contained lock.

The conditions required for this to happen would be pretty odd --
there needs to be a huge amount of cache churn during one of
the protected operations.

The fix for this issue is to allocate in the constructor a fixed array of locks and select
for each EntryLogAndLockTuple a lock from that array
deterministically by ledgerId such that the same ledgerId
will always get the same lock.