### PR TITLE
Migrate command `localconsistencycheck`

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -107,6 +107,7 @@ import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LedgerCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ListFilesOnDiscCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ListLedgersCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.LocalConsistencyCheckCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ReadJournalCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.SanityTestCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookies.InfoCommand;
@@ -1090,21 +1091,9 @@ public class BookieShell implements Tool {
 
         @Override
         public int runCmd(CommandLine cmdLine) throws Exception {
-            LOG.info("=== Performing local consistency check ===");
-            ServerConfiguration conf = new ServerConfiguration(bkConf);
-            LedgerStorage ledgerStorage = Bookie.mountLedgerStorageOffline(conf, null);
-            List <LedgerStorage.DetectedInconsistency> errors = ledgerStorage.localConsistencyCheck(
-                    java.util.Optional.empty());
-            if (errors.size() > 0) {
-                LOG.info("=== Check returned errors: ===");
-                for (LedgerStorage.DetectedInconsistency error : errors) {
-                    LOG.error("Ledger {}, entry {}: ", error.getLedgerId(), error.getEntryId(), error.getException());
-                }
-                return 1;
-            } else {
-                LOG.info("=== Check passed ===");
-                return 0;
-            }
+            LocalConsistencyCheckCommand cmd = new LocalConsistencyCheckCommand();
+            boolean result = cmd.apply(bkConf, new CliFlags());
+            return (result) ? 0 : 1;
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LocalConsistencyCheckCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LocalConsistencyCheckCommand.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.io.IOException;
+import java.util.List;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.bookie.LedgerStorage;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
+import org.apache.bookkeeper.tools.framework.CliFlags;
+import org.apache.bookkeeper.tools.framework.CliSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Command to check local storage for inconsistencies.
+ */
+public class LocalConsistencyCheckCommand extends BookieCommand<CliFlags> {
+
+    static final Logger LOG = LoggerFactory.getLogger(LocalConsistencyCheckCommand.class);
+
+    private static final String NAME = "localconsistencycheck";
+    private static final String DESC = "Validate Ledger Storage internal metadata";
+
+    public LocalConsistencyCheckCommand() {
+        super(CliSpec.newBuilder()
+                     .withName(NAME)
+                     .withDescription(DESC)
+                     .withFlags(new CliFlags())
+                     .build());
+    }
+
+    @Override
+    public boolean apply(ServerConfiguration conf, CliFlags cmdFlags) {
+        try {
+            return check(conf);
+        } catch (IOException e) {
+            throw new UncheckedExecutionException(e.getMessage(), e);
+        }
+    }
+
+    private boolean check(ServerConfiguration conf) throws IOException {
+        LOG.info("=== Performing local consistency check ===");
+        ServerConfiguration serverConfiguration = new ServerConfiguration(conf);
+        LedgerStorage ledgerStorage = Bookie.mountLedgerStorageOffline(serverConfiguration, null);
+        List<LedgerStorage.DetectedInconsistency> errors = ledgerStorage.localConsistencyCheck(
+            java.util.Optional.empty());
+        if (errors.size() > 0) {
+            LOG.info("=== Check returned errors: ===");
+            for (LedgerStorage.DetectedInconsistency error : errors) {
+                LOG.error("Ledger {}, entry {}: ", error.getLedgerId(), error.getEntryId(), error.getException());
+            }
+            return false;
+        } else {
+            LOG.info("=== Check passed ===");
+            return true;
+        }
+    }
+}

--- a/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
+++ b/tools/ledger/src/main/java/org/apache/bookkeeper/tools/cli/commands/BookieCommandGroup.java
@@ -29,6 +29,7 @@ import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LedgerCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ListFilesOnDiscCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ListLedgersCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.LocalConsistencyCheckCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ReadJournalCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.SanityTestCommand;
 import org.apache.bookkeeper.tools.common.BKFlags;
@@ -58,6 +59,8 @@ public class BookieCommandGroup extends CliCommandGroup<BKFlags> {
         .addCommand(new ListLedgersCommand())
         .addCommand(new ConvertToInterleavedStorageCommand())
         .addCommand(new ReadJournalCommand())
+        .addCommand(new ConvertToInterleavedStorageCommand())
+        .addCommand(new LocalConsistencyCheckCommand())
         .build();
 
     public BookieCommandGroup() {

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/LocalConsistencyCheckCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/LocalConsistencyCheckCommandTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.verifyNew;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.bookie.LedgerStorage;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommandTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Unit test for {@link LocalConsistencyCheckCommand}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ LocalConsistencyCheckCommand.class, Bookie.class })
+public class LocalConsistencyCheckCommandTest extends BookieCommandTestBase {
+
+    @Mock
+    private ServerConfiguration serverConfiguration;
+
+    @Mock
+    private LedgerStorage ledgerStorage;
+
+    public LocalConsistencyCheckCommandTest() {
+        super(3, 0);
+    }
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+
+        PowerMockito.whenNew(ServerConfiguration.class).withNoArguments().thenReturn(conf);
+        PowerMockito.whenNew(ServerConfiguration.class).withArguments(eq(conf)).thenReturn(serverConfiguration);
+        PowerMockito.mockStatic(Bookie.class);
+        PowerMockito.when(Bookie.mountLedgerStorageOffline(eq(serverConfiguration), eq(null)))
+                    .thenReturn(ledgerStorage);
+        List<LedgerStorage.DetectedInconsistency> errors = new ArrayList<>();
+        PowerMockito.when(ledgerStorage.localConsistencyCheck(eq(java.util.Optional.empty()))).thenReturn(errors);
+    }
+
+    @Test
+    public void testCommand() throws Exception {
+        LocalConsistencyCheckCommand cmd = new LocalConsistencyCheckCommand();
+        Assert.assertTrue(cmd.apply(bkFlags, new String[] {}));
+        verifyNew(ServerConfiguration.class, times(1)).withArguments(eq(conf));
+        verify(ledgerStorage, times(1)).localConsistencyCheck(eq(java.util.Optional.empty()));
+    }
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

#2042 

Using bkctl run command localconsistencycheck

```
Validate Ledger Storage internal metadata
Usage:  bkctl bookie localconsistencycheck [flags]
Flags:

    -h, --help
        Display help information
```