### PR TITLE
Provide async version of markLedgerUnderreplicated for LedgerUnderreplicationManager

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
@@ -37,13 +37,7 @@ public abstract class BKException extends org.apache.bookkeeper.client.api.BKExc
         if (cause instanceof BKException) {
             return (BKException) cause;
         } else {
-            BKException ex;
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-                ex = new BKInterruptedException();
-            } else {
-                ex = new BKUnexpectedConditionException();
-            }
+            BKException ex = new BKUnexpectedConditionException();
             ex.initCause(cause);
             return ex;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
@@ -20,6 +20,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import java.util.function.Function;
+
 /**
  * Class the enumerates all the possible error conditions.
  *
@@ -27,6 +29,25 @@ package org.apache.bookkeeper.client;
  */
 @SuppressWarnings("serial")
 public abstract class BKException extends org.apache.bookkeeper.client.api.BKException {
+
+    public static final Function<Throwable, BKException> HANDLER = cause -> {
+        if (cause == null) {
+            return null;
+        }
+        if (cause instanceof BKException) {
+            return (BKException) cause;
+        } else {
+            BKException ex;
+            if (cause instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                ex = new BKInterruptedException();
+            } else {
+                ex = new BKUnexpectedConditionException();
+            }
+            ex.initCause(cause);
+            return ex;
+        }
+    };
 
     BKException(int code) {
         super(code);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
@@ -17,10 +17,14 @@
  */
 package org.apache.bookkeeper.meta;
 
+import com.google.common.collect.Lists;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.replication.ReplicationException;
 
@@ -28,12 +32,26 @@ import org.apache.bookkeeper.replication.ReplicationException;
  * Interface for marking ledgers which need to be rereplicated.
  */
 public interface LedgerUnderreplicationManager extends AutoCloseable {
+
     /**
      * Mark a ledger as underreplicated. The replication should
      * then check which fragments are underreplicated and rereplicate them
      */
-    void markLedgerUnderreplicated(long ledgerId, String missingReplica)
-            throws ReplicationException.UnavailableException;
+    default void markLedgerUnderreplicated(long ledgerId, String missingReplica) throws ReplicationException {
+        FutureUtils.result(
+            markLedgerUnderreplicatedAsync(
+                ledgerId, Lists.newArrayList(missingReplica)), ReplicationException.EXCEPTION_HANDLER);
+    }
+
+    /**
+     * Mark a ledger as underreplicated with missing bookies. The replication should then
+     * check which fragements are underreplicated and rereplicate them.
+     *
+     * @param ledgerId ledger id
+     * @param missingReplicas missing replicas
+     * @return a future presents the mark result.
+     */
+    CompletableFuture<Void> markLedgerUnderreplicatedAsync(long ledgerId, Collection<String> missingReplicas);
 
     /**
      * Mark a ledger as fully replicated. If the ledger is not

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -578,6 +578,8 @@ public class Auditor implements AutoCloseable {
                     Sets.newHashSet(lh.getId())
                 ).whenComplete((result, cause) -> {
                     if (null != cause) {
+                        LOG.error("Auditor exception publishing suspected ledger {} with lost bookies {}",
+                            lh.getId(), bookies, cause);
                         callback.processResult(Code.ReplicationException, null, null);
                     } else {
                         callback.processResult(Code.OK, null, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationException.java
@@ -29,9 +29,6 @@ public abstract class ReplicationException extends Exception {
         if (cause instanceof ReplicationException) {
             return (ReplicationException) cause;
         } else {
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
             return new UnavailableException(cause.getMessage(), cause);
         }
     };

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationException.java
@@ -18,10 +18,24 @@
 
 package org.apache.bookkeeper.replication;
 
+import java.util.function.Function;
+
 /**
  * Exceptions for use within the replication service.
  */
 public abstract class ReplicationException extends Exception {
+
+    public static final Function<Throwable, ReplicationException> EXCEPTION_HANDLER = cause -> {
+        if (cause instanceof ReplicationException) {
+            return (ReplicationException) cause;
+        } else {
+            if (cause instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return new UnavailableException(cause.getMessage(), cause);
+        }
+    };
+
     protected ReplicationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestLedgerUnderreplicationManager.java
@@ -53,7 +53,6 @@ import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
 import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.DNS;
 import org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat;
-import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.test.ZooKeeperUtil;
 import org.apache.bookkeeper.util.BookKeeperConstants;
@@ -766,8 +765,7 @@ public class TestLedgerUnderreplicationManager {
     }
 
     private void verifyMarkLedgerUnderreplicated(Collection<String> missingReplica)
-            throws KeeperException, InterruptedException,
-            CompatibilityException, UnavailableException {
+            throws KeeperException, InterruptedException, ReplicationException {
         Long ledgerA = 0xfeadeefdacL;
         String znodeA = getUrLedgerZnode(ledgerA);
         LedgerUnderreplicationManager replicaMgr = lmf1


### PR DESCRIPTION
Descriptions of the changes in this PR:

 ### Motivation

Auditor has multiple places calling sync methods in async callbacks.
This raises the possibility hitting deadlock. Issue #1578 is one of the examples.

After looking into the `LedgerUnderreplicationManager`, `markLedgerUnderreplicated`
is the only interface that will be called in async callbacks. This change is
to provide an async version of `markLedgerUnderreplicated`.

 ### Changes

- add `markLedgerUnderreplicatedAsync` interface in `LedgerUnderreplicationManager`.
- implement the logic of `markLedgerUnderreplicated` using async callbacks
- use `markLedgerUnderreplicatedAsync` in the Auditor

Related Issues: #1578
Master Issue: #1617

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
