### PR TITLE
Issue #1679 : Fix build failure due to javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -764,7 +764,9 @@
         <configuration>
           <!-- Prevent missing javadoc comments from being marked as errors -->
           <additionalparam>-Xdoclint:none -notimestamp</additionalparam>
-          <additionalOptions>-Xdoclint:none -notimestamp</additionalOptions>
+          <additionalOptions>
+            <additionalOption>-Xdoclint:none -notimestamp</additionalOption>
+          </additionalOptions>
           <subpackages>org.apache.bookkeeper.client:org.apache.bookkeeper.client.api:org.apache.bookkeeper.common.annotation:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature:org.apache.bookkeeper.stats</subpackages>
           <groups>
             <group>


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Fix build failure due to javadoc, additionalOptions' type is  an array .
### Changes

correct assignment strategy of additionalOptions to avoid type mismatch

Master Issue: #1679 
