### PR TITLE
Fix flake in AuditorPeriodicBookieCheckTest

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
@@ -66,6 +66,7 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setAuditorPeriodicBookieCheckInterval(CHECK_INTERVAL);
         conf.setMetadataServiceUri(metadataServiceUri);
+        conf.setProperty("clientConnectTimeoutMillis", 500);
         String addr = bs.get(0).getLocalAddress().toString();
 
         auditorElector = new AuditorElector(addr, conf);
@@ -95,7 +96,7 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
                                        LedgerMetadataBuilder.create().withEnsembleSize(3)
                                        .withWriteQuorumSize(3).withAckQuorumSize(3)
                                        .newEnsembleEntry(0L, Lists.newArrayList(
-                                                                 new BookieSocketAddress("1.1.1.1", 1000),
+                                                                 new BookieSocketAddress("192.0.2.1", 1000),
                                                                  getBookie(0), getBookie(1))));
                 long underReplicatedLedger = -1;
                 for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
The flake was occurring because the bookie checker was trying to
connect to a TCP endpoint that didn't respond (1.1.1.1) and was
waiting for the whole tcp connect timeout (10sec), while the test was
waiting 10 seconds for the success condition to occur. The success
condition often occurred just after the test fails.

The solution was to bring the connect timeout for the client down to
500ms, giving the auditor plenty of time to register the
underreplicated ledger.

I guess this used to pass in the past because maybe 1.1.1.1 was
actually rejecting packets instead of dropping them, and these changed
when cloudflare took over the address. I changed the endpoint to
192.0.2.0/24 range (TEST-NET) to avoid a similar scenario in the
future.
