### PR TITLE
Issue #1884: (@W-5697664@) dir_*_usage stats are reported as 0 ...

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
@@ -122,43 +122,46 @@ class LedgerDirsMonitor {
         }
 
         List<File> fullfilledDirs = new ArrayList<File>(ldm.getFullFilledLedgerDirs());
-        boolean hasWritableLedgerDirs = ldm.hasWritableLedgerDirs();
-        float totalDiskUsage = 0;
+        boolean makeWritable = ldm.hasWritableLedgerDirs();
 
-        // When bookie is in READONLY mode .i.e there are no writableLedgerDirs:
-        // - Check if the total disk usage is below DiskLowWaterMarkUsageThreshold.
-        // - If So, walk through the entire list of fullfilledDirs and add them back to writableLedgerDirs list if
-        // their usage is < conf.getDiskUsageThreshold.
+        // When bookie is in READONLY mode, i.e there are no writableLedgerDirs:
+        // - Update fullfilledDirs disk usage.
+        // - If the total disk usage is below DiskLowWaterMarkUsageThreshold
+        // add fullfilledDirs back to writableLedgerDirs list if their usage is < conf.getDiskUsageThreshold.
         try {
-            if (hasWritableLedgerDirs
-                    || (totalDiskUsage = diskChecker.getTotalDiskUsage(ldm.getAllLedgerDirs())) < conf
-                            .getDiskLowWaterMarkUsageThreshold()) {
-                // Check all full-filled disk space usage
-                for (File dir : fullfilledDirs) {
-                    try {
-                        diskUsages.put(dir, diskChecker.checkDir(dir));
-                        ldm.addToWritableDirs(dir, true);
-                    } catch (DiskErrorException e) {
-                        // Notify disk failure to all the listeners
-                        for (LedgerDirsListener listener : ldm.getListeners()) {
-                            listener.diskFailed(dir);
-                        }
-                    } catch (DiskWarnThresholdException e) {
-                        diskUsages.put(dir, e.getUsage());
-                        // the full-filled dir become writable but still
-                        // above
-                        // warn threshold
-                        ldm.addToWritableDirs(dir, false);
-                    } catch (DiskOutOfSpaceException e) {
-                        // the full-filled dir is still full-filled
-                        diskUsages.put(dir, e.getUsage());
-                    }
-                }
-            } else {
-                LOG.debug(
+            if (!makeWritable) {
+                float totalDiskUsage = diskChecker.getTotalDiskUsage(ldm.getAllLedgerDirs());
+                if (totalDiskUsage < conf.getDiskLowWaterMarkUsageThreshold()) {
+                    makeWritable = true;
+                } else {
+                    LOG.debug(
                         "Current TotalDiskUsage: {} is greater than LWMThreshold: {}."
-                            + " So not adding any filledDir to WritableDirsList",
+                                + " So not adding any filledDir to WritableDirsList",
                         totalDiskUsage, conf.getDiskLowWaterMarkUsageThreshold());
+                }
+            }
+            // Update all full-filled disk space usage
+            for (File dir : fullfilledDirs) {
+                try {
+                    diskUsages.put(dir, diskChecker.checkDir(dir));
+                    if (makeWritable) {
+                        ldm.addToWritableDirs(dir, true);
+                    }
+                } catch (DiskErrorException e) {
+                    // Notify disk failure to all the listeners
+                    for (LedgerDirsListener listener : ldm.getListeners()) {
+                        listener.diskFailed(dir);
+                    }
+                } catch (DiskWarnThresholdException e) {
+                    diskUsages.put(dir, e.getUsage());
+                    // the full-filled dir become writable but still above the warn threshold
+                    if (makeWritable) {
+                        ldm.addToWritableDirs(dir, false);
+                    }
+                } catch (DiskOutOfSpaceException e) {
+                    // the full-filled dir is still full-filled
+                    diskUsages.put(dir, e.getUsage());
+                }
             }
         } catch (IOException ioe) {
             LOG.error("Got IOException while monitoring Dirs", ioe);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestLedgerDirsManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestLedgerDirsManager.java
@@ -20,9 +20,7 @@
  */
 package org.apache.bookkeeper.bookie;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -243,7 +241,6 @@ public class TestLedgerDirsManager {
 
     @Test
     public void testLedgerDirsMonitorHandlingLowWaterMark() throws Exception {
-
         ledgerMonitor.shutdown();
 
         final float warn = 0.90f;
@@ -370,18 +367,64 @@ public class TestLedgerDirsManager {
         // should goto readwrite
         setUsageAndThenVerify(curDir1, lwm - 0.17f, curDir2, nospace + 0.03f, mockDiskChecker, mockLedgerDirsListener,
                 false);
-        assertTrue("Only one LedgerDir should be writable", dirsManager.getWritableLedgerDirs().size() == 1);
+        assertEquals("Only one LedgerDir should be writable", 1, dirsManager.getWritableLedgerDirs().size());
 
         // bring both the dirs below lwm
         // should still be readwrite
         setUsageAndThenVerify(curDir1, lwm - 0.03f, curDir2, lwm - 0.02f, mockDiskChecker, mockLedgerDirsListener,
                 false);
-        assertTrue("Both the LedgerDirs should be writable", dirsManager.getWritableLedgerDirs().size() == 2);
+        assertEquals("Both the LedgerDirs should be writable", 2, dirsManager.getWritableLedgerDirs().size());
 
         // bring both the dirs above lwm but < threshold
         // should still be readwrite
         setUsageAndThenVerify(curDir1, lwm + 0.02f, curDir2, lwm + 0.08f, mockDiskChecker, mockLedgerDirsListener,
                 false);
+    }
+
+    @Test
+    public void testLedgerDirsMonitorStartReadOnly() throws Exception {
+        ledgerMonitor.shutdown();
+
+        final float nospace = 0.90f;
+        final float lwm = 0.80f;
+
+        File tmpDir1 = createTempDir("bkTest", ".dir");
+        File curDir1 = Bookie.getCurrentDirectory(tmpDir1);
+        Bookie.checkDirectoryStructure(curDir1);
+
+        File tmpDir2 = createTempDir("bkTest", ".dir");
+        File curDir2 = Bookie.getCurrentDirectory(tmpDir2);
+        Bookie.checkDirectoryStructure(curDir2);
+
+        conf.setDiskUsageThreshold(nospace);
+        conf.setDiskLowWaterMarkUsageThreshold(lwm);
+        conf.setDiskUsageWarnThreshold(nospace);
+        conf.setLedgerDirNames(new String[] { tmpDir1.toString(), tmpDir2.toString() });
+
+        // Both disks are out of space at the start.
+        HashMap<File, Float> usageMap = new HashMap<>();
+        usageMap.put(curDir1, nospace + 0.05f);
+        usageMap.put(curDir2, nospace + 0.05f);
+
+        mockDiskChecker = new MockDiskChecker(nospace, warnThreshold);
+        mockDiskChecker.setUsageMap(usageMap);
+        dirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()),
+                statsLogger);
+
+        ledgerMonitor = new LedgerDirsMonitor(conf, mockDiskChecker, dirsManager);
+        try {
+            ledgerMonitor.init();
+            fail("NoWritableLedgerDirException expected");
+        } catch (NoWritableLedgerDirException exception) {
+            // ok
+        }
+        final MockLedgerDirsListener mockLedgerDirsListener = new MockLedgerDirsListener();
+        dirsManager.addLedgerDirsListener(mockLedgerDirsListener);
+        ledgerMonitor.start();
+
+        Thread.sleep((diskCheckInterval * 2) + 100);
+        verifyUsage(curDir1, nospace + 0.05f, curDir2, nospace + 0.05f, mockLedgerDirsListener, true);
     }
 
     private void setUsageAndThenVerify(File dir1, float dir1Usage, File dir2, float dir2Usage,
@@ -391,26 +434,19 @@ public class TestLedgerDirsManager {
         usageMap.put(dir1, dir1Usage);
         usageMap.put(dir2, dir2Usage);
         mockDiskChecker.setUsageMap(usageMap);
+        verifyUsage(dir1, dir1Usage, dir2, dir2Usage, mockLedgerDirsListener, verifyReadOnly);
+    }
+
+    private void verifyUsage(File dir1, float dir1Usage, File dir2, float dir2Usage,
+                             MockLedgerDirsListener mockLedgerDirsListener, boolean verifyReadOnly) {
         executorController.advance(Duration.ofMillis(diskCheckInterval));
 
         float sample1 = getGauge(dir1.getParent()).getSample().floatValue();
         float sample2 = getGauge(dir2.getParent()).getSample().floatValue();
 
-        if (verifyReadOnly) {
-            assertTrue(mockLedgerDirsListener.readOnly);
-
-            // LedgerDirsMonitor stops updating diskUsages when the bookie is in the readonly mode,
-            // so the stats will reflect an older value at the time when the bookie became readonly
-            assertThat(sample1, greaterThan(90f));
-            assertThat(sample1, lessThan(100f));
-            assertThat(sample2, greaterThan(90f));
-            assertThat(sample2, lessThan(100f));
-        } else {
-            assertFalse(mockLedgerDirsListener.readOnly);
-
-            assertThat(sample1, equalTo(dir1Usage * 100f));
-            assertThat(sample2, equalTo(dir2Usage * 100f));
-        }
+        assertEquals(mockLedgerDirsListener.readOnly, verifyReadOnly);
+        assertThat(sample1, equalTo(dir1Usage * 100f));
+        assertThat(sample2, equalTo(dir2Usage * 100f));
     }
 
     private Gauge<? extends Number> getGauge(String path) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestLedgerDirsManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestLedgerDirsManager.java
@@ -20,7 +20,7 @@
  */
 package org.apache.bookkeeper.bookie;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;


### PR DESCRIPTION
for read-only bookies after a restart

### Motivation

Fixing the Issue #1884:

When a read-only bookie is restarted it keeps reporting `dir_*_usage`
stats as `0` until it becomes writable again.

This is caused by the `LedgerDirsMonitor.check` only updating
`diskUsages` if there are any writable dirs, or if the total usage
goes below the low water mark, otherwise relying on previously filled
values which are `0` after a bookie is restarted.

### Changes

* Change the `LedgerDirsMonitor.check` to update `diskUsages`
  even when there are no writable dirs.
* Add new `testLedgerDirsMonitorStartReadOnly` testing this scenario.
* Simplify previous tests checking read-only since `diskUsages`
  are now updated regardless if a bookie is in read-only mode.

@jvrao @reddycharan 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
