### PR TITLE
Rollback snakeyaml version (Fixes IT tests)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <rocksdb.version>5.13.1</rocksdb.version>
     <shrinkwrap.version>3.0.1</shrinkwrap.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <snakeyaml.version>1.23</snakeyaml.version>
+    <snakeyaml.version>1.19</snakeyaml.version>
     <spotbugs-annotations.version>3.1.1</spotbugs-annotations.version>
     <javax-annotations-api.version>1.3.2</javax-annotations-api.version>
     <testcontainers.version>1.8.3</testcontainers.version>


### PR DESCRIPTION
The stats gen (#1787) change introduced a version of snakeyaml which
is incompatible with arquillian-cube (between 1.19 and 1.23 they
remove some methods).

This was picked up by the integration tests, but overriden to submit.

This change pins the snakeyaml version at 1.19, thereby allowing the
integration tests to run again.
