### PR TITLE
Modules dependencies do not need to be included in checksum Jar

### DIFF
--- a/circe-checksum/src/main/assembly/assembly.xml
+++ b/circe-checksum/src/main/assembly/assembly.xml
@@ -26,15 +26,6 @@
   </formats>
 
   <includeBaseDirectory>false</includeBaseDirectory>
-  <dependencySets>
-    <dependencySet>
-      <excludes>
-        <exclude>org.slf4j:slf4j-api</exclude>
-        <exclude>io.netty</exclude>
-        <exclude>*:nar:*</exclude>
-      </excludes>
-    </dependencySet>
-  </dependencySets>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}/nar/${project.artifactId}-${project.version}-${os.arch}-MacOSX-gpp-jni/lib/${os.arch}-MacOSX-gpp/jni


### PR DESCRIPTION
The current assembly configuration is including the jars of the modules dependency inside its own jar.

These jars are completely ignored, but they take up non trivial space.

With this change the size of `circe-checksum.jar` goes from 2.8 MB to 62 KB.