### PR TITLE
Issue 1927: fix NoNodeException in LocalBookeeper

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -134,17 +134,16 @@ public class LocalBookKeeper {
                     .connectString(zkHost + ":" + zkPort)
                     .sessionTimeoutMs(zkSessionTimeOut)
                     .build()) {
-            List<Op> multiOps = Lists.newArrayListWithExpectedSize(3);
             String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(baseConf);
-            multiOps.add(
-                Op.create(zkLedgersRootPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
+            ZkUtils.createFullPathOptimistic(zkc, zkLedgersRootPath, new byte[0], Ids.OPEN_ACL_UNSAFE,
+                    CreateMode.PERSISTENT);
+            List<Op> multiOps = Lists.newArrayListWithExpectedSize(2);
             multiOps.add(
                 Op.create(zkLedgersRootPath + "/" + AVAILABLE_NODE,
                     new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
             multiOps.add(
                 Op.create(zkLedgersRootPath + "/" + AVAILABLE_NODE + "/" + READONLY,
                     new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
-
             zkc.multi(multiOps);
             // No need to create an entry for each requested bookie anymore as the
             // BookieServers will register themselves with ZooKeeper on startup.
@@ -345,11 +344,6 @@ public class LocalBookKeeper {
                                           String zkDataDir,
                                           String localBookiesConfigDirName)
             throws Exception {
-        if (!BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH.equals(conf.getZkLedgersRootPath())) {
-            throw new Exception("Couldn't use non-default zkLedgersRootPath in LocalBookkeeper. "
-                    + "Default zkLedgersRootPath is " + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH
-                    + ". Yours is " + conf.getZkLedgersRootPath());
-        }
         conf.setMetadataServiceUri(
                 newMetadataServiceUri(
                         zkHost,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -345,7 +345,7 @@ public class LocalBookKeeper {
                                           String zkDataDir,
                                           String localBookiesConfigDirName)
             throws Exception {
-        if (conf.getZkLedgersRootPath() != BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH) {
+        if (!BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH.equals(conf.getZkLedgersRootPath())) {
             throw new Exception("Couldn't use non-default zkLedgersRootPath in LocalBookkeeper. "
                     + "Default zkLedgersRootPath is " + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH
                     + ". Yours is " + conf.getZkLedgersRootPath());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -346,9 +346,9 @@ public class LocalBookKeeper {
                                           String localBookiesConfigDirName)
             throws Exception {
         if (conf.getZkLedgersRootPath() != BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH) {
-            throw new Exception("Couldn't use non-default zkLedgersRootPath in LocalBookkeeper. " +
-                    "Default zkLedgersRootPath is " + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH +
-                    ". Yours is " + conf.getZkLedgersRootPath());
+            throw new Exception("Couldn't use non-default zkLedgersRootPath in LocalBookkeeper. "
+                    + "Default zkLedgersRootPath is " + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH
+                    + ". Yours is " + conf.getZkLedgersRootPath());
         }
         conf.setMetadataServiceUri(
                 newMetadataServiceUri(

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -345,7 +345,11 @@ public class LocalBookKeeper {
                                           String zkDataDir,
                                           String localBookiesConfigDirName)
             throws Exception {
-
+        if (conf.getZkLedgersRootPath() != BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH) {
+            throw new Exception("Couldn't use non-default zkLedgersRootPath in LocalBookkeeper. " +
+                    "Default zkLedgersRootPath is " + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH +
+                    ". Yours is " + conf.getZkLedgersRootPath());
+        }
         conf.setMetadataServiceUri(
                 newMetadataServiceUri(
                         zkHost,
@@ -353,7 +357,6 @@ public class LocalBookKeeper {
                         conf.getLedgerManagerLayoutStringFromFactoryClass(),
                         conf.getZkLedgersRootPath()));
         LocalBookKeeper lb = new LocalBookKeeper(numBookies, initialBookiePort, conf, localBookiesConfigDirName);
-
         ZooKeeperServerShim zks = null;
         File zkTmpDir = null;
         List<File> bkTmpDirs = null;


### PR DESCRIPTION
### Motivation
It addresses #1927 where it provides a conf check at the beginning of startLocalBookiesInternal function.
### Changes

- Add a conf check at the beginning of startLocalBookiesInternal function where non-default zkLedgersRootPath is not allowed.

cc @sijie 