### PR TITLE
ISSUE-1770: Add local checker for Sorted/InterleavedLedgerStorage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
@@ -32,12 +32,17 @@ public abstract class AbstractLogCompactor {
 
     protected final ServerConfiguration conf;
     protected final Throttler throttler;
-    protected final GarbageCollectorThread gcThread;
 
-    public AbstractLogCompactor(GarbageCollectorThread gcThread) {
-        this.gcThread = gcThread;
-        this.conf = gcThread.conf;
+    interface LogRemovalListener {
+        void removeEntryLog(long logToRemove);
+    }
+
+    protected final LogRemovalListener logRemovalListener;
+
+    public AbstractLogCompactor(ServerConfiguration conf, LogRemovalListener logRemovalListener) {
+        this.conf = conf;
         this.throttler = new Throttler(conf);
+        this.logRemovalListener = logRemovalListener;
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
@@ -108,6 +108,10 @@ public interface BookKeeperServerStats {
     // Ledger Storage Stats
     String STORAGE_GET_OFFSET = "STORAGE_GET_OFFSET";
     String STORAGE_GET_ENTRY = "STORAGE_GET_ENTRY";
+
+    // Ledger Storage Scrub Stats
+    String STORAGE_SCRUB_PAGES_SCANNED = "STORAGE_SCRUB_PAGES_SCANNED";
+
     // Ledger Cache Stats
     String LEDGER_CACHE_READ_PAGE = "LEDGER_CACHE_READ_PAGE";
     // SkipList Stats

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -614,7 +614,7 @@ public class Bookie extends BookieCriticalThread {
      * Initialize LedgerStorage instance without checkpointing for use within the shell
      * and other RO users.  ledgerStorage must not have already been initialized.
      *
-     * The caller is responsible for disposing of the ledgerStorage object.
+     * <p>The caller is responsible for disposing of the ledgerStorage object.
      *
      * @param conf Bookie config.
      * @param ledgerStorage Instance to initialize.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -614,6 +614,8 @@ public class Bookie extends BookieCriticalThread {
      * Initialize LedgerStorage instance without checkpointing for use within the shell
      * and other RO users.  ledgerStorage must not have already been initialized.
      *
+     * The caller is responsible for disposing of the ledgerStorage object.
+     *
      * @param conf Bookie config.
      * @param ledgerStorage Instance to initialize.
      * @return Passed ledgerStorage instance
@@ -927,6 +929,7 @@ public class Bookie extends BookieCriticalThread {
         } catch (ExecutionException e) {
             LOG.error("Error on executing a fully flush after replaying journals.");
             shutdown(ExitCode.BOOKIE_EXCEPTION);
+            return;
         }
 
         if (conf.isLocalConsistencyCheckOnStartup()) {
@@ -937,6 +940,7 @@ public class Bookie extends BookieCriticalThread {
             } catch (IOException e) {
                 LOG.error("Got a fatal exception while checking store", e);
                 shutdown(ExitCode.BOOKIE_EXCEPTION);
+                return;
             }
             if (errors != null && errors.size() > 0) {
                 LOG.error("Bookie failed local consistency check:");
@@ -944,6 +948,7 @@ public class Bookie extends BookieCriticalThread {
                     LOG.error("Ledger {}, entry {}: ", error.getLedgerId(), error.getEntryId(), error.getException());
                 }
                 shutdown(ExitCode.BOOKIE_EXCEPTION);
+                return;
             }
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -26,7 +26,6 @@ import static org.apache.bookkeeper.tools.cli.helpers.CommandHelpers.getBookieSo
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -35,7 +34,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.RoundingMode;
@@ -144,6 +142,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.mutable.MutableBoolean;
+import org.apache.commons.lang.mutable.MutableLong;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.AsyncCallback.VoidCallback;
@@ -205,6 +204,7 @@ public class BookieShell implements Tool {
     static final String CMD_GENERATE_COOKIE = "cookie_generate";
 
     static final String CMD_HELP = "help";
+    static final String CMD_LOCALCONSISTENCYCHECK = "localconsistencycheck";
 
     final ServerConfiguration bkConf = new ServerConfiguration();
     File[] indexDirectories;
@@ -237,6 +237,14 @@ public class BookieShell implements Tool {
         String description();
 
         void printUsage();
+    }
+
+    void printInfoLine(String s) {
+        System.out.println(s);
+    }
+
+    void printErrorLine(String s) {
+        System.err.println(s);
     }
 
     abstract class MyCommand implements Command {
@@ -717,7 +725,7 @@ public class BookieShell implements Tool {
         public int runCmd(CommandLine cmdLine) throws Exception {
             String[] leftArgs = cmdLine.getArgs();
             if (leftArgs.length <= 0) {
-                System.err.println("ERROR: missing ledger id");
+                printErrorLine("ERROR: missing ledger id");
                 printUsage();
                 return -1;
             }
@@ -730,7 +738,7 @@ public class BookieShell implements Tool {
             try {
                 ledgerId = ledgerIdFormatter.readLedgerId(leftArgs[0]);
             } catch (IllegalArgumentException iae) {
-                System.err.println("ERROR: invalid ledger id " + leftArgs[0]);
+                printErrorLine("ERROR: invalid ledger id " + leftArgs[0]);
                 printUsage();
                 return -1;
             }
@@ -739,19 +747,69 @@ public class BookieShell implements Tool {
                 // dump ledger info
                 try {
                     DbLedgerStorage.readLedgerIndexEntries(ledgerId, bkConf,
-                            (currentEntry, entryLogId, position) -> System.out.println(
+                            (currentEntry, entryLogId, position) -> printInfoLine(
                                     "entry " + currentEntry + "\t:\t(log: " + entryLogId + ", pos: " + position + ")"));
                 } catch (IOException e) {
                     System.err.printf("ERROR: initializing dbLedgerStorage %s", e.getMessage());
                     return -1;
                 }
-            } else {
+            } else if ((bkConf.getLedgerStorageClass().equals(SortedLedgerStorage.class.getName())
+                    || bkConf.getLedgerStorageClass().equals(InterleavedLedgerStorage.class.getName()))) {
+                ServerConfiguration conf = new ServerConfiguration(bkConf);
+                InterleavedLedgerStorage interleavedStorage = new InterleavedLedgerStorage();
+                Bookie.mountLedgerStorageOffline(conf, interleavedStorage);
+
                 if (printMeta) {
                     // print meta
-                    readLedgerMeta(ledgerId);
+                    printInfoLine("===== LEDGER: " + ledgerIdFormatter.formatLedgerId(ledgerId) + " =====");
+                    LedgerCache.LedgerIndexMetadata meta = interleavedStorage.readLedgerIndexMetadata(ledgerId);
+                    printInfoLine("master key  : " + meta.getMasterKeyHex());
+
+                    long size = meta.size;
+                    if (size % 8 == 0) {
+                        printInfoLine("size        : " + size);
+                    } else {
+                        printInfoLine("size : " + size
+                                + " (not aligned with 8, may be corrupted or under flushing now)");
+                    }
+
+                    printInfoLine("entries     : " + (size / 8));
+                    printInfoLine("isFenced    : " + meta.fenced);
                 }
-                // dump ledger info
-                readLedgerIndexEntries(ledgerId);
+
+                try {
+                    // dump ledger info
+                    printInfoLine("===== LEDGER: " + ledgerIdFormatter.formatLedgerId(ledgerId) + " =====");
+                    for (LedgerCache.PageEntries page : interleavedStorage.getIndexEntries(ledgerId)) {
+                        final MutableLong curEntry = new MutableLong(page.getFirstEntry());
+                        try (LedgerEntryPage lep = page.getLEP()){
+                            lep.getEntries((entry, offset) -> {
+                                while (curEntry.longValue() < entry) {
+                                    printInfoLine("entry " + curEntry + "\t:\tN/A");
+                                    curEntry.increment();
+                                }
+                                long entryLogId = offset >> 32L;
+                                long pos = offset & 0xffffffffL;
+                                printInfoLine("entry " + curEntry + "\t:\t(log:" + entryLogId + ", pos: " + pos + ")");
+                                curEntry.increment();
+                                return true;
+                            });
+                        } catch (IOException ie) {
+                            printInfoLine("Failed to read index page @ " + page.getFirstEntry()
+                                    + ", the index file may be corrupted : "
+                                    + ie.getMessage());
+                            return 1;
+                        }
+
+                        while (curEntry.longValue() < page.getLastEntry()) {
+                            printInfoLine("entry " + curEntry + "\t:\tN/A");
+                            curEntry.increment();
+                        }
+                    }
+                } catch (IOException ie) {
+                    LOG.error("Failed to read index page");
+                    return 1;
+                }
             }
 
             return 0;
@@ -1170,6 +1228,51 @@ public class BookieShell implements Tool {
         @Override
         String getUsage() {
             return "ledgermetadata -ledgerid <ledgerid> [--dump-to-file FILENAME|--restore-from-file FILENAME]";
+        }
+
+        @Override
+        Options getOptions() {
+            return lOpts;
+        }
+    }
+
+    /**
+     * Print the metadata for a ledger.
+     */
+    class LocalConsistencyCheck extends MyCommand {
+        Options lOpts = new Options();
+
+        LocalConsistencyCheck() {
+            super(CMD_LOCALCONSISTENCYCHECK);
+        }
+
+        @Override
+        public int runCmd(CommandLine cmdLine) throws Exception {
+            LOG.info("=== Performing local consistency check ===");
+            ServerConfiguration conf = new ServerConfiguration(bkConf);
+            LedgerStorage ledgerStorage = Bookie.mountLedgerStorageOffline(conf, null);
+            List <LedgerStorage.DetectedInconsistency> errors = ledgerStorage.localConsistencyCheck(
+                    java.util.Optional.empty());
+            if (errors.size() > 0) {
+                LOG.info("=== Check returned errors: ===");
+                for (LedgerStorage.DetectedInconsistency error : errors) {
+                    LOG.error("Ledger {}, entry {}: ", error.getLedgerId(), error.getEntryId(), error.getException());
+                }
+                return 1;
+            } else {
+                LOG.info("=== Check passed ===");
+                return 0;
+            }
+        }
+
+        @Override
+        String getDescription() {
+            return "Validate Ledger Storage internal metadata";
+        }
+
+        @Override
+        String getUsage() {
+            return "localconsistencycheck";
         }
 
         @Override
@@ -2626,41 +2729,12 @@ public class BookieShell implements Tool {
         int runCmd(CommandLine cmdLine) throws Exception {
             LOG.info("=== Converting to DbLedgerStorage ===");
             ServerConfiguration conf = new ServerConfiguration(bkConf);
-            LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
-                    new DiskChecker(bkConf.getDiskUsageThreshold(), bkConf.getDiskUsageWarnThreshold()));
-            LedgerDirsManager ledgerIndexManager = new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
-                    new DiskChecker(bkConf.getDiskUsageThreshold(), bkConf.getDiskUsageWarnThreshold()));
 
             InterleavedLedgerStorage interleavedStorage = new InterleavedLedgerStorage();
+            Bookie.mountLedgerStorageOffline(conf, interleavedStorage);
+
             DbLedgerStorage dbStorage = new DbLedgerStorage();
-
-            CheckpointSource checkpointSource = new CheckpointSource() {
-                    @Override
-                    public Checkpoint newCheckpoint() {
-                        return Checkpoint.MAX;
-                    }
-
-                    @Override
-                    public void checkpointComplete(Checkpoint checkpoint, boolean compact)
-                            throws IOException {
-                    }
-                };
-            Checkpointer checkpointer = new Checkpointer() {
-                @Override
-                public void startCheckpoint(Checkpoint checkpoint) {
-                    // No-op
-                }
-
-                @Override
-                public void start() {
-                    // no-op
-                }
-            };
-
-            interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager,
-                    null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
-            dbStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager, null,
-                    checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
+            Bookie.mountLedgerStorageOffline(conf, dbStorage);
 
             int convertedLedgers = 0;
             for (long ledgerId : interleavedStorage.getActiveLedgersInRange(0, Long.MAX_VALUE)) {
@@ -2668,13 +2742,13 @@ public class BookieShell implements Tool {
                     LOG.debug("Converting ledger {}", ledgerIdFormatter.formatLedgerId(ledgerId));
                 }
 
-                FileInfo fi = getFileInfo(ledgerId);
+                LedgerCache.LedgerIndexMetadata fi = interleavedStorage.readLedgerIndexMetadata(ledgerId);
 
-                Iterable<SortedMap<Long, Long>> entries = getLedgerIndexEntries(ledgerId);
+                LedgerCache.PageEntriesIterable pages = interleavedStorage.getIndexEntries(ledgerId);
 
-                long numberOfEntries = dbStorage.addLedgerToIndex(ledgerId, fi.isFenced(), fi.getMasterKey(), entries);
+                long numberOfEntries = dbStorage.addLedgerToIndex(ledgerId, fi.fenced, fi.masterKey, pages);
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("   -- done. fenced={} entries={}", fi.isFenced(), numberOfEntries);
+                    LOG.debug("   -- done. fenced={} entries={}", fi.fenced, numberOfEntries);
                 }
 
                 // Remove index from old storage
@@ -2921,6 +2995,7 @@ public class BookieShell implements Tool {
         commands.put(CMD_WHOISAUDITOR, new WhoIsAuditorCmd());
         commands.put(CMD_WHATISINSTANCEID, new WhatIsInstanceId());
         commands.put(CMD_LEDGERMETADATA, new LedgerMetadataCmd());
+        commands.put(CMD_LOCALCONSISTENCYCHECK, new LocalConsistencyCheck());
         commands.put(CMD_SIMPLETEST, new SimpleTestCmd());
         commands.put(CMD_BOOKIESANITYTEST, new BookieSanityTestCmd());
         commands.put(CMD_READLOG, new ReadLogCmd());
@@ -3123,23 +3198,6 @@ public class BookieShell implements Tool {
         return lf;
     }
 
-    /**
-     * Get FileInfo for a specified ledger.
-     *
-     * @param ledgerId Ledger Id
-     * @return read only file info instance
-     */
-    ReadOnlyFileInfo getFileInfo(long ledgerId) throws IOException {
-        File ledgerFile = getLedgerFile(ledgerId);
-        if (null == ledgerFile) {
-            throw new FileNotFoundException("No index file found for ledger " + ledgerId
-                    + ". It may be not flushed yet.");
-        }
-        ReadOnlyFileInfo fi = new ReadOnlyFileInfo(ledgerFile, null);
-        fi.readHeader();
-        return fi;
-    }
-
     private synchronized void initEntryLogger() throws IOException {
         if (null == entryLogger) {
             // provide read only entry logger
@@ -3185,77 +3243,6 @@ public class BookieShell implements Tool {
     /// Bookie Shell Commands
     ///
 
-    /**
-     * Read ledger meta.
-     *
-     * @param ledgerId Ledger Id
-     */
-    protected void readLedgerMeta(long ledgerId) throws Exception {
-        System.out.println("===== LEDGER: " + ledgerIdFormatter.formatLedgerId(ledgerId) + " =====");
-        FileInfo fi = getFileInfo(ledgerId);
-        byte[] masterKey = fi.getMasterKey();
-        if (null == masterKey) {
-            System.out.println("master key  : NULL");
-        } else {
-            System.out.println("master key  : " + bytes2Hex(fi.getMasterKey()));
-        }
-        long size = fi.size();
-        if (size % 8 == 0) {
-            System.out.println("size        : " + size);
-        } else {
-            System.out.println("size : " + size + " (not aligned with 8, may be corrupted or under flushing now)");
-        }
-        System.out.println("entries     : " + (size / 8));
-        System.out.println("isFenced    : " + fi.isFenced());
-    }
-
-    /**
-     * Read ledger index entries.
-     *
-     * @param ledgerId Ledger Id
-     * @throws IOException
-     */
-    protected void readLedgerIndexEntries(long ledgerId) throws IOException {
-        System.out.println("===== LEDGER: " + ledgerIdFormatter.formatLedgerId(ledgerId) + " =====");
-        FileInfo fi = getFileInfo(ledgerId);
-        long size = fi.size();
-        System.out.println("size        : " + size);
-        long curSize = 0;
-        long curEntry = 0;
-        LedgerEntryPage lep = new LedgerEntryPage(pageSize, entriesPerPage);
-        lep.usePage();
-        try {
-            while (curSize < size) {
-                lep.setLedgerAndFirstEntry(ledgerId, curEntry);
-                lep.readPage(fi);
-
-                // process a page
-                for (int i = 0; i < entriesPerPage; i++) {
-                    long offset = lep.getOffset(i * 8);
-                    if (0 == offset) {
-                        System.out.println("entry " + curEntry + "\t:\tN/A");
-                    } else {
-                        long entryLogId = offset >> 32L;
-                        long pos = offset & 0xffffffffL;
-                        System.out.println("entry " + curEntry + "\t:\t(log:" + entryLogId + ", pos: " + pos + ")");
-                    }
-                    ++curEntry;
-                }
-
-                curSize += pageSize;
-            }
-        } catch (IOException ie) {
-            LOG.error("Failed to read index page : ", ie);
-            if (curSize + pageSize < size) {
-                System.out.println("Failed to read index page @ " + curSize + ", the index file may be corrupted : "
-                        + ie.getMessage());
-            } else {
-                System.out.println("Failed to read last index page @ " + curSize + ", the index file may be corrupted "
-                        + "or last index page is not fully flushed yet : " + ie.getMessage());
-            }
-        }
-    }
-
     protected void printEntryLogMetadata(long logId) throws IOException {
         LOG.info("Print entryLogMetadata of entrylog {} ({}.log)", logId, Long.toHexString(logId));
         initEntryLogger();
@@ -3264,67 +3251,6 @@ public class BookieShell implements Tool {
             LOG.info("--------- Lid={}, TotalSizeOfEntriesOfLedger={}  ---------",
                     ledgerIdFormatter.formatLedgerId(ledgerId), size);
         });
-    }
-
-    /**
-     * Get an iterable over pages of entries and locations for a ledger.
-     *
-     * @param ledgerId
-     * @return
-     * @throws IOException
-     */
-    protected Iterable<SortedMap<Long, Long>> getLedgerIndexEntries(final long ledgerId) throws IOException {
-        final FileInfo fi = getFileInfo(ledgerId);
-        final long size = fi.size();
-
-        final LedgerEntryPage lep = new LedgerEntryPage(pageSize, entriesPerPage);
-        lep.usePage();
-
-        final Iterator<SortedMap<Long, Long>> iterator = new Iterator<SortedMap<Long, Long>>() {
-            long curSize = 0;
-            long curEntry = 0;
-
-            @Override
-            public boolean hasNext() {
-                return curSize < size;
-            }
-
-            @Override
-            public SortedMap<Long, Long> next() {
-                SortedMap<Long, Long> entries = Maps.newTreeMap();
-                lep.setLedgerAndFirstEntry(ledgerId, curEntry);
-                try {
-                    lep.readPage(fi);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-
-                // process a page
-                for (int i = 0; i < entriesPerPage; i++) {
-                    long offset = lep.getOffset(i * 8);
-                    if (offset != 0) {
-                        entries.put(curEntry, offset);
-                    }
-                    ++curEntry;
-                }
-
-                curSize += pageSize;
-                return entries;
-            }
-
-            @Override
-            public void remove() {
-                throw new RuntimeException("Cannot remove");
-            }
-
-        };
-
-        return new Iterable<SortedMap<Long, Long>>() {
-            @Override
-            public Iterator<SortedMap<Long, Long>> iterator() {
-                return iterator;
-            }
-        };
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannelBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannelBase.java
@@ -25,6 +25,12 @@ import java.nio.channels.FileChannel;
  * to buffer the input and output data. This class is a base class for wrapping the {@link FileChannel}.
  */
 public abstract class BufferedChannelBase {
+    static class ChannelClosed extends IOException {
+        ChannelClosed() {
+            super("Attempting to access a file channel that has already been closed");
+        }
+    }
+
     protected final FileChannel fileChannel;
 
     protected BufferedChannelBase(FileChannel fc) {
@@ -36,7 +42,7 @@ public abstract class BufferedChannelBase {
         // guarantee that once a log file has been closed and possibly deleted during garbage
         // collection, attempts will not be made to read from it
         if (!fileChannel.isOpen()) {
-            throw new IOException("Attempting to access a file channel that has already been closed");
+            throw new ChannelClosed();
         }
         return fileChannel;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannelBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannelBase.java
@@ -25,8 +25,8 @@ import java.nio.channels.FileChannel;
  * to buffer the input and output data. This class is a base class for wrapping the {@link FileChannel}.
  */
 public abstract class BufferedChannelBase {
-    static class ChannelClosed extends IOException {
-        ChannelClosed() {
+    static class BufferedChannelClosedException extends IOException {
+        BufferedChannelClosedException() {
             super("Attempting to access a file channel that has already been closed");
         }
     }
@@ -42,7 +42,7 @@ public abstract class BufferedChannelBase {
         // guarantee that once a log file has been closed and possibly deleted during garbage
         // collection, attempts will not be made to read from it
         if (!fileChannel.isOpen()) {
-            throw new ChannelClosed();
+            throw new BufferedChannelClosedException();
         }
         return fileChannel;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedReadChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedReadChannel.java
@@ -45,7 +45,7 @@ public class BufferedReadChannel extends BufferedChannelBase  {
     long invocationCount = 0;
     long cacheHitCount = 0;
 
-    public BufferedReadChannel(FileChannel fileChannel, int readCapacity) throws IOException {
+    public BufferedReadChannel(FileChannel fileChannel, int readCapacity) {
         super(fileChannel);
         this.readCapacity = readCapacity;
         this.readBuffer = Unpooled.buffer(readCapacity);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -794,7 +794,7 @@ public class EntryLogger {
             if (readFromLogChannel(entryLogId, fc, sizeBuff, pos) != sizeBuff.capacity()) {
                 throw new EntryLookupException.MissingEntryException(ledgerId, entryId, entryLogId, pos);
             }
-        } catch (BufferedChannelBase.ChannelClosed | AsynchronousCloseException e) {
+        } catch (BufferedChannelBase.BufferedChannelClosedException | AsynchronousCloseException e) {
             throw new EntryLookupException.MissingLogFileException(ledgerId, entryId, entryLogId, pos);
         }
         pos += 4;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,6 +59,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.util.DiskChecker;
 import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap.BiConsumerLong;
@@ -321,6 +323,11 @@ public class EntryLogger {
          * Rotate a new entry log to write.
          */
         void onRotateEntryLog();
+    }
+
+    public EntryLogger(ServerConfiguration conf) throws IOException {
+        this(conf, new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold())));
     }
 
     /**
@@ -616,7 +623,8 @@ public class EntryLogger {
     private final FastThreadLocal<ByteBuf> sizeBuffer = new FastThreadLocal<ByteBuf>() {
         @Override
         protected ByteBuf initialValue() throws Exception {
-            return Unpooled.buffer(4);
+            // Max usage is size (4 bytes) + ledgerId (8 bytes) + entryid (8 bytes)
+            return Unpooled.buffer(4 + 8 + 8);
         }
     };
 
@@ -693,10 +701,85 @@ public class EntryLogger {
 
 
 
-    public ByteBuf internalReadEntry(long ledgerId, long entryId, long location)
-            throws IOException, Bookie.NoEntryException {
-        long entryLogId = logIdForOffset(location);
-        long pos = location & 0xffffffffL;
+    /**
+     * Exception type for representing lookup errors.  Useful for disambiguating different error
+     * conditions for reporting purposes.
+     */
+    static class EntryLookupException extends Exception {
+        EntryLookupException(String message) {
+            super(message);
+        }
+
+        /**
+         * Represents case where log file is missing.
+         */
+        static class MissingLogFileException extends EntryLookupException {
+            MissingLogFileException(long ledgerId, long entryId, long entryLogId, long pos) {
+                super(String.format("Missing entryLog %d for ledgerId %d, entry %d at offset %d",
+                        entryLogId,
+                        ledgerId,
+                        entryId,
+                        pos));
+            }
+        }
+
+        /**
+         * Represents case where entry log is present, but does not contain the specified entry.
+         */
+        static class MissingEntryException extends EntryLookupException {
+            MissingEntryException(long ledgerId, long entryId, long entryLogId, long pos) {
+                super(String.format("pos %d (entry %d for ledgerId %d) past end of entryLog %d",
+                        pos,
+                        entryId,
+                        ledgerId,
+                        entryLogId));
+            }
+        }
+
+        /**
+         * Represents case where log is present, but encoded entry length header is invalid.
+         */
+        static class InvalidEntryLengthException extends EntryLookupException {
+            InvalidEntryLengthException(long ledgerId, long entryId, long entryLogId, long pos) {
+                super(String.format("Invalid entry length at pos %d (entry %d for ledgerId %d) for entryLog %d",
+                        pos,
+                        entryId,
+                        ledgerId,
+                        entryLogId));
+            }
+        }
+
+        /**
+         * Represents case where the entry at pos is wrong.
+         */
+        static class WrongEntryException extends EntryLookupException {
+            WrongEntryException(long foundEntryId, long foundLedgerId, long ledgerId,
+                                long entryId, long entryLogId, long pos) {
+                super(String.format(
+                        "Found entry %d, ledger %d at pos %d entryLog %d, should have found entry %d for ledgerId %d",
+                        foundEntryId,
+                        foundLedgerId,
+                        pos,
+                        entryLogId,
+                        entryId,
+                        ledgerId));
+            }
+        }
+    }
+
+    private static class EntryLogEntry {
+        final int entrySize;
+        final BufferedReadChannel fc;
+
+        EntryLogEntry(int entrySize, BufferedReadChannel fc) {
+            this.entrySize = entrySize;
+            this.fc = fc;
+        }
+    }
+
+    private EntryLogEntry getFCForEntryInternal(
+            long ledgerId, long entryId, long entryLogId, long pos)
+            throws EntryLookupException, IOException {
         ByteBuf sizeBuff = sizeBuffer.get();
         sizeBuff.clear();
         pos -= 4; // we want to get the ledgerId and length to check
@@ -704,15 +787,15 @@ public class EntryLogger {
         try {
             fc = getChannelForLogId(entryLogId);
         } catch (FileNotFoundException e) {
-            FileNotFoundException newe = new FileNotFoundException(e.getMessage() + " for " + ledgerId
-                    + " with location " + location);
-            newe.setStackTrace(e.getStackTrace());
-            throw newe;
+            throw new EntryLookupException.MissingLogFileException(ledgerId, entryId, entryLogId, pos);
         }
 
-        if (readFromLogChannel(entryLogId, fc, sizeBuff, pos) != sizeBuff.capacity()) {
-            throw new Bookie.NoEntryException("Short read from entrylog " + entryLogId,
-                                              ledgerId, entryId);
+        try {
+            if (readFromLogChannel(entryLogId, fc, sizeBuff, pos) != sizeBuff.capacity()) {
+                throw new EntryLookupException.MissingEntryException(ledgerId, entryId, entryLogId, pos);
+            }
+        } catch (BufferedChannelBase.ChannelClosed | AsynchronousCloseException e) {
+            throw new EntryLookupException.MissingLogFileException(ledgerId, entryId, entryLogId, pos);
         }
         pos += 4;
         int entrySize = sizeBuff.readInt();
@@ -724,12 +807,42 @@ public class EntryLogger {
         }
         if (entrySize < MIN_SANE_ENTRY_SIZE) {
             LOG.error("Read invalid entry length {}", entrySize);
-            throw new IOException("Invalid entry length " + entrySize);
+            throw new EntryLookupException.InvalidEntryLengthException(ledgerId, entryId, entryLogId, pos);
         }
 
-        ByteBuf data = PooledByteBufAllocator.DEFAULT.directBuffer(entrySize, entrySize);
-        int rc = readFromLogChannel(entryLogId, fc, data, pos);
-        if (rc != entrySize) {
+        long thisLedgerId = sizeBuff.getLong(4);
+        long thisEntryId = sizeBuff.getLong(12);
+        if (thisLedgerId != ledgerId || thisEntryId != entryId) {
+            throw new EntryLookupException.WrongEntryException(
+                    thisEntryId, thisLedgerId, ledgerId, entryId, entryLogId, pos);
+        }
+        return new EntryLogEntry(entrySize, fc);
+    }
+
+    void checkEntry(long ledgerId, long entryId, long location) throws EntryLookupException, IOException {
+        long entryLogId = logIdForOffset(location);
+        long pos = location & 0xffffffffL;
+        getFCForEntryInternal(ledgerId, entryId, entryLogId, pos);
+    }
+
+    public ByteBuf internalReadEntry(long ledgerId, long entryId, long location)
+            throws IOException, Bookie.NoEntryException {
+        long entryLogId = logIdForOffset(location);
+        long pos = location & 0xffffffffL;
+
+        final EntryLogEntry entry;
+        try {
+            entry = getFCForEntryInternal(ledgerId, entryId, entryLogId, pos);
+        } catch (EntryLookupException.MissingEntryException entryLookupError) {
+            throw new Bookie.NoEntryException("Short read from entrylog " + entryLogId,
+                    ledgerId, entryId);
+        } catch (EntryLookupException e) {
+            throw new IOException(e.toString());
+        }
+
+        ByteBuf data = PooledByteBufAllocator.DEFAULT.directBuffer(entry.entrySize, entry.entrySize);
+        int rc = readFromLogChannel(entryLogId, entry.fc, data, pos);
+        if (rc != entry.entrySize) {
             // Note that throwing NoEntryException here instead of IOException is not
             // without risk. If all bookies in a quorum throw this same exception
             // the client will assume that it has reached the end of the ledger.
@@ -740,31 +853,15 @@ public class EntryLogger {
             data.release();
             throw new Bookie.NoEntryException("Short read for " + ledgerId + "@"
                                               + entryId + " in " + entryLogId + "@"
-                                              + pos + "(" + rc + "!=" + entrySize + ")", ledgerId, entryId);
+                                              + pos + "(" + rc + "!=" + entry.entrySize + ")", ledgerId, entryId);
         }
-        data.writerIndex(entrySize);
+        data.writerIndex(entry.entrySize);
 
         return data;
     }
 
     public ByteBuf readEntry(long ledgerId, long entryId, long location) throws IOException, Bookie.NoEntryException {
-        long entryLogId = logIdForOffset(location);
-        long pos = location & 0xffffffffL;
-
         ByteBuf data = internalReadEntry(ledgerId, entryId, location);
-        long thisLedgerId = data.getLong(0);
-        if (thisLedgerId != ledgerId) {
-            data.release();
-            throw new IOException("problem found in " + entryLogId + "@" + entryId + " at position + " + pos
-                    + " entry belongs to " + thisLedgerId + " not " + ledgerId);
-        }
-        long thisEntryId = data.getLong(8);
-        if (thisEntryId != entryId) {
-            data.release();
-            throw new IOException("problem found in " + entryLogId + "@" + entryId + " at position + " + pos
-                    + " entry is " + thisEntryId + " not " + entryId);
-        }
-
         return data;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexInMemPageMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexInMemPageMgr.java
@@ -20,6 +20,7 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import static java.lang.Long.max;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.INDEX_INMEM_ILLEGAL_STATE_DELETE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.INDEX_INMEM_ILLEGAL_STATE_RESET;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LEDGER_CACHE_HIT;
@@ -153,22 +154,11 @@ class IndexInMemPageMgr {
             ConcurrentMap<Long, LedgerEntryPage> lPages = pages.remove(ledgerId);
             if (null != lPages) {
                 for (Map.Entry<Long, LedgerEntryPage> pageEntry: lPages.entrySet()) {
-                    long entryId = pageEntry.getKey();
-                    synchronized (lruCleanPageMap) {
-                        lruCleanPageMap.remove(new EntryKey(ledgerId, entryId));
-                    }
-
                     LedgerEntryPage lep = pageEntry.getValue();
-                    // Cannot imagine under what circumstances we would have a null entry here
-                    // Just being safe
-                    if (null != lep) {
-                        if (lep.inUse()) {
-                            illegalStateDeleteCounter.inc();
-                        }
-                        listOfFreePages.add(lep);
-                    }
+                    lep.usePage();
+                    lep.markDeleted();
+                    lep.releasePage();
                 }
-
             }
         }
 
@@ -318,7 +308,11 @@ class IndexInMemPageMgr {
 
         @Override
         public void onResetInUse(LedgerEntryPage lep) {
-            addToCleanPagesList(lep);
+            if (!lep.isDeleted()) {
+                addToCleanPagesList(lep);
+            } else {
+                addToListOfFreePages(lep);
+            }
         }
 
         @Override
@@ -397,23 +391,9 @@ class IndexInMemPageMgr {
     }
 
     /**
-     * @return entries per page used in ledger cache
-     */
-    public int getEntriesPerPage() {
-        return entriesPerPage;
-    }
-
-    /**
-     * @return page limitation in ledger cache
-     */
-    public int getPageLimit() {
-        return pageLimit;
-    }
-
-    /**
      * @return number of page used in ledger cache
      */
-    public int getNumUsedPages() {
+    private int getNumUsedPages() {
         return pageCount.get();
     }
 
@@ -427,7 +407,7 @@ class IndexInMemPageMgr {
      * @return ledger entry page
      * @throws IOException
      */
-    public LedgerEntryPage getLedgerEntryPage(long ledger,
+    LedgerEntryPage getLedgerEntryPage(long ledger,
                                               long pageEntry) throws IOException {
         LedgerEntryPage lep = getLedgerEntryPageFromCache(ledger, pageEntry, false);
         if (lep == null) {
@@ -615,5 +595,80 @@ class IndexInMemPageMgr {
                 lep.releasePage();
             }
         }
+    }
+
+    /**
+     * Represents a page of the index.
+     */
+    private class PageEntriesImpl implements LedgerCache.PageEntries {
+        final long ledgerId;
+        final long initEntry;
+
+        PageEntriesImpl(long ledgerId, long initEntry) {
+            this.ledgerId = ledgerId;
+            this.initEntry = initEntry;
+        }
+
+        public LedgerEntryPage getLEP() throws IOException {
+            return getLedgerEntryPage(ledgerId, initEntry);
+        }
+
+        public long getFirstEntry() {
+            return initEntry;
+        }
+
+        public long getLastEntry() {
+            return initEntry + entriesPerPage;
+        }
+    }
+
+    /**
+     * Iterable over index pages -- returns PageEntries rather than individual
+     * entries because getEntries() above needs to be able to throw an IOException.
+     */
+    private class PageEntriesIterableImpl implements LedgerCache.PageEntriesIterable {
+        final long ledgerId;
+        final FileInfoBackingCache.CachedFileInfo fi;
+        final long totalEntries;
+
+        long curEntry = 0;
+
+        PageEntriesIterableImpl(long ledgerId) throws IOException {
+            this.ledgerId = ledgerId;
+            this.fi = indexPersistenceManager.getFileInfo(ledgerId, null);
+            this.totalEntries = max(entriesPerPage * (fi.size() / pageSize), getLastEntryInMem(ledgerId));
+        }
+
+        @Override
+        public Iterator<LedgerCache.PageEntries> iterator() {
+            return new Iterator<LedgerCache.PageEntries>() {
+                @Override
+                public boolean hasNext() {
+                    return curEntry < totalEntries;
+                }
+
+                @Override
+                public LedgerCache.PageEntries next() {
+                    LedgerCache.PageEntries next = new PageEntriesImpl(ledgerId, curEntry);
+                    curEntry += entriesPerPage;
+                    return next;
+                }
+            };
+        }
+
+        @Override
+        public void close() {
+            fi.release();
+        }
+    }
+
+    /**
+     * Return iterator over pages for mapping entries to entry loggers.
+     * @param ledgerId
+     * @return Iterator over pages
+     * @throws IOException
+     */
+    public LedgerCache.PageEntriesIterable listEntries(long ledgerId) throws IOException {
+        return new PageEntriesIterableImpl(ledgerId);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -240,7 +240,7 @@ public class IndexPersistenceMgr {
             if (ee.getCause() instanceof IOException) {
                 throw (IOException) ee.getCause();
             } else {
-                throw new IOException("Failed to load file info for ledger " + ledger, ee);
+                throw new LedgerCache.NoIndexForLedger("Failed to load file info for ledger " + ledger, ee);
             }
         } finally {
             pendingGetFileInfoCounter.dec();
@@ -715,4 +715,22 @@ public class IndexPersistenceMgr {
         return lastEntry;
     }
 
+    /**
+     * Read ledger meta.
+     * @param ledgerId Ledger Id
+     */
+    public LedgerCache.LedgerIndexMetadata readLedgerIndexMetadata(long ledgerId) throws IOException {
+        CachedFileInfo fi = null;
+        try {
+            fi = getFileInfo(ledgerId, null);
+            return new LedgerCache.LedgerIndexMetadata(
+                    fi.getMasterKey(),
+                    fi.size(),
+                    fi.isFenced());
+        } finally {
+            if (fi != null) {
+                fi.release();
+            }
+        }
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedStorageRegenerateIndexOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedStorageRegenerateIndexOp.java
@@ -226,5 +226,13 @@ public class InterleavedStorageRegenerateIndexOp {
         public ByteBuf getExplicitLac(long ledgerId) {
             throw new UnsupportedOperationException();
         }
+        @Override
+        public PageEntriesIterable listEntries(long ledgerId) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+        @Override
+        public LedgerIndexMetadata readLedgerIndexMetadata(long ledgerId) throws IOException {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
@@ -169,4 +169,14 @@ public class LedgerCacheImpl implements LedgerCache {
     public void close() throws IOException {
         indexPersistenceManager.close();
     }
+
+    @Override
+    public PageEntriesIterable listEntries(long ledgerId) throws IOException {
+        return indexPageManager.listEntries(ledgerId);
+    }
+
+    @Override
+    public LedgerIndexMetadata readLedgerIndexMetadata(long ledgerId) throws IOException {
+        return indexPersistenceManager.readLedgerIndexMetadata(ledgerId);
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScrubberStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScrubberStats.java
@@ -1,4 +1,4 @@
-/*
+/**
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,28 +21,13 @@
 
 package org.apache.bookkeeper.bookie;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-
-import org.apache.bookkeeper.conf.ServerConfiguration;
-
 /**
- * Read Only Entry Logger.
+ * Stats associated with the consistency checker.
  */
-public class ReadOnlyEntryLogger extends EntryLogger {
+public class ScrubberStats {
+    public static final String SCOPE = "scrubber";
 
-    public ReadOnlyEntryLogger(ServerConfiguration conf) throws IOException {
-        super(conf);
-    }
-
-    @Override
-    protected boolean removeEntryLog(long entryLogId) {
-        // can't remove entry log in readonly mode
-        return false;
-    }
-
-    @Override
-    public synchronized long addEntry(long ledgerId, ByteBuffer entry) throws IOException {
-        throw new IOException("Can't add entry to a readonly entry logger.");
-    }
+    public static final String RUN_DURATION = "runTime";
+    public static final String DETECTED_SCRUB_ERRORS = "detectedScrubErrors";
+    public static final String DETECTED_FATAL_SCRUB_ERRORS = "detectedFatalScrubErrors";
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -21,9 +21,12 @@
 package org.apache.bookkeeper.bookie;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -331,5 +334,10 @@ public class SortedLedgerStorage
     @Override
     public void forceGC() {
         interleavedLedgerStorage.forceGC();
+    }
+
+    @Override
+    public List<DetectedInconsistency> localConsistencyCheck(Optional<RateLimiter> rateLimiter) throws IOException {
+        return interleavedLedgerStorage.localConsistencyCheck(rateLimiter);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -36,7 +36,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -47,6 +46,7 @@ import org.apache.bookkeeper.bookie.CheckpointSource;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.bookie.Checkpointer;
 import org.apache.bookkeeper.bookie.LastAddConfirmedUpdateNotification;
+import org.apache.bookkeeper.bookie.LedgerCache;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
 import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.bookie.StateManager;
@@ -275,8 +275,8 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     public long addLedgerToIndex(long ledgerId, boolean isFenced, byte[] masterKey,
-            Iterable<SortedMap<Long, Long>> entries) throws Exception {
-        return getLedgerSorage(ledgerId).addLedgerToIndex(ledgerId, isFenced, masterKey, entries);
+                                 LedgerCache.PageEntriesIterable pages) throws Exception {
+        return getLedgerSorage(ledgerId).addLedgerToIndex(ledgerId, isFenced, masterKey, pages);
     }
 
     public long getLastEntryInLedger(long ledgerId) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -55,6 +55,9 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String GC_OVERREPLICATED_LEDGER_WAIT_TIME = "gcOverreplicatedLedgerWaitTime";
     protected static final String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
     protected static final String VERIFY_METADATA_ON_GC = "verifyMetadataOnGC";
+    // Scrub Parameters
+    protected static final String LOCAL_SCRUB_PERIOD = "localScrubInterval";
+    protected static final String LOCAL_SCRUB_RATE_LIMIT = "localScrubRateLimit";
     // Sync Parameters
     protected static final String FLUSH_INTERVAL = "flushInterval";
     protected static final String FLUSH_ENTRYLOG_INTERVAL_BYTES = "flushEntrylogBytes";
@@ -226,6 +229,9 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String ENTRY_LOG_PER_LEDGER_COUNTER_LIMITS_MULT_FACTOR =
             "entryLogPerLedgerCounterLimitsMultFactor";
 
+    // Perform local consistency check on bookie startup
+    protected static final String LOCAL_CONSISTENCY_CHECK_ON_STARTUP = "localConsistencyCheckOnStartup";
+
     /**
      * Construct a default configuration object.
      */
@@ -372,6 +378,50 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     public ServerConfiguration setVerifyMetadataOnGc(boolean verifyMetadataOnGC) {
         this.setProperty(VERIFY_METADATA_ON_GC, verifyMetadataOnGC);
         return this;
+    }
+
+    /**
+     * Get whether local scrub is enabled.
+     *
+     * @return Whether local scrub is enabled.
+     */
+    public boolean isLocalScrubEnabled() {
+        return this.getLocalScrubPeriod() != 0;
+    }
+
+    /**
+     * Get local scrub interval.
+     *
+     * @return Number of seconds between scrubs, 0 for disabled.
+     */
+    public long getLocalScrubPeriod() {
+        return this.getLong(LOCAL_SCRUB_PERIOD, 0);
+    }
+
+    /**
+     * Set local scrub period in seconds (0 for disable). Scrub will be scheduled at delays
+     * chosen from the interval (.5 * interval, 1.5 * interval)
+     */
+    public void setLocalScrubPeriod(long period) {
+        this.setProperty(LOCAL_SCRUB_PERIOD, period);
+    }
+
+    /**
+     * Get local scrub rate limit (entries/second).
+     *
+     * @return Max number of entries to scrub per second, 0 for disabled.
+     */
+    public double getLocalScrubRateLimit() {
+        return this.getDouble(LOCAL_SCRUB_RATE_LIMIT, 60);
+    }
+
+    /**
+     * Get local scrub rate limit (entries/second).
+     *
+     * @param scrubRateLimit Max number of entries per second to scan.
+     */
+    public void setLocalScrubRateLimit(double scrubRateLimit) {
+        this.setProperty(LOCAL_SCRUB_RATE_LIMIT, scrubRateLimit);
     }
 
     /**
@@ -3092,5 +3142,12 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
         this.setProperty(ENTRY_LOG_PER_LEDGER_COUNTER_LIMITS_MULT_FACTOR,
                 Integer.toString(entryLogPerLedgerCounterLimitsMultFactor));
         return this;
+    }
+
+    /**
+     * True if a local consistency check should be performed on startup.
+     */
+    public boolean isLocalConsistencyCheckOnStartup() {
+        return this.getBoolean(LOCAL_CONSISTENCY_CHECK_ON_STARTUP, false);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -386,20 +386,20 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return Whether local scrub is enabled.
      */
     public boolean isLocalScrubEnabled() {
-        return this.getLocalScrubPeriod() != 0;
+        return this.getLocalScrubPeriod() > 0;
     }
 
     /**
      * Get local scrub interval.
      *
-     * @return Number of seconds between scrubs, 0 for disabled.
+     * @return Number of seconds between scrubs, <= 0 for disabled.
      */
     public long getLocalScrubPeriod() {
         return this.getLong(LOCAL_SCRUB_PERIOD, 0);
     }
 
     /**
-     * Set local scrub period in seconds (0 for disable). Scrub will be scheduled at delays
+     * Set local scrub period in seconds (<= 0 for disabled). Scrub will be scheduled at delays
      * chosen from the interval (.5 * interval, 1.5 * interval)
      */
     public void setLocalScrubPeriod(long period) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.ExitCode;
+import org.apache.bookkeeper.bookie.ScrubberStats;
 import org.apache.bookkeeper.common.component.ComponentStarter;
 import org.apache.bookkeeper.common.component.LifecycleComponent;
 import org.apache.bookkeeper.common.component.LifecycleComponentStack;
@@ -39,6 +40,7 @@ import org.apache.bookkeeper.server.http.BKHttpServiceProvider;
 import org.apache.bookkeeper.server.service.AutoRecoveryService;
 import org.apache.bookkeeper.server.service.BookieService;
 import org.apache.bookkeeper.server.service.HttpService;
+import org.apache.bookkeeper.server.service.ScrubberService;
 import org.apache.bookkeeper.server.service.StatsProviderService;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.commons.cli.BasicParser;
@@ -301,6 +303,13 @@ public class Main {
 
         serverBuilder.addComponent(bookieService);
         log.info("Load lifecycle component : {}", BookieService.class.getName());
+
+        if (conf.getServerConf().isLocalScrubEnabled()) {
+            serverBuilder.addComponent(
+                    new ScrubberService(
+                            rootStatsLogger.scope(ScrubberStats.SCOPE),
+                    conf, bookieService.getServer().getBookie().getLedgerStorage()));
+        }
 
         // 3. build auto recovery
         if (conf.getServerConf().isAutoRecoveryDaemonEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
@@ -1,0 +1,141 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.server.service;
+
+
+import static org.apache.bookkeeper.bookie.ScrubberStats.DETECTED_FATAL_SCRUB_ERRORS;
+import static org.apache.bookkeeper.bookie.ScrubberStats.DETECTED_SCRUB_ERRORS;
+import static org.apache.bookkeeper.bookie.ScrubberStats.RUN_DURATION;
+
+import com.google.common.util.concurrent.RateLimiter;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.bookkeeper.bookie.ExitCode;
+import org.apache.bookkeeper.bookie.LedgerStorage;
+import org.apache.bookkeeper.server.component.ServerLifecycleComponent;
+import org.apache.bookkeeper.server.conf.BookieConfiguration;
+import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.util.MathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link org.apache.bookkeeper.common.component.LifecycleComponent} that runs stats provider.
+ */
+public class ScrubberService extends ServerLifecycleComponent {
+    private static final Logger LOG = LoggerFactory.getLogger(ScrubberService.class);
+
+    private static final String NAME = "scrubber";
+    private final ScheduledExecutorService executor;
+    private final Random rng = new Random();
+    private final long scrubPeriod;
+    private final Optional<RateLimiter> scrubRateLimiter;
+    private final AtomicBoolean stop = new AtomicBoolean(false);
+    private final LedgerStorage ledgerStorage;
+
+    private final OpStatsLogger scrubCounter;
+    private final Counter errorCounter;
+    private final Counter fatalErrorCounter;
+
+    public ScrubberService(
+            StatsLogger logger,
+            BookieConfiguration conf,
+            LedgerStorage ledgerStorage) {
+        super(NAME, conf, logger);
+        this.executor = Executors.newSingleThreadScheduledExecutor(
+                new DefaultThreadFactory("ScrubThread"));
+        this.scrubPeriod = conf.getServerConf().getLocalScrubPeriod();
+
+        double rateLimit = conf.getServerConf().getLocalScrubRateLimit();
+        this.scrubRateLimiter = rateLimit == 0 ? Optional.empty() : Optional.of(RateLimiter.create(rateLimit));
+
+        this.ledgerStorage = ledgerStorage;
+
+        this.scrubCounter = logger.getOpStatsLogger(RUN_DURATION);
+        this.errorCounter = logger.getCounter(DETECTED_SCRUB_ERRORS);
+        this.fatalErrorCounter = logger.getCounter(DETECTED_FATAL_SCRUB_ERRORS);
+    }
+
+    private long getNextPeriodMS() {
+        return (long) (((double) scrubPeriod) * (1.5 - rng.nextDouble()) * 1000);
+    }
+
+    private void doSchedule() {
+        executor.schedule(
+                this::run,
+                getNextPeriodMS(),
+                TimeUnit.MILLISECONDS);
+
+    }
+
+    private void run() {
+        boolean success = false;
+        long start = MathUtils.nowInNano();
+        try {
+            List<LedgerStorage.DetectedInconsistency> errors = ledgerStorage.localConsistencyCheck(scrubRateLimiter);
+            if (errors.size() > 0) {
+                errorCounter.add(errors.size());
+                LOG.error("Found inconsistency during localConsistencyCheck:");
+                for (LedgerStorage.DetectedInconsistency error : errors) {
+                    LOG.error("Ledger {}, entry {}: ", error.getLedgerId(), error.getEntryId(), error.getException());
+                }
+            }
+            success = true;
+        } catch (IOException e) {
+            fatalErrorCounter.inc();
+            LOG.error("Got fatal exception {} running localConsistencyCheck", e.toString());
+        }
+        if (success) {
+            scrubCounter.registerSuccessfulEvent(MathUtils.elapsedNanos(start), TimeUnit.NANOSECONDS);
+        } else {
+            scrubCounter.registerFailedEvent(MathUtils.elapsedNanos(start), TimeUnit.NANOSECONDS);
+            Runtime.getRuntime().exit(ExitCode.BOOKIE_EXCEPTION);
+        }
+        if (!stop.get()) {
+            doSchedule();
+        }
+    }
+
+    @Override
+    protected void doStart() {
+        doSchedule();
+    }
+
+    @Override
+    protected void doStop() {
+        stop.set(true);
+        executor.shutdown();
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        // no-op
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
@@ -20,12 +20,11 @@
  */
 package org.apache.bookkeeper.server.service;
 
-
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.bookkeeper.bookie.ScrubberStats.DETECTED_FATAL_SCRUB_ERRORS;
 import static org.apache.bookkeeper.bookie.ScrubberStats.DETECTED_SCRUB_ERRORS;
 import static org.apache.bookkeeper.bookie.ScrubberStats.RUN_DURATION;
 
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.RateLimiter;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
@@ -74,7 +73,7 @@ public class ScrubberService extends ServerLifecycleComponent {
                 new DefaultThreadFactory("ScrubThread"));
 
         this.scrubPeriod = conf.getServerConf().getLocalScrubPeriod();
-        Preconditions.checkArgument(
+        checkArgument(
                 scrubPeriod > 0,
                 "localScrubInterval must be > 0 for ScrubberService to be used");
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
@@ -25,6 +25,7 @@ import static org.apache.bookkeeper.bookie.ScrubberStats.DETECTED_FATAL_SCRUB_ER
 import static org.apache.bookkeeper.bookie.ScrubberStats.DETECTED_SCRUB_ERRORS;
 import static org.apache.bookkeeper.bookie.ScrubberStats.RUN_DURATION;
 
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.RateLimiter;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
@@ -73,7 +74,9 @@ public class ScrubberService extends ServerLifecycleComponent {
                 new DefaultThreadFactory("ScrubThread"));
 
         this.scrubPeriod = conf.getServerConf().getLocalScrubPeriod();
-        assert(scrubPeriod > 0); // Otherwise, scrub service is disabled.
+        Preconditions.checkArgument(
+                scrubPeriod > 0,
+                "localScrubInterval must be > 0 for ScrubberService to be used");
 
         double rateLimit = conf.getServerConf().getLocalScrubRateLimit();
         this.scrubRateLimiter = rateLimit == 0 ? Optional.empty() : Optional.of(RateLimiter.create(rateLimit));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
@@ -47,7 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A {@link org.apache.bookkeeper.common.component.LifecycleComponent} that runs stats provider.
+ * A {@link org.apache.bookkeeper.common.component.LifecycleComponent} that runs the scrubber background service.
  */
 public class ScrubberService extends ServerLifecycleComponent {
     private static final Logger LOG = LoggerFactory.getLogger(ScrubberService.class);
@@ -71,7 +71,9 @@ public class ScrubberService extends ServerLifecycleComponent {
         super(NAME, conf, logger);
         this.executor = Executors.newSingleThreadScheduledExecutor(
                 new DefaultThreadFactory("ScrubThread"));
+
         this.scrubPeriod = conf.getServerConf().getLocalScrubPeriod();
+        assert(scrubPeriod > 0); // Otherwise, scrub service is disabled.
 
         double rateLimit = conf.getServerConf().getLocalScrubRateLimit();
         this.scrubRateLimiter = rateLimit == 0 ? Optional.empty() : Optional.of(RateLimiter.create(rateLimit));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -1383,7 +1383,12 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
     private static class MockTransactionalEntryLogCompactor extends TransactionalEntryLogCompactor {
 
         public MockTransactionalEntryLogCompactor(GarbageCollectorThread gcThread) {
-            super(gcThread);
+            super(gcThread.conf,
+                  gcThread.entryLogger,
+                  gcThread.ledgerStorage,
+                  (long entry) -> {
+                gcThread.removeEntryLog(entry);
+            });
         }
 
         synchronized void compactWithIndexFlushFailure(EntryLogMetadata metadata) {
@@ -1405,7 +1410,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
                 LOG.info("Compaction for {} end in PartialFlushIndexPhase.", metadata.getEntryLogId());
                 return;
             }
-            gcThread.removeEntryLog(metadata.getEntryLogId());
+            logRemovalListener.removeEntryLog(metadata.getEntryLogId());
             LOG.info("Compacted entry log : {}.", metadata.getEntryLogId());
         }
 
@@ -1428,7 +1433,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
                 LOG.info("Compaction for entry log {} end in UpdateIndexPhase.", metadata.getEntryLogId());
                 return;
             }
-            gcThread.removeEntryLog(metadata.getEntryLogId());
+            logRemovalListener.removeEntryLog(metadata.getEntryLogId());
             LOG.info("Compacted entry log : {}.", metadata.getEntryLogId());
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorageTest.java
@@ -87,8 +87,6 @@ public class InterleavedLedgerStorageTest {
         File curDir = Bookie.getCurrentDirectory(tmpDir);
         Bookie.checkDirectoryStructure(curDir);
 
-        System.out.println(tmpDir);
-
         conf = TestBKConfiguration.newServerConfiguration();
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
         conf.setEntryLogSizeLimit(2048);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorageTest.java
@@ -1,0 +1,305 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import static org.junit.Assert.assertEquals;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.util.DiskChecker;
+import org.apache.bookkeeper.util.EntryFormatter;
+import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.apache.commons.lang.mutable.MutableLong;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test for InterleavedLedgerStorage.
+ */
+public class InterleavedLedgerStorageTest {
+
+    CheckpointSource checkpointSource = new CheckpointSource() {
+        @Override
+        public Checkpoint newCheckpoint() {
+            return Checkpoint.MAX;
+        }
+
+        @Override
+        public void checkpointComplete(Checkpoint checkpoint, boolean compact) throws IOException {
+        }
+    };
+
+    Checkpointer checkpointer = new Checkpointer() {
+        @Override
+        public void startCheckpoint(Checkpoint checkpoint) {
+            // No-op
+        }
+
+        @Override
+        public void start() {
+            // no-op
+        }
+    };
+
+    ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+    LedgerDirsManager ledgerDirsManager;
+    InterleavedLedgerStorage interleavedStorage = new InterleavedLedgerStorage();
+    final long numWrites = 2000;
+    final long entriesPerWrite = 2;
+
+    @Before
+    public void setUp() throws Exception {
+        File tmpDir = File.createTempFile("bkTest", ".dir");
+        tmpDir.delete();
+        tmpDir.mkdir();
+        File curDir = Bookie.getCurrentDirectory(tmpDir);
+        Bookie.checkDirectoryStructure(curDir);
+
+        System.out.println(tmpDir);
+
+        conf = TestBKConfiguration.newServerConfiguration();
+        conf.setLedgerDirNames(new String[] { tmpDir.toString() });
+        conf.setEntryLogSizeLimit(2048);
+        ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
+
+        interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager,
+                null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE);
+
+        // Insert some ledger & entries in the interleaved storage
+        for (long entryId = 0; entryId < numWrites; entryId++) {
+            for (long ledgerId = 0; ledgerId < 5; ledgerId++) {
+                if (entryId == 0) {
+                    interleavedStorage.setMasterKey(ledgerId, ("ledger-" + ledgerId).getBytes());
+                    interleavedStorage.setFenced(ledgerId);
+                }
+                ByteBuf entry = Unpooled.buffer(128);
+                entry.writeLong(ledgerId);
+                entry.writeLong(entryId * entriesPerWrite);
+                entry.writeBytes(("entry-" + entryId).getBytes());
+
+                interleavedStorage.addEntry(entry);
+            }
+        }
+    }
+
+    @Test
+    public void testIndexEntryIterator() throws Exception {
+        try (LedgerCache.PageEntriesIterable pages = interleavedStorage.getIndexEntries(0)) {
+            MutableLong curEntry = new MutableLong(0);
+            for (LedgerCache.PageEntries page : pages) {
+                try (LedgerEntryPage lep = page.getLEP()) {
+                    lep.getEntries((entry, offset) -> {
+                        Assert.assertEquals(curEntry.longValue(), entry);
+                        Assert.assertNotEquals(0, offset);
+                        curEntry.setValue(entriesPerWrite + entry);
+                        return true;
+                    });
+                }
+            }
+            Assert.assertEquals(entriesPerWrite * numWrites, curEntry.longValue());
+        }
+    }
+
+    @Test
+    public void testConsistencyCheckConcurrentModification() throws Exception {
+        AtomicBoolean done = new AtomicBoolean(false);
+        EntryLogger entryLogger = interleavedStorage.getEntryLogger();
+        List<Exception> asyncErrors = new ArrayList<>();
+        Thread mutator = new Thread(() -> {
+            EntryLogCompactor compactor = new EntryLogCompactor(
+                    conf,
+                    entryLogger,
+                    interleavedStorage,
+                    entryLogger::removeEntryLog);
+            long next = 0;
+            while (!done.get()) {
+                try {
+                    compactor.compact(entryLogger.getEntryLogMetadata(next));
+                    next++;
+                } catch (IOException e) {
+                    asyncErrors.add(e);
+                    break;
+                }
+            }
+        });
+        mutator.start();
+
+        for (int i = 0; i < 100; ++i) {
+            assert interleavedStorage.localConsistencyCheck(Optional.empty()).size() == 0;
+            Thread.sleep(10);
+        }
+
+        done.set(true);
+        mutator.join();
+        for (Exception e: asyncErrors) {
+            throw e;
+        }
+    }
+
+
+    @Test
+    public void testConsistencyMissingEntry() throws Exception {
+        // set 1, 1 to nonsense
+        interleavedStorage.ledgerCache.putEntryOffset(1, 1, 0xFFFFFFFFFFFFFFFFL);
+
+        List<LedgerStorage.DetectedInconsistency> errors = interleavedStorage.localConsistencyCheck(Optional.empty());
+        Assert.assertEquals(1, errors.size());
+        LedgerStorage.DetectedInconsistency inconsistency = errors.remove(0);
+        Assert.assertEquals(1, inconsistency.getEntryId());
+        Assert.assertEquals(1, inconsistency.getLedgerId());
+    }
+
+    @Test
+    public void testWrongEntry() throws Exception {
+        // set 1, 1 to nonsense
+        interleavedStorage.ledgerCache.putEntryOffset(
+                1,
+                1,
+                interleavedStorage.ledgerCache.getEntryOffset(0, 0));
+
+        List<LedgerStorage.DetectedInconsistency> errors = interleavedStorage.localConsistencyCheck(Optional.empty());
+        Assert.assertEquals(1, errors.size());
+        LedgerStorage.DetectedInconsistency inconsistency = errors.remove(0);
+        Assert.assertEquals(1, inconsistency.getEntryId());
+        Assert.assertEquals(1, inconsistency.getLedgerId());
+    }
+
+    @Test
+    public void testShellCommands() throws Exception {
+        interleavedStorage.flush();
+        interleavedStorage.shutdown();
+        final Pattern entryPattern = Pattern.compile(
+                "entry (?<entry>\\d+)\t:\t((?<na>N/A)|\\(log:(?<logid>\\d+), pos: (?<pos>\\d+)\\))");
+
+        class Metadata {
+            final Pattern keyPattern = Pattern.compile("master key +: ([0-9a-f])");
+            final Pattern sizePattern = Pattern.compile("size +: (\\d+)");
+            final Pattern entriesPattern = Pattern.compile("entries +: (\\d+)");
+            final Pattern isFencedPattern = Pattern.compile("isFenced +: (\\w+)");
+
+            public String masterKey;
+            public long size = -1;
+            public long entries = -1;
+            public boolean foundFenced = false;
+
+            void check(String s) {
+                Matcher keyMatcher = keyPattern.matcher(s);
+                if (keyMatcher.matches()) {
+                    masterKey = keyMatcher.group(1);
+                    return;
+                }
+
+                Matcher sizeMatcher = sizePattern.matcher(s);
+                if (sizeMatcher.matches()) {
+                    size = Long.valueOf(sizeMatcher.group(1));
+                    return;
+                }
+
+                Matcher entriesMatcher = entriesPattern.matcher(s);
+                if (entriesMatcher.matches()) {
+                    entries = Long.valueOf(entriesMatcher.group(1));
+                    return;
+                }
+
+                Matcher isFencedMatcher = isFencedPattern.matcher(s);
+                if (isFencedMatcher.matches()) {
+                    Assert.assertEquals("true", isFencedMatcher.group(1));
+                    foundFenced = true;
+                    return;
+                }
+            }
+
+            void validate(long foundEntries) {
+                Assert.assertTrue(entries >= numWrites * entriesPerWrite);
+                Assert.assertEquals(entries, foundEntries);
+                Assert.assertTrue(foundFenced);
+                Assert.assertNotEquals(-1, size);
+            }
+        }
+        final Metadata foundMetadata = new Metadata();
+
+        AtomicLong curEntry = new AtomicLong(0);
+        AtomicLong someEntryLogger = new AtomicLong(-1);
+        BookieShell shell = new BookieShell(
+                LedgerIdFormatter.LONG_LEDGERID_FORMATTER, EntryFormatter.STRING_FORMATTER) {
+            @Override
+            void printInfoLine(String s) {
+                Matcher matcher = entryPattern.matcher(s);
+                System.out.println(s);
+                if (matcher.matches()) {
+                    assertEquals(Long.toString(curEntry.get()), matcher.group("entry"));
+
+                    if (matcher.group("na") == null) {
+                        String logId = matcher.group("logid");
+                        Assert.assertNotEquals(matcher.group("logid"), null);
+                        Assert.assertNotEquals(matcher.group("pos"), null);
+                        Assert.assertTrue((curEntry.get() % entriesPerWrite) == 0);
+                        Assert.assertTrue(curEntry.get() <= numWrites * entriesPerWrite);
+                        if (someEntryLogger.get() == -1) {
+                            someEntryLogger.set(Long.valueOf(logId));
+                        }
+                    } else {
+                        Assert.assertEquals(matcher.group("logid"), null);
+                        Assert.assertEquals(matcher.group("pos"), null);
+                        Assert.assertTrue(((curEntry.get() % entriesPerWrite) != 0)
+                                || ((curEntry.get() >= (entriesPerWrite * numWrites))));
+                    }
+                    curEntry.incrementAndGet();
+                } else {
+                    foundMetadata.check(s);
+                }
+            }
+        };
+        shell.setConf(conf);
+        int res = shell.run(new String[] { "ledger", "-m", "0" });
+        Assert.assertEquals(0, res);
+        Assert.assertTrue(curEntry.get() >= numWrites * entriesPerWrite);
+        foundMetadata.validate(curEntry.get());
+
+        // Should pass consistency checker
+        res = shell.run(new String[] { "localconsistencycheck" });
+        Assert.assertEquals(0, res);
+
+
+        // Remove a logger
+        EntryLogger entryLogger = new EntryLogger(conf);
+        entryLogger.removeEntryLog(someEntryLogger.get());
+
+        // Should fail consistency checker
+        res = shell.run(new String[] { "localconsistencycheck" });
+        Assert.assertEquals(1, res);
+    }
+}


### PR DESCRIPTION
The main goal of this patch is the ScrubberService LifecycleComponent
which runs in the background periodically verifying the internal
consistency of the LedgerStorage. To get that to work:

- LedgerStorage now has a localConsistencyCheck call with
implementations in Interleaved and Sorted.

- In service of that implementation, LedgerCache gains an interface for
iterating safely over the entries of a ledger with a way of handling
concurrently modified or deleted ledgers with corresponding
modifications to LedgerEntryPage for detecting deletion.

- EntryLogger has been refactored to permit checking the correctness
(and throwing a descriptive exception in case of a problem) of an entry
without actually reading it for use within localConsistencyCheck.

- The two mechanisms for iterating over a ledger's entries in
BookieShell have both been replaced with the new single implementation
(InterleavedLedgerStorageTest now has a test checking the output of the
affected command.)

- Misc changes to *LogCompactor to support tests in
InterleavedLedgerStorageTest.

Because the consistency check needs to run in the background and hold
LEP instances potentially for a relatively long time, a delete may
overlap with the scan of an LEP page. As part of this patch,
IndexInMemPageMgr and LedgerEntryPage now permit an LEP to be marked
deleted and not added back to the set of free pages until released.

This patch also adds an option to run the checker on startup (defaults
to false).

(@bug W-5188823@)
(@bug W-5153309@)
(@rev cguttapalem@)
Signed-off-by: Samuel Just <sjust@salesforce.com>