### PR TITLE
Cache InetSocketAddress if hostname is IPAddress

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
@@ -40,14 +40,12 @@ public class BookieSocketAddress {
     // Member fields that make up this class.
     private final String hostname;
     private final int port;
-    private final boolean isHostnameIPAddress;
     private final Optional<InetSocketAddress> socketAddress;
 
     // Constructor that takes in both a port.
     public BookieSocketAddress(String hostname, int port) {
         this.hostname = hostname;
         this.port = port;
-        isHostnameIPAddress = InetAddresses.isInetAddress(hostname);
         /*
          * if ipaddress is used for bookieid then lets cache InetSocketAddress
          * otherwise not cache it. If Hostname is used for bookieid, then it is
@@ -55,7 +53,7 @@ public class BookieSocketAddress {
          * bookieid then it is invalid scenario if node's ipaddress changes and
          * nodes HostName is considered static.
          */
-        if (isHostnameIPAddress) {
+        if (InetAddresses.isInetAddress(hostname)) {
             socketAddress = Optional.of(new InetSocketAddress(hostname, port));
         } else {
             socketAddress = Optional.empty();
@@ -74,8 +72,7 @@ public class BookieSocketAddress {
         } catch (NumberFormatException nfe) {
             throw new UnknownHostException(addr);
         }
-        isHostnameIPAddress = InetAddresses.isInetAddress(hostname);
-        if (isHostnameIPAddress) {
+        if (InetAddresses.isInetAddress(hostname)) {
             socketAddress = Optional.of(new InetSocketAddress(hostname, port));
         } else {
             socketAddress = Optional.empty();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/BookieSocketAddressTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/BookieSocketAddressTest.java
@@ -1,0 +1,50 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.net;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+/**
+ * Tests for BookieSocketAddress getSocketAddress cache logic.
+ */
+
+public class BookieSocketAddressTest {
+
+    @Test
+    public void testHostnameBookieId() throws Exception {
+        BookieSocketAddress hostnameAddress = new BookieSocketAddress("localhost", 3181);
+        InetSocketAddress inetSocketAddress1 = hostnameAddress.getSocketAddress();
+        InetSocketAddress inetSocketAddress2 = hostnameAddress.getSocketAddress();
+        assertFalse("InetSocketAddress should be recreated", inetSocketAddress1 == inetSocketAddress2);
+    }
+
+    @Test
+    public void testIPAddressBookieId() throws Exception {
+        BookieSocketAddress ipAddress = new BookieSocketAddress("127.0.0.1", 3181);
+        InetSocketAddress inetSocketAddress1 = ipAddress.getSocketAddress();
+        InetSocketAddress inetSocketAddress2 = ipAddress.getSocketAddress();
+        assertTrue("InetSocketAddress should be cached", inetSocketAddress1 == inetSocketAddress2);
+    }
+}


### PR DESCRIPTION


Descriptions of the changes in this PR:

- in BookieSocketAddress if IPAddress is hostname then it is okay
to cache InetSocketAddress, since the canonicalhostname of the node
dont change.

