### PR TITLE
[bookie] Fix sorted ledger storage rotating entry log files too frequent

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerBase.java
@@ -21,6 +21,9 @@
 
 package org.apache.bookkeeper.bookie;
 
+import static org.apache.bookkeeper.bookie.EntryLogger.UNASSIGNED_LEDGERID;
+
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.concurrent.FastThreadLocal;
@@ -131,7 +134,18 @@ abstract class EntryLogManagerBase implements EntryLogManager {
      * Creates a new log file. This method should be guarded by a lock,
      * so callers of this method should be in right scope of the lock.
      */
+    @VisibleForTesting
     void createNewLog(long ledgerId) throws IOException {
+        createNewLog(ledgerId, "");
+    }
+
+    void createNewLog(long ledgerId, String reason) throws IOException {
+        if (ledgerId != UNASSIGNED_LEDGERID) {
+            log.info("Creating a new entry log file for ledger '{}' {}", ledgerId, reason);
+        } else {
+            log.info("Creating a new entry log file {}", reason);
+        }
+
         BufferedLogChannel logChannel = getCurrentLogForLedger(ledgerId);
         // first tried to create a new log channel. add current log channel to ToFlush list only when
         // there is a new log channel. it would prevent that a log channel is referenced by both

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
@@ -642,7 +642,7 @@ class EntryLogManagerForEntryLogPerLedger extends EntryLogManagerBase {
                 }
                 createNewLog(ledgerId,
                     ": diskFull = " + diskFull + ", allDisksFull = " + allDisksFull
-                        + ", reachEntryLogLimit = " + reachEntryLogLimit);
+                        + ", reachEntryLogLimit = " + reachEntryLogLimit + ", logChannel = " + logChannel);
             }
 
             return getCurrentLogForLedger(ledgerId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForEntryLogPerLedger.java
@@ -484,7 +484,7 @@ class EntryLogManagerForEntryLogPerLedger extends EntryLogManagerBase {
                 try {
                     if (reachEntryLogLimit(currentLog, 0L)) {
                         log.info("Rolling entry logger since it reached size limitation for ledger: {}", ledgerId);
-                        createNewLog(ledgerId);
+                        createNewLog(ledgerId, "after entry log file is rotated");
                     }
                 } finally {
                     lock.unlock();
@@ -640,7 +640,9 @@ class EntryLogManagerForEntryLogPerLedger extends EntryLogManagerBase {
                 if (logChannel != null) {
                     logChannel.flushAndForceWriteIfRegularFlush(false);
                 }
-                createNewLog(ledgerId);
+                createNewLog(ledgerId,
+                    ": diskFull = " + diskFull + ", allDisksFull = " + allDisksFull
+                        + ", reachEntryLogLimit = " + reachEntryLogLimit);
             }
 
             return getCurrentLogForLedger(ledgerId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForSingleEntryLog.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForSingleEntryLog.java
@@ -92,7 +92,7 @@ class EntryLogManagerForSingleEntryLog extends EntryLogManagerBase {
             boolean rollLog) throws IOException {
         if (null == activeLogChannel) {
             // log channel can be null because the file is deferred to be created
-            createNewLog(UNASSIGNED_LEDGERID);
+            createNewLog(UNASSIGNED_LEDGERID, "because current active log channel has not initialized yet");
         }
 
         boolean reachEntryLogLimit = rollLog ? reachEntryLogLimit(activeLogChannel, entrySize)
@@ -103,7 +103,8 @@ class EntryLogManagerForSingleEntryLog extends EntryLogManagerBase {
             if (activeLogChannel != null) {
                 activeLogChannel.flushAndForceWriteIfRegularFlush(false);
             }
-            createNewLog(UNASSIGNED_LEDGERID);
+            createNewLog(UNASSIGNED_LEDGERID,
+                ": createNewLog = " + createNewLog + ", reachEntryLogLimit = " + reachEntryLogLimit);
             // Reset the flag
             if (createNewLog) {
                 shouldCreateNewEntryLog.set(false);
@@ -238,7 +239,9 @@ class EntryLogManagerForSingleEntryLog extends EntryLogManagerBase {
          */
         if (reachEntryLogLimit(activeLogChannel, 0L) || logIdAfterFlush != logIdBeforeFlush) {
             log.info("Rolling entry logger since it reached size limitation");
-            createNewLog(UNASSIGNED_LEDGERID);
+            createNewLog(UNASSIGNED_LEDGERID,
+                "due to reaching log limit after flushing memtable : logIdBeforeFlush = "
+                    + logIdBeforeFlush + ", logIdAfterFlush = " + logIdAfterFlush);
             return true;
         }
         return false;
@@ -251,7 +254,8 @@ class EntryLogManagerForSingleEntryLog extends EntryLogManagerBase {
             // it means bytes might live at current active entry log, we need
             // roll current entry log and then issue checkpoint to underlying
             // interleaved ledger storage.
-            createNewLog(UNASSIGNED_LEDGERID);
+            createNewLog(UNASSIGNED_LEDGERID,
+                "due to preparing checkpoint : numBytesFlushed = " + numBytesFlushed);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -98,11 +98,32 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
                            Checkpointer checkpointer,
                            StatsLogger statsLogger)
             throws IOException {
+        initializeWithEntryLogListener(
+            conf,
+            ledgerManager,
+            ledgerDirsManager,
+            indexDirsManager,
+            stateManager,
+            checkpointSource,
+            checkpointer,
+            this,
+            statsLogger);
+    }
+
+    void initializeWithEntryLogListener(ServerConfiguration conf,
+                                        LedgerManager ledgerManager,
+                                        LedgerDirsManager ledgerDirsManager,
+                                        LedgerDirsManager indexDirsManager,
+                                        StateManager stateManager,
+                                        CheckpointSource checkpointSource,
+                                        Checkpointer checkpointer,
+                                        EntryLogListener entryLogListener,
+                                        StatsLogger statsLogger) throws IOException {
         checkNotNull(checkpointSource, "invalid null checkpoint source");
         checkNotNull(checkpointer, "invalid null checkpointer");
         this.checkpointSource = checkpointSource;
         this.checkpointer = checkpointer;
-        entryLogger = new EntryLogger(conf, ledgerDirsManager, this, statsLogger.scope(ENTRYLOGGER_SCOPE));
+        entryLogger = new EntryLogger(conf, ledgerDirsManager, entryLogListener, statsLogger.scope(ENTRYLOGGER_SCOPE));
         ledgerCache = new LedgerCacheImpl(conf, activeLedgers,
                 null == indexDirsManager ? ledgerDirsManager : indexDirsManager, statsLogger);
         gcThread = new GarbageCollectorThread(conf, ledgerManager, this, statsLogger.scope("gc"));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -72,7 +72,7 @@ public class SortedLedgerStorage
                            StatsLogger statsLogger)
             throws IOException {
 
-        interleavedLedgerStorage.initialize(
+        interleavedLedgerStorage.initializeWithEntryLogListener(
             conf,
             ledgerManager,
             ledgerDirsManager,
@@ -80,6 +80,9 @@ public class SortedLedgerStorage
             stateManager,
             checkpointSource,
             checkpointer,
+            // uses sorted ledger storage's own entry log listener
+            // since it manages entry log rotations and checkpoints.
+            this,
             statsLogger);
 
         if (conf.isEntryLogPerLedgerEnabled()) {


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Motivation*

A strong behavior was observed when using sorted ledger storage with single entry log manager on production:

"the entry log files are rotated very frequently and small entry log files are produced".

The problem was introduced due to #1410.

At current entry logger, when a new entry log file is created, EntryLogger will notify its listeners
that a new entry log file is rotated via [`onRotateEntryLog`](https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerBase.java#L152).

Before the change in #1410, `SortedLedgerStorage` inherits from `InterleavedLedgerStorage`.
So when a new entry log file is rotated, `SortedLedgerStorage` is notified.

However after the change in #1410, `SortedLedgerStorage` doesn't inherits `InterleavedLedgerStorage` anymore.
Instead, the relationship is changed to composition. `SortedLedgerStorage` is composed using an interleaved ledger
storage. So the entrylog listener contract was broken. `SortedLedgerStorage` will not receive any `onRotateEntryLog`
notification any more.

*Changes*

When `SortedLedgerStorage` initializes, it passes its own entry log listener down to the interleaved ledger storage.
So entry logger can notify the right person for entry log rotations.

*Tests*

Existing tests should cover most of the case. Looking for how to add new test cases.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
