### PR TITLE
Multiple calls to LedgerHandle#close should wait on actual close

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -106,7 +106,7 @@ public class LedgerHandle implements WriteHandle {
     };
 
     private HandleState handleState = HandleState.OPEN;
-    private CompletableFuture<Void> closePromise = new CompletableFuture<>();
+    private final CompletableFuture<Void> closePromise = new CompletableFuture<>();
 
     /**
       * Last entryId which has been confirmed to be written durably to the bookies.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -106,6 +106,7 @@ public class LedgerHandle implements WriteHandle {
     };
 
     private HandleState handleState = HandleState.OPEN;
+    private CompletableFuture<Void> closePromise = new CompletableFuture<>();
 
     /**
       * Last entryId which has been confirmed to be written durably to the bookies.
@@ -508,6 +509,16 @@ public class LedgerHandle implements WriteHandle {
                 final long lastEntry;
                 final long finalLength;
 
+                closePromise.whenComplete((ignore, ex) -> {
+                        if (ex != null) {
+                            cb.closeComplete(
+                                    BKException.getExceptionCode(ex, BKException.Code.UnexpectedConditionException),
+                                    LedgerHandle.this, ctx);
+                        } else {
+                            cb.closeComplete(BKException.Code.OK, LedgerHandle.this, ctx);
+                        }
+                    });
+
                 synchronized (LedgerHandle.this) {
                     prevHandleState = handleState;
 
@@ -524,9 +535,7 @@ public class LedgerHandle implements WriteHandle {
                 // running under any bk locks.
                 errorOutPendingAdds(rc, pendingAdds);
 
-                if (prevHandleState == HandleState.CLOSED) {
-                    cb.closeComplete(BKException.Code.OK, LedgerHandle.this, ctx);
-                } else {
+                if (prevHandleState != HandleState.CLOSED) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Closing ledger: {} at entryId {} with {} bytes", getId(), lastEntry, finalLength);
                     }
@@ -564,12 +573,9 @@ public class LedgerHandle implements WriteHandle {
                             LedgerHandle.this::setLedgerMetadata)
                         .run().whenComplete((metadata, ex) -> {
                                 if (ex != null) {
-                                    cb.closeComplete(
-                                            BKException.getExceptionCode(
-                                                    ex, BKException.Code.UnexpectedConditionException),
-                                            LedgerHandle.this, ctx);
+                                    closePromise.completeExceptionally(ex);
                                 } else {
-                                    cb.closeComplete(BKException.Code.OK, LedgerHandle.this, ctx);
+                                    FutureUtils.complete(closePromise, null);
                                 }
                         });
                 }


### PR DESCRIPTION
The previous behaviour was to complete successfully immediately if
close had already been called on the handle. This allowed for
potential consistency violations, as the caller could believe that the
ledger was closed, when in fact the close operation was still in
progress and could still potentially fail.

Issue: #1712
