### PR TITLE
Use ${sha1} instead of ${ghprbActualCommit} for Pre-commit Jobs

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_precommit_bookie_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_bookie_tests.groovy
@@ -35,7 +35,7 @@ freeStyleJob('bookkeeper_precommit_bookie_tests') {
     'JDK 1.8 (latest)',
     200,
     'ubuntu',
-    '${ghprbActualCommit}')
+    '${sha1}')
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(

--- a/.test-infra/jenkins/job_bookkeeper_precommit_client_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_client_tests.groovy
@@ -35,7 +35,7 @@ freeStyleJob('bookkeeper_precommit_client_tests') {
     'JDK 1.8 (latest)',
     200,
     'ubuntu',
-    '${ghprbActualCommit}')
+    '${sha1}')
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(

--- a/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_integrationtests.groovy
@@ -32,7 +32,7 @@ freeStyleJob('bookkeeper_precommit_integrationtests') {
         'JDK 1.8 (latest)',
         200,
         'ubuntu',
-        '${ghprbActualCommit}')
+        '${sha1}')
 
     throttleConcurrentBuilds {
         // limit builds to 1 per node to avoid conflicts on building docker images

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -44,7 +44,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java8') {
     'JDK 1.8 (latest)',
     200,
     'ubuntu',
-    '${ghprbActualCommit}')
+    '${sha1}')
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java9.groovy
@@ -44,7 +44,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java9') {
     'JDK 1.9 (latest)',
     200,
     'ubuntu',
-    '${ghprbActualCommit}')
+    '${sha1}')
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(

--- a/.test-infra/jenkins/job_bookkeeper_precommit_remaining_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_remaining_tests.groovy
@@ -39,7 +39,7 @@ freeStyleJob('bookkeeper_precommit_remaining_tests') {
     'JDK 1.8 (latest)',
     200,
     'ubuntu',
-    '${ghprbActualCommit}')
+    '${sha1}')
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(

--- a/.test-infra/jenkins/job_bookkeeper_precommit_replication_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_replication_tests.groovy
@@ -35,7 +35,7 @@ freeStyleJob('bookkeeper_precommit_replication_tests') {
     'JDK 1.8 (latest)',
     200,
     'ubuntu',
-    '${ghprbActualCommit}')
+    '${sha1}')
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(

--- a/.test-infra/jenkins/job_bookkeeper_precommit_tls_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_tls_tests.groovy
@@ -35,7 +35,7 @@ freeStyleJob('bookkeeper_precommit_tls_tests') {
     'JDK 1.8 (latest)',
     200,
     'ubuntu',
-    '${ghprbActualCommit}')
+    '${sha1}')
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(

--- a/.test-infra/jenkins/job_bookkeeper_precommit_validation.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_validation.groovy
@@ -35,7 +35,7 @@ mavenJob('bookkeeper_precommit_pullrequest_validation') {
     'JDK 1.8 (latest)',
     200,
     'ubuntu',
-    '${ghprbActualCommit}')
+    '${sha1}')
 
   // Sets that this is a PreCommit job.
   common_job_properties.setPreCommit(


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

According to  the documentation of the GitHub Pull Request plugin:
- ${sha1} means a commit which is the result of merging the PR branch with the target branch
- ${ghprbActualCommit} is directly the PR branch

So currently we are not testing the PR branch against the target branch, but only the branch "as it is"

see:
https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=4&ved=2ahUKEwje0PjpnuDeAhUF2SwKHXN4BgYQFjADegQIAxAB&url=https%3A%2F%2Fwiki.jenkins.io%2Fdisplay%2FJENKINS%2FGitHub%2Bpull%2Brequest%2Bbuilder%2Bplugin&usg=AOvVaw2XvPL5ynRYnqVEWqpe9cs1

### Changes

Use ${sha1} instead of ${ghprbActualCommit} for Pre-commit Jobs

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [x] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [x] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [x] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [x] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [x] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [x] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [x] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [x] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
