### PR TITLE
ISSUE #1653: Clients with zk:// uri's should read layout from store

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -117,7 +117,8 @@ public class ZKMetadataDriverBase implements AutoCloseable {
                         + schemeParts[1] + "' at uri : " + metadataServiceUri);
             }
         } else {
-            ledgerManagerFactoryClass = HierarchicalLedgerManagerFactory.class;
+            // behave as in the +null case, infer the layout from the store or fall back to the default
+            ledgerManagerFactoryClass = null;
         }
         return ledgerManagerFactoryClass;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerManager.java
@@ -183,7 +183,7 @@ public class TestLedgerManager extends BookKeeperClusterTestCase {
         String root0 = "/badzk0";
         zkc.create(root0, new byte[0],
                    Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        conf.setMetadataServiceUri(newMetadataServiceUri(root0));
+        conf.setMetadataServiceUri(newMetadataServiceUri(root0, HierarchicalLedgerManagerFactory.NAME));
 
         LedgerLayout layout = new LedgerLayout("DoesNotExist",
                          0xdeadbeef);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBaseStaticTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBaseStaticTest.java
@@ -64,11 +64,20 @@ public class ZKMetadataDriverBaseStaticTest {
     }
 
     @Test
-    public void testResolveLedgerManagerFactoryDefaultValue() {
+    public void testResolveLedgerManagerFactoryUnspecifiedLayout() {
         assertEquals(
-            HierarchicalLedgerManagerFactory.class,
+            null,
             ZKMetadataDriverBase.resolveLedgerManagerFactory(
-                URI.create("zk://127.0.0.1/ledgers"))
+                        URI.create("zk://127.0.0.1/ledgers"))
+        );
+    }
+
+    @Test
+    public void testResolveLedgerManagerFactoryNullLayout() {
+        assertEquals(
+                null,
+                ZKMetadataDriverBase.resolveLedgerManagerFactory(
+                        URI.create("zk+null://127.0.0.1/ledgers"))
         );
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -315,6 +315,10 @@ public abstract class BookKeeperClusterTestCase {
         return zkUtil.getMetadataServiceUri(ledgersRootPath);
     }
 
+    protected String newMetadataServiceUri(String ledgersRootPath, String type) {
+        return zkUtil.getMetadataServiceUri(ledgersRootPath, type);
+    }
+
     /**
      * Get bookie address for bookie at index.
      */


### PR DESCRIPTION
zk+null:// will cause the layout to be read from the store.  This patch
updates zk:// to do the same.  This matches past behavior with an
unspecified ledgerManagerFactoryClass.

Some tests needed to be updated with the new behavior.

(@bug W-5415120@)
(@rev cguttapalem@)
Signed-off-by: Samuel Just <sjust@salesforce.com>