### PR TITLE
ISSUE 1662: LocalBookKeeper use layout manager and ledger path configs

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/AbstractConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/AbstractConfigurationTest.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.meta.AbstractZkLedgerManagerFactory;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LongHierarchicalLedgerManagerFactory;
+import org.apache.commons.configuration.ConfigurationException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -76,7 +77,7 @@ public class AbstractConfigurationTest {
     }
 
     @SuppressWarnings({ "unchecked" })
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = ConfigurationException.class)
     public void testUnsupportedLedgerManagerFactory() throws Exception {
         LedgerManagerFactory mockFactory = mock(LedgerManagerFactory.class, CALLS_REAL_METHODS);
         conf.setLedgerManagerFactoryClass(mockFactory.getClass());


### PR DESCRIPTION
The URI patch had a side effect of causing LocalBookKeeper to always
use a URI string of the form zk:// which defaults to HLM.  This
patch updates LocalBookKeeper to generate zk+<layout>:// based on
the legacy LEDGER_MANAGER_FACTORY_CLASS config when present.  +null
will be used otherwise and defaults to HLM.  Further, use the
(admittedly deprecated) zkLedgerRootPath config to determine the
ledger path (defaults to /ledger, so the behavior will be unchanged
if unspecified).

(@bug W-5415276@)
(@rev cguttapalem@)
Signed-off-by: Samuel Just <sjust@salesforce.com>