### PR TITLE
Issue#1886 Handle double bookie failures

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1972,6 +1972,11 @@ public class LedgerHandle implements WriteHandle {
         }
     }
 
+    boolean testStubResolveConflict() {
+        // No test inserts by default
+        return false;
+    }
+
     // Contains newly reformed ensemble, bookieIndex, failedBookieAddress
     static final class EnsembleInfo {
         private final ArrayList<BookieSocketAddress> newEnsemble;
@@ -2064,7 +2069,7 @@ public class LedgerHandle implements WriteHandle {
      */
     private final class ReReadLedgerMetadataCb extends OrderedGenericCallback<LedgerMetadata> {
         private final int rc;
-        private final EnsembleInfo ensembleInfo;
+        private EnsembleInfo ensembleInfo;
         private final int curBlockAddCompletions;
         private final int ensembleChangeIdx;
 
@@ -2113,6 +2118,7 @@ public class LedgerHandle implements WriteHandle {
          */
         private boolean resolveConflict(LedgerMetadata newMeta) {
             LedgerMetadata metadata = getLedgerMetadata();
+            testStubResolveConflict();
             if (LOG.isDebugEnabled()) {
                 LOG.debug("[EnsembleChange-L{}-{}] : resolving conflicts - local metadata = \n {} \n,"
                     + " zk metadata = \n {} \n", ledgerId, ensembleChangeIdx, metadata, newMeta);
@@ -2155,12 +2161,7 @@ public class LedgerHandle implements WriteHandle {
             // update the ensemble change metadata again. Otherwise, it means that the ensemble change
             // is already succeed, unset the success and re-adding entries.
             if (!areFailedBookiesReplaced(newMeta, ensembleInfo)) {
-                // If the in-memory data doesn't contains the failed bookie, it means the ensemble change
-                // didn't finish, so try to resolve conflicts with the metadata read from zookeeper and
-                // update ensemble changed metadata again.
-                if (areFailedBookiesReplaced(metadata, ensembleInfo)) {
-                    return updateMetadataIfPossible(metadata, newMeta);
-                }
+                return updateMetadataIfPossible(newMeta);
             } else {
                 ensembleChangeCounter.inc();
                 // We've successfully changed an ensemble
@@ -2222,9 +2223,22 @@ public class LedgerHandle implements WriteHandle {
             metadata.setVersion(newMeta.getVersion());
             // merge ensemble infos from new meta except last ensemble
             // since they might be modified by recovery tool.
+
             metadata.mergeEnsembles(newMeta.getEnsembles());
-            writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions,
-                    ensembleChangeIdx));
+            if (!areFailedBookiesReplaced(metadata, ensembleInfo)) {
+                // If the in-memory data contains the failed bookie, someone else
+                // merged the metadata and reinstated old copy. Let's attempt to
+                // replace the bookie again.
+                try {
+                    ensembleInfo = replaceBookieInMetadata(ensembleInfo.failedBookies, numEnsembleChanges.get());
+                } catch (BKException.BKNotEnoughBookiesException e) {
+                    LOG.error("Could not get additional bookie to remake ensemble, closing ledger: {}", ledgerId);
+                    handleUnrecoverableErrorDuringAdd(e.getCode());
+                    return false;
+                }
+            }
+
+            writeLedgerConfig(new ChangeEnsembleCb(ensembleInfo, curBlockAddCompletions, ensembleChangeIdx));
             return true;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -2161,7 +2161,7 @@ public class LedgerHandle implements WriteHandle {
             // update the ensemble change metadata again. Otherwise, it means that the ensemble change
             // is already succeed, unset the success and re-adding entries.
             if (!areFailedBookiesReplaced(newMeta, ensembleInfo)) {
-                return updateMetadataIfPossible(newMeta);
+                return updateMetadataIfPossible(metadata, newMeta);
             } else {
                 ensembleChangeCounter.inc();
                 // We've successfully changed an ensemble

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -2118,7 +2118,9 @@ public class LedgerHandle implements WriteHandle {
          */
         private boolean resolveConflict(LedgerMetadata newMeta) {
             LedgerMetadata metadata = getLedgerMetadata();
-            testStubResolveConflict();
+            if (testStubResolveConflict()) {
+                LOG.info("Invoked the Stub - Checkout the test case for the expected behavior");
+            }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("[EnsembleChange-L{}-{}] : resolving conflicts - local metadata = \n {} \n,"
                     + " zk metadata = \n {} \n", ledgerId, ensembleChangeIdx, metadata, newMeta);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -2233,7 +2233,6 @@ public class LedgerHandle implements WriteHandle {
                     ensembleInfo = replaceBookieInMetadata(ensembleInfo.failedBookies, numEnsembleChanges.get());
                 } catch (BKException.BKNotEnoughBookiesException e) {
                     LOG.error("Could not get additional bookie to remake ensemble, closing ledger: {}", ledgerId);
-                    handleUnrecoverableErrorDuringAdd(e.getCode());
                     return false;
                 }
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -218,7 +218,6 @@ public class BookieWriteLedgerTest extends
         injectFailedBookies.put(0, newBkAddr);
         when(mlh.testStubResolveConflict()).thenAnswer(
                 invoke -> {
-                    LOG.info("JV inside testInsertEnsembleChange");
                     mlh.replaceBookieInMetadata(injectFailedBookies, 0);
                     return true;
                 });

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -65,6 +65,7 @@ import org.apache.bookkeeper.client.api.WriteAdvHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LongHierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.test.TestCallbacks.GenericCallbackFuture;
 import org.apache.bookkeeper.versioning.LongVersion;
@@ -201,16 +202,16 @@ public class BookieWriteLedgerTest extends
         LedgerMetadata myMetadata = new LedgerMetadata(mlh.getLedgerMetadata());
         // Set it in Metadata server
         long savedVersion = ((LongVersion) mlh.getLedgerMetadata().getVersion()).getLongVersion();
-        GenericCallbackFuture<Void> callbackFuture = new GenericCallbackFuture<>();
+        GenericCallbackFuture<LedgerMetadata> callbackFuture = new GenericCallbackFuture<>();
         bkc.getLedgerManager().writeLedgerMetadata(mlh.getId(), myMetadata, callbackFuture);
-        result(callbackFuture);
+        callbackFuture.get();
         // Set the saved version back
         lh.getLedgerMetadata().setVersion(new LongVersion(savedVersion));
         // Add a bookie
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
         // Put a old bookie to sleep
         CountDownLatch sleepLatch1 = new CountDownLatch(1);
-        ArrayList<BookieSocketAddress> ensemble = mlh.getLedgerMetadata()
+        List<BookieSocketAddress> ensemble = mlh.getLedgerMetadata()
                 .getEnsembles().entrySet().iterator().next().getValue();
         sleepBookie(ensemble.get(0), sleepLatch1);
         Map<Integer, BookieSocketAddress> injectFailedBookies =


### PR DESCRIPTION
For this race condition to happen:
1. ZK metadata version is different from Client write ledger
   handle - Replication worker
2. Client made an ensemble change and replaced a bookie,
   sent change proposal to zk
3. While this is pending, Client made another ensemble change
   replaced the same index with the bookie that was prior to step#2
4. Ensemble change made in step#2 came back to client with
   version conflict error.
5. Client need to resolve this conflict

The fix is to reconsile the local state, zk state, and do bookie
replaceemnt, send the updated metadata to zk.

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>
(@rev Sam Just@)

Descriptions of the changes in this PR:



### Motivation

(Explain: why you're making that change, what is the problem you're trying to solve)

### Changes

(Describe: what changes you have made)

Master Issue: #<master-issue-number>

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
