### PR TITLE
Issue #1987: Migrate command `convert-to-interleaved-storage`

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.EventLoopGroup;
@@ -75,7 +74,6 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import org.apache.bookkeeper.bookie.BookieException.CookieNotFoundException;
 import org.apache.bookkeeper.bookie.BookieException.InvalidCookieException;
-import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
 import org.apache.bookkeeper.bookie.Journal.JournalScanner;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
@@ -109,6 +107,7 @@ import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.tools.cli.commands.bookie.ConvertToInterleavedStorageCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.FormatCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
@@ -2668,89 +2667,9 @@ public class BookieShell implements Tool {
 
         @Override
         int runCmd(CommandLine cmdLine) throws Exception {
-            LOG.info("=== Converting DbLedgerStorage ===");
-            ServerConfiguration conf = new ServerConfiguration(bkConf);
-            LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
-                    new DiskChecker(bkConf.getDiskUsageThreshold(), bkConf.getDiskUsageWarnThreshold()));
-            LedgerDirsManager ledgerIndexManager = new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
-                    new DiskChecker(bkConf.getDiskUsageThreshold(), bkConf.getDiskUsageWarnThreshold()));
-
-            DbLedgerStorage dbStorage = new DbLedgerStorage();
-            InterleavedLedgerStorage interleavedStorage = new InterleavedLedgerStorage();
-
-            CheckpointSource checkpointSource = new CheckpointSource() {
-                    @Override
-                    public Checkpoint newCheckpoint() {
-                        return Checkpoint.MAX;
-                    }
-
-                    @Override
-                    public void checkpointComplete(Checkpoint checkpoint, boolean compact)
-                            throws IOException {
-                    }
-                };
-            Checkpointer checkpointer = new Checkpointer() {
-                @Override
-                public void startCheckpoint(Checkpoint checkpoint) {
-                    // No-op
-                }
-
-                @Override
-                public void start() {
-                    // no-op
-                }
-            };
-
-            dbStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager, null,
-                        checkpointSource, checkpointer, NullStatsLogger.INSTANCE, PooledByteBufAllocator.DEFAULT);
-            interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager,
-                    null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE, PooledByteBufAllocator.DEFAULT);
-            LedgerCache interleavedLedgerCache = interleavedStorage.ledgerCache;
-
-            int convertedLedgers = 0;
-            for (long ledgerId : dbStorage.getActiveLedgersInRange(0, Long.MAX_VALUE)) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Converting ledger {}", ledgerIdFormatter.formatLedgerId(ledgerId));
-                }
-
-                interleavedStorage.setMasterKey(ledgerId, dbStorage.readMasterKey(ledgerId));
-                if (dbStorage.isFenced(ledgerId)) {
-                    interleavedStorage.setFenced(ledgerId);
-                }
-
-                long lastEntryInLedger = dbStorage.getLastEntryInLedger(ledgerId);
-                for (long entryId = 0; entryId <= lastEntryInLedger; entryId++) {
-                    try {
-                        long location = dbStorage.getLocation(ledgerId, entryId);
-                        if (location != 0L) {
-                            interleavedLedgerCache.putEntryOffset(ledgerId, entryId, location);
-                        }
-                    } catch (Bookie.NoEntryException e) {
-                        // Ignore entry
-                    }
-                }
-
-                if (++convertedLedgers % 1000 == 0) {
-                    LOG.info("Converted {} ledgers", convertedLedgers);
-                }
-            }
-
-            dbStorage.shutdown();
-
-            interleavedLedgerCache.flushLedger(true);
-            interleavedStorage.flush();
-            interleavedStorage.shutdown();
-
-            String baseDir = ledgerDirsManager.getAllLedgerDirs().get(0).toString();
-
-            // Rename databases and keep backup
-            Files.move(FileSystems.getDefault().getPath(baseDir, "ledgers"),
-                    FileSystems.getDefault().getPath(baseDir, "ledgers.backup"));
-
-            Files.move(FileSystems.getDefault().getPath(baseDir, "locations"),
-                    FileSystems.getDefault().getPath(baseDir, "locations.backup"));
-
-            LOG.info("---- Done Converting {} ledgers ----", convertedLedgers);
+            ConvertToInterleavedStorageCommand cmd = new ConvertToInterleavedStorageCommand();
+            ConvertToInterleavedStorageCommand.CTISFlags flags = new ConvertToInterleavedStorageCommand.CTISFlags();
+            cmd.apply(bkConf, flags);
             return 0;
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -75,7 +75,6 @@ import org.apache.bookkeeper.bookie.BookieException.CookieNotFoundException;
 import org.apache.bookkeeper.bookie.BookieException.InvalidCookieException;
 import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
 import org.apache.bookkeeper.bookie.Journal.JournalScanner;
