### PR TITLE
Issue-1658 License file: typo "Google Protocal Buffers" instead of "Google Protocol Buffers"

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -492,7 +492,7 @@ a "3-clause BSD" license.  For details, see deps/jsr-305/LICENSE.
 Bundled as lib/com.google.code.findbugs-jsr305-3.0.2.jar
 Source available at https://storage.googleapis.com/google-code-archive-source/v2/code.google.com/jsr-305/source-archive.zip
 ------------------------------------------------------------------------------------
-This product bundles Google Protocal Buffers, which is available under a "3-clause BSD"
+This product bundles Google Protocol Buffers, which is available under a "3-clause BSD"
 license.
 
 Bundled as

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -404,7 +404,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------------
-This product bundles Google Protocal Buffers, which is available under a "3-clause BSD"
+This product bundles Google Protocol Buffers, which is available under a "3-clause BSD"
 license.
 
 Bundled as


### PR DESCRIPTION
Fix a typo in LICENSE files for binary distributions.

Master issue #1658 