### PR TITLE
Remove LedgerMetadata#getEnsembles in favour of #getAllEnsembles

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -589,7 +589,7 @@ public class BookieShell implements Tool {
 
         private Map<Long, Integer> inspectLedger(LedgerMetadata metadata, Set<BookieSocketAddress> bookiesToInspect) {
             Map<Long, Integer> numBookiesToReplacePerEnsemble = new TreeMap<Long, Integer>();
-            for (Map.Entry<Long, ? extends List<BookieSocketAddress>> ensemble : metadata.getEnsembles().entrySet()) {
+            for (Map.Entry<Long, ? extends List<BookieSocketAddress>> ensemble : metadata.getAllEnsembles().entrySet()) {
                 List<BookieSocketAddress> bookieList = ensemble.getValue();
                 System.out.print(ensemble.getKey() + ":\t");
                 int numBookiesToReplace = 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -589,7 +589,8 @@ public class BookieShell implements Tool {
 
         private Map<Long, Integer> inspectLedger(LedgerMetadata metadata, Set<BookieSocketAddress> bookiesToInspect) {
             Map<Long, Integer> numBookiesToReplacePerEnsemble = new TreeMap<Long, Integer>();
-            for (Map.Entry<Long, ? extends List<BookieSocketAddress>> ensemble : metadata.getAllEnsembles().entrySet()) {
+            for (Map.Entry<Long, ? extends List<BookieSocketAddress>> ensemble :
+                     metadata.getAllEnsembles().entrySet()) {
                 List<BookieSocketAddress> bookieList = ensemble.getValue();
                 System.out.print(ensemble.getKey() + ":\t");
                 int numBookiesToReplace = 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -248,7 +248,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector{
                                 return;
                             }
                             SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles =
-                                ledgerMetadata.getEnsembles();
+                                ledgerMetadata.getAllEnsembles();
                             for (List<BookieSocketAddress> ensemble : ensembles.values()) {
                                 // check if this bookie is supposed to have this ledger
                                 if (ensemble.contains(selfBookieAddress)) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -818,8 +818,8 @@ public class BookKeeperAdmin implements AutoCloseable {
                  */
                 Map<Long, Long> ledgerFragmentsRange = new HashMap<Long, Long>();
                 Long curEntryId = null;
-                for (Map.Entry<Long, ? extends List<BookieSocketAddress>> entry : lh.getLedgerMetadata().getEnsembles()
-                         .entrySet()) {
+                for (Map.Entry<Long, ? extends List<BookieSocketAddress>> entry :
+                         lh.getLedgerMetadata().getAllEnsembles().entrySet()) {
                     if (curEntryId != null) {
                         ledgerFragmentsRange.put(curEntryId, entry.getKey() - 1);
                     }
@@ -864,7 +864,7 @@ public class BookKeeperAdmin implements AutoCloseable {
                  */
                 for (final Long startEntryId : ledgerFragmentsToRecover) {
                     Long endEntryId = ledgerFragmentsRange.get(startEntryId);
-                    List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsembles().get(startEntryId);
+                    List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getAllEnsembles().get(startEntryId);
                     // Get bookies to replace
                     Map<Integer, BookieSocketAddress> targetBookieAddresses;
                     try {
@@ -1090,11 +1090,11 @@ public class BookKeeperAdmin implements AutoCloseable {
 
     private static boolean containBookiesInLastEnsemble(LedgerMetadata lm,
                                                         Set<BookieSocketAddress> bookies) {
-        if (lm.getEnsembles().size() <= 0) {
+        if (lm.getAllEnsembles().size() <= 0) {
             return false;
         }
-        Long lastKey = lm.getEnsembles().lastKey();
-        List<BookieSocketAddress> lastEnsemble = lm.getEnsembles().get(lastKey);
+        Long lastKey = lm.getAllEnsembles().lastKey();
+        List<BookieSocketAddress> lastEnsemble = lm.getAllEnsembles().get(lastKey);
         return containBookies(lastEnsemble, bookies);
     }
 
@@ -1546,7 +1546,7 @@ public class BookKeeperAdmin implements AutoCloseable {
 
     public static boolean areEntriesOfLedgerStoredInTheBookie(long ledgerId, BookieSocketAddress bookieAddress,
             LedgerMetadata ledgerMetadata) {
-        Collection<? extends List<BookieSocketAddress>> ensemblesOfSegments = ledgerMetadata.getEnsembles().values();
+        Collection<? extends List<BookieSocketAddress>> ensemblesOfSegments = ledgerMetadata.getAllEnsembles().values();
         Iterator<? extends List<BookieSocketAddress>> ensemblesOfSegmentsIterator = ensemblesOfSegments.iterator();
         List<BookieSocketAddress> ensemble;
         int segmentNo = 0;
@@ -1568,7 +1568,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         int writeQuorumSize = ledgerMetadata.getWriteQuorumSize();
 
         List<Entry<Long, ? extends List<BookieSocketAddress>>> segments =
-            new LinkedList<>(ledgerMetadata.getEnsembles().entrySet());
+            new LinkedList<>(ledgerMetadata.getAllEnsembles().entrySet());
 
         boolean lastSegment = (segmentNo == (segments.size() - 1));
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
@@ -323,7 +323,7 @@ public class LedgerChecker {
         Long curEntryId = null;
         List<BookieSocketAddress> curEnsemble = null;
         for (Map.Entry<Long, ? extends List<BookieSocketAddress>> e : lh
-                .getLedgerMetadata().getEnsembles().entrySet()) {
+                .getLedgerMetadata().getAllEnsembles().entrySet()) {
             if (curEntryId != null) {
                 Set<Integer> bookieIndexes = new HashSet<Integer>();
                 for (int i = 0; i < curEnsemble.size(); i++) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
@@ -51,7 +51,7 @@ public class LedgerFragment {
         this.ensemble = lh.getLedgerMetadata().getEnsemble(firstEntryId);
         this.schedule = lh.getDistributionSchedule();
         SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = lh
-                .getLedgerMetadata().getEnsembles();
+                .getLedgerMetadata().getAllEnsembles();
         this.isLedgerClosed = lh.getLedgerMetadata().isClosed()
                 || !ensemble.equals(ensembles.get(ensembles.lastKey()));
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -378,12 +378,12 @@ public class LedgerFragmentReplicator {
                 lh::getLedgerMetadata,
                 (metadata) -> {
                     // returns true if any of old bookies exist in ensemble
-                    List<BookieSocketAddress> ensemble = metadata.getEnsembles().get(fragmentStartId);
+                    List<BookieSocketAddress> ensemble = metadata.getAllEnsembles().get(fragmentStartId);
                     return oldBookie2NewBookie.keySet().stream().anyMatch(ensemble::contains);
                 },
                 (currentMetadata) -> {
                     // replace all old bookies with new bookies in ensemble
-                    List<BookieSocketAddress> newEnsemble = currentMetadata.getEnsembles().get(fragmentStartId)
+                    List<BookieSocketAddress> newEnsemble = currentMetadata.getAllEnsembles().get(fragmentStartId)
                         .stream().map((bookie) -> oldBookie2NewBookie.getOrDefault(bookie, bookie))
                         .collect(Collectors.toList());
                     return LedgerMetadataBuilder.from(currentMetadata)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -344,7 +344,7 @@ public class LedgerHandle implements WriteHandle {
      * @return the count of fragments
      */
     public synchronized long getNumFragments() {
-        return getLedgerMetadata().getEnsembles().size();
+        return getLedgerMetadata().getAllEnsembles().size();
     }
 
     /**
@@ -354,7 +354,7 @@ public class LedgerHandle implements WriteHandle {
      * @return count of unique bookies
      */
     public synchronized long getNumBookies() {
-        Map<Long, ? extends List<BookieSocketAddress>> m = getLedgerMetadata().getEnsembles();
+        Map<Long, ? extends List<BookieSocketAddress>> m = getLedgerMetadata().getAllEnsembles();
         Set<BookieSocketAddress> s = Sets.newHashSet();
         for (List<BookieSocketAddress> aList : m.values()) {
             s.addAll(aList);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -217,17 +217,6 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
         this.hasPassword = false;
     }
 
-    /**
-     * Get the Map of bookie ensembles for the various ledger fragments
-     * that make up the ledger.
-     *
-     * @return SortedMap of Ledger Fragments and the corresponding
-     * bookie ensembles that store the entries.
-     */
-    public TreeMap<Long, ? extends List<BookieSocketAddress>> getEnsembles() {
-        return ensembles;
-    }
-
     @Override
     public NavigableMap<Long, ? extends List<BookieSocketAddress>> getAllEnsembles() {
         return ensembles;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadataBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadataBuilder.java
@@ -74,7 +74,7 @@ class LedgerMetadataBuilder {
             builder.length = Optional.of(length);
         }
 
-        builder.ensembles.putAll(other.getEnsembles());
+        builder.ensembles.putAll(other.getAllEnsembles());
 
         builder.digestType = other.getDigestType();
         if (other.hasPassword()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/UpdateLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/UpdateLedgerOp.java
@@ -102,7 +102,7 @@ public class UpdateLedgerOp {
                             lm, ledgerId,
                             ref::get,
                             (metadata) -> {
-                                return metadata.getEnsembles().values().stream()
+                                return metadata.getAllEnsembles().values().stream()
                                     .flatMap(Collection::stream)
                                     .filter(b -> b.equals(oldBookieId))
                                     .count() > 0;
@@ -161,7 +161,7 @@ public class UpdateLedgerOp {
                                                            BookieSocketAddress oldBookieId,
                                                            BookieSocketAddress newBookieId) {
         LedgerMetadataBuilder builder = LedgerMetadataBuilder.from(metadata);
-        for (Map.Entry<Long, ? extends List<BookieSocketAddress>> e : metadata.getEnsembles().entrySet()) {
+        for (Map.Entry<Long, ? extends List<BookieSocketAddress>> e : metadata.getAllEnsembles().entrySet()) {
             List<BookieSocketAddress> newEnsemble = e.getValue().stream()
                 .map(b -> b.equals(oldBookieId) ? newBookieId : b)
                 .collect(Collectors.toList());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/BookieLedgerIndexer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/BookieLedgerIndexer.java
@@ -74,7 +74,7 @@ public class BookieLedgerIndexer {
                             LedgerMetadata ledgerMetadata) {
                         if (rc == BKException.Code.OK) {
                             for (Map.Entry<Long, ? extends List<BookieSocketAddress>> ensemble : ledgerMetadata
-                                    .getEnsembles().entrySet()) {
+                                    .getAllEnsembles().entrySet()) {
                                 for (BookieSocketAddress bookie : ensemble
                                         .getValue()) {
                                     putLedger(bookie2ledgersMap,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -364,7 +364,7 @@ public class ReplicationWorker implements Runnable {
             return false;
         }
 
-        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = admin.getLedgerMetadata(lh).getEnsembles();
+        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = admin.getLedgerMetadata(lh).getAllEnsembles();
         List<BookieSocketAddress> finalEnsemble = ensembles.get(ensembles.lastKey());
         Collection<BookieSocketAddress> available = admin.getAvailableBookies();
         for (BookieSocketAddress b : finalEnsemble) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestGcOverreplicatedLedger.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestGcOverreplicatedLedger.java
@@ -148,7 +148,7 @@ public class TestGcOverreplicatedLedger extends LedgerManagerTestCase {
             Assert.fail("No ledger metadata found");
         }
         BookieSocketAddress address = null;
-        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembleMap = newLedgerMetadata.get().getEnsembles();
+        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembleMap = newLedgerMetadata.get().getAllEnsembles();
         for (List<BookieSocketAddress> ensemble : ensembleMap.values()) {
             address = ensemble.get(0);
         }
@@ -235,7 +235,7 @@ public class TestGcOverreplicatedLedger extends LedgerManagerTestCase {
         for (BookieServer bk : bs) {
             allAddresses.add(bk.getLocalAddress());
         }
-        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = ledgerMetadata.getEnsembles();
+        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = ledgerMetadata.getAllEnsembles();
         for (List<BookieSocketAddress> fragmentEnsembles : ensembles.values()) {
             allAddresses.removeAll(fragmentEnsembles);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
@@ -506,7 +506,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
     private boolean verifyFullyReplicated(LedgerHandle lh, long untilEntry) throws Exception {
         LedgerMetadata md = getLedgerMetadata(lh);
 
-        Map<Long, ? extends List<BookieSocketAddress>> ensembles = md.getEnsembles();
+        Map<Long, ? extends List<BookieSocketAddress>> ensembles = md.getAllEnsembles();
 
         HashMap<Long, Long> ranges = new HashMap<Long, Long>();
         ArrayList<Long> keyList = Collections.list(
@@ -586,7 +586,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         long numDupes = 0;
         for (LedgerHandle lh : lhs) {
             LedgerMetadata md = getLedgerMetadata(lh);
-            for (Map.Entry<Long, ? extends List<BookieSocketAddress>> e : md.getEnsembles().entrySet()) {
+            for (Map.Entry<Long, ? extends List<BookieSocketAddress>> e : md.getAllEnsembles().entrySet()) {
                 HashSet<BookieSocketAddress> set = new HashSet<BookieSocketAddress>();
                 long fragment = e.getKey();
 
@@ -619,7 +619,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         closeLedgers(lhs);
 
         // Shutdown last bookie server in last ensemble
-        List<BookieSocketAddress> lastEnsemble = lhs.get(0).getLedgerMetadata().getEnsembles()
+        List<BookieSocketAddress> lastEnsemble = lhs.get(0).getLedgerMetadata().getAllEnsembles()
           .entrySet().iterator().next().getValue();
         BookieSocketAddress bookieToKill = lastEnsemble.get(lastEnsemble.size() - 1);
         killBookie(bookieToKill);
@@ -648,7 +648,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         writeEntriestoLedgers(numMsgs, 0, lhs);
 
         // Shutdown the first bookie server
-        List<BookieSocketAddress> lastEnsemble = lhs.get(0).getLedgerMetadata().getEnsembles()
+        List<BookieSocketAddress> lastEnsemble = lhs.get(0).getLedgerMetadata().getAllEnsembles()
           .entrySet().iterator().next().getValue();
         BookieSocketAddress bookieToKill = lastEnsemble.get(lastEnsemble.size() - 1);
         killBookie(bookieToKill);
@@ -684,7 +684,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         writeEntriestoLedgers(numMsgs, 0, lhs);
 
         // Shutdown the first bookie server
-        List<BookieSocketAddress> lastEnsemble = lhs.get(0).getLedgerMetadata().getEnsembles()
+        List<BookieSocketAddress> lastEnsemble = lhs.get(0).getLedgerMetadata().getAllEnsembles()
           .entrySet().iterator().next().getValue();
         // removed bookie
         BookieSocketAddress bookieToKill = lastEnsemble.get(0);
@@ -728,7 +728,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         for (LedgerHandle newLh : newLhs) {
             // first ensemble should contains bookieToKill2 and not contain bookieToKill
             Map.Entry<Long, ? extends List<BookieSocketAddress>> entry =
-              newLh.getLedgerMetadata().getEnsembles().entrySet().iterator().next();
+              newLh.getLedgerMetadata().getAllEnsembles().entrySet().iterator().next();
             assertFalse(entry.getValue().contains(bookieToKill));
             assertTrue(entry.getValue().contains(bookieToKill2));
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -151,7 +151,7 @@ public class BookieWriteLedgerTest extends
 
         // Shutdown three bookies in the last ensemble and continue writing
         List<BookieSocketAddress> ensemble = lh.getLedgerMetadata()
-                .getEnsembles().entrySet().iterator().next().getValue();
+                .getAllEnsembles().entrySet().iterator().next().getValue();
         killBookie(ensemble.get(0));
         killBookie(ensemble.get(1));
         killBookie(ensemble.get(2));
@@ -196,7 +196,7 @@ public class BookieWriteLedgerTest extends
         CountDownLatch sleepLatch1 = new CountDownLatch(1);
         CountDownLatch sleepLatch2 = new CountDownLatch(1);
         List<BookieSocketAddress> ensemble = lh.getLedgerMetadata()
-                .getEnsembles().entrySet().iterator().next().getValue();
+                .getAllEnsembles().entrySet().iterator().next().getValue();
 
         sleepBookie(ensemble.get(0), sleepLatch1);
 
@@ -389,7 +389,7 @@ public class BookieWriteLedgerTest extends
         startNewBookie();
 
         // Shutdown one bookie in the last ensemble and continue writing
-        List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next()
+        List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getAllEnsembles().entrySet().iterator().next()
                 .getValue();
         killBookie(ensemble.get(0));
 
@@ -528,7 +528,7 @@ public class BookieWriteLedgerTest extends
         startNewBookie();
 
         // Shutdown one bookie in the last ensemble and continue writing
-        List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next()
+        List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getAllEnsembles().entrySet().iterator().next()
                 .getValue();
         killBookie(ensemble.get(0));
 
@@ -847,7 +847,7 @@ public class BookieWriteLedgerTest extends
 
         // Shutdown three bookies in the last ensemble and continue writing
         List<BookieSocketAddress> ensemble = lh.getLedgerMetadata()
-                .getEnsembles().entrySet().iterator().next().getValue();
+                .getAllEnsembles().entrySet().iterator().next().getValue();
         killBookie(ensemble.get(0));
         killBookie(ensemble.get(1));
         killBookie(ensemble.get(2));
@@ -919,7 +919,7 @@ public class BookieWriteLedgerTest extends
         }
         // Start One more bookie and shutdown one from last ensemble before reading
         startNewBookie();
-        List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next()
+        List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getAllEnsembles().entrySet().iterator().next()
                 .getValue();
         killBookie(ensemble.get(0));
 
@@ -989,7 +989,7 @@ public class BookieWriteLedgerTest extends
         CountDownLatch sleepLatch1 = new CountDownLatch(1);
         List<BookieSocketAddress> ensemble;
 
-        ensemble = lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue();
+        ensemble = lh.getLedgerMetadata().getAllEnsembles().entrySet().iterator().next().getValue();
 
         // Put all 3 bookies to sleep and start 3 new ones
         sleepBookie(ensemble.get(0), sleepLatch1);
@@ -1073,7 +1073,7 @@ public class BookieWriteLedgerTest extends
                 if (j == numEntriesToWrite / 2) {
                     // Start One more bookie and shutdown one from last ensemble at half-way
                     startNewBookie();
-                    List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsembles().entrySet()
+                    List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getAllEnsembles().entrySet()
                             .iterator().next().getValue();
                     killBookie(ensemble.get(0));
                 }
@@ -1142,7 +1142,7 @@ public class BookieWriteLedgerTest extends
         }
         // Start One more bookie and shutdown one from last ensemble before reading
         startNewBookie();
-        List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next()
+        List<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getAllEnsembles().entrySet().iterator().next()
                 .getValue();
         killBookie(ensemble.get(0));
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
@@ -74,8 +74,8 @@ public class HandleFailuresTest {
         lh.appendAsync("entry5".getBytes()).get();
 
         verify(clientCtx.getLedgerManager(), times(1)).writeLedgerMetadata(anyLong(), any(), any());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b4, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b4, b2, b3));
     }
 
     @Test
@@ -120,10 +120,10 @@ public class HandleFailuresTest {
 
         future.get();
         verify(clientCtx.getLedgerManager(), times(2)).writeLedgerMetadata(anyLong(), any(), any());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertTrue(lh.getLedgerMetadata().getEnsembles().get(0L).contains(b3));
-        Assert.assertTrue(lh.getLedgerMetadata().getEnsembles().get(0L).contains(b4));
-        Assert.assertTrue(lh.getLedgerMetadata().getEnsembles().get(0L).contains(b5));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertTrue(lh.getLedgerMetadata().getAllEnsembles().get(0L).contains(b3));
+        Assert.assertTrue(lh.getLedgerMetadata().getAllEnsembles().get(0L).contains(b4));
+        Assert.assertTrue(lh.getLedgerMetadata().getAllEnsembles().get(0L).contains(b5));
     }
 
     @Test
@@ -142,8 +142,8 @@ public class HandleFailuresTest {
         lh.close();
 
         Assert.assertTrue(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b4, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b4, b2, b3));
     }
 
     @Test
@@ -163,9 +163,9 @@ public class HandleFailuresTest {
         lh.close();
 
         Assert.assertTrue(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 2);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(1L), Lists.newArrayList(b4, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 2);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(1L), Lists.newArrayList(b4, b2, b3));
         Assert.assertEquals(lh.getLedgerMetadata().getLastEntryId(), 1L);
     }
 
@@ -189,8 +189,8 @@ public class HandleFailuresTest {
                                  () -> lh.getLedgerMetadata().isClosed());
             Assert.assertEquals("Ledger should be empty",
                                 lh.getLedgerMetadata().getLastEntryId(), LedgerHandle.INVALID_ENTRY_ID);
-            Assert.assertEquals("Should be only one ensemble", lh.getLedgerMetadata().getEnsembles().size(), 1);
-            Assert.assertEquals("Ensemble shouldn't have changed", lh.getLedgerMetadata().getEnsembles().get(0L),
+            Assert.assertEquals("Should be only one ensemble", lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+            Assert.assertEquals("Ensemble shouldn't have changed", lh.getLedgerMetadata().getAllEnsembles().get(0L),
                                 Lists.newArrayList(b1, b2, b3));
         }
     }
@@ -217,8 +217,8 @@ public class HandleFailuresTest {
             assertEventuallyTrue("Failure to add should trigger ledger closure",
                                  () -> lh.getLedgerMetadata().isClosed());
             Assert.assertEquals("Ledger should be empty", lh.getLedgerMetadata().getLastEntryId(), 0L);
-            Assert.assertEquals("Should be only one ensemble", lh.getLedgerMetadata().getEnsembles().size(), 1);
-            Assert.assertEquals("Ensemble shouldn't have changed", lh.getLedgerMetadata().getEnsembles().get(0L),
+            Assert.assertEquals("Should be only one ensemble", lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+            Assert.assertEquals("Ensemble shouldn't have changed", lh.getLedgerMetadata().getAllEnsembles().get(0L),
                                 Lists.newArrayList(b1, b2, b3));
         }
     }
@@ -236,7 +236,7 @@ public class HandleFailuresTest {
         CompletableFuture<Void> changeInProgress = new CompletableFuture<>();
         CompletableFuture<Void> blockEnsembleChange = new CompletableFuture<>();
         clientCtx.getMockLedgerManager().setPreWriteHook((ledgerId, metadata) -> {
-                if (metadata.getEnsembles().get(0L).get(1).equals(b4)) { // block the write trying to replace b2 with b4
+                if (metadata.getAllEnsembles().get(0L).get(1).equals(b4)) { // block the write trying to replace b2 with b4
                     changeInProgress.complete(null);
                     return blockEnsembleChange;
                 } else {
@@ -259,8 +259,8 @@ public class HandleFailuresTest {
             Assert.assertEquals(ee.getCause().getClass(), BKException.BKLedgerClosedException.class);
         }
         Assert.assertTrue(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
         Assert.assertEquals(lh.getLedgerMetadata().getLastEntryId(), LedgerHandle.INVALID_ENTRY_ID);
     }
 
@@ -277,7 +277,8 @@ public class HandleFailuresTest {
         CompletableFuture<Void> changeInProgress = new CompletableFuture<>();
         CompletableFuture<Void> blockEnsembleChange = new CompletableFuture<>();
         clientCtx.getMockLedgerManager().setPreWriteHook((ledgerId, metadata) -> {
-                if (metadata.getEnsembles().get(0L).get(1).equals(b4)) { // block the write trying to replace b2 with b4
+                if (metadata.getAllEnsembles().get(0L).get(1).equals(b4)) {
+                    // block the write trying to replace b2 with b4
                     changeInProgress.complete(null);
                     return blockEnsembleChange;
                 } else {
@@ -301,8 +302,8 @@ public class HandleFailuresTest {
             Assert.assertEquals(ee.getCause().getClass(), BKException.BKLedgerClosedException.class);
         }
         Assert.assertTrue(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
         Assert.assertEquals(lh.getLedgerMetadata().getLastEntryId(), 1234L);
     }
 
@@ -319,7 +320,8 @@ public class HandleFailuresTest {
         CompletableFuture<Void> changeInProgress = new CompletableFuture<>();
         CompletableFuture<Void> blockEnsembleChange = new CompletableFuture<>();
         clientCtx.getMockLedgerManager().setPreWriteHook((ledgerId, metadata) -> {
-                if (metadata.getEnsembles().get(0L).get(1).equals(b4)) { // block the write trying to replace b2 with b4
+                if (metadata.getAllEnsembles().get(0L).get(1).equals(b4)) {
+                    // block the write trying to replace b2 with b4
                     changeInProgress.complete(null);
                     return blockEnsembleChange;
                 } else {
@@ -343,8 +345,8 @@ public class HandleFailuresTest {
             Assert.assertEquals(ee.getCause().getClass(), BKException.BKLedgerFencedException.class);
         }
         Assert.assertFalse(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
     }
 
     @Test
@@ -362,17 +364,17 @@ public class HandleFailuresTest {
         clientCtx.getMockBookieClient().errorBookies(b3);
         lh.append("entry2".getBytes());
 
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 2);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(1L), Lists.newArrayList(b1, b2, b4));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 2);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(1L), Lists.newArrayList(b1, b2, b4));
 
 
         CompletableFuture<Void> changeInProgress = new CompletableFuture<>();
         CompletableFuture<Void> blockEnsembleChange = new CompletableFuture<>();
         clientCtx.getMockLedgerManager().setPreWriteHook((ledgerId, metadata) -> {
                  // block the write trying to replace b1 with b5
-                if (metadata.getEnsembles().size() > 2
-                    && metadata.getEnsembles().get(2L).get(0).equals(b5)) {
+                if (metadata.getAllEnsembles().size() > 2
+                    && metadata.getAllEnsembles().get(2L).get(0).equals(b5)) {
                     changeInProgress.complete(null);
                     return blockEnsembleChange;
                 } else {
@@ -394,10 +396,10 @@ public class HandleFailuresTest {
         future.get();
 
         Assert.assertFalse(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 3);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b4, b2, b5));
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(1L), Lists.newArrayList(b1, b2, b4));
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(2L), Lists.newArrayList(b5, b2, b4));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 3);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b4, b2, b5));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(1L), Lists.newArrayList(b1, b2, b4));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(2L), Lists.newArrayList(b5, b2, b4));
     }
 
     @Test
@@ -419,7 +421,7 @@ public class HandleFailuresTest {
         CompletableFuture<Void> blockEnsembleChange = new CompletableFuture<>();
         clientCtx.getMockLedgerManager().setPreWriteHook((ledgerId, metadata) -> {
                  // block the write trying to replace b3 with b4
-                if (metadata.getEnsembles().get(1L).get(2).equals(b4)) {
+                if (metadata.getAllEnsembles().get(1L).get(2).equals(b4)) {
                     changeInProgress.complete(null);
                     return blockEnsembleChange;
                 } else {
@@ -437,8 +439,8 @@ public class HandleFailuresTest {
         blockEnsembleChange.complete(null);
         future.get();
 
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 2);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(1L), Lists.newArrayList(b1, b2, b4));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 2);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(1L), Lists.newArrayList(b1, b2, b4));
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
@@ -236,7 +236,8 @@ public class HandleFailuresTest {
         CompletableFuture<Void> changeInProgress = new CompletableFuture<>();
         CompletableFuture<Void> blockEnsembleChange = new CompletableFuture<>();
         clientCtx.getMockLedgerManager().setPreWriteHook((ledgerId, metadata) -> {
-                if (metadata.getAllEnsembles().get(0L).get(1).equals(b4)) { // block the write trying to replace b2 with b4
+                // block the write trying to replace b2 with b4
+                if (metadata.getAllEnsembles().get(0L).get(1).equals(b4)) {
                     changeInProgress.complete(null);
                     return blockEnsembleChange;
                 } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerClose2Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerClose2Test.java
@@ -106,9 +106,9 @@ public class LedgerClose2Test {
         closeFuture.get();
 
         Assert.assertTrue(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 2);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b4, b2, b5));
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(1L), Lists.newArrayList(b1, b2, b4));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 2);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b4, b2, b5));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(1L), Lists.newArrayList(b1, b2, b4));
         Assert.assertEquals(lh.getLedgerMetadata().getLastEntryId(), 1L);
     }
 
@@ -147,8 +147,8 @@ public class LedgerClose2Test {
         closeFuture.get();
 
         Assert.assertTrue(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
         Assert.assertEquals(lh.getLedgerMetadata().getLastEntryId(), lac);
         Assert.assertEquals(lh.getLedgerMetadata().getLength(), length);
     }
@@ -228,8 +228,8 @@ public class LedgerClose2Test {
 
         closeFuture.get(); // should override in recovery, since this handle knows what it has written
         Assert.assertTrue(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
         Assert.assertEquals(lh.getLedgerMetadata().getLastEntryId(), lac);
         Assert.assertEquals(lh.getLedgerMetadata().getLength(), length);
     }
@@ -260,8 +260,8 @@ public class LedgerClose2Test {
             Assert.assertEquals(ee.getCause().getClass(), BKException.BKLedgerClosedException.class);
         }
         Assert.assertTrue(lh.getLedgerMetadata().isClosed());
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L), Lists.newArrayList(b1, b2, b3));
         Assert.assertEquals(lh.getLedgerMetadata().getLastEntryId(), LedgerHandle.INVALID_ENTRY_ID);
         Assert.assertEquals(lh.getLedgerMetadata().getLength(), 0);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecovery2Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecovery2Test.java
@@ -209,8 +209,8 @@ public class LedgerRecovery2Test {
         lh.recover(recoveryPromise, null, false);
         recoveryPromise.get();
 
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L),
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L),
                             Lists.newArrayList(b1, b4, b3));
     }
 
@@ -238,10 +238,10 @@ public class LedgerRecovery2Test {
         lh.recover(recoveryPromise, null, false);
         recoveryPromise.get();
 
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 2);
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(0L),
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 2);
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(0L),
                             Lists.newArrayList(b1, b2, b3));
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().get(1L),
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().get(1L),
                             Lists.newArrayList(b1, b4, b3));
         Assert.assertEquals(lh.getLastAddConfirmed(), 1L);
     }
@@ -269,10 +269,10 @@ public class LedgerRecovery2Test {
         lh.recover(recoveryPromise, null, false);
         recoveryPromise.get();
 
-        Assert.assertEquals(lh.getLedgerMetadata().getEnsembles().size(), 1);
-        Assert.assertTrue(lh.getLedgerMetadata().getEnsembles().get(0L).contains(b3));
-        Assert.assertTrue(lh.getLedgerMetadata().getEnsembles().get(0L).contains(b4));
-        Assert.assertTrue(lh.getLedgerMetadata().getEnsembles().get(0L).contains(b5));
+        Assert.assertEquals(lh.getLedgerMetadata().getAllEnsembles().size(), 1);
+        Assert.assertTrue(lh.getLedgerMetadata().getAllEnsembles().get(0L).contains(b3));
+        Assert.assertTrue(lh.getLedgerMetadata().getAllEnsembles().get(0L).contains(b4));
+        Assert.assertTrue(lh.getLedgerMetadata().getAllEnsembles().get(0L).contains(b5));
         Assert.assertEquals(lh.getLastAddConfirmed(), 0L);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
@@ -155,7 +155,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
-                     1, lh.getLedgerMetadata().getEnsembles().size());
+                     1, lh.getLedgerMetadata().getAllEnsembles().size());
 
         bsConfs.add(conf0);
         bs.add(startBookie(conf0));
@@ -168,7 +168,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
-                     1, lh.getLedgerMetadata().getEnsembles().size());
+                     1, lh.getLedgerMetadata().getAllEnsembles().size());
 
         // check entries
         verifyEntries(lh, 0, numEntries, 5, 0);
@@ -192,7 +192,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
             lh.addEntry(data);
         }
 
-        for (BookieSocketAddress addr : lh.getLedgerMetadata().getEnsembles().get(0L)) {
+        for (BookieSocketAddress addr : lh.getLedgerMetadata().getAllEnsembles().get(0L)) {
             assertTrue(
                     LEDGER_ENSEMBLE_BOOKIE_DISTRIBUTION + " should be > 0 for " + addr,
                     bkc.getTestStatsProvider().getCounter(
@@ -221,7 +221,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
-                     1, lh.getLedgerMetadata().getEnsembles().size());
+                     1, lh.getLedgerMetadata().getAllEnsembles().size());
         assertTrue(
                 "Stats should not have captured an ensemble change",
                 bkc.getTestStatsProvider().getOpStatsLogger(
@@ -238,7 +238,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
-                     1, lh.getLedgerMetadata().getEnsembles().size());
+                     1, lh.getLedgerMetadata().getAllEnsembles().size());
 
         logger.info("Kill bookie 2 and write another {} entries.", numEntries);
 
@@ -250,7 +250,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensemble change should kick in
         assertEquals("There should be ensemble change if ack quorum couldn't be formed.",
-                     2, lh.getLedgerMetadata().getEnsembles().size());
+                     2, lh.getLedgerMetadata().getAllEnsembles().size());
         assertTrue(
                 "Stats should have captured an ensemble change",
                 bkc.getTestStatsProvider().getOpStatsLogger(
@@ -278,7 +278,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
-                     2, lh.getLedgerMetadata().getEnsembles().size());
+                     2, lh.getLedgerMetadata().getAllEnsembles().size());
 
         // check entries
         verifyEntries(lh, 0, numEntries, 5, 0);
@@ -316,7 +316,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is ensemble changed
         assertEquals("There should be ensemble change if ack quorum is broken.",
-                     2, lh.getLedgerMetadata().getEnsembles().size());
+                     2, lh.getLedgerMetadata().getAllEnsembles().size());
 
         bsConfs.add(conf0);
         bs.add(startBookie(conf0));
@@ -331,7 +331,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("There should be no ensemble change after adding failed bookies back.",
-                     2, lh.getLedgerMetadata().getEnsembles().size());
+                     2, lh.getLedgerMetadata().getAllEnsembles().size());
 
         // check entries
         verifyEntries(lh, 0, numEntries, 5, 0);
@@ -372,7 +372,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("There should be ensemble change if breaking ack quorum.",
-                     2, lh.getLedgerMetadata().getEnsembles().size());
+                     2, lh.getLedgerMetadata().getAllEnsembles().size());
 
         for (ServerConfiguration conf : confs) {
             bsConfs.add(conf);
@@ -386,7 +386,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("There should not be ensemble changed if delaying ensemble change is enabled.",
-                     2, lh.getLedgerMetadata().getEnsembles().size());
+                     2, lh.getLedgerMetadata().getAllEnsembles().size());
 
         // check entries
         verifyEntries(lh, 0, numEntries, 5, 0);
@@ -414,7 +414,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("The ensemble should change when a bookie is readonly even if we delay ensemble change.",
-            2, lh.getLedgerMetadata().getEnsembles().size());
+            2, lh.getLedgerMetadata().getAllEnsembles().size());
 
     }
 
@@ -438,7 +438,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
         }
 
         assertEquals("There should be ensemble change if delaying ensemble change is enabled.",
-            1, lh.getLedgerMetadata().getEnsembles().size());
+            1, lh.getLedgerMetadata().getAllEnsembles().size());
 
         // kill two bookies, but we still have 3 bookies for the ack quorum.
         setBookieToReadOnly(readOnlyBookie);
@@ -449,7 +449,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
 
         // ensure there is no ensemble changed
         assertEquals("The ensemble should change when a bookie is readonly even if we delay ensemble change.",
-            2, lh.getLedgerMetadata().getEnsembles().size());
+            2, lh.getLedgerMetadata().getAllEnsembles().size());
         assertEquals(3, lh.getCurrentEnsemble().size());
         assertFalse(lh.getCurrentEnsemble().contains(failedBookie));
         assertFalse(lh.getCurrentEnsemble().contains(readOnlyBookie));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
@@ -88,9 +88,9 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
         final AtomicBoolean failTest = new AtomicBoolean(false);
         final byte[] entry = "test-disable-ensemble-change".getBytes(UTF_8);
 
-        assertEquals(1, lh.getLedgerMetadata().getEnsembles().size());
+        assertEquals(1, lh.getLedgerMetadata().getAllEnsembles().size());
         ArrayList<BookieSocketAddress> ensembleBeforeFailure =
-                new ArrayList<>(lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue());
+                new ArrayList<>(lh.getLedgerMetadata().getAllEnsembles().entrySet().iterator().next().getValue());
 
         final RateLimiter rateLimiter = RateLimiter.create(10);
 
@@ -120,9 +120,9 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
 
         // check the ensemble after failure
         assertEquals("No new ensemble should be added when disable ensemble change.",
-                1, lh.getLedgerMetadata().getEnsembles().size());
+                1, lh.getLedgerMetadata().getAllEnsembles().size());
         ArrayList<BookieSocketAddress> ensembleAfterFailure =
-                new ArrayList<>(lh.getLedgerMetadata().getEnsembles().entrySet().iterator().next().getValue());
+                new ArrayList<>(lh.getLedgerMetadata().getAllEnsembles().entrySet().iterator().next().getValue());
         assertArrayEquals(ensembleBeforeFailure.toArray(new BookieSocketAddress[ensembleBeforeFailure.size()]),
                 ensembleAfterFailure.toArray(new BookieSocketAddress[ensembleAfterFailure.size()]));
 
@@ -161,7 +161,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
             assertFalse("Ledger should be closed when enable ensemble change again.",
                     lh.getLedgerMetadata().isClosed());
             assertEquals("New ensemble should be added when enable ensemble change again.",
-                    2, lh.getLedgerMetadata().getEnsembles().size());
+                    2, lh.getLedgerMetadata().getAllEnsembles().size());
         } else {
             assertTrue("Should fail adding entries when enable ensemble change again.",
                     failTest.get());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestFencing.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestFencing.java
@@ -351,7 +351,7 @@ public class TestFencing extends BookKeeperClusterTestCase {
         }
 
         CountDownLatch sleepLatch = new CountDownLatch(1);
-        sleepBookie(writelh.getLedgerMetadata().getEnsembles().get(0L).get(1), sleepLatch);
+        sleepBookie(writelh.getLedgerMetadata().getAllEnsembles().get(0L).get(1), sleepLatch);
 
         LedgerHandle readlh = bkc.openLedger(writelh.getId(),
                                              digestType, "testPasswd".getBytes());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerChecker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerChecker.java
@@ -78,7 +78,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         for (int i = 0; i < 10; i++) {
             lh.addEntry(TEST_LEDGER_ENTRY_DATA);
         }
-        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getEnsembles()
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles()
                 .get(0L).get(0);
         LOG.info("Killing {}", replicaToKill);
         killBookie(replicaToKill);
@@ -98,7 +98,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
             result.iterator().next().getAddresses().contains(replicaToKill));
 
         BookieSocketAddress replicaToKill2 = lh.getLedgerMetadata()
-                .getEnsembles().get(0L).get(1);
+                .getAllEnsembles().get(0L).get(1);
         LOG.info("Killing {}", replicaToKill2);
         killBookie(replicaToKill2);
 
@@ -138,7 +138,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
 
         // Kill the 3rd BK from ensemble.
         List<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
-                .getEnsembles().get(0L);
+                .getAllEnsembles().get(0L);
         BookieSocketAddress lastBookieFromEnsemble = firstEnsemble.get(2);
         LOG.info("Killing " + lastBookieFromEnsemble + " from ensemble="
                 + firstEnsemble);
@@ -147,13 +147,13 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         startNewBookie();
 
         LOG.info("Ensembles after first entry :"
-                + lh.getLedgerMetadata().getEnsembles());
+                + lh.getLedgerMetadata().getAllEnsembles());
 
         // Adding one more entry. Here enseble should be reformed.
         lh.addEntry(TEST_LEDGER_ENTRY_DATA);
 
         LOG.info("Ensembles after second entry :"
-                + lh.getLedgerMetadata().getEnsembles());
+                + lh.getLedgerMetadata().getAllEnsembles());
 
         Set<LedgerFragment> result = getUnderReplicatedFragments(lh);
 
@@ -181,7 +181,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         lh.addEntry(TEST_LEDGER_ENTRY_DATA);
 
         List<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
-                .getEnsembles().get(0L);
+                .getAllEnsembles().get(0L);
 
         BookieSocketAddress firstBookieFromEnsemble = firstEnsemble.get(0);
         killBookie(firstEnsemble, firstBookieFromEnsemble);
@@ -214,7 +214,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
                 TEST_LEDGER_PASSWORD);
 
         List<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
-                .getEnsembles().get(0L);
+                .getAllEnsembles().get(0L);
         BookieSocketAddress firstBookieFromEnsemble = firstEnsemble.get(0);
         killBookie(firstBookieFromEnsemble);
         startNewBookie();
@@ -259,7 +259,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
 
         // Kill all three bookies
         List<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
-                .getEnsembles().get(0L);
+                .getAllEnsembles().get(0L);
         for (BookieSocketAddress bkAddr : firstEnsemble) {
             killBookie(firstEnsemble, bkAddr);
         }
@@ -302,7 +302,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
     public void testShouldGet2FragmentsWithEmptyLedgerButBookiesDead() throws Exception {
         LedgerHandle lh = bkc.createLedger(3, 2, BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
-        for (BookieSocketAddress b : lh.getLedgerMetadata().getEnsembles().get(0L)) {
+        for (BookieSocketAddress b : lh.getLedgerMetadata().getAllEnsembles().get(0L)) {
             killBookie(b);
         }
         Set<LedgerFragment> result = getUnderReplicatedFragments(lh);
@@ -322,7 +322,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
                 TEST_LEDGER_PASSWORD);
         lh.addEntry(TEST_LEDGER_ENTRY_DATA);
         List<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
-                .getEnsembles().get(0L);
+                .getAllEnsembles().get(0L);
         BookieSocketAddress lastBookieFromEnsemble = firstEnsemble.get(0);
         LOG.info("Killing " + lastBookieFromEnsemble + " from ensemble="
                 + firstEnsemble);
@@ -356,7 +356,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
             lh.addEntry(TEST_LEDGER_ENTRY_DATA);
         }
         List<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
-                .getEnsembles().get(0L);
+                .getAllEnsembles().get(0L);
         DistributionSchedule.WriteSet writeSet = lh.getDistributionSchedule().getWriteSet(lh.getLastAddPushed());
         BookieSocketAddress lastBookieFromEnsemble = firstEnsemble.get(writeSet.get(0));
         LOG.info("Killing " + lastBookieFromEnsemble + " from ensemble="
@@ -401,7 +401,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         LedgerHandle lh = bkc.createLedger(3, 3, BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
         List<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
-                .getEnsembles().get(0L);
+                .getAllEnsembles().get(0L);
         lh.close();
 
         BookieSocketAddress lastBookieFromEnsemble = firstEnsemble.get(0);
@@ -428,7 +428,7 @@ public class TestLedgerChecker extends BookKeeperClusterTestCase {
         LedgerHandle lh = bkc.createLedger(3, 2, BookKeeper.DigestType.CRC32,
                 TEST_LEDGER_PASSWORD);
         List<BookieSocketAddress> firstEnsemble = lh.getLedgerMetadata()
-            .getEnsembles().get(0L);
+            .getAllEnsembles().get(0L);
         lh.addEntry(TEST_LEDGER_ENTRY_DATA);
         lh.close();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
@@ -87,7 +87,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         for (int i = 0; i < 10; i++) {
             lh.addEntry(data);
         }
-        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getEnsembles()
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles()
                 .get(0L).get(0);
 
         LOG.info("Killing Bookie", replicaToKill);
@@ -112,7 +112,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
 
         // Killing all bookies except newly replicated bookie
         SortedMap<Long, ? extends List<BookieSocketAddress>> allBookiesBeforeReplication = lh
-                .getLedgerMetadata().getEnsembles();
+                .getLedgerMetadata().getAllEnsembles();
         for (Entry<Long, ? extends List<BookieSocketAddress>> entry : allBookiesBeforeReplication.entrySet()) {
             List<BookieSocketAddress> bookies = entry.getValue();
             for (BookieSocketAddress bookie : bookies) {
@@ -141,7 +141,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         for (int i = 0; i < 10; i++) {
             lh.addEntry(data);
         }
-        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getEnsembles()
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles()
                 .get(0L).get(0);
 
         startNewBookie();
@@ -154,7 +154,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         }
 
         BookieSocketAddress replicaToKill2 = lh.getLedgerMetadata()
-                .getEnsembles().get(0L).get(1);
+                .getAllEnsembles().get(0L).get(1);
 
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
         LOG.info("New Bookie addr : {}", newBkAddr);
@@ -200,7 +200,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         }
 
         // Kill the first Bookie
-        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getEnsembles()
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles()
                 .get(0L).get(0);
         killBookie(replicaToKill);
         LOG.info("Killed Bookie =" + replicaToKill);
@@ -210,7 +210,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
             lh.addEntry(data);
         }
         // Kill the second Bookie
-        replicaToKill = lh.getLedgerMetadata().getEnsembles().get(0L).get(0);
+        replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
         killBookie(replicaToKill);
         LOG.info("Killed Bookie =" + replicaToKill);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestMaxEnsembleChangeNum.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestMaxEnsembleChangeNum.java
@@ -56,7 +56,7 @@ public class TestMaxEnsembleChangeNum extends MockBookKeeperTestCase {
                 writer.append(ByteBuffer.wrap(data));
             }
             assertEquals("There should be zero ensemble change",
-                    1, getLedgerMetadata(lId).getEnsembles().size());
+                    1, getLedgerMetadata(lId).getAllEnsembles().size());
 
             simulateEnsembleChangeWithWriter(changeNum, numEntries, writer);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSequenceRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSequenceRead.java
@@ -55,7 +55,7 @@ public class TestSequenceRead extends BookKeeperClusterTestCase {
     private LedgerHandle createLedgerWithDuplicatedBookies() throws Exception {
         final LedgerHandle lh = bkc.createLedger(3, 3, 3, digestType, passwd);
         // introduce duplicated bookies in an ensemble.
-        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = lh.getLedgerMetadata().getEnsembles();
+        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = lh.getLedgerMetadata().getAllEnsembles();
         TreeMap<Long, List<BookieSocketAddress>> newEnsembles = new TreeMap<>();
         for (Map.Entry<Long, ? extends List<BookieSocketAddress>> entry : ensembles.entrySet()) {
             List<BookieSocketAddress> newList = new ArrayList<BookieSocketAddress>(entry.getValue().size());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
@@ -138,7 +138,7 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
 
         // sleep second bookie
         CountDownLatch sleepLatch = new CountDownLatch(1);
-        BookieSocketAddress second = lnospec.getLedgerMetadata().getEnsembles().get(0L).get(1);
+        BookieSocketAddress second = lnospec.getLedgerMetadata().getAllEnsembles().get(0L).get(1);
         sleepBookie(second, sleepLatch);
 
         try {
@@ -194,9 +194,9 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
 
         // sleep bookie 1, 2 & 4
         CountDownLatch sleepLatch = new CountDownLatch(1);
-        sleepBookie(l.getLedgerMetadata().getEnsembles().get(0L).get(1), sleepLatch);
-        sleepBookie(l.getLedgerMetadata().getEnsembles().get(0L).get(2), sleepLatch);
-        sleepBookie(l.getLedgerMetadata().getEnsembles().get(0L).get(4), sleepLatch);
+        sleepBookie(l.getLedgerMetadata().getAllEnsembles().get(0L).get(1), sleepLatch);
+        sleepBookie(l.getLedgerMetadata().getAllEnsembles().get(0L).get(2), sleepLatch);
+        sleepBookie(l.getLedgerMetadata().getAllEnsembles().get(0L).get(4), sleepLatch);
 
         try {
             // read first entry, should complete faster than timeout
@@ -218,8 +218,8 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
 
             // bookies 1 & 2 should be registered as slow bookies because of speculative reads
             Set<BookieSocketAddress> expectedSlowBookies = new HashSet<>();
-            expectedSlowBookies.add(l.getLedgerMetadata().getEnsembles().get(0L).get(1));
-            expectedSlowBookies.add(l.getLedgerMetadata().getEnsembles().get(0L).get(2));
+            expectedSlowBookies.add(l.getLedgerMetadata().getAllEnsembles().get(0L).get(1));
+            expectedSlowBookies.add(l.getLedgerMetadata().getAllEnsembles().get(0L).get(2));
             assertEquals(((RackawareEnsemblePlacementPolicy) bkspec.getPlacementPolicy()).slowBookies.asMap().keySet(),
                 expectedSlowBookies);
 
@@ -268,8 +268,8 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
         // sleep bookies
         CountDownLatch sleepLatch0 = new CountDownLatch(1);
         CountDownLatch sleepLatch1 = new CountDownLatch(1);
-        sleepBookie(l.getLedgerMetadata().getEnsembles().get(0L).get(0), sleepLatch0);
-        sleepBookie(l.getLedgerMetadata().getEnsembles().get(0L).get(1), sleepLatch1);
+        sleepBookie(l.getLedgerMetadata().getAllEnsembles().get(0L).get(0), sleepLatch0);
+        sleepBookie(l.getLedgerMetadata().getAllEnsembles().get(0L).get(1), sleepLatch1);
 
         try {
             // read goes to first bookie, spec read timeout occurs,
@@ -328,7 +328,7 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
 
         LedgerHandle l = bkspec.openLedger(id, digestType, passwd);
 
-        List<BookieSocketAddress> ensemble = l.getLedgerMetadata().getEnsembles().get(0L);
+        List<BookieSocketAddress> ensemble = l.getLedgerMetadata().getAllEnsembles().get(0L);
         BitSet allHosts = new BitSet(ensemble.size());
         for (int i = 0; i < ensemble.size(); i++) {
             allHosts.set(i, true);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
@@ -239,7 +239,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
             lh.close();
             LedgerHandle openLedger = bk.openLedger(lh.getId(), digestType, PASSWORD.getBytes());
             final LedgerMetadata ledgerMetadata = openLedger.getLedgerMetadata();
-            assertEquals("Failed to reform ensemble!", 2, ledgerMetadata.getEnsembles().size());
+            assertEquals("Failed to reform ensemble!", 2, ledgerMetadata.getAllEnsembles().size());
             ensemble = ledgerMetadata.getEnsemble(0);
             assertTrue("Failed to update the ledger metadata to use bookie host name",
                     ensemble.contains(toBookieAddr));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
@@ -335,7 +335,7 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
             writeQuorumSize, ackQuorumSize, password, customMetadata);
         registerMockLedgerMetadata(ledgerId, ledgerMetadata);
 
-        ledgerMetadata.getEnsembles().values().forEach(bookieAddressList -> {
+        ledgerMetadata.getAllEnsembles().values().forEach(bookieAddressList -> {
             bookieAddressList.forEach(bookieAddress -> {
                     registerMockEntryForRead(ledgerId, BookieProtocol.LAST_ADD_CONFIRMED, bookieAddress, entryData, -1);
                     registerMockEntryForRead(ledgerId, 0, bookieAddress, entryData, -1);
@@ -356,7 +356,7 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
             writeQuorumSize, ackQuorumSize, password, customMetadata);
         registerMockLedgerMetadata(ledgerId, ledgerMetadata);
 
-        ledgerMetadata.getEnsembles().values().forEach(bookieAddressList -> {
+        ledgerMetadata.getAllEnsembles().values().forEach(bookieAddressList -> {
             bookieAddressList.forEach(bookieAddress -> {
                 registerMockEntryForRead(ledgerId, BookieProtocol.LAST_ADD_CONFIRMED, bookieAddress, entryData, -1);
                 registerMockEntryForRead(ledgerId, 0, bookieAddress, entryData, -1);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
@@ -96,7 +96,7 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
 
                 LedgerHandle lh = bkc.createLedger(3, 3, DigestType.CRC32, "passwd".getBytes());
                 LedgerMetadata md = LedgerHandleAdapter.getLedgerMetadata(lh);
-                List<BookieSocketAddress> ensemble = new ArrayList<>(md.getEnsembles().get(0L));
+                List<BookieSocketAddress> ensemble = new ArrayList<>(md.getAllEnsembles().get(0L));
                 ensemble.set(0, new BookieSocketAddress("1.1.1.1", 1000));
                 md.updateEnsemble(0L, ensemble);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
@@ -480,9 +480,9 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
 
     private BookieSocketAddress replaceBookieWithWriteFailingBookie(LedgerHandle lh) throws Exception {
         int bookieIdx = -1;
-        Long entryId = LedgerHandleAdapter.getLedgerMetadata(lh).getEnsembles().firstKey();
+        Long entryId = LedgerHandleAdapter.getLedgerMetadata(lh).getAllEnsembles().firstKey();
         List<BookieSocketAddress> curEnsemble = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(entryId);
+                .getLedgerMetadata(lh).getAllEnsembles().get(entryId);
 
         // Identify a bookie in the current ledger ensemble to be replaced
         BookieSocketAddress replacedBookie = null;
@@ -577,8 +577,8 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
         // check that ensemble has changed and the bookie that rejected writes has
         // been replaced in the ensemble
         LedgerHandle newLh = bkc.openLedger(lh.getId(), DigestType.CRC32, "passwd".getBytes());
-        for (Map.Entry<Long, ? extends List<BookieSocketAddress>> e : LedgerHandleAdapter.getLedgerMetadata(newLh).
-                getEnsembles().entrySet()) {
+        for (Map.Entry<Long, ? extends List<BookieSocketAddress>> e :
+                 newLh.getLedgerMetadata().getAllEnsembles().entrySet()) {
             List<BookieSocketAddress> ensemble = e.getValue();
             assertFalse("Ensemble hasn't been updated", ensemble.contains(replacedBookie));
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -151,7 +151,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         LedgerHandle lh = listOfLedgerHandle.get(0);
         int ledgerReplicaIndex = 0;
         BookieSocketAddress replicaToKillAddr = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(0L).get(0);
+                .getLedgerMetadata(lh).getAllEnsembles().get(0L).get(0);
 
         final String urLedgerZNode = getUrLedgerZNode(lh);
         ledgerReplicaIndex = getReplicaIndexInLedger(lh, replicaToKillAddr);
@@ -200,7 +200,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         LedgerHandle lhandle = listOfLedgerHandle.get(0);
         int ledgerReplicaIndex = 0;
         BookieSocketAddress replicaToKillAddr = LedgerHandleAdapter
-                .getLedgerMetadata(lhandle).getEnsembles().get(0L).get(0);
+                .getLedgerMetadata(lhandle).getAllEnsembles().get(0L).get(0);
 
         CountDownLatch latch = new CountDownLatch(listOfLedgerHandle.size());
         for (LedgerHandle lh : listOfLedgerHandle) {
@@ -262,7 +262,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         closeLedgers(listOfLedgerHandle);
         LedgerHandle handle = listOfLedgerHandle.get(0);
         BookieSocketAddress replicaToKillAddr = LedgerHandleAdapter
-                .getLedgerMetadata(handle).getEnsembles().get(0L).get(0);
+                .getLedgerMetadata(handle).getAllEnsembles().get(0L).get(0);
         LOG.info("Killing Bookie:" + replicaToKillAddr);
 
         // Each ledger, there will be two events : create urLedger and after
@@ -341,11 +341,11 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
                     watchUrLedgerNode(getUrLedgerZNode(lh), latch));
         }
         BookieSocketAddress replicaToKillAddr = LedgerHandleAdapter
-                .getLedgerMetadata(listOfLedgerHandle.get(0)).getEnsembles()
+                .getLedgerMetadata(listOfLedgerHandle.get(0)).getAllEnsembles()
                 .get(0L).get(0);
         killBookie(replicaToKillAddr);
         replicaToKillAddr = LedgerHandleAdapter
-                .getLedgerMetadata(listOfLedgerHandle.get(0)).getEnsembles()
+                .getLedgerMetadata(listOfLedgerHandle.get(0)).getAllEnsembles()
                 .get(0L).get(0);
         killBookie(replicaToKillAddr);
         // waiting to publish urLedger znode by Auditor
@@ -384,9 +384,9 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         watchUrLedgerNode(urZNode, latch);
 
         BookieSocketAddress replicaToKill = LedgerHandleAdapter
-            .getLedgerMetadata(lh).getEnsembles().get(0L).get(2);
+            .getLedgerMetadata(lh).getAllEnsembles().get(0L).get(2);
         LOG.info("Killing last bookie, {}, in ensemble {}", replicaToKill,
-                 LedgerHandleAdapter.getLedgerMetadata(lh).getEnsembles().get(0L));
+                 LedgerHandleAdapter.getLedgerMetadata(lh).getAllEnsembles().get(0L));
         killBookie(replicaToKill);
 
         getAuditor(10, TimeUnit.SECONDS).submitAuditTask().get(); // ensure auditor runs
@@ -399,9 +399,9 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         }
 
         replicaToKill = LedgerHandleAdapter
-            .getLedgerMetadata(lh).getEnsembles().get(0L).get(1);
+            .getLedgerMetadata(lh).getAllEnsembles().get(0L).get(1);
         LOG.info("Killing second bookie, {}, in ensemble {}", replicaToKill,
-                 LedgerHandleAdapter.getLedgerMetadata(lh).getEnsembles().get(0L));
+                 LedgerHandleAdapter.getLedgerMetadata(lh).getAllEnsembles().get(0L));
         killBookie(replicaToKill);
 
         getAuditor(10, TimeUnit.SECONDS).submitAuditTask().get(); // ensure auditor runs
@@ -443,8 +443,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         List<LedgerHandle> listOfLedgerHandle = createLedgersAndAddEntries(1, 5);
         LedgerHandle lh = listOfLedgerHandle.get(0);
         int ledgerReplicaIndex = 0;
-        final SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles();
+        final SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = lh.getLedgerMetadata().getAllEnsembles();
         final List<BookieSocketAddress> bkAddresses = ensembles.get(0L);
         BookieSocketAddress replicaToKillAddr = bkAddresses.get(0);
         for (BookieSocketAddress bookieSocketAddress : bkAddresses) {
@@ -522,8 +521,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         List<LedgerHandle> listOfLedgerHandle = createLedgersAndAddEntries(1, 5);
         LedgerHandle lh = listOfLedgerHandle.get(0);
         int ledgerReplicaIndex = 0;
-        final SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles();
+        final SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = lh.getLedgerMetadata().getAllEnsembles();
         final List<BookieSocketAddress> bkAddresses = ensembles.get(0L);
         BookieSocketAddress replicaToKillAddr = bkAddresses.get(0);
         for (BookieSocketAddress bookieSocketAddress : bkAddresses) {
@@ -577,8 +575,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
     }
 
     private int getReplicaIndexInLedger(LedgerHandle lh, BookieSocketAddress replicaToKill) {
-        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles();
+        SortedMap<Long, ? extends List<BookieSocketAddress>> ensembles = lh.getLedgerMetadata().getAllEnsembles();
         int ledgerReplicaIndex = -1;
         for (BookieSocketAddress addr : ensembles.get(0L)) {
             ++ledgerReplicaIndex;
@@ -595,8 +592,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         LedgerHandle openLedger = bkc
                 .openLedger(lh.getId(), digestType, PASSWD);
 
-        BookieSocketAddress inetSocketAddress = LedgerHandleAdapter
-                .getLedgerMetadata(openLedger).getEnsembles().get(0L)
+        BookieSocketAddress inetSocketAddress = openLedger.getLedgerMetadata().getAllEnsembles().get(0L)
                 .get(ledgerReplicaIndex);
         assertEquals("Rereplication has been failed and ledgerReplicaIndex :"
                 + ledgerReplicaIndex, newBookieServer.getLocalAddress(),

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestAutoRecoveryAlongWithBookieServers.java
@@ -75,7 +75,7 @@ public class TestAutoRecoveryAlongWithBookieServers extends
         }
         lh.close();
         BookieSocketAddress replicaToKill = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(0L).get(0);
+                .getLedgerMetadata(lh).getAllEnsembles().get(0L).get(0);
 
         killBookie(replicaToKill);
 
@@ -88,7 +88,7 @@ public class TestAutoRecoveryAlongWithBookieServers extends
 
         // Killing all bookies except newly replicated bookie
         for (Entry<Long, ? extends List<BookieSocketAddress>> entry :
-                 lh.getLedgerMetadata().getEnsembles().entrySet()) {
+                 lh.getLedgerMetadata().getAllEnsembles().entrySet()) {
             List<BookieSocketAddress> bookies = entry.getValue();
             for (BookieSocketAddress bookie : bookies) {
                 if (bookie.equals(newBkAddr)) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -38,7 +38,6 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.ClientUtil;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.client.LedgerHandleAdapter;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -139,8 +139,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         for (int i = 0; i < 10; i++) {
             lh.addEntry(data);
         }
-        BookieSocketAddress replicaToKill = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(0L).get(0);
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
@@ -188,8 +187,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
             lh.addEntry(data);
         }
         lh.close();
-        BookieSocketAddress replicaToKill = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(0L).get(0);
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
         LOG.info("Killing Bookie", replicaToKill);
         ServerConfiguration killedBookieConfig = killBookie(replicaToKill);
 
@@ -238,8 +236,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
             lh.addEntry(data);
         }
         lh.close();
-        BookieSocketAddress replicaToKill = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(0L).get(0);
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
         LOG.info("Killing Bookie", replicaToKill);
         ServerConfiguration killedBookieConfig = killBookie(replicaToKill);
 
@@ -295,8 +292,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
             lh.addEntry(data);
         }
         lh.close();
-        BookieSocketAddress replicaToKill = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(0L).get(0);
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
 
@@ -330,8 +326,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         for (int i = 0; i < 10; i++) {
             lh1.addEntry(data);
         }
-        BookieSocketAddress replicaToKillFromFirstLedger = LedgerHandleAdapter
-                .getLedgerMetadata(lh1).getEnsembles().get(0L).get(0);
+        BookieSocketAddress replicaToKillFromFirstLedger = lh1.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
         LOG.info("Killing Bookie", replicaToKillFromFirstLedger);
 
@@ -342,8 +337,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         for (int i = 0; i < 10; i++) {
             lh2.addEntry(data);
         }
-        BookieSocketAddress replicaToKillFromSecondLedger = LedgerHandleAdapter
-                .getLedgerMetadata(lh2).getEnsembles().get(0L).get(0);
+        BookieSocketAddress replicaToKillFromSecondLedger = lh2.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
         LOG.info("Killing Bookie", replicaToKillFromSecondLedger);
 
@@ -402,8 +396,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         for (int i = 0; i < 10; i++) {
             lh.addEntry(data);
         }
-        BookieSocketAddress replicaToKill = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(0L).get(0);
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
@@ -470,7 +463,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
 
         // kill all bookies
         for (int i = 0; i < ensembleSize; i++) {
-            bookiesKilled[i] = LedgerHandleAdapter.getLedgerMetadata(lh).getEnsembles().get(0L).get(i);
+            bookiesKilled[i] = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(i);
             killedBookiesConfig[i] = getBkConf(bookiesKilled[i]);
             LOG.info("Killing Bookie", bookiesKilled[i]);
             killBookie(bookiesKilled[i]);
@@ -589,8 +582,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         for (int i = 0; i < 10; i++) {
             lh.addEntry(data);
         }
-        BookieSocketAddress replicaToKill = LedgerHandleAdapter
-                .getLedgerMetadata(lh).getEnsembles().get(0L).get(0);
+        BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
         LOG.info("Killing Bookie", replicaToKill);
         killBookie(replicaToKill);
@@ -683,7 +675,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
             throws Exception {
         // Killing all bookies except newly replicated bookie
         for (Entry<Long, ? extends List<BookieSocketAddress>> entry :
-                 lh.getLedgerMetadata().getEnsembles().entrySet()) {
+                 lh.getLedgerMetadata().getAllEnsembles().entrySet()) {
             List<BookieSocketAddress> bookies = entry.getValue();
             for (BookieSocketAddress bookie : bookies) {
                 if (bookie.equals(excludeBK)) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -666,7 +666,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
         LedgerHandle lh = bkc.createLedger(3, 3, BookKeeper.DigestType.CRC32, "passwd".getBytes());
         LedgerMetadata md = LedgerHandleAdapter.getLedgerMetadata(lh);
-        List<BookieSocketAddress> ensemble = new ArrayList<>(md.getEnsembles().get(0L));
+        List<BookieSocketAddress> ensemble = new ArrayList<>(md.getAllEnsembles().get(0L));
         ensemble.set(0, new BookieSocketAddress("1.1.1.1", 1000));
         md.updateEnsemble(0L, ensemble);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -435,8 +435,8 @@ public class TestTLS extends BookKeeperClusterTestCase {
 
         ClientConfiguration clientConf = new ClientConfiguration(baseClientConf);
         LedgerMetadata metadata = testClient(clientConf, 2);
-        assertTrue(metadata.getEnsembles().size() > 0);
-        Collection<? extends List<BookieSocketAddress>> ensembles = metadata.getEnsembles().values();
+        assertTrue(metadata.getAllEnsembles().size() > 0);
+        Collection<? extends List<BookieSocketAddress>> ensembles = metadata.getAllEnsembles().values();
         for (List<BookieSocketAddress> bookies : ensembles) {
             for (BookieSocketAddress bookieAddress : bookies) {
                 int port = bookieAddress.getPort();

--- a/stream/distributedlog/core/src/main/java/org/apache/bookkeeper/client/LedgerReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/bookkeeper/client/LedgerReader.java
@@ -83,7 +83,7 @@ public class LedgerReader {
     }
 
     public static SortedMap<Long, ? extends List<BookieSocketAddress>> bookiesForLedger(final LedgerHandle lh) {
-        return lh.getLedgerMetadata().getEnsembles();
+        return lh.getLedgerMetadata().getAllEnsembles();
     }
 
     public void readEntriesFromAllBookies(final LedgerHandle lh, long eid,

--- a/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
+++ b/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
@@ -104,7 +104,7 @@ class TestCompatRecoveryNoPassword {
                                           long untilEntry) throws Exception {
         LedgerMetadata md = getLedgerMetadata(bookkeeper, lh.getId())
 
-        def ensembles = md.getEnsembles()
+        def ensembles = md.getAllEnsembles()
 
         def ranges = new HashMap<Long, Long>()
         def keyList = new ArrayList(ensembles.keySet())


### PR DESCRIPTION
They do the same thing except that #getEnsembles returns a TreeMap
while #getAllEnsembles returns a NavigableMap.

LedgerMetadata#getAllEnsembles is part of the api interface.

Master issue: #281