-import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 import org.apache.bookkeeper.bookie.storage.ldb.LocationsIndexRebuildOp;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.MetaStoreException;
@@ -2069,12 +2068,12 @@ public class BookieShell implements Tool {
                         for (File dir : ledgerDirectories) {
                             newCookie.writeToDirectory(dir);
                         }
-                        LOG.info("Updated cookie file present in ledgerDirectories {}", ledgerDirectories);
+                        LOG.info("Updated cookie file present in ledgerDirectories {}", (Object) ledgerDirectories);
                         if (ledgerDirectories != indexDirectories) {
                             for (File dir : indexDirectories) {
                                 newCookie.writeToDirectory(dir);
                             }
-                            LOG.info("Updated cookie file present in indexDirectories {}", indexDirectories);
+                            LOG.info("Updated cookie file present in indexDirectories {}", (Object) indexDirectories);
                         }
                     }
                     // writes newcookie to zookeeper

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.Cleanup;
+import lombok.Getter;
 import org.apache.bookkeeper.bookie.Bookie.NoLedgerException;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.bookie.EntryLogger.EntryLogListener;
@@ -84,6 +85,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     private static final Logger LOG = LoggerFactory.getLogger(InterleavedLedgerStorage.class);
 
     EntryLogger entryLogger;
+    @Getter
     LedgerCache ledgerCache;
     protected CheckpointSource checkpointSource;
     protected Checkpointer checkpointer;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommand.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import com.beust.jcommander.Parameter;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.bookie.CheckpointSource;
