### PR TITLE
Decorate OrderedExecutor threads rather than runnables

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
@@ -17,18 +17,27 @@
  */
 package org.apache.bookkeeper.common.util;
 
+import com.google.common.util.concurrent.ForwardingListeningExecutorService;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.bookkeeper.stats.StatsLogger;
 
@@ -117,6 +126,11 @@ public class OrderedScheduler extends OrderedExecutor implements ScheduledExecut
     @Override
     protected ListeningScheduledExecutorService getBoundedExecutor(ThreadPoolExecutor executor) {
         return new BoundedScheduledExecutorService((ScheduledThreadPoolExecutor) executor, this.maxTasksInQueue);
+    }
+
+    @Override
+    protected ListeningScheduledExecutorService addExecutorDecorators(ExecutorService executor) {
+        return new OrderedSchedulerDecoratedThread((ListeningScheduledExecutorService) executor);
     }
 
     @Override
@@ -285,5 +299,85 @@ public class OrderedScheduler extends OrderedExecutor implements ScheduledExecut
                                                      long initialDelay, long delay, TimeUnit unit) {
         return chooseThread().scheduleWithFixedDelay(timedRunnable(command), initialDelay, delay, unit);
     }
+
+    class OrderedSchedulerDecoratedThread extends ForwardingListeningExecutorService
+        implements ListeningScheduledExecutorService {
+        private final ListeningScheduledExecutorService delegate;
+
+        private OrderedSchedulerDecoratedThread(ListeningScheduledExecutorService delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+            protected ListeningExecutorService delegate() {
+                return delegate;
+            }
+
+            @Override
+            public ListenableScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+                return delegate.schedule(timedRunnable(command), delay, unit);
+            }
+
+            @Override
+            public <V> ListenableScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+                return delegate.schedule(timedCallable(callable), delay, unit);
+            }
+
+            @Override
+            public ListenableScheduledFuture<?> scheduleAtFixedRate(Runnable command,
+                                                                    long initialDelay, long period, TimeUnit unit) {
+                return delegate.scheduleAtFixedRate(timedRunnable(command), initialDelay, period, unit);
+            }
+
+            @Override
+            public ListenableScheduledFuture<?> scheduleWithFixedDelay(Runnable command,
+                                                                       long initialDelay, long delay, TimeUnit unit) {
+                return delegate.scheduleAtFixedRate(timedRunnable(command), initialDelay, delay, unit);
+            }
+
+            @Override
+            public <T> ListenableFuture<T> submit(Callable<T> task) {
+                return super.submit(timedCallable(task));
+            }
+
+            @Override
+            public ListenableFuture<?> submit(Runnable task) {
+                return super.submit(timedRunnable(task));
+            }
+
+            @Override
+            public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+                return super.invokeAll(timedCallables(tasks));
+            }
+
+            @Override
+            public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks,
+                                                 long timeout, TimeUnit unit) throws InterruptedException {
+                return super.invokeAll(timedCallables(tasks), timeout, unit);
+            }
+
+            @Override
+            public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+                    throws InterruptedException, ExecutionException {
+                return super.invokeAny(timedCallables(tasks));
+            }
+
+            @Override
+            public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout,
+                                   TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+
+                return super.invokeAny(timedCallables(tasks), timeout, unit);
+            }
+
+            @Override
+            public <T> ListenableFuture<T> submit(Runnable task, T result) {
+                return super.submit(timedRunnable(task), result);
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                super.execute(timedRunnable(command));
+            }
+        };
 
 }

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestOrderedExecutorDecorators.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestOrderedExecutorDecorators.java
@@ -1,0 +1,157 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.common.util;
+
+import static org.apache.bookkeeper.common.util.SafeRunnable.safeRun;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+import static org.mockito.AdditionalAnswers.answerVoid;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.MDC;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test that decorators applied by OrderedExecutor/Scheduler are correctly applied.
+ */
+public class TestOrderedExecutorDecorators {
+    private static final Logger log = LoggerFactory.getLogger(TestOrderedExecutorDecorators.class);
+    private static final String MDC_KEY = "mdc-key";
+
+    private Appender mockAppender;
+    private final Queue<String> capturedEvents = new ConcurrentLinkedQueue<>();
+
+    public static String mdcFormat(Object mdc, String message) {
+        return String.format("[%s:%s] %s", MDC_KEY, mdc, message);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MDC.clear();
+        mockAppender = mock(Appender.class);
+        when(mockAppender.getName()).thenReturn("MockAppender");
+
+        LogManager.getRootLogger().addAppender(mockAppender);
+        LogManager.getRootLogger().setLevel(Level.INFO);
+
+        doAnswer(answerVoid((LoggingEvent event) -> {
+                    capturedEvents.add(mdcFormat(event.getMDC(MDC_KEY),
+                                                 event.getRenderedMessage()));
+                })).when(mockAppender).doAppend(any());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LogManager.getRootLogger().removeAppender(mockAppender);
+        capturedEvents.clear();
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCInvokeOrdered() throws Exception {
+        OrderedExecutor executor = OrderedExecutor.newBuilder()
+            .name("test").numThreads(20).preserveMdcForTaskExecution(true).build();
+
+        try {
+            MDC.put(MDC_KEY, "testMDCInvokeOrdered");
+            executor.submitOrdered(10, () -> {
+                    log.info("foobar");
+                    return 10;
+                }).get();
+            assertThat(capturedEvents,
+                       hasItem(mdcFormat("testMDCInvokeOrdered", "foobar")));
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void testMDCInvokeDirectOnChosen() throws Exception {
+        OrderedExecutor executor = OrderedExecutor.newBuilder()
+            .name("test").numThreads(20).preserveMdcForTaskExecution(true).build();
+
+        try {
+            MDC.put(MDC_KEY, "testMDCInvokeOrdered");
+            executor.chooseThread(10).submit(() -> {
+                    log.info("foobar");
+                    return 10;
+                }).get();
+            assertThat(capturedEvents,
+                       hasItem(mdcFormat("testMDCInvokeOrdered", "foobar")));
+        } finally {
+            executor.shutdown();
+        }
+
+    }
+
+
+    @Test
+    public void testMDCScheduleOrdered() throws Exception {
+        OrderedScheduler scheduler = OrderedScheduler.newSchedulerBuilder()
+            .name("test").numThreads(20).preserveMdcForTaskExecution(true).build();
+
+        try {
+            MDC.put(MDC_KEY, "testMDCInvokeOrdered");
+            scheduler.scheduleOrdered(10, safeRun(() -> {
+                        log.info("foobar");
+                    }), 0, TimeUnit.DAYS).get();
+            assertThat(capturedEvents,
+                       hasItem(mdcFormat("testMDCInvokeOrdered", "foobar")));
+        } finally {
+            scheduler.shutdown();
+        }
+    }
+
+    @Test
+    public void testMDCScheduleDirectOnChosen() throws Exception {
+                OrderedScheduler scheduler = OrderedScheduler.newSchedulerBuilder()
+            .name("test").numThreads(20).preserveMdcForTaskExecution(true).build();
+
+        try {
+            MDC.put(MDC_KEY, "testMDCInvokeOrdered");
+            scheduler.chooseThread(10).schedule(safeRun(() -> {
+                        log.info("foobar");
+                    }), 0, TimeUnit.DAYS).get();
+            assertThat(capturedEvents,
+                       hasItem(mdcFormat("testMDCInvokeOrdered", "foobar")));
+        } finally {
+            scheduler.shutdown();
+        }
+    }
+
+}


### PR DESCRIPTION
Actually, decorate the runnables too, but apply the decoration in a
decorator on the thread so that if a runnable/callable is passed to
the thread, the decoration will be applied.

This allows users of OrderedExecutor/Scheduler to use
executor.chooseThread() for CompletableFuture async handlers and still
get things like the MDC context.
