### PR TITLE
Allow construction of mock client context from scratch

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
@@ -20,15 +20,26 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.function.BooleanSupplier;
 
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.discover.MockRegistrationClient;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.MockLedgerManager;
 import org.apache.bookkeeper.proto.BookieClient;
+import org.apache.bookkeeper.proto.MockBookieClient;
+import org.apache.bookkeeper.stats.NullStatsLogger;
 
-class MockClientContext implements ClientContext {
-    private ClientInternalConf conf;
+/**
+ * Mock client context to allow testing client functionality with no external dependencies.
+ * The client context can be created with defaults, copied from another context or constructed from scratch.
+ */
+public class MockClientContext implements ClientContext {
+    private ClientInternalConf internalConf;
     private LedgerManager ledgerManager;
     private BookieWatcher bookieWatcher;
     private EnsemblePlacementPolicy placementPolicy;
@@ -37,6 +48,26 @@ class MockClientContext implements ClientContext {
     private OrderedScheduler scheduler;
     private BookKeeperClientStats clientStats;
     private BooleanSupplier isClientClosed;
+    private MockRegistrationClient regClient;
+
+    static MockClientContext create() {
+        ClientConfiguration conf = new ClientConfiguration();
+        OrderedScheduler scheduler = OrderedScheduler.newSchedulerBuilder().name("mock-executor").numThreads(1).build();
+        MockRegistrationClient regClient = new MockRegistrationClient();
+        EnsemblePlacementPolicy placementPolicy = new DefaultEnsemblePlacementPolicy();
+
+        return new MockClientContext()
+            .setConf(ClientInternalConf.fromConfig(conf))
+            .setLedgerManager(new MockLedgerManager())
+            .setBookieWatcher(new BookieWatcherImpl(conf, placementPolicy, regClient, NullStatsLogger.INSTANCE))
+            .setPlacementPolicy(placementPolicy)
+            .setRegistrationClient(regClient)
+            .setBookieClient(new MockBookieClient(scheduler))
+            .setMainWorkerPool(scheduler)
+            .setScheduler(scheduler)
+            .setClientStats(BookKeeperClientStats.newInstance(NullStatsLogger.INSTANCE))
+            .setIsClientClosed(() -> false);
+    }
 
     static MockClientContext copyOf(ClientContext other) {
         return new MockClientContext()
@@ -51,54 +82,74 @@ class MockClientContext implements ClientContext {
             .setIsClientClosed(other::isClientClosed);
     }
 
-    MockClientContext setConf(ClientInternalConf conf) {
-        this.conf = conf;
+    public MockRegistrationClient getMockRegistrationClient() {
+        checkState(regClient != null);
+        return regClient;
+    }
+
+    public MockLedgerManager getMockLedgerManager() {
+        checkState(ledgerManager instanceof MockLedgerManager);
+        return (MockLedgerManager) ledgerManager;
+    }
+
+    public MockBookieClient getMockBookieClient() {
+        checkState(bookieClient instanceof MockBookieClient);
+        return (MockBookieClient) bookieClient;
+    }
+
+    public MockClientContext setConf(ClientInternalConf conf) {
+        this.internalConf = internalConf;
         return this;
     }
 
-    MockClientContext setLedgerManager(LedgerManager ledgerManager) {
+    public MockClientContext setLedgerManager(LedgerManager ledgerManager) {
         this.ledgerManager = ledgerManager;
         return this;
     }
 
-    MockClientContext setBookieWatcher(BookieWatcher bookieWatcher) {
+    public MockClientContext setBookieWatcher(BookieWatcher bookieWatcher) {
         this.bookieWatcher = bookieWatcher;
         return this;
     }
 
-    MockClientContext setPlacementPolicy(EnsemblePlacementPolicy placementPolicy) {
+    public MockClientContext setPlacementPolicy(EnsemblePlacementPolicy placementPolicy) {
         this.placementPolicy = placementPolicy;
         return this;
     }
 
-    MockClientContext setBookieClient(BookieClient bookieClient) {
+    public MockClientContext setBookieClient(BookieClient bookieClient) {
         this.bookieClient = bookieClient;
         return this;
     }
 
-    MockClientContext setMainWorkerPool(OrderedExecutor mainWorkerPool) {
+    public MockClientContext setMainWorkerPool(OrderedExecutor mainWorkerPool) {
         this.mainWorkerPool = mainWorkerPool;
         return this;
     }
 
-    MockClientContext setScheduler(OrderedScheduler scheduler) {
+    public MockClientContext setScheduler(OrderedScheduler scheduler) {
         this.scheduler = scheduler;
         return this;
     }
 
-    MockClientContext setClientStats(BookKeeperClientStats clientStats) {
+    public MockClientContext setClientStats(BookKeeperClientStats clientStats) {
         this.clientStats = clientStats;
         return this;
     }
 
-    MockClientContext setIsClientClosed(BooleanSupplier isClientClosed) {
+    public MockClientContext setIsClientClosed(BooleanSupplier isClientClosed) {
         this.isClientClosed = isClientClosed;
+        return this;
+    }
+
+    public MockClientContext setRegistrationClient(MockRegistrationClient regClient) {
+        this.regClient = regClient;
         return this;
     }
 
     @Override
     public ClientInternalConf getConf() {
-        return this.conf;
+        return this.internalConf;
     }
 
     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
@@ -33,6 +33,7 @@ import org.apache.bookkeeper.meta.MockLedgerManager;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.MockBookieClient;
 import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.mockito.Mockito;
 
 /**
  * Mock client context to allow testing client functionality with no external dependencies.
@@ -97,38 +98,38 @@ public class MockClientContext implements ClientContext {
         return (MockBookieClient) bookieClient;
     }
 
-    public MockClientContext setConf(ClientInternalConf conf) {
-        this.internalConf = internalConf;
+    public MockClientContext setConf(ClientInternalConf internalConf) {
+        this.internalConf = maybeSpy(internalConf);
         return this;
     }
 
     public MockClientContext setLedgerManager(LedgerManager ledgerManager) {
-        this.ledgerManager = ledgerManager;
+        this.ledgerManager = maybeSpy(ledgerManager);
         return this;
     }
 
     public MockClientContext setBookieWatcher(BookieWatcher bookieWatcher) {
-        this.bookieWatcher = bookieWatcher;
+        this.bookieWatcher = maybeSpy(bookieWatcher);
         return this;
     }
 
     public MockClientContext setPlacementPolicy(EnsemblePlacementPolicy placementPolicy) {
-        this.placementPolicy = placementPolicy;
+        this.placementPolicy = maybeSpy(placementPolicy);
         return this;
     }
 
     public MockClientContext setBookieClient(BookieClient bookieClient) {
-        this.bookieClient = bookieClient;
+        this.bookieClient = maybeSpy(bookieClient);
         return this;
     }
 
     public MockClientContext setMainWorkerPool(OrderedExecutor mainWorkerPool) {
-        this.mainWorkerPool = mainWorkerPool;
+        this.mainWorkerPool = maybeSpy(mainWorkerPool);
         return this;
     }
 
     public MockClientContext setScheduler(OrderedScheduler scheduler) {
-        this.scheduler = scheduler;
+        this.scheduler = maybeSpy(scheduler);
         return this;
     }
 
@@ -143,8 +144,16 @@ public class MockClientContext implements ClientContext {
     }
 
     public MockClientContext setRegistrationClient(MockRegistrationClient regClient) {
-        this.regClient = regClient;
+        this.regClient = maybeSpy(regClient);
         return this;
+    }
+
+    private static <T> T maybeSpy(T orig) {
+        if (Mockito.mockingDetails(orig).isSpy()) {
+            return orig;
+        } else {
+            return Mockito.spy(orig);
+        }
     }
 
     @Override


### PR DESCRIPTION
So that ledger handle functionality can be tested without
instantiating a BookKeeper client.
