### PR TITLE
Remove LedgerMetadata copy constructor

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadata.java
@@ -152,36 +152,6 @@ public class LedgerMetadata implements org.apache.bookkeeper.client.api.LedgerMe
         this.customMetadata.putAll(customMetadata);
     }
 
-    /**
-     * Copy Constructor.
-     */
-    LedgerMetadata(LedgerMetadata other) {
-        this.ensembleSize = other.ensembleSize;
-        this.writeQuorumSize = other.writeQuorumSize;
-        this.ackQuorumSize = other.ackQuorumSize;
-        this.length = other.length;
-        this.lastEntryId = other.lastEntryId;
-        this.metadataFormatVersion = other.metadataFormatVersion;
-        this.state = other.state;
-        this.hasPassword = other.hasPassword;
-        this.digestType = other.digestType;
-        this.ctime = other.ctime;
-        this.storeCtime = other.storeCtime;
-        this.password = new byte[other.password.length];
-        System.arraycopy(other.password, 0, this.password, 0, other.password.length);
-        this.ensembles = Collections.unmodifiableNavigableMap(
-                other.ensembles.entrySet().stream().collect(TreeMap::new,
-                                                            (m, e) -> m.put(e.getKey(),
-                                                                            ImmutableList.copyOf(e.getValue())),
-                                                            TreeMap::putAll));
-        if (state != LedgerMetadataFormat.State.CLOSED) {
-            currentEnsemble = this.ensembles.lastEntry().getValue();
-        } else {
-            currentEnsemble = null;
-        }
-        this.customMetadata = other.customMetadata;
-    }
-
     @Override
     public NavigableMap<Long, ? extends List<BookieSocketAddress>> getAllEnsembles() {
         return ensembles;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -104,7 +104,7 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
                             }
                             // keep a copy of ledger metadata before proceeding
                             // ledger recovery
-                            metadataForRecovery = new LedgerMetadata(lh.getLedgerMetadata());
+                            metadataForRecovery = lh.getLedgerMetadata();
                             doRecoveryRead();
                         } else if (rc == BKException.Code.UnauthorizedAccessException) {
                             submitCallback(rc);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -372,7 +372,7 @@ public abstract class MockBookKeeperTestCase {
                 if (ledgerMetadata == null) {
                     promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
                 } else {
-                    promise.complete(new Versioned<>(new LedgerMetadata(ledgerMetadata), new LongVersion(1)));
+                    promise.complete(new Versioned<>(ledgerMetadata, new LongVersion(1)));
                 }
             });
             return promise;
@@ -426,7 +426,7 @@ public abstract class MockBookKeeperTestCase {
             executor.executeOrdered(ledgerId, () -> {
 
                     LedgerMetadata ledgerMetadata = (LedgerMetadata) args[1];
-                    mockLedgerMetadataRegistry.put(ledgerId, new LedgerMetadata(ledgerMetadata));
+                    mockLedgerMetadataRegistry.put(ledgerId, ledgerMetadata);
                     promise.complete(new Versioned<>(ledgerMetadata, new LongVersion(1)));
             });
             return promise;


### PR DESCRIPTION
A copy constructor makes no sense when it's not possible to mutate the object.

Master issue: #281
