### PR TITLE
[bookie-http-server] Fix: broken vertx rest endpoints

### DIFF
--- a/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxHttpServer.java
+++ b/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxHttpServer.java
@@ -70,6 +70,9 @@ public class VertxHttpServer implements HttpServer {
             @Override
             public void bindHandler(String endpoint, VertxAbstractHandler handler) {
                 router.get(endpoint).handler(handler);
+                router.put(endpoint).handler(handler);
+                router.post(endpoint).handler(handler);
+                router.delete(endpoint).handler(handler);
             }
         };
         requestRouter.bindAll();


### PR DESCRIPTION
### Motivation
Right now, vertx-http-server is not serving any rest endpoint except get because vertx server doesn't add put/post/delete http-methods into routing rules.

### Modification
Add put/post/delete http-methods into routing rules.