### PR TITLE
Migrate command `listfilesondisk`

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -111,6 +111,7 @@ import org.apache.bookkeeper.tools.cli.commands.bookie.FormatCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LedgerCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.ListFilesOnDiscCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.SanityTestCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookies.InfoCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookies.ListBookiesCommand;
@@ -1602,38 +1603,11 @@ public class BookieShell implements Tool {
             boolean journal = cmdLine.hasOption("txn");
             boolean entrylog = cmdLine.hasOption("log");
             boolean index = cmdLine.hasOption("idx");
-            boolean all = false;
 
-            if (!journal && !entrylog && !index && !all) {
-                all = true;
-            }
-
-            if (all || journal) {
-                File[] journalDirs = bkConf.getJournalDirs();
-                List<File> journalFiles = listFilesAndSort(journalDirs, "txn");
-                System.out.println("--------- Printing the list of Journal Files ---------");
-                for (File journalFile : journalFiles) {
-                    System.out.println(journalFile.getCanonicalPath());
-                }
-                System.out.println();
-            }
-            if (all || entrylog) {
-                File[] ledgerDirs = bkConf.getLedgerDirs();
-                List<File> ledgerFiles = listFilesAndSort(ledgerDirs, "log");
-                System.out.println("--------- Printing the list of EntryLog/Ledger Files ---------");
-                for (File ledgerFile : ledgerFiles) {
-                    System.out.println(ledgerFile.getCanonicalPath());
-                }
-                System.out.println();
-            }
-            if (all || index) {
-                File[] indexDirs = (bkConf.getIndexDirs() == null) ? bkConf.getLedgerDirs() : bkConf.getIndexDirs();
-                List<File> indexFiles = listFilesAndSort(indexDirs, "idx");
-                System.out.println("--------- Printing the list of Index Files ---------");
-                for (File indexFile : indexFiles) {
-                    System.out.println(indexFile.getCanonicalPath());
-                }
-            }
+            ListFilesOnDiscCommand.LFODFlags flags = new ListFilesOnDiscCommand.LFODFlags().journal(journal)
+                                                         .entrylog(entrylog).index(index);
+            ListFilesOnDiscCommand cmd = new ListFilesOnDiscCommand(flags);
+            cmd.apply(bkConf, flags);
             return 0;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommand.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import com.beust.jcommander.Parameter;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.bookkeeper.bookie.BookieShell;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
+import org.apache.bookkeeper.tools.framework.CliFlags;
+import org.apache.bookkeeper.tools.framework.CliSpec;
+
+/**
+ * Command to list the files in JournalDirectory/LedgerDirectories/IndexDirectories.
+ */
+public class ListFilesOnDiscCommand extends BookieCommand<ListFilesOnDiscCommand.LFODFlags > {
+
+    private static final String NAME = "listfilesondisc";
+    private static final String DESC = "List the files in JournalDirectory/LedgerDirectories/IndexDirectories.";
+
+    public ListFilesOnDiscCommand() {
+        this(new LFODFlags());
+    }
+
+    public ListFilesOnDiscCommand(LFODFlags flags) {
+        super(CliSpec.<LFODFlags>newBuilder().withName(NAME).withDescription(DESC).withFlags(flags).build());
+    }
+
+    /**
+     * Flags for list files on disc command.
+     */
+    @Accessors(fluent = true)
+    @Setter
+    public static class LFODFlags extends CliFlags {
+        @Parameter(names = {"-txn", "--journal"}, description = "Print list of Journal Files")
+        private boolean journal;
+
+        @Parameter(names = {"-log", "--entrylog"}, description = "Print list of EntryLog Files")
+        private boolean entrylog;
+
+        @Parameter(names = {"-idx", "--index"}, description = "Print list of Index Files")
+        private boolean index;
+    }
+
+    @Override
+    public boolean apply(ServerConfiguration conf, LFODFlags cmdFlags) {
+        try {
+            return handler(conf, cmdFlags);
+        } catch (IOException e) {
+            throw new UncheckedExecutionException(e.getMessage(), e);
+        }
+    }
+
+    private boolean handler(ServerConfiguration conf, LFODFlags cmd) throws IOException {
+        if (cmd.journal) {
+            File[] journalDirs = conf.getJournalDirs();
+            List<File> journalFiles = BookieShell.listFilesAndSort(journalDirs, "txn");
+            System.out.println("--------- Printing the list of Journal Files ---------");
+            for (File journalFile : journalFiles) {
+                System.out.println(journalFile.getCanonicalPath());
+            }
+            System.out.println();
+        }
+        if (cmd.entrylog) {
+            File[] ledgerDirs = conf.getLedgerDirs();
+            List<File> ledgerFiles = BookieShell.listFilesAndSort(ledgerDirs, "log");
+            System.out.println("--------- Printing the list of EntryLog/Ledger Files ---------");
+            for (File ledgerFile : ledgerFiles) {
+                System.out.println(ledgerFile.getCanonicalPath());
+            }
+            System.out.println();
+        }
+        if (cmd.index) {
+            File[] indexDirs = (conf.getIndexDirs() == null) ? conf.getLedgerDirs() : conf.getIndexDirs();
+            List<File> indexFiles = BookieShell.listFilesAndSort(indexDirs, "idx");
+            System.out.println("--------- Printing the list of Index Files ---------");
+            for (File indexFile : indexFiles) {
+                System.out.println(indexFile.getCanonicalPath());
+            }
+        }
+        return true;
+    }
+}

--- a/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
+++ b/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
@@ -25,6 +25,7 @@ import org.apache.bookkeeper.tools.cli.commands.bookie.FormatCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LedgerCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.ListFilesOnDiscCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.SanityTestCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
 import org.apache.bookkeeper.tools.framework.CliCommandGroup;
@@ -48,6 +49,7 @@ public class BookieCommandGroup extends CliCommandGroup<BKFlags> {
         .addCommand(new FormatCommand())
         .addCommand(new SanityTestCommand())
         .addCommand(new LedgerCommand())
+        .addCommand(new ListFilesOnDiscCommand())
         .build();
 
     public BookieCommandGroup() {

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommandTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.bookkeeper.bookie.BookieShell;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommandTestBase;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+
+/**
+ * Unit test for {@link ListFilesOnDiscCommand}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ListFilesOnDiscCommand.class })
+public class ListFilesOnDiscCommandTest extends BookieCommandTestBase {
+
+    @Rule
+    private TemporaryFolder folder = new TemporaryFolder();
+
+    public ListFilesOnDiscCommandTest() {
+        super(3, 0);
+    }
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        createTmpDirs();
+        whenNew(ServerConfiguration.class).withNoArguments().thenReturn(conf);
+    }
+
+    private void createTmpDirs() throws IOException {
+        File journals = folder.newFolder("journals");
+        conf.setJournalDirsName(new String[] { journals.getAbsolutePath() });
+        journals.mkdir();
+        File ledgers = folder.newFolder("ledgers");
+        conf.setLedgerDirNames(new String[] { ledgers.getAbsolutePath() });
+        ledgers.mkdir();
+        File index = folder.newFolder("index");
+        conf.setIndexDirName(new String[] { index.getAbsolutePath() });
+        index.mkdir();
+
+        for (int i = 0; i < 10; i++) {
+            File.createTempFile("journal-" + i, ".txn", journals);
+            File.createTempFile("ledger-" + i, ".log", ledgers);
+            File.createTempFile("index-" + i, ".idx", index);
+        }
+        System.out.println("over");
+    }
+
+    @Test
+    public void testListJournalCommand() {
+        testCommand("-txn");
+        Assert.assertEquals(10, BookieShell.listFilesAndSort(conf.getJournalDirs(), "txn").size());
+    }
+
+    @Test
+    public void testListJournalLongCommand() {
+        testCommand("--journal");
+        Assert.assertEquals(10, BookieShell.listFilesAndSort(conf.getJournalDirs(), "txn").size());
+    }
+
+    @Test
+    public void testListEntryLogCommand() {
+        testCommand("-log");
+        Assert.assertEquals(10, BookieShell.listFilesAndSort(conf.getLedgerDirs(), "log").size());
+    }
+
+    @Test
+    public void testListEntryLogLongCommand() {
+        testCommand("--entrylog");
+        Assert.assertEquals(10, BookieShell.listFilesAndSort(conf.getLedgerDirs(), "log").size());
+    }
+
+    @Test
+    public void testListIndexCommand() {
+        testCommand("-idx");
+        Assert.assertEquals(10, BookieShell.listFilesAndSort(conf.getIndexDirs(), "idx").size());
+    }
+
+    @Test
+    public void testListIndexLongCommand() {
+        testCommand("--index");
+        Assert.assertEquals(10, BookieShell.listFilesAndSort(conf.getIndexDirs(), "idx").size());
+    }
+
+    private void testCommand(String... args) {
+        ListFilesOnDiscCommand cmd = new ListFilesOnDiscCommand();
+        Assert.assertTrue(cmd.apply(bkFlags, args));
+    }
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

- Replace command `listfilesondisk` 

### Motivation

- Use `bkctl` to run command `listfilesondisk`
- #1989 
### Changes

- Add command in `bkctl`
