### PR TITLE
Only publish suspect ledgers if they have missing fragments

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -647,6 +647,11 @@ public class Auditor implements AutoCloseable {
                 for (LedgerFragment f : fragments) {
                     bookies.addAll(f.getAddresses());
                 }
+                if (bookies.isEmpty()) {
+                    // no missing fragments
+                    callback.processResult(Code.OK, null, null);
+                    return;
+                }
                 publishSuspectedLedgersAsync(
                     bookies.stream().map(BookieSocketAddress::toString).collect(Collectors.toList()),
                     Sets.newHashSet(lh.getId())


### PR DESCRIPTION
This is a fix for a flake in
AuditorPeriodicCheckTest#testIndexCorruption. Auditor#checkAllLedgers()
runs a check on all ledgers, passing ProcessLostFragmentsCb as a
callback to LedgerChecker#checkLedger for each one.

LedgerChecker#checkLedger triggers the callback on completion,
regardless of whether there are fragments missing on not. Previously,
ProcessLostFragments was not checking if there were lost fragments
before publishing the ledger as suspected in zookeeper.

The flake triggered as there were always two ledgers that existed when
the check occurred, both would be reported as suspected, and it was
random which would be returned while polling for underreplicated
ledgers.

The fix is to check that something is actually underreplicated before
publishing.
