### PR TITLE
Use conf value in RackawareEnsemblePlacementPolicyImpl.initialize method

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -386,7 +386,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                     ((RackChangeNotifier) dnsResolver).registerRackChangeListener(this);
                 }
             } catch (RuntimeException re) {
-                if (!enforceMinNumRacksPerWriteQuorum) {
+                if (!conf.getEnforceMinNumRacksPerWriteQuorum()) {
                     LOG.info("Failed to initialize DNS Resolver {}, used default subnet resolver : {}", dnsResolverName,
                             re, re.getMessage());
                     dnsResolver = new DefaultResolver(() -> this.getDefaultRack());


### PR DESCRIPTION


Descriptions of the changes in this PR:

- Use conf value in RackawareEnsemblePlacementPolicyImpl.initialize method,
instead of uninitialized enforceMinNumRacksPerWriteQuorum variable