### PR TITLE
Fix license issues in master

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -275,30 +275,30 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [37]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [38]
 - lib/org.codehaus.jackson-jackson-core-asl-1.9.11.jar [39]
-- lib/org.codehaus.jackson-jackson-mapper-asl-1.9.11.jar [40]
-- lib/com.google.api.grpc-proto-google-common-protos-1.0.0.jar [41]
-- lib/com.google.code.gson-gson-2.7.jar [42]
-- lib/io.opencensus-opencensus-api-0.11.0.jar [43]
-- lib/io.opencensus-opencensus-contrib-grpc-metrics-0.11.0.jar [43]
-- lib/com.squareup.okhttp-okhttp-2.5.0.jar [44]
-- lib/com.squareup.okio-okio-1.13.0.jar [45]
-- lib/io.grpc-grpc-all-1.12.0.jar [46]
-- lib/io.grpc-grpc-auth-1.12.0.jar [46]
-- lib/io.grpc-grpc-context-1.12.0.jar [46]
-- lib/io.grpc-grpc-core-1.12.0.jar [46]
-- lib/io.grpc-grpc-netty-1.12.0.jar [46]
-- lib/io.grpc-grpc-okhttp-1.12.0.jar [46]
-- lib/io.grpc-grpc-protobuf-1.12.0.jar [46]
-- lib/io.grpc-grpc-protobuf-lite-1.12.0.jar [46]
-- lib/io.grpc-grpc-protobuf-nano-1.12.0.jar [46]
-- lib/io.grpc-grpc-stub-1.12.0.jar [46]
-- lib/io.grpc-grpc-testing-1.12.0.jar [46]
-- lib/org.apache.curator-curator-client-4.0.1.jar [47]
-- lib/org.apache.curator-curator-framework-4.0.1.jar [47]
-- lib/org.apache.curator-curator-recipes-4.0.1.jar [47]
-- lib/org.inferred-freebuilder-1.14.9.jar [48]
-- lib/com.google.errorprone-error_prone_annotations-2.1.2.jar [49]
-- lib/org.apache.yetus-audience-annotations-0.5.0.jar [50]
+- lib/org.codehaus.jackson-jackson-mapper-asl-1.9.11.jar [39]
+- lib/com.google.api.grpc-proto-google-common-protos-1.0.0.jar [40]
+- lib/com.google.code.gson-gson-2.7.jar [41]
+- lib/io.opencensus-opencensus-api-0.11.0.jar [42]
+- lib/io.opencensus-opencensus-contrib-grpc-metrics-0.11.0.jar [42]
+- lib/com.squareup.okhttp-okhttp-2.5.0.jar [43]
+- lib/com.squareup.okio-okio-1.13.0.jar [44]
+- lib/io.grpc-grpc-all-1.12.0.jar [45]
+- lib/io.grpc-grpc-auth-1.12.0.jar [45]
+- lib/io.grpc-grpc-context-1.12.0.jar [45]
+- lib/io.grpc-grpc-core-1.12.0.jar [45]
+- lib/io.grpc-grpc-netty-1.12.0.jar [45]
+- lib/io.grpc-grpc-okhttp-1.12.0.jar [45]
+- lib/io.grpc-grpc-protobuf-1.12.0.jar [45]
+- lib/io.grpc-grpc-protobuf-lite-1.12.0.jar [45]
+- lib/io.grpc-grpc-protobuf-nano-1.12.0.jar [45]
+- lib/io.grpc-grpc-stub-1.12.0.jar [45]
+- lib/io.grpc-grpc-testing-1.12.0.jar [45]
+- lib/org.apache.curator-curator-client-4.0.1.jar [46]
+- lib/org.apache.curator-curator-framework-4.0.1.jar [46]
+- lib/org.apache.curator-curator-recipes-4.0.1.jar [46]
+- lib/org.inferred-freebuilder-1.14.9.jar [47]
+- lib/com.google.errorprone-error_prone_annotations-2.1.2.jar [48]
+- lib/org.apache.yetus-audience-annotations-0.5.0.jar [49]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.8.9
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.8.9
@@ -311,7 +311,7 @@ Apache Software License, Version 2.
 [9] Source available at https://github.com/ben-manes/caffeine/tree/v2.3.4
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/configuration/tags/CONFIGURATION_1_10/
 [11] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-io.git;a=tag;h=603579
-[12] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=tag;h=375459
+[12] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [13] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [14] Source available at https://github.com/twitter/finagle/tree/finagle-6.44.0
 [15] Source available at https://github.com/twitter/finagle/tree/finagle-6.43.0
@@ -337,18 +337,17 @@ Apache Software License, Version 2.
 [36] Source available at https://github.com/cbeust/jcommander/tree/jcommander-1.48
 [37] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [38] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[39] Source available at https://github.com/codehaus/jackson/tree/1.9
