### PR TITLE
BP-38: Bypass journal ledger

### DIFF
--- a/site/bps/BP-38-bypass-journal-ledger.md
+++ b/site/bps/BP-38-bypass-journal-ledger.md
@@ -8,8 +8,7 @@ release: "N/A"
 ### Motivation
 
 To guarantee high durability, BK write journal before flush data to persistent device which will cause two write of data.
-At the presence of replicating and auto-recovery mechanism, the two-write is a bit waste of the persistent device bandwidth,
-especially on the [scenarios](https://cwiki.apache.org/confluence/display/BOOKKEEPER/BP-14+Relax+durability) which prefer weak durability guarantee.
+But we may not need this level of persistence under [scenarios](https://cwiki.apache.org/confluence/display/BOOKKEEPER/BP-14+Relax+durability) which prefer weak durability guarantee.
 This proposal is aimed at providing bypass journal ledger, this feature includes these parts work:
  - add new write flag `BYPASS_JOURNAL` to existing protocol
  - impl the newly write flag at the client side and server side

--- a/site/bps/BP-bypass-journal-ledger.md
+++ b/site/bps/BP-bypass-journal-ledger.md
@@ -1,0 +1,97 @@
+---
+title: "BP-38: bypass journal ledger"
+issue: https://github.com/apache/bookkeeper/issues/1918
+state: "Under Discussion"
+release: "N/A"
+---
+
+### Motivation
+
+To guarantee high durability, BK write journal before flush data to persistent device which will cause two write of data.
+At the presence of replicating and auto-recovery mechanism, the two-write is a bit waste of the persistent device bandwidth,
+especially on the [scenarios](https://cwiki.apache.org/confluence/display/BOOKKEEPER/BP-14+Relax+durability) which prefer weak durability guarantee.
+This proposal is aimed at providing bypass journal ledger, this feature includes these parts work:
+ - add new write flag `BYPASS_JOURNAL` to existing protocol
+ - impl the newly write flag at the client side and server side
+ 
+The details of changes are listed in Section “[Proposed Changes](#proposed-changes)”.
+ 
+### Public Interfaces
+
+This feature will introduce new 'WRITE_FLAG' to enable single write storage impl.
+Like `DEFERRED_SYNC`, when we construct `WriteHandle`, we can pass `BYPASS_JOURNAL`, then every `AddRequest` will carry this flag.
+As for monitoring, we can add metrics to record the main time interval during the io path.
+The detailed compatibility related stuff is in Section “[CDMP](#compatibility-deprecation-and-migration-plan)”.
+
+### Proposed Changes
+
+While the main approach is based on [`WRITE_FLAG` impl](https://github.com/apache/bookkeeper/pull/742),
+the actual implementation is more tricky. In my opinion, there are three different solution:
+
+1. Relax LAC protocol
+
+    Just modify server side code, if the write flag is `BYPASS_JOURNAL`, after write to `LegerStorage`(the data maybe in the memTable, or the buffer of File, or the os cache),
+return to the client directly.
+This impl is like [disable syncData](https://github.com/apache/bookkeeper/issues/753), once all the replica fails, the BK cluster can't recovery from it.
+Note, the user shall know the weak durability for his use case when using this impl.
+
+2. Extend `Force` API
+
+    Like `DEFERRED_SYNC`, the normal 'bypass-journal' operation don't advance LAC on the client.
+Only advance LAC using `force` api. To support this new 'bypass-journal' option, we need theses changes:
+
+    - Add persistent callback to LedgerStorage
+    
+        Maintain non-persistent entry list and `maxPersistentEntryId` on `LedgerDescriptor`
+If the entry is 'bypass-journal', the callback for this entry is not null, and it will receives notification after persistent.
+    
+    - Extend the force request
+        
+        If the force request contains bypass journal option, get `maxPersistentEntryId` from `LedgerDescriptor`
+ or impl force method on `LedgerDescriptor`, which force the entry to persistent device through `LedgerStorage`.
+
+    In addition to these changes, we should consider who is responsible for the `force` execution? How often to schedule 'force'?
+
+3. Add NonPersistentLAC semantic to existing LAC protocol
+
+    To not violate LAC semantics like method 1, we can add `NonPersistentLAC` semantic, this includes these changes:
+
+    - Add persistent callback to LedgerStorage
+
+        Maintain non-persistent entry list and `maxPersistentEntryId` on `LedgerDescriptor`.
+        
+    - Wire protocol changes
+    
+        Add optional `maxPersistentEntryId` field to `AddResponse`. When the `AddRequest` has 'bypass-journal' option, the server get `maxPersistentEntryId` from `LedgerDescriptor`.
+
+    - Client side changes
+    
+        Add `nonPersistentLAC` to WriteHandle. WriteHandle with 'bypass-journal' option updates the LAC using `maxPersistentEntryId`, and update `nonPersistentLAC` if receives enough ack.
+        For normal WriteHandle, the `nonPersistentLAC` is set to null to keep original LAC advance logic. 
+
+### Compatibility, Deprecation, and Migration Plan
+
+As this new feature only add one ledger creating option and corresponding ledger implementation. It has no effect
+on existing users. After this feature is implemented, user can use this function directly on new released version which includes this implementation.
+When user use the latest client which has the `BYPASS_JOURNAL` write flag, but the bookie is old versions which can't do bypass-journal process,
+ the bookie will reject this type write. Old client has no chance to use this new write flag, and the new bookie can handle as usual.
+
+### Test Plan
+
+- unit tests for newly introduced write_flag at client side and server side
+- end-to-end tests for the new Protocol request/response
+- compat tests (client with this new writeflags will not be able to write on old bookies)
+
+### Rejected Alternatives
+
+To avoid two write of data, we can write the data to one log abstraction in the bookie, either by bypassing journal or 
+ bypassing entryLog. If we choose bypassing entryLog, then we will do lots of work to enable rich read on journal,
+ which is more huge work compared with bypassing journal.
+ 
+### sub-task/ small basic component task
+
+- [ ] server side changes (bypass-journal)
+- [ ] client side implementation (writeflag BYPASS_JOURNAL implementation on the client side)
+- [ ] compat tests (client with writeflags will not be able to write on old bookies)
+- [ ] docs update
+

--- a/site/community/bookkeeper_proposals.md
+++ b/site/community/bookkeeper_proposals.md
@@ -85,7 +85,7 @@ using Google Doc.
 
 This section lists all the _bookkeeper proposals_ made to BookKeeper.
 
-*Next Proposal Number: 38*
+*Next Proposal Number: 39*
 
 ### Inprogress
 
@@ -109,6 +109,7 @@ Proposal | State
 [BP-35: 128 bits support](../../bps/BP-35-128-bits-support) | Accepted
 [BP-36: Stats documentation annotation](../../bps/BP-36-stats-documentation-annotation) | Accepted
 [BP-37: Improve configuration management for better documentation](../../bps/BP-37-conf-documentation) | Accepted
+[BP-38: Bypass journal ledger](../../bps/BP-38-bypass-journal-ledger) | Draft
 
 ### Adopted
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

To guarantee high durability, BK write journal before flush data to persistent device which will cause two write of data.
At the presence of replicating and auto-recovery mechanism, the two-write is a bit waste of the persistent device bandwidth,
especially on the [scenarios](https://cwiki.apache.org/confluence/display/BOOKKEEPER/BP-14+Relax+durability) which prefer weak durability guarantee.
This proposal is aimed at providing bypass journal ledger, this feature includes these parts work:
 - add new write flag `BYPASS_JOURNAL` to existing protocol
 - impl the newly write flag at the client side and server side

### Changes

(Describe: what changes you have made)

Master Issue: #1945

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java11]: skip build on java11. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
