### PR TITLE
Cancel LAC watch when longpoll LAC times out

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -1409,6 +1409,13 @@ public class Bookie extends BookieCriticalThread {
         return handle.waitForLastAddConfirmedUpdate(previousLAC, watcher);
     }
 
+    public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                    Watcher<LastAddConfirmedUpdateNotification> watcher)
+            throws IOException {
+        LedgerDescriptor handle = handles.getReadOnlyHandle(ledgerId);
+        handle.cancelWaitForLastAddConfirmedUpdate(watcher);
+    }
+
     @VisibleForTesting
     public LedgerStorage getLedgerStorage() {
         return ledgerStorage;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -151,6 +151,10 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
         return true;
     }
 
+    synchronized void cancelWaitForLastAddConfirmedUpdate(Watcher<LastAddConfirmedUpdateNotification> watcher) {
+        deleteWatcher(watcher);
+    }
+
     public boolean isClosed() {
         return isClosed;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -374,6 +374,19 @@ public class IndexPersistenceMgr {
         }
     }
 
+    void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                          Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException {
+        CachedFileInfo fi = null;
+        try {
+            fi = getFileInfo(ledgerId, null);
+            fi.cancelWaitForLastAddConfirmedUpdate(watcher);
+        } finally {
+            if (null != fi) {
+                fi.release();
+            }
+        }
+    }
+
     long updateLastAddConfirmed(long ledgerId, long lac) throws IOException {
         CachedFileInfo fi = null;
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -352,6 +352,12 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         return ledgerCache.waitForLastAddConfirmedUpdate(ledgerId, previousLAC, watcher);
     }
 
+    @Override
+    public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                    Watcher<LastAddConfirmedUpdateNotification> watcher)
+            throws IOException {
+        ledgerCache.cancelWaitForLastAddConfirmedUpdate(ledgerId, watcher);
+    }
 
     @Override
     public long addEntry(ByteBuf entry) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedStorageRegenerateIndexOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedStorageRegenerateIndexOp.java
@@ -217,6 +217,12 @@ public class InterleavedStorageRegenerateIndexOp {
             throw new UnsupportedOperationException();
         }
         @Override
