### PR TITLE
Add validateConf to AbstractDNSToSwitchMapping

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -387,8 +387,8 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                 }
             } catch (RuntimeException re) {
                 if (!conf.getEnforceMinNumRacksPerWriteQuorum()) {
-                    LOG.info("Failed to initialize DNS Resolver {}, used default subnet resolver : {}", dnsResolverName,
-                            re, re.getMessage());
+                    LOG.error("Failed to initialize DNS Resolver {}, used default subnet resolver : {}",
+                            dnsResolverName, re, re.getMessage());
                     dnsResolver = new DefaultResolver(() -> this.getDefaultRack());
                 } else {
                     /*

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
@@ -65,6 +65,7 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
 
     public void setConf(Configuration conf) {
         this.conf = conf;
+        validateConf();
     }
 
     /**
@@ -138,4 +139,10 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
                 && ((AbstractDNSToSwitchMapping) mapping).isSingleSwitch();
     }
 
+    /**
+     * when setConf is called it should do sanity checking of the conf/env. and
+     * throw RuntimeException if things are not valid.
+     */
+    protected void validateConf() {
+    }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

- when setConf of AbstractDNSToSwitchMapping  is called it
should do sanity checking of the conf/env. and throw
RuntimeException if things are not valid.
- For RawScriptBasedMapping.validateConf, try executing
the script with no arguments for sanity check purpose.
Here it is expected that running script with no arguments
would do sanity check of the script and the env.

(there are 2 commits in this PR, but this PR is meant for the second commit and there is other PR for the first commit)