### PR TITLE
[bookie] Avoid throwing exceptions if a loopback address is returned from the possible ip check

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -316,13 +316,23 @@ public class Bookie extends BookieCriticalThread {
         // we need to loop through all possible bookie identifiers to ensure it is treated as a new environment
         // just because of bad configuration
         List<BookieSocketAddress> addresses = Lists.newArrayListWithExpectedSize(3);
+        // we are checking all possibilities here, so we don't need to fail if we can only get
+        // loopback address. it will fail anyway when the bookie attempts to listen on loopback address.
         try {
             // ip address
             addresses.add(getBookieAddress(
-                new ServerConfiguration(conf).setUseHostNameAsBookieID(false).setAdvertisedAddress(null)));
+                new ServerConfiguration(conf)
+                    .setUseHostNameAsBookieID(false)
+                    .setAdvertisedAddress(null)
+                    .setAllowLoopback(true)
+            ));
             // host name
             addresses.add(getBookieAddress(
-                new ServerConfiguration(conf).setUseHostNameAsBookieID(true).setAdvertisedAddress(null)));
+                new ServerConfiguration(conf)
+                    .setUseHostNameAsBookieID(true)
+                    .setAdvertisedAddress(null)
+                    .setAllowLoopback(true)
+            ));
             // advertised address
             if (null != conf.getAdvertisedAddress()) {
                 addresses.add(getBookieAddress(conf));
@@ -569,7 +579,10 @@ public class Bookie extends BookieCriticalThread {
             && !conf.getAllowLoopback()) {
             throw new UnknownHostException("Trying to listen on loopback address, "
                     + addr + " but this is forbidden by default "
-                    + "(see ServerConfiguration#getAllowLoopback())");
+                    + "(see ServerConfiguration#getAllowLoopback()).\n"
+                    + "If this happen, you can consider specifying the network interface"
+                    + " to listen on (e.g. listeningInterface=eth0) or specifying the"
+                    + " advertised address (e.g. advertisedAddress=172.x.y.z)");
         }
         return addr;
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

 ### Motivation

At some network environment, a loopback address might be returned by default. However when you
want to specify `advertisedAddress` to avoid the loopback address, it still throws exception as
following:

```
17:23:35.696 [main] ERROR org.apache.bookkeeper.server.Main - Failed to build bookie server
org.apache.bookkeeper.bookie.BookieException$UnknownBookieIdException: java.net.UnknownHostException: Trying to listen on loopback address, 127.0.0.1:3181 but this is forbidden by default (see ServerConfiguration#getAllowLoopback())
	at org.apache.bookkeeper.bookie.Bookie.possibleBookieIds(Bookie.java:325) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.bookie.Bookie.checkEnvironmentWithStorageExpansion(Bookie.java:415) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.bookie.Bookie.checkEnvironment(Bookie.java:256) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.bookie.Bookie.<init>(Bookie.java:627) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.proto.BookieServer.newBookie(BookieServer.java:115) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.proto.BookieServer.<init>(BookieServer.java:96) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.server.service.BookieService.<init>(BookieService.java:42) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.server.Main.buildBookieServer(Main.java:299) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.server.Main.doMain(Main.java:219) [org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.server.Main.main(Main.java:201) [org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.proto.BookieServer.main(BookieServer.java:252) [org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
Caused by: java.net.UnknownHostException: Trying to listen on loopback address, 127.0.0.1:3181 but this is forbidden by default (see ServerConfiguration#getAllowLoopback())
	at org.apache.bookkeeper.bookie.Bookie.getBookieAddress(Bookie.java:564) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	at org.apache.bookkeeper.bookie.Bookie.possibleBookieIds(Bookie.java:315) ~[org.apache.bookkeeper-bookkeeper-server-4.7.1.jar:4.7.1]
	... 10 more
```

The exception is thrown on `possibleBookieIds` check. However we don't need to throw exception on `possibleBookieIds` check
if it is a loopback address. We can defer the exception until bookie attempts to listen on the loopback address.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
