### PR TITLE
Remove unnecessary log statement in LedgerDirsManager.getWritableLedgerDirs

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -157,7 +157,6 @@ public class LedgerDirsManager {
             String errMsg = "All ledger directories are non writable";
             NoWritableLedgerDirException e = new NoWritableLedgerDirException(
                     errMsg);
-            LOG.error(errMsg, e);
             throw e;
         }
         return writableLedgerDirectories;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
@@ -108,6 +108,7 @@ class LedgerDirsMonitor {
             // bookie cannot get writable dir but considered to be writable
             ldm.getWritableLedgerDirs();
         } catch (NoWritableLedgerDirException e) {
+            LOG.warn("LedgerDirsMonitor check process: All ledger directories are non writable");
             boolean highPriorityWritesAllowed = true;
             try {
                 // disk check can be frequent, so disable 'loggingNoWritable' to avoid log flooding.


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation


- when Bookie reaches diskusage threshold, LedgerDirsMonitor for every diskCheckInterval it logs NoWritableLedgerDirException call stack and message "All ledger directories are non writable".

### Changes

So remove unneccessary log statement in LedgerDirsManager.getWritableLedgerDirs and let the caller deal with the thrown exception.
