### PR TITLE
Fix EntryLoggerAllocator.stop

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
@@ -206,11 +206,12 @@ class EntryLoggerAllocator {
         // wait until the preallocation finished.
         allocatorExecutor.shutdown();
         try {
-            if (!allocatorExecutor.awaitTermination(3, TimeUnit.SECONDS)) {
+            if (!allocatorExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
                 log.warn("Timedout while awaiting for allocatorExecutor's termination, so force shuttingdown");
             }
         } catch (InterruptedException e) {
             log.warn("Got InterruptedException while awaiting termination of allocatorExecutor, so force shuttingdown");
+            Thread.currentThread().interrupt();
         }
         allocatorExecutor.shutdownNow();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
@@ -40,6 +40,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.EntryLogger.BufferedLogChannel;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -203,6 +205,15 @@ class EntryLoggerAllocator {
     void stop() {
         // wait until the preallocation finished.
         allocatorExecutor.shutdown();
+        try {
+            if (!allocatorExecutor.awaitTermination(3, TimeUnit.SECONDS)) {
+                log.warn("Timedout while awaiting for allocatorExecutor's termination, so force shuttingdown");
+            }
+        } catch (InterruptedException e) {
+            log.warn("Got InterruptedException while awaiting termination of allocatorExecutor, so force shuttingdown");
+        }
+        allocatorExecutor.shutdownNow();
+
         log.info("Stopped entry logger preallocator.");
     }
 


### PR DESCRIPTION


Descriptions of the changes in this PR:

- make sure EntryLoggerAllocator.stop terminates pending allocatorExecutor's task.
Otherwise tests would flap, since even after EntryLoggerAllocator.stop, there is
possibility of new entrylog creation, which is not expected.