### PR TITLE
Issue #1977: Migrate command 'bookieinit'

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -109,8 +109,8 @@ import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.stats.NullStatsLogger;
-import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.FormatCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookies.InfoCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookies.ListBookiesCommand;
@@ -2154,7 +2154,6 @@ public class BookieShell implements Tool {
             return retValue;
         }
 
-        @SuppressWarnings("unchecked")
         private int updateBookieIdInCookie(final String bookieId, final boolean useHostname)
                 throws Exception {
             return runFunctionWithRegistrationManager(bkConf, rm -> {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -112,6 +112,7 @@ import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookies.ListBookiesCommand;
 import org.apache.bookkeeper.tools.cli.commands.client.SimpleTestCommand;
@@ -508,7 +509,8 @@ public class BookieShell implements Tool {
         @Override
         int runCmd(CommandLine cmdLine) throws Exception {
             ServerConfiguration conf = new ServerConfiguration(bkConf);
-            boolean result = BookKeeperAdmin.initBookie(conf);
+            InitCommand initCommand = new InitCommand();
+            boolean result = initCommand.apply(conf, new CliFlags());
             return (result) ? 0 : 1;
         }
     }
@@ -2162,6 +2164,7 @@ public class BookieShell implements Tool {
             return retValue;
         }
 
+        @SuppressWarnings("unchecked")
         private int updateBookieIdInCookie(final String bookieId, final boolean useHostname)
                 throws Exception {
             return runFunctionWithRegistrationManager(bkConf, rm -> {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/InitCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/InitCommand.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.bookkeeper.tools.cli.commands.bookie;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/InitCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/InitCommand.java
@@ -1,0 +1,37 @@
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
+import org.apache.bookkeeper.tools.framework.CliFlags;
+import org.apache.bookkeeper.tools.framework.CliSpec;
+
+/**
+ * A command to initialize new bookie.
+ */
+public class InitCommand extends BookieCommand<CliFlags> {
+
+    private static final String NAME = "init";
+    private static final String DESC = "Initialize new bookie.";
+
+    public InitCommand() {
+        super(CliSpec.newBuilder()
+                .withName(NAME)
+                .withDescription(DESC)
+                .withFlags(new CliFlags())
+                .build());
+    }
+
+    @Override
+    public boolean apply(ServerConfiguration conf, CliFlags cmdFlags) {
+
+        boolean result = false;
+        try {
+            result = BookKeeperAdmin.initBookie(conf);
+        } catch (Exception e) {
+            throw new UncheckedExecutionException(e.getMessage(), e);
+        }
+        return result;
+    }
+}

--- a/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
+++ b/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.tools.cli.commands;
 import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_INFRA_SERVICE;
 
 import org.apache.bookkeeper.tools.cli.BKCtl;
+import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
 import org.apache.bookkeeper.tools.framework.CliCommandGroup;
@@ -40,6 +41,7 @@ public class BookieCommandGroup extends CliCommandGroup<BKFlags> {
         .withParent(BKCtl.NAME)
         .withCategory(CATEGORY_INFRA_SERVICE)
         .addCommand(new LastMarkCommand())
+        .addCommand(new InitCommand())
         .build();
 
     public BookieCommandGroup() {

--- a/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
+++ b/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
@@ -21,8 +21,8 @@ package org.apache.bookkeeper.tools.cli.commands;
 import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_INFRA_SERVICE;
 
 import org.apache.bookkeeper.tools.cli.BKCtl;
-import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.FormatCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
 import org.apache.bookkeeper.tools.framework.CliCommandGroup;

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/InitCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/InitCommandTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommandTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Unit test for {@link InitCommand}
+ */
+@RunWith(PowerMockRunner.class)
+public class InitCommandTest extends BookieCommandTestBase {
+
+    public InitCommandTest() {
+        super(3, 0);
+    }
+
+    public void set() throws Exception {
+        PowerMockito.whenNew(ServerConfiguration.class).withNoArguments().thenReturn(conf);
+
+        PowerMockito.mockStatic(BookKeeperAdmin.class);
+        PowerMockito.when(BookKeeperAdmin.initBookie(any()));
+        when(BookKeeperAdmin.initBookie(any(ServerConfiguration.class))).thenReturn(anyBoolean());
+    }
+
+    @Test
+    public void testInitCommand() {
+        InitCommand initCommand = new InitCommand();
+        try {
+            initCommand.apply(bkFlags, new String[] { "" });
+        } catch (Exception e) {
+            fail("Should not throw any exception here.");
+        }
+    }
+}

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/InitCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/InitCommandTest.java
@@ -18,9 +18,6 @@
 package org.apache.bookkeeper.tools.cli.commands.bookie;
 
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -32,21 +29,20 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
- * Unit test for {@link InitCommand}
+ * Unit test for {@link InitCommand}.
  */
 @RunWith(PowerMockRunner.class)
+@PrepareForTest({BookKeeperAdmin.class})
 public class InitCommandTest extends BookieCommandTestBase {
 
     public InitCommandTest() {
         super(3, 0);
     }
 
-    public void set() throws Exception {
+    public void setup() throws Exception {
         PowerMockito.whenNew(ServerConfiguration.class).withNoArguments().thenReturn(conf);
-
         PowerMockito.mockStatic(BookKeeperAdmin.class);
-        PowerMockito.when(BookKeeperAdmin.initBookie(any()));
-        when(BookKeeperAdmin.initBookie(any(ServerConfiguration.class))).thenReturn(anyBoolean());
+        PowerMockito.when(BookKeeperAdmin.initBookie(conf)).thenReturn(true);
     }
 
     @Test


### PR DESCRIPTION
Descriptions of the changes in this PR:

Migrate command `bookieinit` from shell to bkctl

### Motivation

 Issue #1977 

### Changes

- Replace command `bookieinit` in shell