+        public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                        Watcher<LastAddConfirmedUpdateNotification> watcher)
+                throws IOException {
+            throw new UnsupportedOperationException();
+        }
+        @Override
         public void deleteLedger(long ledgerId) throws IOException {
         }
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
@@ -53,6 +53,8 @@ public interface LedgerCache extends Closeable {
     boolean waitForLastAddConfirmedUpdate(long ledgerId,
                                           long previousLAC,
                                           Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException;
+    void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                             Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException;
 
     void deleteLedger(long ledgerId) throws IOException;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
@@ -92,6 +92,13 @@ public class LedgerCacheImpl implements LedgerCache {
     }
 
     @Override
+    public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                    Watcher<LastAddConfirmedUpdateNotification> watcher)
+            throws IOException {
+        indexPersistenceManager.cancelWaitForLastAddConfirmedUpdate(ledgerId, watcher);
+    }
+
+    @Override
     public void putEntryOffset(long ledger, long entry, long offset) throws IOException {
         indexPageManager.putEntryOffset(ledger, entry, offset);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
@@ -80,6 +80,8 @@ public abstract class LedgerDescriptor {
     abstract boolean waitForLastAddConfirmedUpdate(long previousLAC,
                                                    Watcher<LastAddConfirmedUpdateNotification> watcher)
         throws IOException;
+    abstract void cancelWaitForLastAddConfirmedUpdate(Watcher<LastAddConfirmedUpdateNotification> watcher)
+            throws IOException;
 
     abstract void setExplicitLac(ByteBuf entry) throws IOException;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -168,4 +168,9 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
                                           Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException {
         return ledgerStorage.waitForLastAddConfirmedUpdate(ledgerId, previousLAC, watcher);
     }
+
+    @Override
+    void cancelWaitForLastAddConfirmedUpdate(Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException {
+        ledgerStorage.cancelWaitForLastAddConfirmedUpdate(ledgerId, watcher);
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -137,6 +137,16 @@ public interface LedgerStorage {
                                           Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException;
 
     /**
+     * Cancel a previous wait for last add confirmed update.
+     *
+     * @param ledgerId The ledger being watched.
+     * @param watcher The watcher to cancel.
+     * @throws IOException
+     */
+    void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException;
+
+    /**
      * Flushes all data in the storage. Once this is called,
      * add data written to the LedgerStorage up until this point
      * has been persisted to perminant storage

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -228,6 +228,13 @@ public class SortedLedgerStorage
     }
 
     @Override
+    public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                    Watcher<LastAddConfirmedUpdateNotification> watcher)
+            throws IOException {
+        interleavedLedgerStorage.cancelWaitForLastAddConfirmedUpdate(ledgerId, watcher);
+    }
+
+    @Override
     public void checkpoint(final Checkpoint checkpoint) throws IOException {
         long numBytesFlushed = memTable.flush(this, checkpoint);
         interleavedLedgerStorage.getEntryLogger().prepareSortedLedgerStorageCheckpoint(numBytesFlushed);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -210,6 +210,13 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     @Override
+    public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                    Watcher<LastAddConfirmedUpdateNotification> watcher)
+            throws IOException {
+        getLedgerSorage(ledgerId).cancelWaitForLastAddConfirmedUpdate(ledgerId, watcher);
+    }
+
+    @Override
     public void flush() throws IOException {
         for (LedgerStorage ls : ledgerStorageList) {
             ls.flush();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -757,6 +757,13 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     }
 
     @Override
+    public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                    Watcher<LastAddConfirmedUpdateNotification> watcher)
+            throws IOException {
+        getOrAddLedgerInfo(ledgerId).cancelWaitForLastAddConfirmedUpdate(watcher);
+    }
+
+    @Override
     public void setExplicitlac(long ledgerId, ByteBuf lac) throws IOException {
         getOrAddLedgerInfo(ledgerId).setExplicitLac(lac);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/TransientLedgerInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/TransientLedgerInfo.java
@@ -99,6 +99,11 @@ class TransientLedgerInfo extends Watchable<LastAddConfirmedUpdateNotification> 
         return true;
     }
 
+    synchronized void cancelWaitForLastAddConfirmedUpdate(Watcher<LastAddConfirmedUpdateNotification> watcher)
+            throws IOException {
+        deleteWatcher(watcher);
+    }
+
     public ByteBuf getExplicitLac() {
         ByteBuf retLac = null;
         synchronized (this) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3.java
@@ -163,9 +163,10 @@ class LongPollReadEntryProcessorV3 extends ReadEntryProcessorV3 implements Watch
                 }
                 synchronized (this) {
                     expirationTimerTask = requestTimer.newTimeout(timeout -> {
-                        // When the timeout expires just get whatever is the current
-                        // readLastConfirmed
-                        LongPollReadEntryProcessorV3.this.scheduleDeferredRead(true);
+                            requestProcessor.bookie.cancelWaitForLastAddConfirmedUpdate(ledgerId, this);
+                            // When the timeout expires just get whatever is the current
+                            // readLastConfirmed
+                            LongPollReadEntryProcessorV3.this.scheduleDeferredRead(true);
                     }, readRequest.getTimeOut(), TimeUnit.MILLISECONDS);
                 }
                 return null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3.java
@@ -142,7 +142,7 @@ class LongPollReadEntryProcessorV3 extends ReadEntryProcessorV3 implements Watch
 
             final boolean watched;
             try {
-                watched = requestProcessor.bookie.waitForLastAddConfirmedUpdate(ledgerId, previousLAC, this);
+                watched = requestProcessor.getBookie().waitForLastAddConfirmedUpdate(ledgerId, previousLAC, this);
             } catch (Bookie.NoLedgerException e) {
                 logger.info("No ledger found while longpoll reading ledger {}, previous lac = {}.",
                         ledgerId, previousLAC);
@@ -163,7 +163,7 @@ class LongPollReadEntryProcessorV3 extends ReadEntryProcessorV3 implements Watch
                 }
                 synchronized (this) {
                     expirationTimerTask = requestTimer.newTimeout(timeout -> {
-                            requestProcessor.bookie.cancelWaitForLastAddConfirmedUpdate(ledgerId, this);
+                            requestProcessor.getBookie().cancelWaitForLastAddConfirmedUpdate(ledgerId, this);
                             // When the timeout expires just get whatever is the current
                             // readLastConfirmed
                             LongPollReadEntryProcessorV3.this.scheduleDeferredRead(true);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -174,7 +174,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
                                      boolean readLACPiggyBack,
                                      Stopwatch startTimeSw)
         throws IOException {
-        ByteBuf entryBody = requestProcessor.bookie.readEntry(ledgerId, entryId);
+        ByteBuf entryBody = requestProcessor.getBookie().readEntry(ledgerId, entryId);
         if (null != fenceResult) {
             handleReadResultForFenceRead(entryBody, readResponseBuilder, entryId, startTimeSw);
             return null;
@@ -184,7 +184,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
                 if (readLACPiggyBack) {
                     readResponseBuilder.setEntryId(entryId);
                 } else {
-                    long knownLAC = requestProcessor.bookie.readLastAddConfirmed(ledgerId);
+                    long knownLAC = requestProcessor.getBookie().readLastAddConfirmed(ledgerId);
                     readResponseBuilder.setMaxLAC(knownLAC);
                 }
                 registerSuccessfulEvent(readStats, startTimeSw);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
@@ -356,6 +356,12 @@ public class TestSyncThread {
         }
 
         @Override
+        public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                        Watcher<LastAddConfirmedUpdateNotification> watcher)
+                throws IOException {
+        }
+
+        @Override
         public void checkpoint(Checkpoint checkpoint)
                 throws IOException {
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -678,5 +678,11 @@ public class GcLedgersTest extends LedgerManagerTestCase {
                 throws IOException {
             return false;
         }
+
+        @Override
+        public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                        Watcher<LastAddConfirmedUpdateNotification> watcher)
+                throws IOException {
+        }
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -275,6 +275,12 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         }
 
         @Override
+        public void cancelWaitForLastAddConfirmedUpdate(long ledgerId,
+                                                        Watcher<LastAddConfirmedUpdateNotification> watcher)
+                throws IOException {
+        }
+
+        @Override
         public void setExplicitlac(long ledgerId, ByteBuf lac) throws IOException {
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3Test.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.proto;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.ByteString;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.util.HashedWheelTimer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+
+
+/**
+ * Unit test {@link LongPollReadEntryProcessorV3}.
+ */
+public class LongPollReadEntryProcessorV3Test {
+    ExecutorService executor;
+    HashedWheelTimer timer;
+
+    @Before
+    public void setup() {
+        executor = Executors.newSingleThreadExecutor();
+        timer = new HashedWheelTimer();
+    }
+
+    @After
+    public void teardown() {
+        timer.stop();
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testWatchIsCancelledOnTimeout() throws Exception {
+        Request request = Request.newBuilder()
+            .setHeader(BKPacketHeader.newBuilder()
+                       .setTxnId(System.currentTimeMillis())
+                       .setVersion(ProtocolVersion.VERSION_THREE)
+                       .setOperation(OperationType.READ_ENTRY)
+                       .build())
+            .setReadRequest(ReadRequest.newBuilder()
+                            .setLedgerId(10)
+                            .setEntryId(1)
+                            .setMasterKey(ByteString.copyFrom(new byte[0]))
+                            .setPreviousLAC(0)
+                            .setTimeOut(1)
+                            .build())
+            .build();
+
+        Channel channel = mock(Channel.class);
+        Bookie bookie = mock(Bookie.class);
+
+        BookieRequestProcessor requestProcessor = mock(BookieRequestProcessor.class);
+        when(requestProcessor.getBookie()).thenReturn(bookie);
+        when(requestProcessor.getRequestStats()).thenReturn(new RequestStats(NullStatsLogger.INSTANCE));
+
+        when(bookie.waitForLastAddConfirmedUpdate(anyLong(), anyLong(), any()))
+            .thenReturn(true);
+        when(bookie.readEntry(anyLong(), anyLong())).thenReturn(Unpooled.buffer());
+        when(bookie.readLastAddConfirmed(anyLong())).thenReturn(Long.valueOf(1));
+
+        CompletableFuture<Void> cancelFuture = new CompletableFuture<>();
+
+        doAnswer(invocationOnMock -> {
+                cancelFuture.complete(null);
+                return null;
+            }).when(bookie).cancelWaitForLastAddConfirmedUpdate(anyLong(), any());
+
+        LongPollReadEntryProcessorV3 processor = new LongPollReadEntryProcessorV3(
+            request,
+            channel,
+            requestProcessor,
+            executor, executor, timer);
+
+        processor.run();
+
+        cancelFuture.get(10, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
Otherwise the watch objects will accumulate and eventually cause an
OOM on the bookie, if LAC doesn't progress.
