### PR TITLE
ISSUE-1967: make ledger creation and removal robust to zk connectionloss

### DIFF
--- a/bookkeeper-proto/src/main/proto/DataFormats.proto
+++ b/bookkeeper-proto/src/main/proto/DataFormats.proto
@@ -60,6 +60,8 @@ message LedgerMetadataFormat {
         optional bytes value = 2;
     }
     repeated cMetadataMapEntry customMetadata = 11;
+
+    optional int64 cToken = 12;
 }
 
 message LedgerRereplicationLayoutFormat {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadataBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadataBuilder.java
@@ -63,6 +63,9 @@ public class LedgerMetadataBuilder {
     private boolean storeCtime = false;
     private Map<String, byte[]> customMetadata = Collections.emptyMap();
 
+    private static final long BLANK_CTOKEN = 0;
+    private long cToken = BLANK_CTOKEN;
+
     public static LedgerMetadataBuilder create() {
         return new LedgerMetadataBuilder();
     }
@@ -181,6 +184,11 @@ public class LedgerMetadataBuilder {
         return this;
     }
 
+    public LedgerMetadataBuilder withCToken(long cToken) {
+        this.cToken = cToken;
+        return this;
+    }
+
     public LedgerMetadata build() {
         checkArgument(ensembleSize >= writeQuorumSize, "Write quorum must be less or equal to ensemble size");
         checkArgument(writeQuorumSize >= ackQuorumSize, "Write quorum must be greater or equal to ack quorum");
@@ -189,6 +197,7 @@ public class LedgerMetadataBuilder {
                                       ensembleSize, writeQuorumSize, ackQuorumSize,
                                       state, lastEntryId, length, ensembles,
                                       digestType, password, ctime, storeCtime,
+                                      cToken,
                                       customMetadata);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadataImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadataImpl.java
@@ -69,6 +69,8 @@ class LedgerMetadataImpl implements LedgerMetadata {
 
     private final Map<String, byte[]> customMetadata;
 
+    private long cToken;
+
     LedgerMetadataImpl(int metadataFormatVersion,
                        int ensembleSize,
                        int writeQuorumSize,
@@ -81,6 +83,7 @@ class LedgerMetadataImpl implements LedgerMetadata {
                        Optional<byte[]> password,
                        long ctime,
                        boolean storeCtime,
+                       long cToken,
                        Map<String, byte[]> customMetadata) {
         checkArgument(ensembles.size() > 0, "There must be at least one ensemble in the ledger");
         if (state == State.CLOSED) {
@@ -126,6 +129,8 @@ class LedgerMetadataImpl implements LedgerMetadata {
         }
         this.ctime = ctime;
         this.storeCtime = storeCtime;
+
+        this.cToken = cToken;
 
         this.customMetadata = ImmutableMap.copyOf(customMetadata);
     }
@@ -267,5 +272,10 @@ class LedgerMetadataImpl implements LedgerMetadata {
 
     boolean shouldStoreCtime() {
         return storeCtime;
+    }
+
+    @Override
+    public long getCToken() {
+        return cToken;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerMetadata.java
@@ -174,4 +174,11 @@ public interface LedgerMetadata {
      * @return the format version.
      */
     int getMetadataFormatVersion();
+
+    /**
+     * Get the unique creator token of the Ledger.
+     *
+     * @return the creator token
+     */
+    long getCToken();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -33,9 +33,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.LedgerMetadataBuilder;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
@@ -247,8 +249,19 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
     }
 
     @Override
-    public CompletableFuture<Versioned<LedgerMetadata>> createLedgerMetadata(long ledgerId, LedgerMetadata metadata) {
+    public CompletableFuture<Versioned<LedgerMetadata>> createLedgerMetadata(long ledgerId,
+                                                                             LedgerMetadata inputMetadata) {
         CompletableFuture<Versioned<LedgerMetadata>> promise = new CompletableFuture<>();
+        /*
+         * Create a random number and use it as creator token.
+         */
+        final long cToken = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+        final LedgerMetadata metadata;
+        if (inputMetadata.getMetadataFormatVersion() > 2) {
+            metadata = LedgerMetadataBuilder.from(inputMetadata).withCToken(cToken).build();
+        } else {
+            metadata = inputMetadata;
+        }
         String ledgerPath = getLedgerPath(ledgerId);
         StringCallback scb = new StringCallback() {
             @Override
@@ -256,8 +269,39 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                 if (rc == Code.OK.intValue()) {
                     promise.complete(new Versioned<>(metadata, new LongVersion(0)));
                 } else if (rc == Code.NODEEXISTS.intValue()) {
-                    LOG.warn("Failed to create ledger metadata for {} which already exist", ledgerId);
-                    promise.completeExceptionally(new BKException.BKLedgerExistException());
+                    LOG.info("Ledger metadata for {} appears to already exist, checking cToken",
+                            ledgerId);
+                    if (metadata.getMetadataFormatVersion() > 2) {
+                        CompletableFuture<Versioned<LedgerMetadata>> readFuture = readLedgerMetadata(ledgerId);
+                        readFuture.handle((readMetadata, exception) -> {
+                            if (exception == null) {
+                                if (readMetadata.getValue().getCToken() == cToken) {
+                                    FutureUtils.complete(promise, new Versioned<>(metadata, new LongVersion(0)));
+                                } else {
+                                    LOG.warn("Failed to create ledger metadata for {} which already exists", ledgerId);
+                                    promise.completeExceptionally(new BKException.BKLedgerExistException());
+                                }
+                            } else if (exception instanceof KeeperException.NoNodeException) {
+                                // This is a pretty strange case.  We tried to create the node, found that it
+                                // already exists, but failed to find it when we reread it.  It's possible that
+                                // we successfully created it, got an erroneous NODEEXISTS due to a resend,
+                                // and then it got removed.  It's also possible that we actually lost the race
+                                // and then it got removed.  I'd argue that returning an error here is the right
+                                // path since recreating it is likely to cause problems.
+                                LOG.warn("Ledger {} appears to have already existed and then been removed, failing"
+                                        + " with LedgerExistException");
+                                promise.completeExceptionally(new BKException.BKLedgerExistException());
+                            } else {
+                                LOG.error("Could not validate node for ledger {} after LedgerExistsException", ledgerId,
+                                        exception);
+                                promise.completeExceptionally(new BKException.ZKException());
+                            }
+                            return null;
+                        });
+                    } else {
+                        LOG.warn("Failed to create ledger metadata for {} which already exists", ledgerId);
+                        promise.completeExceptionally(new BKException.BKLedgerExistException());
+                    }
                 } else {
                     LOG.error("Could not create node for ledger {}", ledgerId,
                             KeeperException.create(Code.get(rc), path));
@@ -301,8 +345,8 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
             @Override
             public void processResult(int rc, String path, Object ctx) {
                 if (rc == KeeperException.Code.NONODE.intValue()) {
-                    LOG.warn("Ledger node does not exist in ZooKeeper: ledgerId={}", ledgerId);
-                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                    LOG.warn("Ledger node does not exist in ZooKeeper: ledgerId={}.  Returning success.", ledgerId);
+                    FutureUtils.complete(promise, null);
                 } else if (rc == KeeperException.Code.OK.intValue()) {
                     // removed listener on ledgerId
                     Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -257,7 +257,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
          */
         final long cToken = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
         final LedgerMetadata metadata;
-        if (inputMetadata.getMetadataFormatVersion() > 2) {
+        if (inputMetadata.getMetadataFormatVersion() > LedgerMetadataSerDe.METADATA_FORMAT_VERSION_2) {
             metadata = LedgerMetadataBuilder.from(inputMetadata).withCToken(cToken).build();
         } else {
             metadata = inputMetadata;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerMetadataSerDe.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerMetadataSerDe.java
@@ -78,7 +78,7 @@ public class LedgerMetadataSerDe {
     public static final int METADATA_FORMAT_VERSION_3 = 3;
 
     public static final int MAXIMUM_METADATA_FORMAT_VERSION = METADATA_FORMAT_VERSION_3;
-    public static final int CURRENT_METADATA_FORMAT_VERSION = METADATA_FORMAT_VERSION_2;
+    public static final int CURRENT_METADATA_FORMAT_VERSION = METADATA_FORMAT_VERSION_3;
     private static final int LOWEST_COMPAT_METADATA_FORMAT_VERSION = METADATA_FORMAT_VERSION_1;
 
     // for pulling the version
@@ -204,6 +204,8 @@ public class LedgerMetadataSerDe {
                 }
                 builder.addSegment(segmentBuilder.build());
             }
+
+            builder.setCToken(metadata.getCToken());
 
             builder.build().writeDelimitedTo(os);
             return os.toByteArray();
@@ -428,6 +430,10 @@ public class LedgerMetadataSerDe {
             builder.withCustomMetadata(data.getCustomMetadataList().stream().collect(
                                                Collectors.toMap(e -> e.getKey(),
                                                                 e -> e.getValue().toByteArray())));
+        }
+
+        if (data.hasCToken()) {
+            builder.withCToken(data.getCToken());
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ZooKeeperClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ZooKeeperClient.java
@@ -271,7 +271,7 @@ public class ZooKeeperClient extends ZooKeeper implements Watcher, AutoCloseable
         return new Builder();
     }
 
-    ZooKeeperClient(String connectString,
+    protected ZooKeeperClient(String connectString,
                     int sessionTimeoutMs,
                     ZooKeeperWatcherBase watcherManager,
                     RetryPolicy connectRetryPolicy,
@@ -329,7 +329,7 @@ public class ZooKeeperClient extends ZooKeeper implements Watcher, AutoCloseable
         }
     }
 
-    protected void waitForConnection() throws KeeperException, InterruptedException {
+    public void waitForConnection() throws KeeperException, InterruptedException {
         watcherManager.waitForConnection();
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
@@ -273,9 +273,8 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         try {
             result(ledgerManager.removeLedgerMetadata(ledgerId, version));
-            fail("Should fail to remove metadata if no such ledger exists");
         } catch (BKException bke) {
-            assertEquals(Code.NoSuchLedgerExistsException, bke.getCode());
+            fail("Should succeed");
         }
 
         verify(mockZk, times(1))
@@ -294,7 +293,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
 
         try {
             result(ledgerManager.removeLedgerMetadata(ledgerId, version));
-            fail("Should fail to remove metadata if no such ledger exists");
+            fail("Should fail to remove metadata upon ZKException");
         } catch (BKException bke) {
             assertEquals(Code.ZKException, bke.getCode());
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerMetadataSerDe.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerMetadataSerDe.java
@@ -60,9 +60,9 @@ public class TestLedgerMetadataSerDe {
 
     // version 3, since 4.9.x, protobuf binary format
     private static final String version3 =
-        "Qm9va2llTWV0YWRhdGFGb3JtYXRWZXJzaW9uCTMKXggCEAMYACD///////////8BKAEyMgoOMTkyL"
+        "Qm9va2llTWV0YWRhdGFGb3JtYXRWZXJzaW9uCTMKYAgCEAMYACD///////////8BKAEyMgoOMTkyL"
         + "jAuMi4xOjMxODEKDjE5Mi4wLjIuMjozMTgxCg4xOTIuMC4yLjM6MzE4MRAAOANCBmZvb2JhckgB"
-        + "UP///////////wE=";
+        + "UP///////////wFgAA==";
 
     private static void testDecodeEncode(String encoded) throws Exception {
         LedgerMetadataSerDe serDe = new LedgerMetadataSerDe();

--- a/tests/backward-compat/yahoo-custom-version/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeYahooCustom.groovy
+++ b/tests/backward-compat/yahoo-custom-version/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeYahooCustom.groovy
@@ -208,6 +208,13 @@ class TestCompatUpgradeYahooCustom {
                                                    "org.apache.bookkeeper.stats.NullStatsProvider")
 
         Assert.assertTrue(BookKeeperClusterUtils.startAllBookiesWithVersion(docker, currentVersion))
-        exerciseClients(preUpgradeLedgers)
+        // Since METADATA_VERSION is upgraded and it is using binary format, the older
+        // clients which are expecting text format would fail to read ledger metadata.
+        try {
+            exerciseClients(preUpgradeLedgers)
+        } catch (Exception exc) {
+            Assert.assertEquals(exc.getClass().getName(),
+              "org.apache.bookkeeper.client.BKException\$ZKException")
+        }
     }
 }

--- a/tests/backward-compat/yahoo-custom-version/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeYahooCustom.groovy
+++ b/tests/backward-compat/yahoo-custom-version/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeYahooCustom.groovy
@@ -170,11 +170,16 @@ class TestCompatUpgradeYahooCustom {
             openAndVerifyEntries(currentCL, currentBK, ledger4.getId())
             assertCantWrite(yahooCL, ledger4)
 
-            // yahoo client can fence a bookie created by current client
+            // Since METADATA_VERSION is upgraded and it is using binary format, the older
+            // clients which are expecting text format would fail to read ledger metadata.
             def ledger5 = createAndWrite(currentCL, currentBK)
             ledgers.add(ledger5.getId())
-            openAndVerifyEntries(yahooCL, yahooBK, ledger5.getId())
-            assertCantWrite(currentCL, ledger5)
+            try {
+                openAndVerifyEntries(yahooCL, yahooBK, ledger5.getId())
+            } catch (Exception exc) {
+                Assert.assertEquals(exc.getClass().getName(),
+                  "org.apache.bookkeeper.client.BKException\$ZKException")
+            }
         } finally {
             currentBK.close()
             currentCL.close()


### PR DESCRIPTION

Descriptions of the changes in this PR:

The bookkeeper project ZooKeeperClient wrapper for the ZooKeeper client
will resend zk node creations and removals upon reconnect after a
ConnectionLoss event. In the event that the original succeeded, the
resent operation will erroneously return LedgerExistException or
NoSuchLedgerExistsException for creation and removal respectively.

For removal, this patch limits the operation by allowing it to always
succeed if the ledger does not exist in order to make it idempotent.
This is appears to be the simplest solution as exclusive removal isn't
important.

**Note, the above is an actual change to the bk client semantics**

For creation, exclusive creation is cleary important for correctness,
so this patch adds a creator token field to the LedgerMetdata to
disambiguate the above race from a real race. For
AbstractZkLedgerManager, this is simply a random long value.

There's an oportunity for optimization with the above if exclusive
ledger creation failures are expected to be common.  You only actually
need to perform this check if the operation was really resent.  I chose
not to go this route yet because it would require messing with the
ZooKeeperClient interface to surface that information without burdening
other callers.

If the client is set to version 2 or older, this field will be ignored
and the old behavior will be retained.  If the client is version 3 or
newer but creation races with an older client, the new client will
interpret the nonce to be BLANK and thereby detect the race correctly.

