### PR TITLE
Replace guava multimap in PCBC with custom impl (Cherry-pick)

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/SynchronizedHashMultiMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/SynchronizedHashMultiMap.java
@@ -1,0 +1,83 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.util.collections;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Simple multimap implementation that only stores key reference once.
+ *
+ * <p>Implementation is aimed at storing PerChannelBookieClient completions when there
+ * are duplicates. If the key is a pooled object, it must not exist once the value
+ * has been removed from the map, which can happen with guava multimap implemenations.
+ *
+ * <p>With this map is implemented with pretty heavy locking, but this shouldn't be an
+ * issue as the multimap only needs to be used in rare cases, i.e. when a user tries
+ * to read or the same entry twice at the same time. This class should *NOT*  be used
+ * in critical path code.
+ *
+ * <p>A unique key-value pair will only be stored once.
+ */
+public class SynchronizedHashMultiMap<K, V> {
+
+    HashMap<Integer, Set<Pair<K, V>>> map = new HashMap<>();
+
+    public synchronized void put(K k, V v) {
+        map.computeIfAbsent(k.hashCode(), (ignore) -> new HashSet<>()).add(Pair.of(k, v));
+    }
+
+    public synchronized Optional<K> getAnyKey() {
+        return map.values().stream().findAny().flatMap(pairs -> pairs.stream().findAny().map(p -> p.getLeft()));
+    }
+
+    public synchronized Optional<V> removeAny(K k) {
+        Set<Pair<K, V>> set = map.getOrDefault(k.hashCode(), Collections.emptySet());
+        Optional<Pair<K, V>> pair = set.stream().filter(p -> p.getLeft().equals(k)).findAny();
+        pair.ifPresent(p -> set.remove(p));
+        return pair.map(p -> p.getRight());
+    }
+
+    public synchronized int removeIf(BiPredicate<K, V> predicate) {
+        int removedSum = map.values().stream().mapToInt(
+                pairs -> {
+                    int removed = 0;
+                    // Can't use removeIf because we need the count
+                    Iterator<Pair<K, V>> iter = pairs.iterator();
+                    while (iter.hasNext()) {
+                        Pair<K, V> kv = iter.next();
+                        if (predicate.test(kv.getLeft(), kv.getRight())) {
+                            iter.remove();
+                            removed++;
+                        }
+                    }
+                    return removed;
+                }).sum();
+        map.values().removeIf((s) -> s.isEmpty());
+        return removedSum;
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/SynchronizedHashMultiMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/SynchronizedHashMultiMapTest.java
@@ -1,0 +1,99 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.util.collections;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for SynchronizedHashMultiMap.
+ */
+public class SynchronizedHashMultiMapTest {
+    @Test
+    public void testGetAnyKey() {
+        SynchronizedHashMultiMap<Integer, Integer> map = new SynchronizedHashMultiMap<>();
+        Assert.assertFalse(map.getAnyKey().isPresent());
+
+        map.put(1, 2);
+        Assert.assertEquals(map.getAnyKey().get(), Integer.valueOf(1));
+
+        map.put(1, 3);
+        Assert.assertEquals(map.getAnyKey().get(), Integer.valueOf(1));
+
+        map.put(2, 4);
+        int res = map.getAnyKey().get();
+        Assert.assertTrue(res == 1 || res == 2);
+
+        map.removeIf((k, v) -> k == 1);
+        Assert.assertEquals(map.getAnyKey().get(), Integer.valueOf(2));
+    }
+
+    @Test
+    public void testRemoveAny() {
+        SynchronizedHashMultiMap<Integer, Integer> map = new SynchronizedHashMultiMap<>();
+        Assert.assertFalse(map.removeAny(1).isPresent());
+
+        map.put(1, 2);
+        map.put(1, 3);
+        map.put(2, 4);
+        map.put(2, 4);
+
+        Optional<Integer> v = map.removeAny(1);
+        int firstVal = v.get();
+        Assert.assertTrue(firstVal == 2 || firstVal == 3);
+
+        v = map.removeAny(1);
+        int secondVal = v.get();
+        Assert.assertTrue(secondVal == 2 || secondVal == 3);
+        Assert.assertNotEquals(secondVal, firstVal);
+
+        v = map.removeAny(2);
+        Assert.assertTrue(v.isPresent());
+        Assert.assertEquals(v.get(), Integer.valueOf(4));
+
+        Assert.assertFalse(map.removeAny(1).isPresent());
+        Assert.assertFalse(map.removeAny(2).isPresent());
+        Assert.assertFalse(map.removeAny(3).isPresent());
+    }
+
+    @Test
+    public void testRemoveIf() {
+        SynchronizedHashMultiMap<Integer, Integer> map = new SynchronizedHashMultiMap<>();
+        Assert.assertEquals(map.removeIf((k, v) -> true), 0);
+
+        map.put(1, 2);
+        map.put(1, 3);
+        map.put(2, 4);
+        map.put(2, 4);
+
+        Assert.assertEquals(map.removeIf((k, v) -> v == 4), 1);
+        Assert.assertEquals(map.removeIf((k, v) -> k == 1), 2);
+
+        map.put(1, 2);
+        map.put(1, 3);
+        map.put(2, 4);
+
+        Assert.assertEquals(map.removeIf((k, v) -> false), 0);
+        Assert.assertEquals(map.removeIf((k, v) -> true), 3);
+    }
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

(cherry-pick #1569)

For a long time PerChannelBookieClient has used guava
LinkedListMultiMap to store conflicting V2 completion keys and
values. This is problematic though. Completion keys are pooled
objects. When a key-value pair is stored in a LinkedListMultiMap, if
it is the first value for that key, a collection is created for the
values, and added to a top-level map using the key, and then the key
and the value are added to the collection. When a second value is
added for the same key, the key and value are simply added to the
collection. The problem occurs when the first key is removed. PBCB
will recycle the key object, but this object is still being used in
the multimap in the top-level map. This causes all sorts of fun like
NullPointerException and IllegalStateException.

Because of this, this patch introduces a very simple multimap
implementation that only stores the key one time (in the collection)
and uses the hashCode of the key to separate the collections into
buckets. It's pretty inefficient, but this code it only hit in the
rare case where a client is trying to read or write the same entry
from the same ledger more than once at the same time.

Author: Ivan Kelly <ivan@ivankelly.net>

Reviewers: Enrico Olivelli <eolivelli@gmail.com>

This closes #1569 from ivankelly/conc-test-flake

Master Issue: #1569 
> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
