### PR TITLE
ReadEntryCallback in ReadLedgerEntriesCmd shouldn't release buffer.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -854,7 +854,6 @@ public class BookieShell implements Tool {
                                     System.out.println("Data: " + ByteBufUtil.prettyHexDump(buffer));
                                 }
 
-                                buffer.release();
                                 future.complete(null);
                                 }, null, BookieProtocol.FLAG_NONE);
 


### PR DESCRIPTION


Descriptions of the changes in this PR:

- ReadEntryCallback in ReadLedgerEntriesCmd shouldn't release buffer,
which is not owned by the callback.

### Motivation

with the following change, Per channel bookie clients owns the buffer for read responses. So it is not correct for ReadEntryCallback in ReadLedgerEntriesCmd to release buffer
https://github.com/apache/bookkeeper/commit/8d048abce486c63d428041f77ee9a506756f4d1e#diff-e50ee2c1aec1539ea185a94605b0e550R1611

because of this issue I'm seeing following error with ReadLedgerEntriesCmd
```
/Workspace/SFStorage/bookkeeper/bookkeeper-server/bin$ ./bookkeeper shell -localbookie readledger -bookie ****  -ledgerid 00000000-0000-0000-0000-000000000003 -firstentryid 1 -lastentryid 3
JAVA_HOME not set, using java from PATH. (/usr/bin/java)

--------- Lid=00000000-0000-0000-0000-000000000003, Eid=1 ---------
18:32:03,724 ERROR Unexpected throwable caught 
io.netty.util.IllegalReferenceCountException: refCnt: 0, increment: 1
	at io.netty.buffer.AbstractReferenceCountedByteBuf.release0(AbstractReferenceCountedByteBuf.java:100) ~[netty-all-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:84) ~[netty-all-4.1.22.Final.jar:4.1.22.Final]
	at org.apache.bookkeeper.proto.PerChannelBookieClient$ReadCompletion.handleV3Response(PerChannelBookieClient.java:1699) ~[bookkeeper-server-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at org.apache.bookkeeper.proto.PerChannelBookieClient$3.safeRun(PerChannelBookieClient.java:1286) ~[bookkeeper-server-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [bookkeeper-common-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_172]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_172]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.22.Final.jar:4.1.22.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_172]

--------- Lid=00000000-0000-0000-0000-000000000003, Eid=2 ---------

18:32:03,733 ERROR Unexpected throwable caught 
io.netty.util.IllegalReferenceCountException: refCnt: 0, increment: 1
	at io.netty.buffer.AbstractReferenceCountedByteBuf.release0(AbstractReferenceCountedByteBuf.java:100) ~[netty-all-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:84) ~[netty-all-4.1.22.Final.jar:4.1.22.Final]
	at org.apache.bookkeeper.proto.PerChannelBookieClient$ReadCompletion.handleV3Response(PerChannelBookieClient.java:1699) ~[bookkeeper-server-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at org.apache.bookkeeper.proto.PerChannelBookieClient$3.safeRun(PerChannelBookieClient.java:1286) ~[bookkeeper-server-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [bookkeeper-common-4.7.0-SNAPSHOT.jar:4.7.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_172]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_172]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.22.Final.jar:4.1.22.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_172]
```