### PR TITLE
ISSUE #1737: EntryMemTable.newEntry: always make a copy

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTable.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTable.java
@@ -366,13 +366,8 @@ public class EntryMemTable implements AutoCloseable{
         int offset = 0;
         int length = entry.remaining();
 
-        if (entry.hasArray()) {
-            buf = entry.array();
-            offset = entry.arrayOffset();
-        } else {
-            buf = new byte[length];
-            entry.get(buf);
-        }
+        buf = new byte[length];
+        entry.get(buf);
         return new EntryKeyValue(ledgerId, entryId, buf, offset, length);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -1756,6 +1756,18 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
+     * Set the max size we should allocate from the skiplist arena. Allocations
+     * larger than this should be allocated directly by the VM to avoid fragmentation.
+     *
+     * @param size max alloc size.
+     * @return server configuration object.
+     */
+    public ServerConfiguration setSkipListArenaMaxAllocSize(int size) {
+        setProperty(SKIP_LIST_MAX_ALLOC_ENTRY, size);
+        return this;
+    }
+
+    /**
      * Should the data be fsynced on journal before acknowledgment.
      *
      * <p>Default is true


### PR DESCRIPTION
Retaining a reference to that array assumes that the caller
won't reuse the array for something else -- an assumption
violated by Journal.scanJournal and probably other callers.

(@bug W-5499346@)
(@rev cguttapalem@)
Signed-off-by: Samuel Just <sjust@salesforce.com>