### PR TITLE
Explicit error message if extent is not present on ZK

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -171,7 +171,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
                             } catch (BKException e) {
                                 rc = e.getCode();
                             }
-                            if (rc != BKException.Code.NoSuchLedgerExistsException) {
+                            if (rc != BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                                 LOG.warn("Ledger {} Missing in metadata list, but ledgerManager returned rc: {}.",
                                          bkLid, rc);
                                 continue;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BKException.java
@@ -72,6 +72,8 @@ public abstract class BKException extends org.apache.bookkeeper.client.api.BKExc
             return new BKNotEnoughBookiesException();
         case Code.NoSuchLedgerExistsException:
             return new BKNoSuchLedgerExistsException();
+        case Code.NoSuchLedgerExistsOnMetadataServerException:
+            return new BKNoSuchLedgerExistsOnMetadataServerException();
         case Code.BookieHandleNotAvailableException:
             return new BKBookieHandleNotAvailableException();
         case Code.ZKException:
@@ -277,6 +279,14 @@ public abstract class BKException extends org.apache.bookkeeper.client.api.BKExc
     public static class BKNoSuchLedgerExistsException extends BKException {
         public BKNoSuchLedgerExistsException() {
             super(BKException.Code.NoSuchLedgerExistsException);
+        }
+    }
+    /**
+     * Bookkeeper no such ledger exists on metadata server exception.
+     */
+    public static class BKNoSuchLedgerExistsOnMetadataServerException extends BKException {
+        public BKNoSuchLedgerExistsOnMetadataServerException() {
+            super(Code.NoSuchLedgerExistsOnMetadataServerException);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1542,7 +1542,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         } catch (ExecutionException e) {
             if (e.getCause() != null
                     && e.getCause().getClass()
-                    .equals( BKException.BKNoSuchLedgerExistsOnMetadataServerException.class)) {
+                    .equals(BKException.BKNoSuchLedgerExistsOnMetadataServerException.class)) {
                 LOG.debug("Ledger: {} has been deleted", ledgerId);
                 return false;
             } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -492,7 +492,7 @@ public class BookKeeperAdmin implements AutoCloseable {
                 bkc.getLedgerManager().readLedgerMetadata(lid)
                     .whenComplete((metadata, exception) -> {
                             if (BKException.getExceptionCode(exception)
-                                == BKException.Code.NoSuchLedgerExistsException) {
+                                == BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                                 // the ledger was deleted during this iteration.
                                 cb.processResult(BKException.Code.OK, null, null);
                                 return;
@@ -1541,7 +1541,7 @@ public class BookKeeperAdmin implements AutoCloseable {
             throw new RuntimeException(ie);
         } catch (ExecutionException e) {
             if (e.getCause() != null
-                    && e.getCause().getClass().equals(BKException.BKNoSuchLedgerExistsException.class)) {
+                    && e.getCause().getClass().equals(BKException.BKNoSuchLedgerExistsOnMetadataServerException.class)) {
                 LOG.debug("Ledger: {} has been deleted", ledgerId);
                 return false;
             } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1541,7 +1541,8 @@ public class BookKeeperAdmin implements AutoCloseable {
             throw new RuntimeException(ie);
         } catch (ExecutionException e) {
             if (e.getCause() != null
-                    && e.getCause().getClass().equals(BKException.BKNoSuchLedgerExistsOnMetadataServerException.class)) {
+                    && e.getCause().getClass()
+                    .equals( BKException.BKNoSuchLedgerExistsOnMetadataServerException.class)) {
                 LOG.debug("Ledger: {} has been deleted", ledgerId);
                 return false;
             } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
@@ -264,7 +264,8 @@ public class LedgerChecker {
 
         public void readEntryComplete(int rc, long ledgerId, long entryId,
                                       ByteBuf buffer, Object ctx) {
-            if (BKException.Code.NoSuchEntryException != rc && BKException.Code.NoSuchLedgerExistsException != rc) {
+            if (BKException.Code.NoSuchEntryException != rc && BKException.Code.NoSuchLedgerExistsException != rc
+                    && BKException.Code.NoSuchLedgerExistsOnMetadataServerException != rc) {
                 entryMayExist.set(true);
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/UpdateLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/UpdateLedgerOp.java
@@ -116,7 +116,7 @@ public class UpdateLedgerOp {
             outstanding.add(writePromise);
             writePromise.whenComplete((metadata, ex) -> {
                         if (ex != null
-                            && !(ex instanceof BKException.BKNoSuchLedgerExistsException)) {
+                            && !(ex instanceof BKException.BKNoSuchLedgerExistsOnMetadataServerException)) {
                             String error = String.format("Failed to update ledger metadata %s, replacing %s with %s",
                                                          ledgerId, oldBookieId, newBookieId);
                             LOG.error(error, ex);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
@@ -116,7 +116,9 @@ public class BKException extends Exception {
         case Code.NotEnoughBookiesException:
             return "Not enough non-faulty bookies available";
         case Code.NoSuchLedgerExistsException:
-            return "No such ledger exists";
+            return "No such ledger exists on Bookies";
+        case Code.NoSuchLedgerExistsOnMetadataServerException:
+            return "No such ledger exists on Metadata Server";
         case Code.BookieHandleNotAvailableException:
             return "Bookie handle is not available";
         case Code.ZKException:
@@ -241,6 +243,9 @@ public class BKException extends Exception {
          */
         int TimeoutException = -23;
         int SecurityException = -24;
+
+        /** No such ledger exists one metadata server. */
+        int NoSuchLedgerExistsOnMetadataServerException = -25;
 
         /**
          * Operation is illegal.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/OpenBuilderBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/OpenBuilderBase.java
@@ -66,7 +66,7 @@ public abstract class OpenBuilderBase implements OpenBuilder {
     protected int validate() {
         if (ledgerId < 0) {
             LOG.error("invalid ledgerId {} < 0", ledgerId);
-            return Code.NoSuchLedgerExistsException;
+            return Code.NoSuchLedgerExistsOnMetadataServerException;
         }
         return Code.OK;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -127,8 +127,8 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                             }
                         });
                 }
-            } else if (BKException.getExceptionCode(exception) ==
-                    BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
+            } else if (BKException.getExceptionCode(exception)
+                    == BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                 // the ledger is removed, do nothing
                 Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
                 if (null != listenerSet) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -127,7 +127,8 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                             }
                         });
                 }
-            } else if (BKException.getExceptionCode(exception) == BKException.Code.NoSuchLedgerExistsException) {
+            } else if (BKException.getExceptionCode(exception) ==
+                    BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                 // the ledger is removed, do nothing
                 Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
                 if (null != listenerSet) {
@@ -302,7 +303,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
             public void processResult(int rc, String path, Object ctx) {
                 if (rc == KeeperException.Code.NONODE.intValue()) {
                     LOG.warn("Ledger node does not exist in ZooKeeper: ledgerId={}", ledgerId);
-                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                 } else if (rc == KeeperException.Code.OK.intValue()) {
                     // removed listener on ledgerId
                     Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
@@ -393,7 +394,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                         LOG.debug("No such ledger: " + ledgerId,
                                   KeeperException.create(KeeperException.Code.get(rc), path));
                     }
-                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                     return;
                 }
                 if (rc != KeeperException.Code.OK.intValue()) {
@@ -450,7 +451,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                     promise.complete(new Versioned<>(metadata, new LongVersion(stat.getVersion())));
                 } else if (KeeperException.Code.NONODE.intValue() == rc) {
                     LOG.warn("Ledger node does not exist in ZooKeeper: ledgerId={}", ledgerId);
-                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                 } else {
                     LOG.warn("Conditional update ledger metadata failed: {}", KeeperException.Code.get(rc));
                     promise.completeExceptionally(new BKException.ZKException());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
@@ -65,7 +65,7 @@ public interface LedgerManager extends Closeable {
      * @return Future which, when completed, denotes that the ledger metadata has been removed.
      *         Completed with an exception:<ul>
      *          <li>{@link BKException.BKMetadataVersionException} if version doesn't match</li>
-     *          <li>{@link BKException.BKNoSuchLedgerExistsException} if ledger not exist</li>
+     *          <li>{@link BKException.BKNoSuchLedgerExistsOnMetadataServerException} if ledger not exist</li>
      *          <li>{@link BKException.ZKException} for other issues</li>
      *          </ul>
      */
@@ -78,7 +78,7 @@ public interface LedgerManager extends Closeable {
      *          Ledger Id
      * @return Future which, when completed, contains the requested versioned metadata.
      *         Completed with an exception::<ul>
-     *          <li>{@link BKException.BKNoSuchLedgerExistsException} if ledger not exist</li>
+     *          <li>{@link BKException.BKNoSuchLedgerExistsOnMetadataServerException} if ledger not exist</li>
      *          <li>{@link BKException.ZKException} for other issues</li>
      *          </ul>
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
@@ -263,8 +263,8 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
                                 }
                             });
                     }
-                } else if (BKException.getExceptionCode(exception) ==
-                        BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
+                } else if (BKException.getExceptionCode(exception)
+                        == BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                     // the ledger is removed, do nothing
                     Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
                     if (null != listenerSet) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
@@ -263,7 +263,8 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
                                 }
                             });
                     }
-                } else if (BKException.getExceptionCode(exception) == BKException.Code.NoSuchLedgerExistsException) {
+                } else if (BKException.getExceptionCode(exception) ==
+                        BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                     // the ledger is removed, do nothing
                     Set<LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
                     if (null != listenerSet) {
@@ -416,7 +417,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
                     int bkRc;
                     if (MSException.Code.NoKey.getCode() == rc) {
                         LOG.warn("Ledger entry does not exist in meta table: ledgerId={}", ledgerId);
-                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                     } else if (MSException.Code.OK.getCode() == rc) {
                         FutureUtils.complete(promise, null);
                     } else {
@@ -438,7 +439,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
                     if (MSException.Code.NoKey.getCode() == rc) {
                         LOG.error("No ledger metadata found for ledger " + ledgerId + " : ",
                                 MSException.create(MSException.Code.get(rc), "No key " + key + " found."));
-                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                         return;
                     }
                     if (MSException.Code.OK.getCode() != rc) {
@@ -489,7 +490,7 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
                         promise.completeExceptionally(new BKException.BKMetadataVersionException());
                     } else if (MSException.Code.NoKey.getCode() == rc) {
                         LOG.warn("Ledger {} doesn't exist when writing its ledger metadata.", ledgerId);
-                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                     } else if (MSException.Code.OK.getCode() == rc) {
                         promise.complete(new Versioned<>(metadata, version));
                     } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -895,7 +895,7 @@ public class Auditor implements AutoCloseable {
                         numFragmentsPerLedger.registerSuccessfulValue(lh.getNumFragments());
                         numBookiesPerLedger.registerSuccessfulValue(lh.getNumBookies());
                         numLedgersChecked.inc();
-                    } else if (Code.NoSuchLedgerExistsException == rc) {
+                    } else if (Code.NoSuchLedgerExistsOnMetadataServerException == rc) {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Ledger {} was deleted before we could check it", ledgerId);
                         }
@@ -967,7 +967,8 @@ public class Auditor implements AutoCloseable {
                         }
                         iterCallback.processResult(BKException.Code.OK, null, null);
                     } else if (BKException
-                            .getExceptionCode(exception) == BKException.Code.NoSuchLedgerExistsException) {
+                            .getExceptionCode(exception) ==
+                            BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                         LOG.debug("Ignoring replication of already deleted ledger {}", ledgerId);
                         iterCallback.processResult(BKException.Code.OK, null, null);
                     } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -966,9 +966,8 @@ public class Auditor implements AutoCloseable {
                             }
                         }
                         iterCallback.processResult(BKException.Code.OK, null, null);
-                    } else if (BKException
-                            .getExceptionCode(exception) ==
-                            BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
+                    } else if (BKException.getExceptionCode(exception)
+                            == BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                         LOG.debug("Ignoring replication of already deleted ledger {}", ledgerId);
                         iterCallback.processResult(BKException.Code.OK, null, null);
                     } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/BookieLedgerIndexer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/BookieLedgerIndexer.java
@@ -76,7 +76,7 @@ public class BookieLedgerIndexer {
                                     }
                                     iterCallback.processResult(BKException.Code.OK, null, null);
                                 } else if (BKException.getExceptionCode(exception)
-                                           == BKException.Code.NoSuchLedgerExistsException) {
+                                           == BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                                     LOG.info("Ignoring replication of already deleted ledger {}", ledgerId);
                                     iterCallback.processResult(BKException.Code.OK, null, null);
                                 } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.bookie.BookieThread;
 import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsException;
+import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsOnMetadataServerException;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
@@ -330,14 +330,14 @@ public class ReplicationWorker implements Runnable {
                 return false;
             }
 
-        } catch (BKNoSuchLedgerExistsException e) {
+        } catch (BKNoSuchLedgerExistsOnMetadataServerException e) {
             // Ledger might have been deleted by user
-            LOG.info("BKNoSuchLedgerExistsException while opening "
+            LOG.info("BKNoSuchLedgerExistsOnMetadataServerException while opening "
                 + "ledger {} for replication. Other clients "
                 + "might have deleted the ledger. "
                 + "So, no harm to continue", ledgerIdToReplicate);
             underreplicationManager.markLedgerReplicated(ledgerIdToReplicate);
-            getExceptionCounter("BKNoSuchLedgerExistsException").inc();
+            getExceptionCounter("BKNoSuchLedgerExistsOnMetadataServerException").inc();
             return false;
         } catch (BKNotEnoughBookiesException e) {
             logBKExceptionAndReleaseLedger(e, ledgerIdToReplicate);
@@ -456,7 +456,7 @@ public class ReplicationWorker implements Runnable {
                     Thread.currentThread().interrupt();
                     LOG.info("InterruptedException while fencing the ledger {}"
                             + " for rereplication of postponed ledgers", ledgerId, e);
-                } catch (BKNoSuchLedgerExistsException bknsle) {
+                } catch (BKNoSuchLedgerExistsOnMetadataServerException bknsle) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Ledger {} was deleted, safe to continue", ledgerId, bknsle);
                     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeper.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeper.java
@@ -163,7 +163,7 @@ public class MockBookKeeper extends BookKeeper {
 
         MockLedgerHandle lh = ledgers.get(lId);
         if (lh == null) {
-            cb.openComplete(BKException.Code.NoSuchLedgerExistsException, null, ctx);
+            cb.openComplete(BKException.Code.NoSuchLedgerExistsOnMetadataServerException, null, ctx);
         } else if (lh.digest != digestType) {
             cb.openComplete(BKException.Code.DigestMatchException, null, ctx);
         } else if (!Arrays.equals(lh.passwd, passwd)) {
@@ -190,7 +190,7 @@ public class MockBookKeeper extends BookKeeper {
             ledgers.remove(lId);
             cb.deleteComplete(0, ctx);
         } else {
-            cb.deleteComplete(BKException.Code.NoSuchLedgerExistsException, ctx);
+            cb.deleteComplete(BKException.Code.NoSuchLedgerExistsOnMetadataServerException, ctx);
         }
     }
 
@@ -203,7 +203,7 @@ public class MockBookKeeper extends BookKeeper {
         }
 
         if (!ledgers.containsKey(lId)) {
-            throw BKException.create(BKException.Code.NoSuchLedgerExistsException);
+            throw BKException.create(BKException.Code.NoSuchLedgerExistsOnMetadataServerException);
         }
 
         ledgers.remove(lId);
@@ -238,7 +238,7 @@ public class MockBookKeeper extends BookKeeper {
 
                 MockLedgerHandle lh = ledgers.get(ledgerId);
                 if (lh == null) {
-                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                 } else if (lh.digest != DigestType.fromApiDigestType(digestType)) {
                     promise.completeExceptionally(new BKException.BKDigestMatchException());
                 } else if (!Arrays.equals(lh.passwd, password)) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -379,7 +379,7 @@ public abstract class MockBookKeeperTestCase {
             executor.executeOrdered(ledgerId, () -> {
                 LedgerMetadata ledgerMetadata = mockLedgerMetadataRegistry.get(ledgerId);
                 if (ledgerMetadata == null) {
-                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                 } else {
                     promise.complete(new Versioned<>(ledgerMetadata, new LongVersion(1)));
                 }
@@ -398,7 +398,7 @@ public abstract class MockBookKeeperTestCase {
                     if (mockLedgerMetadataRegistry.remove(ledgerId) != null) {
                         promise.complete(null);
                     } else {
-                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
                     }
                 });
             return promise;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperApiTest.java
@@ -41,7 +41,7 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.BKDigestMatchException;
 import org.apache.bookkeeper.client.BKException.BKDuplicateEntryIdException;
 import org.apache.bookkeeper.client.BKException.BKLedgerFencedException;
-import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsException;
+import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsOnMetadataServerException;
 import org.apache.bookkeeper.client.BKException.BKUnauthorizedAccessException;
 import org.apache.bookkeeper.client.MockBookKeeperTestCase;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -339,7 +339,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
         }
     }
 
-    @Test(expected = BKNoSuchLedgerExistsException.class)
+    @Test(expected = BKNoSuchLedgerExistsOnMetadataServerException.class)
     public void testDeleteLedger() throws Exception {
         long lId;
 
@@ -358,7 +358,7 @@ public class BookKeeperApiTest extends MockBookKeeperTestCase {
             .execute());
     }
 
-    @Test(expected = BKNoSuchLedgerExistsException.class)
+    @Test(expected = BKNoSuchLedgerExistsOnMetadataServerException.class)
     public void testCannotDeleteLedgerTwice() throws Exception {
         long lId;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.bookkeeper.client.BKException.BKClientClosedException;
 import org.apache.bookkeeper.client.BKException.BKIncorrectParameterException;
-import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsException;
+import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsOnMetadataServerException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.LedgerMetadataBuilder;
@@ -307,12 +307,12 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
         fail("shoud not be able to create a ledger with such specs");
     }
 
-    @Test(expected = BKNoSuchLedgerExistsException.class)
+    @Test(expected = BKNoSuchLedgerExistsOnMetadataServerException.class)
     public void testOpenLedgerNoId() throws Exception {
         result(newOpenLedgerOp().execute());
     }
 
-    @Test(expected = BKNoSuchLedgerExistsException.class)
+    @Test(expected = BKNoSuchLedgerExistsOnMetadataServerException.class)
     public void testOpenLedgerBadId() throws Exception {
         result(newOpenLedgerOp()
             .withPassword(password)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
@@ -275,7 +275,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
             result(ledgerManager.removeLedgerMetadata(ledgerId, version));
             fail("Should fail to remove metadata if no such ledger exists");
         } catch (BKException bke) {
-            assertEquals(Code.NoSuchLedgerExistsException, bke.getCode());
+            assertEquals(Code.NoSuchLedgerExistsOnMetadataServerException, bke.getCode());
         }
 
         verify(mockZk, times(1))
@@ -366,7 +366,7 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
             result(ledgerManager.readLedgerMetadata(ledgerId));
             fail("Should fail on reading ledger metadata if a ledger doesn't exist");
         } catch (BKException bke) {
-            assertEquals(Code.NoSuchLedgerExistsException, bke.getCode());
+            assertEquals(Code.NoSuchLedgerExistsOnMetadataServerException, bke.getCode());
         }
 
         verify(mockZk, times(1))

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -406,7 +406,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
      *
      * ScanAndCompareGarbageCollector/GC should clean data of ledger only if both the LedgerManager.getLedgerRanges says
      * that ledger is not existing and also ledgerManager.readLedgerMetadata fails with error
-     * NoSuchLedgerExistsException.
+     * NoSuchLedgerExistsOnMetadataServerException.
      *
      */
     @Test
@@ -464,7 +464,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
      *
      * ScanAndCompareGarbageCollector/GC should clean data of ledger only if both the LedgerManager.getLedgerRanges says
      * that ledger is not existing and also ledgerManager.readLedgerMetadata fails with error
-     * NoSuchLedgerExistsException.
+     * NoSuchLedgerExistsOnMetadataServerException.
      *
      */
     @Test
@@ -508,7 +508,8 @@ public class GcLedgersTest extends LedgerManagerTestCase {
      *
      * ScanAndCompareGarbageCollector/GC should clean data of ledger only if both the LedgerManager.getLedgerRanges says
      * that ledger is not existing and also ledgerManager.readLedgerMetadata fails with error
-     * NoSuchLedgerExistsException, but is shouldn't delete if the readLedgerMetadata fails with any other error.
+     * NoSuchLedgerExistsOnMetadataServerException, but is shouldn't delete if the readLedgerMetadata fails with any
+     * other error.
      */
     @Test
     public void testGcLedgersIfReadLedgerMetadataFailsForDeletedLedgers() throws Exception {

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocator.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocator.java
@@ -271,7 +271,7 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
         try {
             bkc.get().openLedger(lh1.getId(), BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
             fail("LedgerHandle allocated by allocator1 should be deleted.");
-        } catch (BKException.BKNoSuchLedgerExistsException nslee) {
+        } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException nslee) {
             // as expected
         }
         long eid = lh2.addEntry("hello world".getBytes());

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/tools/TestDistributedLogTool.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/tools/TestDistributedLogTool.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.net.URI;
-import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsException;
+import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsOnMetadataServerException;
 import org.apache.bookkeeper.common.util.ReflectionUtils;
 import org.apache.distributedlog.DLMTestUtil;
 import org.apache.distributedlog.DLSN;
@@ -203,7 +203,7 @@ public class TestDistributedLogTool extends TestDistributedLogBase {
         // correct functionality.
         try {
             cmd.runCmd();
-        } catch (BKNoSuchLedgerExistsException ex) {
+        } catch (BKNoSuchLedgerExistsOnMetadataServerException ex) {
         }
     }
 
@@ -214,7 +214,7 @@ public class TestDistributedLogTool extends TestDistributedLogBase {
         cmd.setLedgerId(99999999);
         try {
             cmd.runCmd();
-        } catch (BKNoSuchLedgerExistsException ex) {
+        } catch (BKNoSuchLedgerExistsOnMetadataServerException ex) {
         }
     }
 

--- a/tests/integration/smoke/src/test/java/org/apache/bookkeeper/tests/integration/TestBookieShellCluster.java
+++ b/tests/integration/smoke/src/test/java/org/apache/bookkeeper/tests/integration/TestBookieShellCluster.java
@@ -211,7 +211,8 @@ public class TestBookieShellCluster extends BookieShellTestBase {
                 validateNEntries(bk, ledgerId, numEntries);
                 Assert.fail("Shouldn't have been able to find anything");
             } catch (ExecutionException ee) {
-                Assert.assertEquals(ee.getCause().getClass(), BKException.BKNoSuchLedgerExistsException.class);
+                Assert.assertEquals(ee.getCause().getClass(),
+                        BKException.BKNoSuchLedgerExistsOnMetadataServerException.class);
             }
 
             log.info("Restore the ledger metadata");


### PR DESCRIPTION
Client can get no extent error in the following two scenarios.
1. When client attempted to read/open an extent that
   is not on ZK (metadata server)
2. When client attempted to read a Ledger which is on metadata
   server, but somehow missing on bookies (Data server)

It is quite confusing to get the same error, NoSuchLedgerExists
for both these cases. This checkin introduced a new error at the
BookKeeper client level, NoSuchLedgerExistsOnMetadataServer if
it is not available on ZK.

For errors related to Ledger is not available on bookie,
I left NoSuchLedgerExists as-is(instead of changing it to
NoSuchLedgerExistsOnDataServer) to minimize code changes.

This change alone provides enough distinction between these
two types of errors.

Signed-off-by: Venkateswararao Jujjuri (JV) <vjujjuri@salesforce.com>

Descriptions of the changes in this PR:



### Motivation

(Explain: why you're making that change, what is the problem you're trying to solve)

### Changes

(Describe: what changes you have made)

Master Issue: #<master-issue-number>

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java11]: skip build on java11. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
