### PR TITLE
[tools] improve bkctl help message

### DIFF
--- a/tools/all/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
+++ b/tools/all/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
@@ -18,6 +18,8 @@
  */
 package org.apache.bookkeeper.tools.cli.commands;
 
+import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_INFRA_SERVICE;
+
 import org.apache.bookkeeper.tools.cli.BKCtl;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
@@ -36,6 +38,7 @@ public class BookieCommandGroup extends CliCommandGroup<BKFlags> {
         .withName(NAME)
         .withDescription(DESC)
         .withParent(BKCtl.NAME)
+        .withCategory(CATEGORY_INFRA_SERVICE)
         .addCommand(new LastMarkCommand())
         .build();
 

--- a/tools/all/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookiesCommandGroup.java
+++ b/tools/all/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookiesCommandGroup.java
@@ -18,6 +18,8 @@
  */
 package org.apache.bookkeeper.tools.cli.commands;
 
+import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_INFRA_SERVICE;
+
 import org.apache.bookkeeper.tools.cli.BKCtl;
 import org.apache.bookkeeper.tools.cli.commands.bookies.ListBookiesCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
@@ -36,6 +38,7 @@ public class BookiesCommandGroup extends CliCommandGroup<BKFlags> {
         .withName(NAME)
         .withDescription(DESC)
         .withParent(BKCtl.NAME)
+        .withCategory(CATEGORY_INFRA_SERVICE)
         .addCommand(new ListBookiesCommand())
         .build();
 

--- a/tools/all/src/main/java/org/apache/bookkeeper/tools/cli/commands/LedgerCommandGroup.java
+++ b/tools/all/src/main/java/org/apache/bookkeeper/tools/cli/commands/LedgerCommandGroup.java
@@ -18,6 +18,8 @@
  */
 package org.apache.bookkeeper.tools.cli.commands;
 
+import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_LEDGER_SERVICE;
+
 import org.apache.bookkeeper.tools.cli.BKCtl;
 import org.apache.bookkeeper.tools.cli.commands.client.SimpleTestCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
@@ -36,6 +38,7 @@ public class LedgerCommandGroup extends CliCommandGroup<BKFlags> {
         .withName(NAME)
         .withDescription(DESC)
         .withParent(BKCtl.NAME)
+        .withCategory(CATEGORY_LEDGER_SERVICE)
         .addCommand(new SimpleTestCommand())
         .build();
 

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/common/BKCommandCategories.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/common/BKCommandCategories.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bookkeeper.tools.common;
+
+/**
+ * Classes to keep a list of command categories.
+ */
+public final class BKCommandCategories {
+
+    // commands that operate cluster and nodes
+    public static final String CATEGORY_INFRA_SERVICE = "Infrastructure commands";
+
+    // commands that operate ledger service
+    public static final String CATEGORY_LEDGER_SERVICE = "Ledger service commands";
+
+    // commands that operate table service
+    public static final String CATEGORY_TABLE_SERVICE = "Table service commands";
+
+}

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/CliCommand.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/CliCommand.java
@@ -42,6 +42,11 @@ public class CliCommand<GlobalFlagsT extends CliFlags, CommandFlagsT extends Cli
     }
 
     @Override
+    public String category() {
+        return spec.category();
+    }
+
+    @Override
     public String name() {
         return name;
     }

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/CliSpec.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/CliSpec.java
@@ -67,10 +67,12 @@ public class CliSpec<CliFlagsT extends CliFlags> {
         private PrintStream console = System.out;
         private boolean isCommandGroup = false;
         private String argumentsUsage = "";
+        private String category = "";
 
         private Builder() {}
 
         private Builder(CliSpec<CliFlagsT> spec) {
+            this.category = spec.category;
             this.name = spec.name;
             this.parent = spec.parent;
             this.usage = spec.usage;
@@ -83,6 +85,11 @@ public class CliSpec<CliFlagsT extends CliFlags> {
             this.runFunc = spec.runFunc;
             this.console = spec.console;
             this.isCommandGroup = spec.isCommandGroup;
+        }
+
+        public Builder<CliFlagsT> withCategory(String category) {
+            this.category = category;
+            return this;
         }
 
         public Builder<CliFlagsT> withName(String name) {
@@ -142,6 +149,7 @@ public class CliSpec<CliFlagsT extends CliFlags> {
 
         public CliSpec<CliFlagsT> build() {
             return new CliSpec<>(
+                category,
                 name,
                 parent,
                 usage,
@@ -158,6 +166,7 @@ public class CliSpec<CliFlagsT extends CliFlags> {
 
     }
 
+    private final String category;
     private final String name;
     private final String parent;
     private final String usage;
@@ -171,7 +180,8 @@ public class CliSpec<CliFlagsT extends CliFlags> {
     // whether the cli spec is for a command group.
     private final boolean isCommandGroup;
 
-    private CliSpec(String name,
+    private CliSpec(String category,
+                    String name,
                     String parent,
                     String usage,
                     String argumentsUsage,
@@ -182,6 +192,7 @@ public class CliSpec<CliFlagsT extends CliFlags> {
                     Function<CliFlagsT, Boolean> runFunc,
                     PrintStream console,
                     boolean isCommandGroup) {
+        this.category = category;
         this.name = name;
         this.parent = parent;
         this.usage = usage;
@@ -193,6 +204,10 @@ public class CliSpec<CliFlagsT extends CliFlags> {
         this.runFunc = runFunc;
         this.console = console;
         this.isCommandGroup = isCommandGroup;
+    }
+
+    public String category() {
+        return category;
     }
 
     public String name() {

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/Command.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/Command.java
@@ -33,6 +33,13 @@ public interface Command<GlobalFlagsT extends CliFlags> {
     }
 
     /**
+     * Return category of this command belongs to.
+     *
+     * @return category name
+     */
+    default String category() { return ""; }
+
+    /**
      * Return command name.
      *
      * @return command name.

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/Command.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/Command.java
@@ -37,7 +37,9 @@ public interface Command<GlobalFlagsT extends CliFlags> {
      *
      * @return category name
      */
-    default String category() { return ""; }
+    default String category() {
+        return "";
+    }
 
     /**
      * Return command name.

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/CommandUtils.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/CommandUtils.java
@@ -27,9 +27,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.stream.IntStream;
 import org.apache.commons.lang.StringUtils;
 

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/CommandUtils.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/CommandUtils.java
@@ -27,7 +27,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.IntStream;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Utils to process a commander.
@@ -164,9 +168,6 @@ public class CommandUtils {
             return;
         }
 
-        printer.println("Commands:");
-        printer.println();
-
         int longestCommandName = commands
             .keySet()
             .stream()
@@ -174,17 +175,44 @@ public class CommandUtils {
             .max()
             .orElse(0);
 
+        // group the commands by category
+        Map<String, Map<String, Command>> categorizedCommands = new TreeMap<>();
         for (Map.Entry<String, Command> commandEntry : commands.entrySet()) {
             if ("help".equals(commandEntry.getKey())) {
-                // don't print help message along with available other commands
+                // don't add help message along with other commands
                 continue;
             }
-            printCommand(printer, commandEntry.getKey(), commandEntry.getValue(), longestCommandName);
+            String category = commandEntry.getValue().category();
+            Map<String, Command> subCommands = categorizedCommands.get(category);
+            if (null == subCommands) {
+                subCommands = new TreeMap<>();
+                categorizedCommands.put(category, subCommands);
+            }
+            subCommands.put(commandEntry.getKey(), commandEntry.getValue());
+        }
+
+        // there is only one category, print all of them under `Commands`.
+        if (categorizedCommands.size() <= 1) {
+            printer.println("Commands:");
+            printer.println();
+        }
+
+        for (Map.Entry<String, Map<String, Command>> categoryEntry : categorizedCommands.entrySet()) {
+            String category = categoryEntry.getKey();
+            printCategoryHeader(printer, category);
+            Map<String, Command> subCommands = categoryEntry.getValue();
+            for (Map.Entry<String, Command> commandEntry : subCommands.entrySet()) {
+                printCommand(printer, commandEntry.getKey(), commandEntry.getValue(), longestCommandName);
+            }
+            printer.println();
         }
 
         Command helpCmd = commands.get("help");
         if (null != helpCmd) {
-            printer.println();
+            if (categorizedCommands.size() > 1) {
+                // if commands has been categorized, put help
+                printCategoryHeader(printer, "Other commands");
+            }
             printCommand(printer, "help", helpCmd, longestCommandName);
         }
 
@@ -213,6 +241,21 @@ public class CommandUtils {
             0,
             startOfDescription,
             command.description());
+    }
+
+    private static void printCategoryHeader(PrintStream printer,
+                                            String category) {
+        if (StringUtils.isEmpty(category)) {
+            return;
+        }
+
+        printIndent(printer, 0);
+        printDescription(
+            printer,
+            0,
+            0,
+            category + " :");
+        printer.println();
     }
 
 }

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/ClusterCommandGroup.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/ClusterCommandGroup.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.stream.cli;
 
+import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_INFRA_SERVICE;
+
 import org.apache.bookkeeper.stream.cli.commands.cluster.InitClusterCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
 import org.apache.bookkeeper.tools.framework.CliCommandGroup;
@@ -34,6 +36,7 @@ public class ClusterCommandGroup extends CliCommandGroup<BKFlags> {
         .withName(NAME)
         .withDescription(DESC)
         .withParent("bkctl")
+        .withCategory(CATEGORY_INFRA_SERVICE)
         .addCommand(new InitClusterCommand())
         .build();
 

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/NamespaceCommandGroup.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/NamespaceCommandGroup.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.stream.cli;
 
+import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_TABLE_SERVICE;
+
 import org.apache.bookkeeper.stream.cli.commands.namespace.CreateNamespaceCommand;
 import org.apache.bookkeeper.stream.cli.commands.namespace.DeleteNamespaceCommand;
 import org.apache.bookkeeper.stream.cli.commands.namespace.GetNamespaceCommand;
@@ -36,6 +38,7 @@ public class NamespaceCommandGroup extends CliCommandGroup<BKFlags> {
         .withName(NAME)
         .withDescription(DESC)
         .withParent("bkctl")
+        .withCategory(CATEGORY_TABLE_SERVICE)
         .addCommand(new CreateNamespaceCommand())
         .addCommand(new GetNamespaceCommand())
         .addCommand(new DeleteNamespaceCommand())

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/TableAdminCommandGroup.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/TableAdminCommandGroup.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.stream.cli;
 
+import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_TABLE_SERVICE;
+
 import org.apache.bookkeeper.stream.cli.commands.table.CreateTableCommand;
 import org.apache.bookkeeper.stream.cli.commands.table.DeleteTableCommand;
 import org.apache.bookkeeper.stream.cli.commands.table.GetTableCommand;
@@ -36,6 +38,7 @@ public class TableAdminCommandGroup extends CliCommandGroup<BKFlags> {
         .withName(NAME)
         .withDescription(DESC)
         .withParent("bkctl")
+        .withCategory(CATEGORY_TABLE_SERVICE)
         .addCommand(new CreateTableCommand())
         .addCommand(new GetTableCommand())
         .addCommand(new DeleteTableCommand())

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/TableCommandGroup.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/TableCommandGroup.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.stream.cli;
 
+import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_TABLE_SERVICE;
+
 import org.apache.bookkeeper.stream.cli.commands.table.DelCommand;
 import org.apache.bookkeeper.stream.cli.commands.table.GetCommand;
 import org.apache.bookkeeper.stream.cli.commands.table.IncrementCommand;
@@ -37,6 +39,7 @@ public class TableCommandGroup extends CliCommandGroup<BKFlags> {
         .withName(NAME)
         .withDescription(DESC)
         .withParent("bkctl")
+        .withCategory(CATEGORY_TABLE_SERVICE)
         .addCommand(new PutCommand())
         .addCommand(new GetCommand())
         .addCommand(new IncrementCommand())


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Motivation*

Currently `bin/bktcl help` will output all command groups all together.
It is a bit hard to tell what command groups to use, especially some
commands are used for table service.

*Changes*

Introduce `category` in the cli spec to define which category that a
command group belongs to. So when it prints out the help message, it
can use that information to categorize the command groups together
to provide better user experience.

*Results*

```
$ bin/bkctl help
bkctl interacts and operates Apache BookKeeper clusters

Usage:  bkctl [flags] [command group] [commands]

Infrastructure commands :

    bookie          Commands on operating a single bookie
    bookies         Commands on operating a cluster of bookies
    cluster         Commands on administrating bookkeeper clusters

Ledger service commands :

    ledger          Commands on interacting with ledgers

Table service commands :

    namespace       Commands on operating namespaces
    table           Commands on interacting with tables
    tables          Commands on operating tables

Other commands :

    help            Display help information about it
```

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
