### PR TITLE
ISSUE #1623: ReadOnlyLedgerHandle: don't schedule monitorPendingAddOps()

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
@@ -177,7 +177,8 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
     }
 
     @Override
-    protected void initializeExplicitLacFlushPolicy() {
+    protected void initializeWriteHandleState() {
+        // Essentially a noop, we don't want to set up write handle state here for a ReadOnlyLedgerHandle
         explicitLacFlushPolicy = ExplicitLacFlushPolicy.VOID_EXPLICITLAC_FLUSH_POLICY;
     }
 


### PR DESCRIPTION
The LedgerHandle constructor schedules an addEntryQuorumTimeout check
with the bk client scheduler. However, the only place this callback is
canceled is in the closeAsync (the one which returns a future, not to be
confused with asyncClose) method. asyncClose and close() both leak this
callback. Moreover, ReadOnlyLedgerHandle invokes the LedgerHandle
constructor and so also creates this callback, but it overrides close()
and asyncClose() without passing them through.

ReadOnlyLedgerHandle already overrides
initializeExplicitLacFlushPolicy() to avoid write specific state.  This
patch generalizes that hack to initializeWriteHandleState() and the
cleanup to tearDownWriteHandleState().  tearDownWriteHandleState() is
moved into doAsyncClose(), which appears to be called for closes in
general.

(rev cguttapalem)
(bug W-5362724)
Signed-off-by: Samuel Just <sjustsalesforce.com>

Author: Samuel Just <sjust@salesforce.com>

Reviewers: Ivan Kelly <ivank@apache.org>, Enrico Olivelli <eolivelli@gmail.com>, Sijie Guo <sijie@apache.org>

This closes #1624 from athanatos/forupstream/wip-1623, closes #1623

(cherry picked from commit 9279dcc13b95406dbcb7a333fcb8a8961f52bf16)

Conflicts:
	bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java

Conflicts mainly revolved around refactors in LedgerHandle to remove the
explicit bkclient.

(cherry picked from commit e58e0747e93bed3c4bff5a2b866986fdba621c4e)

Conflicts:
	bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java