-[40] Source available at https://github.com/codehaus/jackson/tree/1.9
-[41] Source available at https://github.com/googleapis/googleapis
-[42] Source available at https://github.com/google/gson/tree/gson-parent-2.7
-[43] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.11.0
-[44] Source available at https://github.com/square/okhttp/tree/parent-2.5.0
-[45] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
-[46] Source available at https://github.com/grpc/grpc-java/tree/v1.12.0
-[47] Source available at https://github.com/apache/curator/tree/apache-curator-4.0.1
-[48] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9
-[49] Source available at https://github.com/google/error-prone/tree/v2.1.2
-[50] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
+[39] Source available at https://github.com/codehaus/jackson/tree/d1c26ec538a8701cff7548009254fd6183b71873
+[40] Source available at https://github.com/googleapis/googleapis
+[41] Source available at https://github.com/google/gson/tree/gson-parent-2.7
+[42] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.11.0
+[43] Source available at https://github.com/square/okhttp/tree/parent-2.5.0
+[44] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
+[45] Source available at https://github.com/grpc/grpc-java/tree/v1.12.0
+[46] Source available at https://github.com/apache/curator/tree/apache-curator-4.0.1
+[47] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9
+[48] Source available at https://github.com/google/error-prone/tree/v2.1.2
+[49] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
 
 
 ------------------------------------------------------------------------------------

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -240,30 +240,30 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [24]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
 - lib/org.codehaus.jackson-jackson-core-asl-1.9.11.jar [26]
-- lib/org.codehaus.jackson-jackson-mapper-asl-1.9.11.jar [27]
-- lib/com.google.api.grpc-proto-google-common-protos-1.0.0.jar [28]
-- lib/com.google.code.gson-gson-2.7.jar [29]
-- lib/io.opencensus-opencensus-api-0.11.0.jar [30]
-- lib/io.opencensus-opencensus-contrib-grpc-metrics-0.11.0.jar [30]
-- lib/com.squareup.okhttp-okhttp-2.5.0.jar [31]
-- lib/com.squareup.okio-okio-1.13.0.jar [32]
-- lib/io.grpc-grpc-all-1.12.0.jar [33]
-- lib/io.grpc-grpc-auth-1.12.0.jar [33]
-- lib/io.grpc-grpc-context-1.12.0.jar [33]
-- lib/io.grpc-grpc-core-1.12.0.jar [33]
-- lib/io.grpc-grpc-netty-1.12.0.jar [33]
-- lib/io.grpc-grpc-okhttp-1.12.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.12.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.12.0.jar [33]
-- lib/io.grpc-grpc-protobuf-nano-1.12.0.jar [33]
-- lib/io.grpc-grpc-stub-1.12.0.jar [33]
-- lib/io.grpc-grpc-testing-1.12.0.jar [33]
-- lib/org.apache.curator-curator-client-4.0.1.jar [34]
-- lib/org.apache.curator-curator-framework-4.0.1.jar [34]
-- lib/org.apache.curator-curator-recipes-4.0.1.jar [34]
-- lib/org.inferred-freebuilder-1.14.9.jar [35]
-- lib/com.google.errorprone-error_prone_annotations-2.1.2.jar [36]
-- lib/org.apache.yetus-audience-annotations-0.5.0.jar [37]
+- lib/org.codehaus.jackson-jackson-mapper-asl-1.9.11.jar [26]
+- lib/com.google.api.grpc-proto-google-common-protos-1.0.0.jar [27]
+- lib/com.google.code.gson-gson-2.7.jar [28]
+- lib/io.opencensus-opencensus-api-0.11.0.jar [29]
+- lib/io.opencensus-opencensus-contrib-grpc-metrics-0.11.0.jar [29]
+- lib/com.squareup.okhttp-okhttp-2.5.0.jar [30]
+- lib/com.squareup.okio-okio-1.13.0.jar [31]
+- lib/io.grpc-grpc-all-1.12.0.jar [32]
+- lib/io.grpc-grpc-auth-1.12.0.jar [32]
+- lib/io.grpc-grpc-context-1.12.0.jar [32]
+- lib/io.grpc-grpc-core-1.12.0.jar [32]
+- lib/io.grpc-grpc-netty-1.12.0.jar [32]
+- lib/io.grpc-grpc-okhttp-1.12.0.jar [32]
+- lib/io.grpc-grpc-protobuf-1.12.0.jar [32]
+- lib/io.grpc-grpc-protobuf-lite-1.12.0.jar [32]
+- lib/io.grpc-grpc-protobuf-nano-1.12.0.jar [32]
+- lib/io.grpc-grpc-stub-1.12.0.jar [32]
+- lib/io.grpc-grpc-testing-1.12.0.jar [32]
+- lib/org.apache.curator-curator-client-4.0.1.jar [33]
+- lib/org.apache.curator-curator-framework-4.0.1.jar [33]
+- lib/org.apache.curator-curator-recipes-4.0.1.jar [33]
+- lib/org.inferred-freebuilder-1.14.9.jar [34]
+- lib/com.google.errorprone-error_prone_annotations-2.1.2.jar [35]
+- lib/org.apache.yetus-audience-annotations-0.5.0.jar [36]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.8.9
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.8.9
@@ -283,25 +283,24 @@ Apache Software License, Version 2.
 [16] Source available at http://logging.apache.org/log4j/1.2/download.html
 [17] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
