### PR TITLE
Use useradd -l option for docker scripts

### DIFF
--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -52,7 +52,7 @@ fi
 docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
 FROM ${IMAGE_NAME}
 RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME} && \
-  useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
+  useradd -l -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
 ENV  HOME /home/${USER_NAME}
 UserSpecificDocker
 

--- a/site/docker/run.sh
+++ b/site/docker/run.sh
@@ -42,7 +42,7 @@ fi
 docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
 FROM ${IMAGE_NAME}
 RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME} && \
-  useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
+  useradd -l -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
 ENV  HOME /home/${USER_NAME}
 UserSpecificDocker
 


### PR DESCRIPTION
This is a workaround for the Docker issue https://github.com/moby/moby/issues/5419

If you run the scripts with an very large uid the script hangs and it fills up the disk which contains /var/lib/docker

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [x] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [x] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [x] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [x] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [x] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [x] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [x] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [x] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---