### PR TITLE
Docker autobuild hook

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
 
 ARG BK_VERSION=4.9.0
 ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
-ARG GPG_KEY=FD74402C
+ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
 
 ENV BOOKIE_PORT=3181
 EXPOSE $BOOKIE_PORT
@@ -30,18 +30,18 @@ ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
 ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0
 
-
 # Download Apache Bookkeeper, untar and clean up
 RUN set -x \
     && adduser "${BK_USER}" \
     && yum install -y java-1.8.0-openjdk-headless wget bash python sudo \
     && mkdir -pv /opt \
     && cd /opt \
-    && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz" \
-    && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.asc" \
-    && wget -q "https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz.sha512" \
+    && wget -q "${DISTRO_URL}" \
+    && wget -q "${DISTRO_URL}.asc" \
+    && wget -q "${DISTRO_URL}.sha512" \
     && sha512sum -c ${DISTRO_NAME}.tar.gz.sha512 \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-key "$GPG_KEY" \
+    && wget https://dist.apache.org/repos/dist/release/bookkeeper/KEYS \
+    && gpg --import KEYS \
     && gpg --batch --verify "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz" \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --build-arg BK_VERSION=$DOCKER_TAG -t $IMAGE_NAME .

--- a/site/community/release_guide.md
+++ b/site/community/release_guide.md
@@ -472,14 +472,25 @@ Copy the source release from the `dev` repository to the `release` repository at
 
 2. Merge the Release Notes pull request and make sure the Release Notes is updated.
 
-### Update Dockerfile
+### Git tag
 
-> NOTE: The dockerfile PR should only be merged after the release package is showed up under https://archive.apache.org/dist/bookkeeper/
+> NOTE: Only create the release tag after the release package is showed up under https://archive.apache.org/dist/bookkeeper/ as creating the tag triggers a docker autobuild which needs the package to exist. If you forget to do so, the build will fail. In this case you can delete the tag from github and push it again.
 
-1. Update the `BK_VERSION` and `GPG_KEY` in `docker/Dockerfile` (e.g. [Pull Request 436](https://github.com/apache/bookkeeper/pull/436) ),
-    send a pull request for review and get an approval from the community.
+Create and push a new signed for the released version by copying the tag for the final release tag, as follows
 
-2. Once the pull request is approved, merge this pull request into master and make sure it is cherry-picked into corresponding branch.
+```shell
+git tag -s "${TAG}" "${RC_TAG}"
+git push apache "${TAG}"
+```
+
+Remove rc tags:
+
+```shell
+for num in $(seq 0 ${RC_NUM}); do
+    git tag -d "v${VERSION}-rc${num}"
+    git push apache :"v${VERSION}-rc${num}"
+done
+```
 
 ### Update DC/OS BookKeeper package
 
@@ -547,24 +558,6 @@ It is easy if only version need be bump.
     $ git add repo/packages/B/bookkeeper/2
     $ git commit -m "new bookkeeper version"
     ```
-
-### Git tag
-
-Create and push a new signed for the released version by copying the tag for the final release tag, as follows
-
-```shell
-git tag -s "${TAG}" "${RC_TAG}"
-git push apache "${TAG}"
-```
-
-Remove rc tags:
-
-```shell
-for num in $(seq 0 ${RC_NUM}); do
-    git tag -d "v${VERSION}-rc${num}"
-    git push apache :"v${VERSION}-rc${num}"
-done
-```
 
 ### Verify Docker Image
 


### PR DESCRIPTION
This hook will allow docker autobuild to build from the offical tag
and removes the need to update the dockerfile after the release has
been made.

It also adds a build arg, DISTRO_URL which can be used for testing
release candidates.

```
docker build --build-arg BK_VERSION=4.9.1
    --build-arg DISTRO_URL=<rc-tarball-url> .
```
