### PR TITLE
Don't cache Bookie hostname DNS resolution forever

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
@@ -39,13 +39,10 @@ public class BookieSocketAddress {
     private final String hostname;
     private final int port;
 
-    private final InetSocketAddress socketAddress;
-
     // Constructor that takes in both a port.
     public BookieSocketAddress(String hostname, int port) {
         this.hostname = hostname;
         this.port = port;
-        socketAddress = new InetSocketAddress(hostname, port);
     }
 
     // Constructor from a String "serialized" version of this class.
@@ -60,7 +57,6 @@ public class BookieSocketAddress {
         } catch (NumberFormatException nfe) {
             throw new UnknownHostException(addr);
         }
-        socketAddress = new InetSocketAddress(hostname, port);
     }
 
     // Public getters
@@ -74,7 +70,7 @@ public class BookieSocketAddress {
 
     // Method to return an InetSocketAddress for the regular port.
     public InetSocketAddress getSocketAddress() {
-        return socketAddress;
+        return new InetSocketAddress(hostname, port);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
@@ -70,6 +70,11 @@ public class BookieSocketAddress {
 
     // Method to return an InetSocketAddress for the regular port.
     public InetSocketAddress getSocketAddress() {
+        // Return each time a new instance of the InetSocketAddress because the hostname
+        // gets resolved in its constructor and then cached forever.
+        // If we keep using the same InetSocketAddress instance, if bookies are advertising
+        // hostnames and the IP change, the BK client will keep forever to try to connect
+        // to the old IP.
         return new InetSocketAddress(hostname, port);
     }
 


### PR DESCRIPTION
### Motivation

`BookieSocketAddress` is resolving the bookie DNS name in its constructor and then using the already resolved `InetSocketAddress` instance.

If the IP of a bookie changes, the BK client will continue to use the old IP address.

### Changes

Construct a new `InetSocketAddress` each time `getSocketAddress()` gets called (eg: each time we attempt to make a new connection) so that we're making sure to get the right IP.

I cannot think of a good way to add unit test for this at this point, suggestions are welcome. 

I think this should be included in a patch release as well 4.7.3 or 4.8.1