### PR TITLE
Avoid useless verify if LedgerEntryRequest completed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -131,6 +131,9 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
          */
         boolean complete(int bookieIndex, BookieSocketAddress host, final ByteBuf buffer) {
             ByteBuf content;
+            if (isComplete()) {
+                return false;
+            }
             try {
                 content = lh.macManager.verifyDigestAndReturnData(eId, buffer);
             } catch (BKDigestMatchException e) {


### PR DESCRIPTION
Avoid useless verify if LedgerEntryRequest completed

Change-Id: Ifda2a6e218c49105a5627be69566ea2ce4a57699

Descriptions of the changes in this PR:
Print misleading logs when the SpeculativeRequestExecutionPolicy is turned on：
2019-04-03 18:30:49,839 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: -1 , actual: 602
2019-04-03 18:30:49,839 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: -1 , actual: 606
2019-04-03 18:30:49,839 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: -1 , actual: 610
2019-04-03 18:30:49,839 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: -1 , actual: 614
2019-04-03 18:30:49,843 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 644 , actual: 622
2019-04-03 18:30:49,843 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 640 , actual: 626
2019-04-03 18:30:49,843 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 656 , actual: 630
2019-04-03 18:30:49,843 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 652 , actual: 634
2019-04-03 18:30:49,843 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 648 , actual: 638
2019-04-03 18:30:49,846 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 660 , actual: 642
2019-04-03 18:30:49,846 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 675 , actual: 646
2019-04-03 18:30:49,846 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 671 , actual: 650
2019-04-03 18:30:49,846 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 667 , actual: 654
2019-04-03 18:30:49,846 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 663 , actual: 658
2019-04-03 18:30:49,848 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: -1 , actual: 670
2019-04-03 18:30:49,849 ERROR org.apache.bookkeeper.client.DigestManager: Entry-id mismatch in authenticated message, expected: 692 , actual: 662



### Motivation
Avoid useless verify and redundant logging(caused by the use of recycled `entryImpl`) if LedgerEntryRequest completed

### Changes
Return immediately if completed

Master Issue: #<master-issue-number>

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java11]: skip build on java11. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
