### PR TITLE
Fix selectFromNetworkLocation in RackawareEnsemblePlacementPolicyImpl

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -722,8 +722,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
         }
 
         try {
-            return selectRandomInternal(knownNodes, 1, fullExclusionBookiesList, TruePredicate.INSTANCE,
-                    EnsembleForReplacementWithNoConstraints.INSTANCE).get(0);
+            return selectRandomInternal(knownNodes, 1, fullExclusionBookiesList, predicate, ensemble).get(0);
         } catch (BKNotEnoughBookiesException e) {
             if (!fallbackToRandom) {
                 LOG.error(


### PR DESCRIPTION

Descriptions of the changes in this PR:

Since beginning, selectFromNetworkLocation(excludeRacks, excludeBookies,..)
method kind of ignores predicate/ensemble passed to that method
https://github.com/apache/bookkeeper/blob/branch-4.7/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java#L694.

This was kind of ok, because so far effectively this method is called from only
one place - https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java#L612,
which passes TruePredicate.INSTANCE and EnsembleForReplacementWithNoConstraints.INSTANCE.

But it is not ideal to ignore those parameters in selectFromNetworkLocation(excludeRacks, excludeBookies,..),
from future usage perspective. So passing the received predicate and ensemble to the underlying calls.
