### PR TITLE
autorecovery-use-metadata-driver (part 1) : move AutoRecoveryMain to use MetadataBookieDriver

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AutoRecoveryMainTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AutoRecoveryMainTest.java
@@ -74,37 +74,4 @@ public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
                 main.replicationWorker.isRunning());
     }
 
-    /**
-     * Test that, if an autorecovery looses its ZK connection/session
-     * it will shutdown.
-     */
-    @Test
-    public void testAutoRecoverySessionLoss() throws Exception {
-        AutoRecoveryMain main1 = new AutoRecoveryMain(bsConfs.get(0));
-        AutoRecoveryMain main2 = new AutoRecoveryMain(bsConfs.get(1));
-        main1.start();
-        main2.start();
-        Thread.sleep(500);
-        assertTrue("AuditorElectors should be running",
-                main1.auditorElector.isRunning() && main2.auditorElector.isRunning());
-        assertTrue("Replication workers should be running",
-                main1.replicationWorker.isRunning() && main2.replicationWorker.isRunning());
-
-        zkUtil.expireSession(main1.zk);
-        zkUtil.expireSession(main2.zk);
-
-        for (int i = 0; i < 10; i++) { // give it 10 seconds to shutdown
-            if (!main1.auditorElector.isRunning()
-                && !main2.auditorElector.isRunning()
-                && !main1.replicationWorker.isRunning()
-                && !main2.replicationWorker.isRunning()) {
-                break;
-            }
-            Thread.sleep(1000);
-        }
-        assertFalse("Elector1 should have shutdown", main1.auditorElector.isRunning());
-        assertFalse("Elector2 should have shutdown", main2.auditorElector.isRunning());
-        assertFalse("RW1 should have shutdown", main1.replicationWorker.isRunning());
-        assertFalse("RW2 should have shutdown", main2.replicationWorker.isRunning());
-    }
 }


### PR DESCRIPTION

Descriptions of the changes in this PR:

### Motivation

We are introducing Etcd as the metadata storage. However AutoRecovery currently is still tied to zookeeper. In order to use Etcd as the metadata storage, we have to move AutoRecovery related classes to use metadata driver API.

### Changes

This is the first change for changing AutoRecovery to use metadata driver. It changed AutoRecoveryMain to use metadata driver api and also removed the shutdown logic on session expired, which doesn't make any sense for current retryable zookeeper.



> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---