### PR TITLE
ISSUE-2067: reduce byte[] allocation in add entry

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -20,7 +20,6 @@ package org.apache.bookkeeper.proto.checksum;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ReferenceCountUtil;
 
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
@@ -99,41 +98,17 @@ public abstract class DigestManager {
      */
     public ByteBufList computeDigestAndPackageForSending(long entryId, long lastAddConfirmed, long length,
             ByteBuf data) {
-        if (this.useV2Protocol) {
-            /*
-             * For V2 protocol, use pooled direct ByteBuf's to avoid object allocation in DigestManager.
-             */
-            ByteBuf headersBuffer = allocator.buffer(METADATA_LENGTH + macCodeLength);
-            headersBuffer.writeLong(ledgerId);
-            headersBuffer.writeLong(entryId);
-            headersBuffer.writeLong(lastAddConfirmed);
-            headersBuffer.writeLong(length);
+        ByteBuf headersBuffer = allocator.buffer(METADATA_LENGTH + macCodeLength);
+        headersBuffer.writeLong(ledgerId);
+        headersBuffer.writeLong(entryId);
+        headersBuffer.writeLong(lastAddConfirmed);
+        headersBuffer.writeLong(length);
 
-            update(headersBuffer);
-            update(data);
-            populateValueAndReset(headersBuffer);
+        update(headersBuffer);
+        update(data);
+        populateValueAndReset(headersBuffer);
 
-            return ByteBufList.get(headersBuffer, data);
-        } else {
-            /*
-             * For V3 protocol, use unpooled heap ByteBuf's (backed by accessible array): The one object
-             * allocation here saves us later allocations when converting to protobuf ByteString.
-             */
-            ByteBuf sendBuffer = Unpooled.buffer(METADATA_LENGTH + macCodeLength + data.readableBytes());
-            sendBuffer.writeLong(ledgerId);
-            sendBuffer.writeLong(entryId);
-            sendBuffer.writeLong(lastAddConfirmed);
-            sendBuffer.writeLong(length);
-
-            update(sendBuffer);
-            update(data);
-            populateValueAndReset(sendBuffer);
-
-            sendBuffer.writeBytes(data, data.readerIndex(), data.readableBytes());
-            ReferenceCountUtil.release(data);
-
-            return ByteBufList.get(sendBuffer);
-        }
+        return ByteBufList.get(headersBuffer, data);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -98,7 +98,12 @@ public abstract class DigestManager {
      */
     public ByteBufList computeDigestAndPackageForSending(long entryId, long lastAddConfirmed, long length,
             ByteBuf data) {
-        ByteBuf headersBuffer = allocator.buffer(METADATA_LENGTH + macCodeLength);
+        ByteBuf headersBuffer;
+        if (this.useV2Protocol) {
+            headersBuffer = allocator.buffer(METADATA_LENGTH + macCodeLength);
+        } else {
+            headersBuffer = Unpooled.buffer(METADATA_LENGTH + macCodeLength);
+        }
         headersBuffer.writeLong(ledgerId);
         headersBuffer.writeLong(entryId);
         headersBuffer.writeLong(lastAddConfirmed);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerMetadataSerDe.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerMetadataSerDe.java
@@ -130,6 +130,7 @@ public class TestLedgerMetadataSerDe {
             .newEnsembleEntry(0L, Lists.newArrayList(new BookieSocketAddress("192.0.2.1", 3181),
                                                      new BookieSocketAddress("192.0.2.2", 3181),
                                                      new BookieSocketAddress("192.0.2.3", 3181)))
+            .withMetadataFormatVersion(LedgerMetadataSerDe.METADATA_FORMAT_VERSION_2)
             .build();
         byte[] encoded = serDe.serialize(metadata);
 
@@ -170,6 +171,7 @@ public class TestLedgerMetadataSerDe {
                                       new BookieSocketAddress("192.0.2.1", 1234),
                                       new BookieSocketAddress("192.0.2.2", 1234),
                                       new BookieSocketAddress("192.0.2.3", 1234)))
+            .withMetadataFormatVersion(LedgerMetadataSerDe.METADATA_FORMAT_VERSION_2)
             .build();
 
         LedgerMetadataSerDe serDe = new LedgerMetadataSerDe();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerMetadataSerDe.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/TestLedgerMetadataSerDe.java
@@ -130,7 +130,6 @@ public class TestLedgerMetadataSerDe {
             .newEnsembleEntry(0L, Lists.newArrayList(new BookieSocketAddress("192.0.2.1", 3181),
                                                      new BookieSocketAddress("192.0.2.2", 3181),
                                                      new BookieSocketAddress("192.0.2.3", 3181)))
-            .withMetadataFormatVersion(LedgerMetadataSerDe.METADATA_FORMAT_VERSION_2)
             .build();
         byte[] encoded = serDe.serialize(metadata);
 
@@ -171,7 +170,6 @@ public class TestLedgerMetadataSerDe {
                                       new BookieSocketAddress("192.0.2.1", 1234),
                                       new BookieSocketAddress("192.0.2.2", 1234),
                                       new BookieSocketAddress("192.0.2.3", 1234)))
-            .withMetadataFormatVersion(LedgerMetadataSerDe.METADATA_FORMAT_VERSION_2)
             .build();
 
         LedgerMetadataSerDe serDe = new LedgerMetadataSerDe();


### PR DESCRIPTION
Descriptions of the changes in this PR:
This change removes a byte[] copy in DigestManager digest calculation
(computeDigestAndPackageForSending)
that puts crc header and payload in a continuous buffer. Instead,
it uses protobuf ByteString.concat to concatenate header and payload
without copy when building protobuf message.




### Motivation

In add entry code path, I see lots of byte[] allocated to do digest calculation.  It's possible to not allocate byte[]. 

### Changes

Don't allocate a ByteBuf to copy data. Keep header and data separate, but use ByteString.concat when construct protobuf message.

Master Issue: #2067 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java11]: skip build on java11. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