-[19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=tag;h=3ad2e8
+[19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [20] Source available at https://github.com/apache/zookeeper/tree/release-3.4.13
 [21] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.5.v20170502
 [22] Source available at https://github.com/facebook/rocksdb/tree/v5.13.1
 [23] Source available at https://github.com/cbeust/jcommander/tree/jcommander-1.48
 [24] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[26] Source available at https://github.com/codehaus/jackson/tree/1.9
-[27] Source available at https://github.com/codehaus/jackson/tree/1.9
-[28] Source available at https://github.com/googleapis/googleapis
-[29] Source available at https://github.com/google/gson/tree/gson-parent-2.7
-[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.11.0
-[31] Source available at https://github.com/square/okhttp/tree/parent-2.5.0
-[32] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.12.0
-[34] Source available at https://github.com/apache/curator/tree/apache-curator-4.0.1
-[35] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9
-[36] Source available at https://github.com/google/error-prone/tree/v2.1.2
-[37] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
+[26] Source available at https://github.com/codehaus/jackson/tree/d1c26ec538a8701cff7548009254fd6183b71873
+[27] Source available at https://github.com/googleapis/googleapis
+[28] Source available at https://github.com/google/gson/tree/gson-parent-2.7
+[29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.11.0
+[30] Source available at https://github.com/square/okhttp/tree/parent-2.5.0
+[31] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
+[32] Source available at https://github.com/grpc/grpc-java/tree/v1.12.0
+[33] Source available at https://github.com/apache/curator/tree/apache-curator-4.0.1
+[34] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9
+[35] Source available at https://github.com/google/error-prone/tree/v2.1.2
+[36] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-all-4.1.22.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -127,3 +127,51 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
+- lib/io.grpc-grpc-all-1.12.0.jar
+- lib/io.grpc-grpc-auth-1.12.0.jar
+- lib/io.grpc-grpc-context-1.12.0.jar
+- lib/io.grpc-grpc-core-1.12.0.jar
+- lib/io.grpc-grpc-netty-1.12.0.jar
+- lib/io.grpc-grpc-okhttp-1.12.0.jar
+- lib/io.grpc-grpc-protobuf-1.12.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.12.0.jar
+- lib/io.grpc-grpc-protobuf-nano-1.12.0.jar
+- lib/io.grpc-grpc-stub-1.12.0.jar
+- lib/io.grpc-grpc-testing-1.12.0.jar
+
+Copyright 2014, gRPC Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This product contains a modified portion of 'OkHttp', an open source
+HTTP & SPDY client for Android and Java applications, which can be obtained
+at:
+
+  * LICENSE:
+    * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/square/okhttp
+  * LOCATION_IN_GRPC:
+    * okhttp/third_party/okhttp
+
+This product contains a modified portion of 'Netty', an open source
+networking library, which can be obtained at:
+
+  * LICENSE:
+    * netty/third_party/netty/LICENSE.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://netty.io
+  * LOCATION_IN_GRPC:
+    * netty/third_party/netty
+
+------------------------------------------------------------------------------------

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -87,3 +87,51 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
+- lib/io.grpc-grpc-all-1.12.0.jar
+- lib/io.grpc-grpc-auth-1.12.0.jar
+- lib/io.grpc-grpc-context-1.12.0.jar
+- lib/io.grpc-grpc-core-1.12.0.jar
+- lib/io.grpc-grpc-netty-1.12.0.jar
+- lib/io.grpc-grpc-okhttp-1.12.0.jar
+- lib/io.grpc-grpc-protobuf-1.12.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.12.0.jar
+- lib/io.grpc-grpc-protobuf-nano-1.12.0.jar
+- lib/io.grpc-grpc-stub-1.12.0.jar
+- lib/io.grpc-grpc-testing-1.12.0.jar
+
+Copyright 2014, gRPC Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This product contains a modified portion of 'OkHttp', an open source
+HTTP & SPDY client for Android and Java applications, which can be obtained
+at:
+
+  * LICENSE:
+    * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/square/okhttp
+  * LOCATION_IN_GRPC:
+    * okhttp/third_party/okhttp
+
+This product contains a modified portion of 'Netty', an open source
+networking library, which can be obtained at:
+
+  * LICENSE:
+    * netty/third_party/netty/LICENSE.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://netty.io
+  * LOCATION_IN_GRPC:
+    * netty/third_party/netty
+
+------------------------------------------------------------------------------------


### PR DESCRIPTION
The only blocking error is that the GRPC NOTICE had not been bubbled
up to our notice.

The links for common-lang 3.6 and jackson 1.9.11 were also wrong, and
while these aren't required in license files, bad links makes it
harder to check if a dependency has been correct noted in the LICENSE
and NOTICE.
