### PR TITLE
Bring back statslogger to BookKeeper client in ReplicationWorker process.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -153,6 +153,9 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     // enforce minimum number of racks per write quorum
     public static final String ENFORCE_MIN_NUM_RACKS_PER_WRITE_QUORUM = "enforceMinNumRacksPerWriteQuorum";
 
+    // option to limit stats logging
+    public static final String LIMIT_STATS_LOGGING = "limitStatsLogging";
+
     protected AbstractConfiguration() {
         super();
         if (READ_SYSTEM_PROPERTIES) {
@@ -875,6 +878,29 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
         setProperty(PRESERVE_MDC_FOR_TASK_EXECUTION, enabled);
         return getThis();
     }
+
+    /**
+     * Return the flag indicating whether to limit stats logging.
+     *
+     * @return
+     *      the boolean flag indicating whether to limit stats logging
+     */
+    public boolean getLimitStatsLogging() {
+        return getBoolean(LIMIT_STATS_LOGGING, false);
+    }
+
+    /**
+     * Sets flag to limit the stats logging.
+     *
+     * @param limitStatsLogging
+     *          flag to limit the stats logging.
+     * @return configuration.
+     */
+    public T setLimitStatsLogging(boolean limitStatsLogging) {
+        setProperty(LIMIT_STATS_LOGGING, limitStatsLogging);
+        return getThis();
+    }
+
     /**
      * Trickery to allow inheritance with fluent style.
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -171,8 +171,12 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
     @Override
     public PerChannelBookieClient create(BookieSocketAddress address, PerChannelBookieClientPool pcbcPool,
             SecurityHandlerFactory shFactory) throws SecurityException {
-        return new PerChannelBookieClient(conf, executor, eventLoopGroup, address, statsLogger,
-                                          authProviderFactory, registry, pcbcPool, shFactory);
+        StatsLogger statsLoggerForPCBC = statsLogger;
+        if (conf.getLimitStatsLogging()) {
+            statsLoggerForPCBC = NullStatsLogger.INSTANCE;
+        }
+        return new PerChannelBookieClient(conf, executor, eventLoopGroup, address, statsLoggerForPCBC,
+                authProviderFactory, registry, pcbcPool, shFactory);
     }
 
     public PerChannelBookieClientPool lookupClient(BookieSocketAddress addr) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -71,6 +71,7 @@ import org.apache.bookkeeper.replication.ReplicationException.BKAuditException;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.annotations.StatsDoc;
@@ -161,12 +162,16 @@ public class Auditor implements AutoCloseable {
     )
     private final Counter numDelayedBookieAuditsCancelled;
 
-    static BookKeeper createBookKeeperClient(ServerConfiguration conf)
+    static BookKeeper createBookKeeperClient(ServerConfiguration conf) throws InterruptedException, IOException {
+        return createBookKeeperClient(conf, NullStatsLogger.INSTANCE);
+    }
+
+    static BookKeeper createBookKeeperClient(ServerConfiguration conf, StatsLogger statsLogger)
             throws InterruptedException, IOException {
         ClientConfiguration clientConfiguration = new ClientConfiguration(conf);
         clientConfiguration.setClientRole(ClientConfiguration.CLIENT_ROLE_SYSTEM);
         try {
-            return BookKeeper.forConfig(clientConfiguration).build();
+            return BookKeeper.forConfig(clientConfiguration).statsLogger(statsLogger).build();
         } catch (BKException e) {
             throw new IOException("Failed to create bookkeeper client", e);
         }

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -538,6 +538,9 @@ groups:
         - Twitter Ostrich   : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider
         - Twitter Science   : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider
     default: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+  - param: limitStatsLogging
+    description: option to limit stats logging
+    default: 'false'
 
 - name: Prometheus Metrics Provider Settings
   params:


### PR DESCRIPTION

Descriptions of the changes in this PR:

- https://github.com/apache/bookkeeper/commit/2837f6257baf15dc9dd9eb4bcac34596b442be33
had inadvertently removed StatsLogger to BookKeeper client instance in ReplicationWorker process.
So restore StatsLogger in BookKeeper client object.
- Also introduce new config called - 'limitStatsLogging', which would be used to limit statslogging
as and when needed.
- currently this config is used to limit the stats from PCBC. Because if AR process is running in
each Bookie node, then for each AR there will be n number of PCBCs and totally it comes out to
n^2 PCBCs in the cluster. Which is unmanageable from stats collector perspective. So this config
value can be set to true in AR config.