+import org.apache.bookkeeper.bookie.Checkpointer;
+import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
+import org.apache.bookkeeper.bookie.LedgerCache;
+import org.apache.bookkeeper.bookie.LedgerDirsManager;
+import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
+import org.apache.bookkeeper.tools.framework.CliFlags;
+import org.apache.bookkeeper.tools.framework.CliSpec;
+import org.apache.bookkeeper.util.DiskChecker;
+import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A command to convert bookie indexes from DbLedgerStorage to InterleavedStorage format.
+ */
+public class ConvertToInterleavedStorageCommand extends BookieCommand<ConvertToInterleavedStorageCommand.CTISFlags> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConvertToInterleavedStorageCommand.class);
+    private static final String NAME = "converttointerleavedstorage";
+    private static final String DESC = "Convert bookie indexes from DbLedgerStorage to InterleavedStorage format";
+
+    @Setter
+    private LedgerIdFormatter ledgerIdFormatter;
+
+    public ConvertToInterleavedStorageCommand() {
+        this(new CTISFlags());
+    }
+
+    public ConvertToInterleavedStorageCommand(CTISFlags flags) {
+        super(CliSpec.<CTISFlags>newBuilder().withName(NAME).withDescription(DESC).withFlags(flags).build());
+    }
+
+    /**
+     * Flags for this command.
+     */
+    @Accessors(fluent = true)
+    public static class CTISFlags extends CliFlags{
+
+        @Parameter(names = { "-l", "--ledgeridformatter" }, description = "Set ledger id formatter")
+        private String ledgerIdFormatter = "";
+
+    }
+
+    @Override
+    public boolean apply(ServerConfiguration conf, CTISFlags cmdFlags) {
+        initLedgerIdFormatter(conf, cmdFlags);
+        try {
+            return handle(conf);
+        } catch (Exception e) {
+            throw new UncheckedExecutionException(e.getMessage(), e);
+        }
+    }
+
+    private boolean handle(ServerConfiguration bkConf) throws Exception {
+        LOG.info("=== Converting DbLedgerStorage ===");
+        ServerConfiguration conf = new ServerConfiguration(bkConf);
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
+            new DiskChecker(bkConf.getDiskUsageThreshold(), bkConf.getDiskUsageWarnThreshold()));
+        LedgerDirsManager ledgerIndexManager = new LedgerDirsManager(bkConf, bkConf.getLedgerDirs(),
+            new DiskChecker(bkConf.getDiskUsageThreshold(), bkConf.getDiskUsageWarnThreshold()));
+
+        DbLedgerStorage dbStorage = new DbLedgerStorage();
+        InterleavedLedgerStorage interleavedStorage = new InterleavedLedgerStorage();
+
+        CheckpointSource checkpointSource = new CheckpointSource() {
+            @Override
+            public Checkpoint newCheckpoint() {
+                return Checkpoint.MAX;
+            }
+
+            @Override
+            public void checkpointComplete(Checkpoint checkpoint, boolean compact) {}
+        };
+        Checkpointer checkpointer = new Checkpointer() {
+            @Override
+            public void startCheckpoint(CheckpointSource.Checkpoint checkpoint) {
+                // No-op
+            }
+
+            @Override
+            public void start() {
+                // no-op
+            }
+        };
+
+        dbStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager, null,
+            checkpointSource, checkpointer, NullStatsLogger.INSTANCE, PooledByteBufAllocator.DEFAULT);
+        interleavedStorage.initialize(conf, null, ledgerDirsManager, ledgerIndexManager,
+            null, checkpointSource, checkpointer, NullStatsLogger.INSTANCE, PooledByteBufAllocator.DEFAULT);
+        LedgerCache interleavedLedgerCache = interleavedStorage.getLedgerCache();
+
+        int convertedLedgers = 0;
+        for (long ledgerId : dbStorage.getActiveLedgersInRange(0, Long.MAX_VALUE)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Converting ledger {}", ledgerIdFormatter.formatLedgerId(ledgerId));
+            }
+
+            interleavedStorage.setMasterKey(ledgerId, dbStorage.readMasterKey(ledgerId));
+            if (dbStorage.isFenced(ledgerId)) {
+                interleavedStorage.setFenced(ledgerId);
+            }
+
+            long lastEntryInLedger = dbStorage.getLastEntryInLedger(ledgerId);
+            for (long entryId = 0; entryId <= lastEntryInLedger; entryId++) {
+                try {
+                    long location = dbStorage.getLocation(ledgerId, entryId);
+                    if (location != 0L) {
+                        interleavedLedgerCache.putEntryOffset(ledgerId, entryId, location);
+                    }
+                } catch (Bookie.NoEntryException e) {
+                    // Ignore entry
+                }
+            }
+
+            if (++convertedLedgers % 1000 == 0) {
+                LOG.info("Converted {} ledgers", convertedLedgers);
+            }
+        }
+
+        dbStorage.shutdown();
+
+        interleavedLedgerCache.flushLedger(true);
+        interleavedStorage.flush();
+        interleavedStorage.shutdown();
+
+        String baseDir = ledgerDirsManager.getAllLedgerDirs().get(0).toString();
+
+        // Rename databases and keep backup
+        Files.move(FileSystems.getDefault().getPath(baseDir, "ledgers"),
+            FileSystems.getDefault().getPath(baseDir, "ledgers.backup"));
+
+        Files.move(FileSystems.getDefault().getPath(baseDir, "locations"),
+            FileSystems.getDefault().getPath(baseDir, "locations.backup"));
+
+        LOG.info("---- Done Converting {} ledgers ----", convertedLedgers);
+        return true;
+    }
+
+    private void initLedgerIdFormatter(ServerConfiguration conf, CTISFlags flags) {
+        if (this.ledgerIdFormatter != null) {
+            return;
+        }
+        if (flags.ledgerIdFormatter.equals("")) {
+            this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(conf);
+        } else {
+            this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(flags.ledgerIdFormatter, conf);
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommand.java
@@ -51,6 +51,7 @@ public class ConvertToInterleavedStorageCommand extends BookieCommand<ConvertToI
     private static final Logger LOG = LoggerFactory.getLogger(ConvertToInterleavedStorageCommand.class);
     private static final String NAME = "converttointerleavedstorage";
     private static final String DESC = "Convert bookie indexes from DbLedgerStorage to InterleavedStorage format";
+    private static final String NOT_INIT = "default formatter";
 
     @Setter
     private LedgerIdFormatter ledgerIdFormatter;
@@ -70,7 +71,7 @@ public class ConvertToInterleavedStorageCommand extends BookieCommand<ConvertToI
     public static class CTISFlags extends CliFlags{
 
         @Parameter(names = { "-l", "--ledgeridformatter" }, description = "Set ledger id formatter")
-        private String ledgerIdFormatter = "";
+        private String ledgerIdFormatter = NOT_INIT;
 
     }
 
@@ -173,7 +174,7 @@ public class ConvertToInterleavedStorageCommand extends BookieCommand<ConvertToI
         if (this.ledgerIdFormatter != null) {
             return;
         }
-        if (flags.ledgerIdFormatter.equals("")) {
+        if (flags.ledgerIdFormatter.equals(NOT_INIT)) {
             this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(conf);
         } else {
             this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(flags.ledgerIdFormatter, conf);

--- a/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
+++ b/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
@@ -21,7 +21,11 @@ package org.apache.bookkeeper.tools.cli.commands;
 import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_INFRA_SERVICE;
 
 import org.apache.bookkeeper.tools.cli.BKCtl;
-import org.apache.bookkeeper.tools.cli.commands.bookie.*;
+import org.apache.bookkeeper.tools.cli.commands.bookie.ConvertToInterleavedStorageCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.FormatCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.LedgerCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
 import org.apache.bookkeeper.tools.framework.CliCommandGroup;
 import org.apache.bookkeeper.tools.framework.CliSpec;

--- a/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
+++ b/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
@@ -21,10 +21,7 @@ package org.apache.bookkeeper.tools.cli.commands;
 import static org.apache.bookkeeper.tools.common.BKCommandCategories.CATEGORY_INFRA_SERVICE;
 
 import org.apache.bookkeeper.tools.cli.BKCtl;
-import org.apache.bookkeeper.tools.cli.commands.bookie.FormatCommand;
-import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
-import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
-import org.apache.bookkeeper.tools.cli.commands.bookie.LedgerCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.*;
 import org.apache.bookkeeper.tools.common.BKFlags;
 import org.apache.bookkeeper.tools.framework.CliCommandGroup;
 import org.apache.bookkeeper.tools.framework.CliSpec;
@@ -46,6 +43,7 @@ public class BookieCommandGroup extends CliCommandGroup<BKFlags> {
         .addCommand(new InitCommand())
         .addCommand(new FormatCommand())
         .addCommand(new LedgerCommand())
+        .addCommand(new ConvertToInterleavedStorageCommand())
         .build();
 
     public BookieCommandGroup() {

--- a/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
+++ b/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
@@ -51,8 +51,7 @@ public class BookieCommandGroup extends CliCommandGroup<BKFlags> {
         .addCommand(new SanityTestCommand())
         .addCommand(new LedgerCommand())
         .addCommand(new ConvertToDBStorageCommand())
-        .addCommand(new ConvertToInterleavedStorageCommand()
-        .build();
+        .addCommand(new ConvertToInterleavedStorageCommand()).build();
 
     public BookieCommandGroup() {
         super(spec);

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommandTest.java
@@ -161,7 +161,7 @@ public class ConvertToInterleavedStorageCommandTest extends BookieCommandTestBas
             verify(interleavedLedgerStorage, times(1)).flush();
             verify(interleavedLedgerStorage, times(1)).shutdown();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new UncheckedExecutionException(e.getMessage(), e);
         }
     }
 }

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommandTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Vector;
+import java.util.stream.LongStream;
+import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
+import org.apache.bookkeeper.bookie.LedgerCache;
+import org.apache.bookkeeper.bookie.LedgerDirsManager;
+import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
+import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommandTestBase;
+import org.apache.bookkeeper.util.DiskChecker;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Unit test for {@link ConvertToInterleavedStorageCommand}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ConvertToInterleavedStorageCommand.class, LedgerCache.class })
+public class ConvertToInterleavedStorageCommandTest extends BookieCommandTestBase {
+
+    @Rule
+    private TemporaryFolder folder = new TemporaryFolder();
+
+    public ConvertToInterleavedStorageCommandTest() {
+        super(3, 0);
+    }
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+
+        createTmpFile();
+        PowerMockito.whenNew(ServerConfiguration.class).withNoArguments().thenReturn(conf);
+        PowerMockito.whenNew(ServerConfiguration.class).withParameterTypes(AbstractConfiguration.class)
+            .withArguments(eq(conf)).thenReturn(conf);
+
+        DiskChecker diskChecker = mock(DiskChecker.class);
+        whenNew(DiskChecker.class).withArguments(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold())
+            .thenReturn(diskChecker);
+
+        LedgerDirsManager ledgerDirsManager = mock(LedgerDirsManager.class);
+        whenNew(LedgerDirsManager.class).withParameterTypes(ServerConfiguration.class, File[].class, DiskChecker.class)
+            .withArguments(conf, conf.getLedgerDirs(), diskChecker).thenReturn(ledgerDirsManager);
+        when(ledgerDirsManager.getAllLedgerDirs()).thenReturn(getFileList());
+
+        DbLedgerStorage dbStorage = mock(DbLedgerStorage.class);
+        whenNew(DbLedgerStorage.class).withNoArguments().thenReturn(dbStorage);
+        when(dbStorage.getActiveLedgersInRange(anyLong(), anyLong())).thenReturn(this::getLedgerId);
+
+        LedgerCache interleavedLedgerCache = mock(LedgerCache.class);
+        doNothing().when(interleavedLedgerCache).flushLedger(anyBoolean());
+
+        InterleavedLedgerStorage interleavedLedgerStorage = mock(InterleavedLedgerStorage.class);
+        whenNew(InterleavedLedgerStorage.class).withNoArguments().thenReturn(interleavedLedgerStorage);
+        doNothing().when(interleavedLedgerStorage).flush();
+        doNothing().when(interleavedLedgerStorage).shutdown();
+        when(interleavedLedgerStorage.getLedgerCache()).thenReturn(interleavedLedgerCache);
+    }
+
+    private Iterator<Long> getLedgerId() {
+        Vector<Long> longs = new Vector<>();
+        LongStream.range(0L, 10L).forEach(longs::add);
+        return longs.iterator();
+    }
+
+    private List<File> getFileList() {
+        List<File> files = new LinkedList<>();
+        files.add(folder.getRoot());
+        return files;
+    }
+
+    private void createTmpFile() {
+        try {
+            folder.newFile("ledgers");
+            folder.newFile("locations");
+            System.out.println(folder.getRoot().getAbsolutePath());
+        } catch (IOException e) {
+            throw new UncheckedExecutionException(e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void testConvertToInterleavedStorageCommand() {
+        ConvertToInterleavedStorageCommand cmd = new ConvertToInterleavedStorageCommand();
+        Assert.assertTrue(cmd.apply(bkFlags, new String[] { "" }));
+    }
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

- Migrate command `convert-to-interleaved-storage`

### Motivation

- #1987 
- Use `bkctl` to run command `convert-to-interleaved-storage`

### Changes

- Add command in `bookiegroup`
