### PR TITLE
Wait for LAC update even if ledger fenced

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -139,8 +139,7 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
 
     synchronized boolean waitForLastAddConfirmedUpdate(long previousLAC,
                                                        Watcher<LastAddConfirmedUpdateNotification> watcher) {
-        if ((null != lac && lac > previousLAC)
-                || isClosed || ((stateBits & STATE_FENCED_BIT) == STATE_FENCED_BIT)) {
+        if ((null != lac && lac > previousLAC) || isClosed) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Wait For LAC {} , {}", this.lac, previousLAC);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/TransientLedgerInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/TransientLedgerInfo.java
@@ -91,7 +91,7 @@ class TransientLedgerInfo extends Watchable<LastAddConfirmedUpdateNotification> 
     synchronized boolean waitForLastAddConfirmedUpdate(long previousLAC,
             Watcher<LastAddConfirmedUpdateNotification> watcher) throws IOException {
         lastAccessed = System.currentTimeMillis();
-        if ((lac != NOT_ASSIGNED_LAC && lac > previousLAC) || isClosed || ledgerIndex.get(ledgerId).getFenced()) {
+        if ((lac != NOT_ASSIGNED_LAC && lac > previousLAC) || isClosed) {
             return false;
         }
 


### PR DESCRIPTION
Previous behaviour was to return straight away. However, LAC can
change when the ledger is fenced and there is no guarantee that a
fenced ledger will turn into a closed ledger (fencing client may
crash), which would cause the client tailing with longpoll LAC to go
into a tight loop.
