### PR TITLE
Issue 2020: close db properly to avoid open RocksDB failure at the second time

### DIFF
--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/sc/StorageContainerRegistryImpl.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/sc/StorageContainerRegistryImpl.java
@@ -101,6 +101,11 @@ public class StorageContainerRegistryImpl implements StorageContainerRegistry {
                     } else {
                         log.warn("Fail to de-register StorageContainer ('{}') when failed to start", scId, cause);
                     }
+                    log.info("Release resources hold by StorageContainer ('{}') during de-register", scId);
+                    newStorageContainer.stop().exceptionally(throwable -> {
+                        log.error("Stop StorageContainer ('{}') fail during de-register", scId);
+                        return null;
+                    });
                 } else {
                     log.info("Successfully started registered StorageContainer ('{}').", scId);
                 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

If not releasing resources of failed/closed asyncStore, new creating of the same store identifier will fail, mainly caused by RocksDBException, like #2020 shows.

### Changes

add scStores to factory's instance variable at the `addstore` method of `MVCCStoreFactoryImpl` class;
release store when open fail;

Descriptions of the changes in this PR:

Master Issue: #2020 

