### PR TITLE
Bump journal and fileinfo version.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -554,7 +554,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return fileinfo format version to write.
      */
     public int getFileInfoFormatVersionToWrite() {
-        return this.getInt(FILEINFO_FORMAT_VERSION_TO_WRITE, 0);
+        return this.getInt(FILEINFO_FORMAT_VERSION_TO_WRITE, 1);
     }
 
     /**
@@ -657,7 +657,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return journal format version to write.
      */
     public int getJournalFormatVersionToWrite() {
-        return this.getInt(JOURNAL_FORMAT_VERSION_TO_WRITE, 4);
+        return this.getInt(JOURNAL_FORMAT_VERSION_TO_WRITE, 6);
     }
 
     /**

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -272,20 +272,19 @@ journalDirectories=/tmp/bk-txn
 # journalDirectory=/tmp/bk-txn
 
 # The journal format version to write.
-# Available formats are 1-5:
+# Available formats are 1-6:
 # 1: no header
 # 2: a header section was added
 # 3: ledger key was introduced
 # 4: fencing key was introduced
 # 5: expanding header to 512 and padding writes to align sector size configured by `journalAlignmentSize`
 # 6: persisting explicitLac is introduced
-# By default, it is `4`. If you'd like to enable `padding-writes` feature, you can set journal version to `5`.
+# By default, it is `6`.
+# If you'd like to disable persisting ExplicitLac, you can set this config to < `6` and also
+# fileInfoFormatVersionToWrite should be set to 0. If there is mismatch then the serverconfig is considered invalid.
 # You can disable `padding-writes` by setting journal version back to `4`. This feature is available in 4.5.0
 # and onward versions.
-# If you'd like to enable persisting ExplicitLac, you can set this config to 6 and also 
-# fileInfoFormatVersionToWrite should be atleast 1. If there is mismatch then the serverconfig is considered 
-# invalid.
-# journalFormatVersionToWrite=4
+# journalFormatVersionToWrite=6
 
 # Max file size of journal file, in mega bytes
 # A new journal file will be created when the old one reaches the file size limitation
@@ -445,7 +444,7 @@ ledgerDirectories=/tmp/bk-data
 # active at a given point in time
 # maximumNumberOfActiveEntryLogs=500
 
-# in EntryLogManagerForEntryLogPerLedger, this config value specifies the metrics cache size 
+# in EntryLogManagerForEntryLogPerLedger, this config value specifies the metrics cache size
 # limits in multiples of entrylogMap cache size limits.
 # entryLogPerLedgerCounterLimitsMultFactor=10
 
@@ -600,10 +599,11 @@ ledgerDirectories=/tmp/bk-data
 #  Available formats are 0-1:
 #   0: Initial version
 #   1: persisting explicitLac is introduced
-#  By default, it is `0`. If you'd like to enable persisting ExplicitLac, you can set
-#  this config to 1 and also journalFormatVersionToWrite should be atleast 6. If 
-#  there is mismatch then the serverconfig is considered invalid.
-# fileInfoFormatVersionToWrite = 0
+# By default, it is `1`.
+# If you'd like to disable persisting ExplicitLac, you can set this config to 0 and
+# also journalFormatVersionToWrite should be set to < 6. If there is mismatch then the
+# serverconfig is considered invalid.
+# fileInfoFormatVersionToWrite = 1
 
 # Size of a index page in ledger cache, in bytes
 # A larger index page can improve performance writing page to disk,

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -200,10 +200,10 @@ groups:
        5: expanding header to 512 and padding writes to align sector size configured by `journalAlignmentSize`
        6: persisting explicitLac is introduced
 
-      By default, it is `4`. If you'd like to enable `padding-writes` feature, you can set journal version to `5`.
+      By default, it is `6`. 
+      If you'd like to disable persisting ExplicitLac, you can set this config to < `6` and also fileInfoFormatVersionToWrite should be set to 0. If there is mismatch then the serverconfig is considered invalid.
       You can disable `padding-writes` by setting journal version back to `4`. This feature is available in 4.5.0 and onward versions.
-      If you'd like to enable persisting ExplicitLac, you can set this config to 6 and also fileInfoFormatVersionToWrite should be atleast 1. If there is mismatch then the serverconfig is considered invalid.
-    default: 4
+    default: 6
   - param: journalMaxSizeMB
     description: Max file size of journal file, in mega bytes. A new journal file will be created when the old one reaches the file size limitation.
     default: 2048
@@ -422,8 +422,8 @@ groups:
        0: Initial version
        1: persisting explicitLac is introduced
 
-      By default, it is `0`. If you'd like to enable persisting ExplicitLac, you can set this config to 1 and also journalFormatVersionToWrite should be atleast 6. If there is mismatch then the serverconfig is considered invalid.
-    default: 0
+      By default, it is `1`. If you'd like to disable persisting ExplicitLac, you can set this config to 0 and also journalFormatVersionToWrite should be set to < 6. If there is mismatch then the serverconfig is considered invalid.
+    default: 1
   - param: pageSize
     description: |
       Size of a index page in ledger cache, in bytes. A larger index page can improve performance writing page to disk, which is efficent when you have small number of ledgers and these ledgers have similar number of entries. If you have large number of ledgers and each ledger has fewer entries, smaller index page would improve memory usage.


### PR DESCRIPTION


Descriptions of the changes in this PR:


- As part of ISSUE #1527, new versions of 'journalFormatVersionToWrite'
and 'fileInfoFormatVersionToWrite' are introduced. Since 4.8 release version
is created, default values of these versions should be bumped.