### PR TITLE
Revert maxLedgerMetadataFormatVersion changes in layout

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1164,7 +1164,7 @@ public class BookieShell implements Tool {
     void printLedgerMetadata(long ledgerId, LedgerMetadata md, boolean printMeta) {
         System.out.println("ledgerID: " + ledgerIdFormatter.formatLedgerId(ledgerId));
         if (printMeta) {
-            System.out.println(md.toString());
+            System.out.println(new String(new LedgerMetadataSerDe().serialize(md), UTF_8));
         }
     }
 
@@ -1173,10 +1173,7 @@ public class BookieShell implements Tool {
      */
     class LedgerMetadataCmd extends MyCommand {
         Options lOpts = new Options();
-        // the max version won't actually take effect as this tool
-        // never creates new metadata (there'll already be a format version in the existing metadata)
-        LedgerMetadataSerDe serDe = new LedgerMetadataSerDe(
-                LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+        LedgerMetadataSerDe serDe = new LedgerMetadataSerDe();
 
         LedgerMetadataCmd() {
             super(CMD_LEDGERMETADATA);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractHierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractHierarchicalLedgerManager.java
@@ -49,9 +49,8 @@ public abstract class AbstractHierarchicalLedgerManager extends AbstractZkLedger
      * @param zk
      *          ZooKeeper Client Handle
      */
-    public AbstractHierarchicalLedgerManager(AbstractConfiguration conf, ZooKeeper zk,
-                                             int maxLedgerMetadataFormatVersion) {
-        super(conf, zk, maxLedgerMetadataFormatVersion);
+    public AbstractHierarchicalLedgerManager(AbstractConfiguration conf, ZooKeeper zk) {
+        super(conf, zk);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -159,9 +159,8 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
      * @param zk
      *          ZooKeeper Client Handle
      */
-    protected AbstractZkLedgerManager(AbstractConfiguration conf, ZooKeeper zk,
-                                      int maxLedgerMetadataFormatVersion) {
-        this.serDe = new LedgerMetadataSerDe(maxLedgerMetadataFormatVersion);
+    protected AbstractZkLedgerManager(AbstractConfiguration conf, ZooKeeper zk) {
+        this.serDe = new LedgerMetadataSerDe();
         this.conf = conf;
         this.zk = zk;
         this.ledgerRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
@@ -160,8 +160,8 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
 
         // if layoutManager is null, return the default ledger manager
         if (layoutManager == null) {
-            return new FlatLedgerManagerFactory().initialize(conf, null,
-                    FlatLedgerManagerFactory.CUR_VERSION, LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+            return new FlatLedgerManagerFactory()
+                   .initialize(conf, null, FlatLedgerManagerFactory.CUR_VERSION);
         }
 
         LedgerManagerFactory lmFactory;
@@ -172,9 +172,8 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
 
         if (layout == null) { // no existing layout
             lmFactory = createNewLMFactory(conf, layoutManager, factoryClass);
-            return lmFactory.initialize(conf, layoutManager,
-                                        lmFactory.getCurrentVersion(),
-                                        LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+            return lmFactory
+                    .initialize(conf, layoutManager, lmFactory.getCurrentVersion());
         }
         if (log.isDebugEnabled()) {
             log.debug("read ledger layout {}", layout);
@@ -198,8 +197,7 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
             } else {
                 throw new IOException("Unknown ledger manager type: " + lmType);
             }
-            return lmFactory.initialize(conf, layoutManager, layout.getManagerVersion(),
-                                        layout.getMaxLedgerMetadataFormatVersion());
+            return lmFactory.initialize(conf, layoutManager, layout.getManagerVersion());
         }
 
         // handle V2 layout case
@@ -229,8 +227,7 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
         }
         // instantiate a factory
         lmFactory = ReflectionUtils.newInstance(factoryClass);
-        return lmFactory.initialize(conf, layoutManager, layout.getManagerVersion(),
-                                    layout.getMaxLedgerMetadataFormatVersion());
+        return lmFactory.initialize(conf, layoutManager, layout.getManagerVersion());
     }
 
     private static String normalizedLedgerManagerFactoryClassName(String factoryClass,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManager.java
@@ -55,9 +55,8 @@ class FlatLedgerManager extends AbstractZkLedgerManager {
      *          ZooKeeper Client Handle
      * @throws IOException when version is not compatible
      */
-    public FlatLedgerManager(AbstractConfiguration conf, ZooKeeper zk,
-                             int maxLedgerMetadataFormatVersion) {
-        super(conf, zk, maxLedgerMetadataFormatVersion);
+    public FlatLedgerManager(AbstractConfiguration conf, ZooKeeper zk) {
+        super(conf, zk);
 
         ledgerPrefix = ledgerRootPath + "/" + StringUtils.LEDGER_NODE_PREFIX;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManagerFactory.java
@@ -41,7 +41,6 @@ public class FlatLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
     public static final int CUR_VERSION = 1;
 
     AbstractConfiguration conf;
-    private int maxLedgerMetadataFormatVersion;
 
     @Override
     public int getCurrentVersion() {
@@ -51,8 +50,7 @@ public class FlatLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
     @Override
     public LedgerManagerFactory initialize(final AbstractConfiguration conf,
                                            final LayoutManager layoutManager,
-                                           final int factoryVersion,
-                                           int maxLedgerMetadataFormatVersion)
+                                           final int factoryVersion)
     throws IOException {
         checkArgument(layoutManager == null || layoutManager instanceof ZkLayoutManager);
 
@@ -63,7 +61,6 @@ public class FlatLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
         this.conf = conf;
 
         this.zk = layoutManager == null ? null : ((ZkLayoutManager) layoutManager).getZk();
-        this.maxLedgerMetadataFormatVersion = maxLedgerMetadataFormatVersion;
         return this;
     }
 
@@ -82,7 +79,7 @@ public class FlatLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
 
     @Override
     public LedgerManager newLedgerManager() {
-        return new FlatLedgerManager(conf, zk, maxLedgerMetadataFormatVersion);
+        return new FlatLedgerManager(conf, zk);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManager.java
@@ -46,11 +46,10 @@ class HierarchicalLedgerManager extends AbstractHierarchicalLedgerManager {
     LegacyHierarchicalLedgerManager legacyLM;
     LongHierarchicalLedgerManager longLM;
 
-    public HierarchicalLedgerManager(AbstractConfiguration conf, ZooKeeper zk,
-                                     int maxLedgerMetadataFormatVersion) {
-        super(conf, zk, maxLedgerMetadataFormatVersion);
-        legacyLM = new LegacyHierarchicalLedgerManager(conf, zk, maxLedgerMetadataFormatVersion);
-        longLM = new LongHierarchicalLedgerManager (conf, zk, maxLedgerMetadataFormatVersion);
+    public HierarchicalLedgerManager(AbstractConfiguration conf, ZooKeeper zk) {
+        super(conf, zk);
+        legacyLM = new LegacyHierarchicalLedgerManager(conf, zk);
+        longLM = new LongHierarchicalLedgerManager (conf, zk);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManagerFactory.java
@@ -42,6 +42,6 @@ public class HierarchicalLedgerManagerFactory extends LegacyHierarchicalLedgerMa
 
     @Override
     public LedgerManager newLedgerManager() {
-        return new HierarchicalLedgerManager(conf, zk, maxLedgerMetadataFormatVersion);
+        return new HierarchicalLedgerManager(conf, zk);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
@@ -43,15 +43,12 @@ public interface LedgerManagerFactory extends AutoCloseable {
      *          Layout manager used for initialize ledger manager factory
      * @param factoryVersion
      *          What version used to initialize factory.
-     * @param maxLedgerMetadataFormatVersion
-     *          Maximum format version for ledger metadata.
      * @return ledger manager factory instance
      * @throws IOException when fail to initialize the factory.
      */
     LedgerManagerFactory initialize(AbstractConfiguration conf,
                                     LayoutManager layoutManager,
-                                    int factoryVersion,
-                                    int maxLedgerMetadataFormatVersion)
+                                    int factoryVersion)
         throws IOException;
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerMetadataSerDe.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerMetadataSerDe.java
@@ -63,12 +63,6 @@ public class LedgerMetadataSerDe {
     private static final String V1_CLOSED_TAG = "CLOSED";
     private static final int V1_IN_RECOVERY_ENTRY_ID = -102;
 
-    private final int maxLedgerMetadataFormatVersion;
-
-    public LedgerMetadataSerDe(int maxLedgerMetadataFormatVersion) {
-        this.maxLedgerMetadataFormatVersion = maxLedgerMetadataFormatVersion;
-    }
-
     public byte[] serialize(LedgerMetadata metadata) {
         if (metadata.getMetadataFormatVersion() == 1) {
             return serializeVersion1(metadata);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManager.java
@@ -69,9 +69,8 @@ class LegacyHierarchicalLedgerManager extends AbstractHierarchicalLedgerManager 
      * @param zk
      *          ZooKeeper Client Handle
      */
-    public LegacyHierarchicalLedgerManager(AbstractConfiguration conf, ZooKeeper zk,
-                                           int maxLedgerMetadataFormatVersion) {
-        super(conf, zk, maxLedgerMetadataFormatVersion);
+    public LegacyHierarchicalLedgerManager(AbstractConfiguration conf, ZooKeeper zk) {
+        super(conf, zk);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManagerFactory.java
@@ -38,7 +38,6 @@ public class LegacyHierarchicalLedgerManagerFactory extends AbstractZkLedgerMana
     public static final int CUR_VERSION = 1;
 
     AbstractConfiguration conf;
-    int maxLedgerMetadataFormatVersion;
 
     @Override
     public int getCurrentVersion() {
@@ -48,8 +47,7 @@ public class LegacyHierarchicalLedgerManagerFactory extends AbstractZkLedgerMana
     @Override
     public LedgerManagerFactory initialize(final AbstractConfiguration conf,
                                            final LayoutManager lm,
-                                           final int factoryVersion,
-                                           int maxLedgerMetadataFormatVersion)
+                                           final int factoryVersion)
             throws IOException {
         checkArgument(lm instanceof ZkLayoutManager);
 
@@ -60,7 +58,6 @@ public class LegacyHierarchicalLedgerManagerFactory extends AbstractZkLedgerMana
                                 + factoryVersion);
         }
         this.conf = conf;
-        this.maxLedgerMetadataFormatVersion = maxLedgerMetadataFormatVersion;
         this.zk = zkLayoutManager.getZk();
         return this;
     }
@@ -83,7 +80,7 @@ public class LegacyHierarchicalLedgerManagerFactory extends AbstractZkLedgerMana
 
     @Override
     public LedgerManager newLedgerManager() {
-        return new LegacyHierarchicalLedgerManager(conf, zk, maxLedgerMetadataFormatVersion);
+        return new LegacyHierarchicalLedgerManager(conf, zk);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManager.java
@@ -70,9 +70,8 @@ class LongHierarchicalLedgerManager extends AbstractHierarchicalLedgerManager {
      * @param zk
      *            ZooKeeper Client Handle
      */
-    public LongHierarchicalLedgerManager(AbstractConfiguration conf, ZooKeeper zk,
-                                         int maxLedgerMetadataFormatVersion) {
-        super(conf, zk, maxLedgerMetadataFormatVersion);
+    public LongHierarchicalLedgerManager(AbstractConfiguration conf, ZooKeeper zk) {
+        super(conf, zk);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManagerFactory.java
@@ -26,7 +26,7 @@ public class LongHierarchicalLedgerManagerFactory extends HierarchicalLedgerMana
 
     @Override
     public LedgerManager newLedgerManager() {
-        return new LongHierarchicalLedgerManager(conf, zk, maxLedgerMetadataFormatVersion);
+        return new LongHierarchicalLedgerManager(conf, zk);
     }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
@@ -96,7 +96,6 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
     public static final String META_FIELD = ".META";
 
     AbstractConfiguration conf;
-    private int maxLedgerMetadataFormatVersion;
     MetaStore metastore;
 
     @Override
@@ -107,8 +106,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
     @Override
     public LedgerManagerFactory initialize(final AbstractConfiguration conf,
                                            final LayoutManager layoutManager,
-                                           final int factoryVersion,
-                                           int maxLedgerMetadataFormatVersion) throws IOException {
+                                           final int factoryVersion) throws IOException {
         checkArgument(layoutManager instanceof ZkLayoutManager);
         ZkLayoutManager zkLayoutManager = (ZkLayoutManager) layoutManager;
 
@@ -117,7 +115,6 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
         }
         this.conf = conf;
         this.zk = zkLayoutManager.getZk();
-        this.maxLedgerMetadataFormatVersion = maxLedgerMetadataFormatVersion;
 
         // load metadata store
         String msName = conf.getMetastoreImplClass();
@@ -283,12 +280,11 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
             }
         }
 
-        MsLedgerManager(final AbstractConfiguration conf, final ZooKeeper zk, final MetaStore metastore,
-                        int maxLedgerMetadataFormatVersion) {
+        MsLedgerManager(final AbstractConfiguration conf, final ZooKeeper zk, final MetaStore metastore) {
             this.conf = conf;
             this.zk = zk;
             this.metastore = metastore;
-            this.serDe = new LedgerMetadataSerDe(maxLedgerMetadataFormatVersion);
+            this.serDe = new LedgerMetadataSerDe();
 
             try {
                 ledgerTable = metastore.createScannableTable(TABLE_NAME);
@@ -655,7 +651,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
 
     @Override
     public LedgerManager newLedgerManager() {
-        return new MsLedgerManager(conf, zk, metastore, maxLedgerMetadataFormatVersion);
+        return new MsLedgerManager(conf, zk, metastore);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLedgerMetaService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLedgerMetaService.java
@@ -53,7 +53,7 @@ public class GetLedgerMetaService implements HttpEndpointService {
         checkNotNull(conf);
         this.conf = conf;
         this.bookieServer = bookieServer;
-        this.serDe = new LedgerMetadataSerDe(LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+        this.serDe = new LedgerMetadataSerDe();
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListLedgerService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListLedgerService.java
@@ -58,7 +58,7 @@ public class ListLedgerService implements HttpEndpointService {
         checkNotNull(conf);
         this.conf = conf;
         this.bookieServer = bookieServer;
-        this.serDe = new LedgerMetadataSerDe(LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+        this.serDe = new LedgerMetadataSerDe();
 
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerMetadataTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerMetadataTest.java
@@ -80,8 +80,7 @@ public class LedgerMetadataTest {
             .withCreationTime(System.currentTimeMillis())
             .storingCreationTime(true)
             .build();
-        LedgerMetadataFormat format = new LedgerMetadataSerDe(LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION)
-            .buildProtoFormat(lm);
+        LedgerMetadataFormat format = new LedgerMetadataSerDe().buildProtoFormat(lm);
         assertTrue(format.hasCtime());
     }
 
@@ -95,8 +94,7 @@ public class LedgerMetadataTest {
         LedgerMetadata lm = LedgerMetadataBuilder.create()
             .newEnsembleEntry(0L, ensemble).build();
 
-        LedgerMetadataFormat format = new LedgerMetadataSerDe(LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION)
-            .buildProtoFormat(lm);
+        LedgerMetadataFormat format = new LedgerMetadataSerDe().buildProtoFormat(lm);
         assertFalse(format.hasCtime());
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
@@ -50,7 +50,6 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
-import org.apache.bookkeeper.meta.LedgerMetadataSerDe;
 import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.meta.exceptions.Code;
 import org.apache.bookkeeper.meta.exceptions.MetadataException;
@@ -185,8 +184,7 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
             if (null == lmFactory) {
                 try {
                     lmFactory = new TestLedgerManagerFactory()
-                        .initialize(conf, layoutManager, TestLedgerManagerFactory.CUR_VERSION,
-                                    LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+                        .initialize(conf, layoutManager, TestLedgerManagerFactory.CUR_VERSION);
                 } catch (IOException e) {
                     throw new MetadataException(Code.METADATA_SERVICE_ERROR, e);
                 }
@@ -202,8 +200,7 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
             if (null == lmFactory) {
                 try {
                     lmFactory = new TestLedgerManagerFactory()
-                        .initialize(conf, layoutManager, TestLedgerManagerFactory.CUR_VERSION,
-                                    LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+                        .initialize(conf, layoutManager, TestLedgerManagerFactory.CUR_VERSION);
                 } catch (IOException e) {
                     throw new MetadataException(Code.METADATA_SERVICE_ERROR, e);
                 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
@@ -110,9 +110,9 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         this.conf = new ClientConfiguration();
         this.ledgerManager = mock(
-                AbstractZkLedgerManager.class,
-                withSettings()
-                .useConstructor(conf, mockZk, LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION)
+            AbstractZkLedgerManager.class,
+            withSettings()
+                .useConstructor(conf, mockZk)
                 .defaultAnswer(CALLS_REAL_METHODS));
         List<BookieSocketAddress> ensemble = Lists.newArrayList(
                 new BookieSocketAddress("192.0.2.1", 3181),
@@ -142,7 +142,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
         assertSame(conf, ledgerManager.conf);
         assertSame(scheduler, ledgerManager.scheduler);
 
-        this.serDe = new LedgerMetadataSerDe(LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+        this.serDe = new LedgerMetadataSerDe();
     }
 
     @After
@@ -303,15 +303,13 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
     @Test
     public void testRemoveLedgerMetadataHierarchical() throws Exception {
-        HierarchicalLedgerManager hlm = new HierarchicalLedgerManager(conf, mockZk,
-                LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+        HierarchicalLedgerManager hlm = new HierarchicalLedgerManager(conf, mockZk);
         testRemoveLedgerMetadataHierarchicalLedgerManager(hlm);
     }
 
     @Test
     public void testRemoveLedgerMetadataLongHierarchical() throws Exception {
-        LongHierarchicalLedgerManager hlm = new LongHierarchicalLedgerManager(conf, mockZk,
-                LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+        LongHierarchicalLedgerManager hlm = new LongHierarchicalLedgerManager(conf, mockZk);
         testRemoveLedgerMetadataHierarchicalLedgerManager(hlm);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/MockLedgerManager.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/MockLedgerManager.java
@@ -72,7 +72,7 @@ public class MockLedgerManager implements LedgerManager {
         this.metadataMap = metadataMap;
         this.executor = executor;
         this.ownsExecutor = ownsExecutor;
-        this.serDe = new LedgerMetadataSerDe(LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+        this.serDe = new LedgerMetadataSerDe();
     }
 
     public MockLedgerManager newClient() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerLayout.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerLayout.java
@@ -18,12 +18,8 @@
  */
 package org.apache.bookkeeper.meta;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
 
 import org.junit.Test;
 
@@ -67,43 +63,4 @@ public class TestLedgerLayout {
             hierarchical1.getLayoutFormatVersion());
     }
 
-    @Test
-    public void testParseNoMaxLedgerMetadataFormatVersion() throws Exception {
-        LedgerLayout layout = LedgerLayout.parseLayout("1\nblahblahLM:3".getBytes(UTF_8));
-
-        assertEquals(layout.getMaxLedgerMetadataFormatVersion(), 2);
-    }
-
-    @Test
-    public void testParseWithMaxLedgerMetadataFormatVersion() throws Exception {
-        LedgerLayout layout = LedgerLayout.parseLayout(
-                "1\nblahblahLM:3\nMAX_LEDGER_METADATA_FORMAT_VERSION:123".getBytes(UTF_8));
-
-        assertEquals(layout.getMaxLedgerMetadataFormatVersion(), 123);
-    }
-
-    @Test
-    public void testCorruptMaxLedgerLayout() throws Exception {
-        try {
-            LedgerLayout.parseLayout("1\nblahblahLM:3\nMAXXX_LEDGER_METADATA_FORMAT_VERSION:123".getBytes(UTF_8));
-            fail("Shouldn't have been able to parse");
-        } catch (IOException ioe) {
-            // expected
-        }
-
-        try {
-            LedgerLayout.parseLayout("1\nblahblahLM:3\nMAXXX_LEDGER_METADATA_FORMAT_VERSION:blah".getBytes(UTF_8));
-            fail("Shouldn't have been able to parse");
-        } catch (IOException ioe) {
-            // expected
-        }
-    }
-
-    @Test
-    public void testMoreFieldsAdded() throws Exception {
-        LedgerLayout layout = LedgerLayout.parseLayout(
-                "1\nblahblahLM:3\nMAX_LEDGER_METADATA_FORMAT_VERSION:123\nFOO:BAR".getBytes(UTF_8));
-
-        assertEquals(layout.getMaxLedgerMetadataFormatVersion(), 123);
-    }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -387,8 +387,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         assertEquals(1, respBody.size());
         // verify LedgerMetadata content is equal
         assertTrue(respBody.get(ledgerId.toString()).toString()
-                .equals(new String(new LedgerMetadataSerDe(LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION)
-                                   .serialize(lh[0].getLedgerMetadata()))));
+                .equals(new String(new LedgerMetadataSerDe().serialize(lh[0].getLedgerMetadata()))));
     }
 
     @Test

--- a/metadata-drivers/etcd/src/main/java/org/apache/bookkeeper/metadata/etcd/EtcdLedgerManagerFactory.java
+++ b/metadata-drivers/etcd/src/main/java/org/apache/bookkeeper/metadata/etcd/EtcdLedgerManagerFactory.java
@@ -42,7 +42,6 @@ class EtcdLedgerManagerFactory implements LedgerManagerFactory {
 
     private String scope;
     private Client client;
-    private int maxLedgerMetadataFormatVersion;
 
     @Override
     public int getCurrentVersion() {
@@ -52,8 +51,7 @@ class EtcdLedgerManagerFactory implements LedgerManagerFactory {
     @Override
     public LedgerManagerFactory initialize(AbstractConfiguration conf,
                                            LayoutManager layoutManager,
-                                           int factoryVersion,
-                                           int maxLedgerMetadataFormatVersion) throws IOException {
+                                           int factoryVersion) throws IOException {
         checkArgument(layoutManager instanceof EtcdLayoutManager);
 
         EtcdLayoutManager etcdLayoutManager = (EtcdLayoutManager) layoutManager;
@@ -68,7 +66,6 @@ class EtcdLedgerManagerFactory implements LedgerManagerFactory {
             throw new IOException("Invalid metadata service uri", e);
         }
         this.client = etcdLayoutManager.getClient();
-        this.maxLedgerMetadataFormatVersion = maxLedgerMetadataFormatVersion;
         return this;
     }
 
@@ -85,7 +82,7 @@ class EtcdLedgerManagerFactory implements LedgerManagerFactory {
 
     @Override
     public LedgerManager newLedgerManager() {
-        return new EtcdLedgerManager(client, scope, maxLedgerMetadataFormatVersion);
+        return new EtcdLedgerManager(client, scope);
     }
 
     @Override

--- a/metadata-drivers/etcd/src/main/java/org/apache/bookkeeper/metadata/etcd/EtcdMetadataDriverBase.java
+++ b/metadata-drivers/etcd/src/main/java/org/apache/bookkeeper/metadata/etcd/EtcdMetadataDriverBase.java
@@ -27,7 +27,6 @@ import org.apache.bookkeeper.common.net.ServiceURI;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
 import org.apache.bookkeeper.meta.LayoutManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
-import org.apache.bookkeeper.meta.LedgerMetadataSerDe;
 import org.apache.bookkeeper.meta.exceptions.Code;
 import org.apache.bookkeeper.meta.exceptions.MetadataException;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -107,8 +106,7 @@ class EtcdMetadataDriverBase implements AutoCloseable {
         if (null == lmFactory) {
             try {
                 lmFactory = new EtcdLedgerManagerFactory();
-                lmFactory.initialize(conf, layoutManager, EtcdLedgerManagerFactory.VERSION,
-                                     LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+                lmFactory.initialize(conf, layoutManager, EtcdLedgerManagerFactory.VERSION);
             } catch (IOException ioe) {
                 throw new MetadataException(
                     Code.METADATA_SERVICE_ERROR, "Failed to initialize ledger manager factory", ioe);

--- a/metadata-drivers/etcd/src/test/java/org/apache/bookkeeper/metadata/etcd/EtcdLedgerManagerTest.java
+++ b/metadata-drivers/etcd/src/test/java/org/apache/bookkeeper/metadata/etcd/EtcdLedgerManagerTest.java
@@ -55,7 +55,6 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRange;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
-import org.apache.bookkeeper.meta.LedgerMetadataSerDe;
 import org.apache.bookkeeper.metadata.etcd.helpers.ValueStream;
 import org.apache.bookkeeper.metadata.etcd.testing.EtcdTestBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -82,8 +81,7 @@ public class EtcdLedgerManagerTest extends EtcdTestBase {
     public void setUp() throws Exception {
         super.setUp();
         this.scope = RandomStringUtils.randomAlphabetic(8);
-        this.lm = new EtcdLedgerManager(etcdClient, scope,
-                                        LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION);
+        this.lm = new EtcdLedgerManager(etcdClient, scope);
     }
 
     @Override

--- a/tests/shaded/distributedlog-core-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/DistributedLogCoreShadedJarTest.java
+++ b/tests/shaded/distributedlog-core-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/DistributedLogCoreShadedJarTest.java
@@ -179,7 +179,7 @@ public class DistributedLogCoreShadedJarTest {
         when(manager.readLedgerLayout()).thenReturn(layout);
 
         LedgerManagerFactory factory = mock(LedgerManagerFactory.class);
-        when(factory.initialize(any(AbstractConfiguration.class), same(manager), anyInt(), anyInt()))
+        when(factory.initialize(any(AbstractConfiguration.class), same(manager), anyInt()))
             .thenReturn(factory);
         PowerMockito.mockStatic(ReflectionUtils.class);
         when(ReflectionUtils.newInstance(any(Class.class)))
@@ -191,7 +191,7 @@ public class DistributedLogCoreShadedJarTest {
             if (allowShaded) {
                 assertSame(factory, result);
                 verify(factory, times(1))
-                    .initialize(any(AbstractConfiguration.class), same(manager), anyInt(), anyInt());
+                    .initialize(any(AbstractConfiguration.class), same(manager), anyInt());
             } else {
                 fail("Should fail to instantiate ledger manager factory if allowShaded is false");
             }


### PR DESCRIPTION
There is ongoing discussions about how to do this, so I'm reverting this
change for now to allow 4.9 release to proceed. The change modifies the
contents of the layout znode, so once they're in an official release they
cannot be removed without breaking BC.

The reverted changes are:

dd684b Ledger manager factories initialized with max metadata version
dce4fd Add max ledger metadata format version to layout

Master issue: #723
