### PR TITLE
Issue 2023: change cached thread pool to fixed thread pool

### DIFF
--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/PerfClient.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/PerfClient.java
@@ -324,7 +324,7 @@ public class PerfClient implements Runnable {
 
                     final CountDownLatch latch = new CountDownLatch(tasks.size());
                     @Cleanup("shutdown")
-                    ExecutorService executor = Executors.newFixedThreadPool(task.size());
+                    ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
                     for (BenchmarkTask task : tasks) {
                         executor.submit(() -> {
                             try {

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/PerfClient.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/PerfClient.java
@@ -324,7 +324,7 @@ public class PerfClient implements Runnable {
 
                     final CountDownLatch latch = new CountDownLatch(tasks.size());
                     @Cleanup("shutdown")
-                    ExecutorService executor = Executors.newCachedThreadPool();
+                    ExecutorService executor = Executors.newFixedThreadPool(task.size());
                     for (BenchmarkTask task : tasks) {
                         executor.submit(() -> {
                             try {


### PR DESCRIPTION
Descriptions of the changes in this PR:

change newCachedThreadPool() to newFixedThreadPool(int)

### Motivation

newFixedThreadPool(int) can be freely configured with the total number of threads, while cached thread pool may cause OutOfMemoryError when there are too many threads need to created.