### PR TITLE
AbstractZkLedgerManager should catch all exceptions from parseConfig

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -402,8 +402,8 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                     LongVersion version = new LongVersion(stat.getVersion());
                     LedgerMetadata metadata = LedgerMetadata.parseConfig(data, Optional.of(stat.getCtime()));
                     promise.complete(new Versioned<>(metadata, version));
-                } catch (IOException e) {
-                    LOG.error("Could not parse ledger metadata for ledger: " + ledgerId, e);
+                } catch (Throwable t) {
+                    LOG.error("Could not parse ledger metadata for ledger: {}", ledgerId, t);
                     promise.completeExceptionally(new BKException.ZKException());
                 }
             }


### PR DESCRIPTION
And always complete the request if an exception does occur, rather
than throwing it out to the higher level, and hanging the request
forever.
