### PR TITLE
Shutdown appropriate EntryLogger instance.

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -1076,6 +1076,7 @@ public class EntryLogTest {
      */
     @Test
     public void testCacheMaximumSizeEvictionPolicy() throws Exception {
+        entryLogger.shutdown();
         final int cacheMaximumSize = 20;
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
@@ -1086,7 +1087,7 @@ public class EntryLogTest {
         LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
 
-        EntryLogger entryLogger = new EntryLogger(conf, ledgerDirsManager);
+        entryLogger = new EntryLogger(conf, ledgerDirsManager);
         EntryLogManagerForEntryLogPerLedger entryLogManager =
                 (EntryLogManagerForEntryLogPerLedger) entryLogger.getEntryLogManager();
 


### PR DESCRIPTION

Descriptions of the changes in this PR:

- EntryLogger's instance shutdown method should be called
- Otherwise test would flap, since in tearDown method, FileUtils.deleteDirectory can fail because of EntryLogFile PreAllocation task.
