### PR TITLE
 HTTP GetMetaService returns JSON rather than calling #serialize

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -132,7 +132,7 @@ class LedgerCreateOp {
             metadataBuilder.withCustomMetadata(customMetadata);
         }
         if (bk.getConf().getStoreSystemtimeAsLedgerCreationTime()) {
-            metadataBuilder.withCreationTime(System.currentTimeMillis());
+            metadataBuilder.withCreationTime(System.currentTimeMillis()).storingCreationTime(true);
         }
 
         // select bookies for first ensemble

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.net;
 
 import static org.apache.bookkeeper.util.BookKeeperConstants.COLON;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.net.InetAddresses;
 import io.netty.channel.local.LocalAddress;
 
@@ -91,6 +92,7 @@ public class BookieSocketAddress {
     }
 
     // Method to return an InetSocketAddress for the regular port.
+    @JsonIgnore
     public InetSocketAddress getSocketAddress() {
         /*
          * Return each time a new instance of the InetSocketAddress if hostname
@@ -106,6 +108,7 @@ public class BookieSocketAddress {
     /**
      * Maps the socketAddress to a "local" address.
      */
+    @JsonIgnore
     public LocalAddress getLocalAddress() {
         // for local address, we just need "port" to differentiate different addresses.
         return new LocalAddress("" + port);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLedgerMetaService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLedgerMetaService.java
@@ -18,7 +18,6 @@
  */
 package org.apache.bookkeeper.server.http.service;
 
-import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.Maps;
@@ -68,9 +67,9 @@ public class GetLedgerMetaService implements HttpEndpointService {
             LedgerManager manager = mFactory.newLedgerManager();
 
             // output <ledgerId: ledgerMetadata>
-            Map<String, String> output = Maps.newHashMap();
+            Map<String, Object> output = Maps.newHashMap();
             LedgerMetadata md = manager.readLedgerMetadata(ledgerId).get().getValue();
-            output.put(ledgerId.toString(), new String(serDe.serialize(md), UTF_8));
+            output.put(ledgerId.toString(), md);
 
             manager.close();
 


### PR DESCRIPTION
Once the binary ledger metadata serializing is available, the output
of GetMetaService would no longer be understandable. In preparation
for this, make GetMetaService use output JSON, rather than directly
calling #serialize.

Master issue: #723
