### PR TITLE
Let OS choose port for vertx test

### DIFF
--- a/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxHttpServer.java
+++ b/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxHttpServer.java
@@ -46,9 +46,14 @@ public class VertxHttpServer implements HttpServer {
     private Vertx vertx;
     private boolean isRunning;
     private HttpServiceProvider httpServiceProvider;
+    private int listeningPort = -1;
 
     public VertxHttpServer() {
         this.vertx = Vertx.vertx();
+    }
+
+    int getListeningPort() {
+        return listeningPort;
     }
 
     @Override
@@ -58,7 +63,7 @@ public class VertxHttpServer implements HttpServer {
 
     @Override
     public boolean startServer(int port) {
-        CompletableFuture<AsyncResult> future = new CompletableFuture<>();
+        CompletableFuture<AsyncResult<io.vertx.core.http.HttpServer>> future = new CompletableFuture<>();
         VertxHttpHandlerFactory handlerFactory = new VertxHttpHandlerFactory(httpServiceProvider);
         Router router = Router.router(vertx);
         HttpRouter<VertxAbstractHandler> requestRouter = new HttpRouter<VertxAbstractHandler>(handlerFactory) {
@@ -76,9 +81,10 @@ public class VertxHttpServer implements HttpServer {
             }
         });
         try {
-            AsyncResult asyncResult = future.get();
+            AsyncResult<io.vertx.core.http.HttpServer> asyncResult = future.get();
             if (asyncResult.succeeded()) {
                 LOG.info("Vertx Http server started successfully");
+                listeningPort = asyncResult.result().actualPort();
                 isRunning = true;
                 return true;
             } else {

--- a/bookkeeper-http/vertx-http-server/src/test/java/org/apache/bookkeeper/http/vertx/TestVertxHttpServer.java
+++ b/bookkeeper-http/vertx-http-server/src/test/java/org/apache/bookkeeper/http/vertx/TestVertxHttpServer.java
@@ -21,6 +21,7 @@
 package org.apache.bookkeeper.http.vertx;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -39,19 +40,13 @@ import org.junit.Test;
  * Unit test {@link VertxHttpServer}.
  */
 public class TestVertxHttpServer {
-
-    private int port = 8080;
-
     @Test
     public void testStartBasicHttpServer() throws Exception {
         VertxHttpServer httpServer = new VertxHttpServer();
         HttpServiceProvider httpServiceProvider = NullHttpServiceProvider.getInstance();
         httpServer.initialize(httpServiceProvider);
-        int port = getNextPort();
-        while (!httpServer.startServer(port)) {
-            httpServer.stopServer();
-            port = getNextPort();
-        }
+        assertTrue(httpServer.startServer(0));
+        int port = httpServer.getListeningPort();
         HttpResponse httpResponse = sendGet(getUrl(port, HttpRouter.HEARTBEAT));
         assertEquals(HttpServer.StatusCode.OK.getValue(), httpResponse.responseCode);
         assertEquals(HeartbeatService.HEARTBEAT.trim(), httpResponse.responseBody.trim());
@@ -63,11 +58,8 @@ public class TestVertxHttpServer {
         VertxHttpServer httpServer = new VertxHttpServer();
         HttpServiceProvider httpServiceProvider = NullHttpServiceProvider.getInstance();
         httpServer.initialize(httpServiceProvider);
-        int port = getNextPort();
-        while (!httpServer.startServer(port)) {
-            httpServer.stopServer();
-            port = getNextPort();
-        }
+        assertTrue(httpServer.startServer(0));
+        int port = httpServer.getListeningPort();
         HttpResponse httpResponse = sendGet(getUrl(port, HttpRouter.METRICS));
         assertEquals(HttpServer.StatusCode.OK.getValue(), httpResponse.responseCode);
         httpServer.stopServer();
@@ -108,12 +100,5 @@ public class TestVertxHttpServer {
             this.responseCode = responseCode;
             this.responseBody = responseBody;
         }
-    }
-
-    private int getNextPort() throws Exception {
-        if (port > 65535) {
-            throw new Exception("No port available");
-        }
-        return port++;
     }
 }


### PR DESCRIPTION
The previous implementation was searching for a open port by
repeatedly trying to startServer on ports starting at 8080. However,
after the first attempt fails, the Vertx instance in VertxHttpServer
is broken and the test hangs. 8080 is a very common port to have stuff
running on, so these hangs have happened to be repeatedly.

This fix is to allow the OS to choose the port, by specifying 0 as the
listening port and querying afterwards.

Issue: #1821
