### PR TITLE
Update and flush lastLogMark when replaying journal

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -924,7 +924,7 @@ public class Bookie extends BookieCriticalThread {
             journal.scanJournal(id, logPosition, scanner);
             // Update LastLogMark to Long.MAX_VALUE position after replaying journal
             // After LedgerStorage flush, SyncThread should persist this to disk
-            journal.getLastLogMark().setCurLogMark(id, Long.MAX_VALUE);
+            journal.setLastLogMarkToEof(id);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -872,6 +872,7 @@ public class Bookie extends BookieCriticalThread {
                         recBuff.rewind();
                         handle.addEntry(Unpooled.wrappedBuffer(recBuff));
                     }
+
                 } catch (NoLedgerException nsle) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Skip replaying entries of ledger {} since it was deleted.", ledgerId);
@@ -883,10 +884,49 @@ public class Bookie extends BookieCriticalThread {
         };
 
         for (Journal journal : journals) {
-            journal.replay(scanner);
+            replay(journal, scanner);
         }
         long elapsedTs = System.currentTimeMillis() - startTs;
         LOG.info("Finished replaying journal in {} ms.", elapsedTs);
+    }
+
+    /**
+     * Replay journal files and updates journal's in-memory lastLogMark object.
+     *
+     * @param journal Journal object corresponding to a journalDir
+     * @param scanner Scanner to process replayed entries.
+     * @throws IOException
+     */
+    private void replay(Journal journal, JournalScanner scanner) throws IOException {
+        final LogMark markedLog = journal.getLastLogMark().getCurMark();
+        List<Long> logs = Journal.listJournalIds(journal.getJournalDirectory(), journalId -> {
+            if (journalId < markedLog.getLogFileId()) {
+                return false;
+            }
+            return true;
+        });
+        // last log mark may be missed due to no sync up before
+        // validate filtered log ids only when we have markedLogId
+        if (markedLog.getLogFileId() > 0) {
+            if (logs.size() == 0 || logs.get(0) != markedLog.getLogFileId()) {
+                throw new IOException("Recovery log " + markedLog.getLogFileId() + " is missing");
+            }
+        }
+
+        // TODO: When reading in the journal logs that need to be synced, we
+        // should use BufferedChannels instead to minimize the amount of
+        // system calls done.
+        for (Long id : logs) {
+            long logPosition = 0L;
+            if (id == markedLog.getLogFileId()) {
+                logPosition = markedLog.getLogFileOffset();
+            }
+            LOG.info("Replaying journal {} from position {}", id, logPosition);
+            journal.scanJournal(id, logPosition, scanner);
+            // Update LastLogMark to Long.MAX_VALUE position after replaying journal
+            // After LedgerStorage flush, SyncThread should persist this to disk
+            journal.getLastLogMark().setCurLogMark(id, Long.MAX_VALUE);
+        }
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -872,7 +872,6 @@ public class Bookie extends BookieCriticalThread {
                         recBuff.rewind();
                         handle.addEntry(Unpooled.wrappedBuffer(recBuff));
                     }
-
                 } catch (NoLedgerException nsle) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Skip replaying entries of ledger {} since it was deleted.", ledgerId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -710,6 +710,15 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
     }
 
     /**
+     * Update lastLogMark of the journal,
+     * Indicates that the file has been processed.
+     * @param id
+     */
+    void setLastLogMarkToEof(Long id) {
+        lastLogMark.getCurMark().setLogMark(id, Long.MAX_VALUE);
+    }
+
+    /**
      * Application tried to schedule a checkpoint. After all the txns added
      * before checkpoint are persisted, a <i>checkpoint</i> will be returned
      * to application. Application could use <i>checkpoint</i> to do its logic.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -59,6 +59,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.bookkeeper.bookie.BookieException.DiskPartitionDuplicationException;
 import org.apache.bookkeeper.bookie.BookieException.MetadataStoreException;
+import org.apache.bookkeeper.bookie.Journal.LastLogMark;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -134,6 +135,126 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
             driver.close();
         }
         super.tearDown();
+    }
+
+    @Test
+    public void testOneJournalReplayForBookieRestartInReadOnlyMode() throws Exception {
+        testJournalReplayForBookieRestartInReadOnlyMode(1);
+    }
+
+    @Test
+    public void testFourJournalReplayForBookieRestartInReadOnlyMode() throws Exception {
+        testJournalReplayForBookieRestartInReadOnlyMode(4);
+    }
+
+    /**
+     * Tests that journal replay works correctly when bookie crashes and starts up in RO mode
+     */
+    private void testJournalReplayForBookieRestartInReadOnlyMode(int numOfJournalDirs) throws Exception {
+        File tmpLedgerDir = createTempDir("DiskCheck", "test");
+        File tmpJournalDir = createTempDir("DiskCheck", "test");
+
+        String[] journalDirs = new String[numOfJournalDirs];
+        for (int i = 0; i < numOfJournalDirs; i++) {
+            journalDirs[i] = tmpJournalDir.getAbsolutePath() + "/journal-" + i;
+        }
+
+        final ServerConfiguration conf = newServerConfiguration()
+                .setJournalDirsName(journalDirs)
+                .setLedgerDirNames(new String[] { tmpLedgerDir.getPath() })
+                .setDiskCheckInterval(1000)
+                .setLedgerStorageClass(SortedLedgerStorage.class.getName())
+                .setAutoRecoveryDaemonEnabled(false)
+                .setZkTimeout(5000);
+
+        BookieServer server = new MockBookieServer(conf);
+        server.start();
+
+        List<LastLogMark> lastLogMarkList = new ArrayList<>(journalDirs.length);
+
+        for (int i = 0; i < journalDirs.length; i++) {
+            Journal journal = server.getBookie().journals.get(i);
+            // LastLogMark should be (0, 0) at the bookie clean start
+            journal.getLastLogMark().readLog();
+            lastLogMarkList.add(journal.getLastLogMark().markLog());
+            assertEquals(0, lastLogMarkList.get(i).getCurMark().compare(new LogMark(0, 0)));
+        }
+
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setMetadataServiceUri(metadataServiceUri);
+        BookKeeper bkClient = new BookKeeper(clientConf);
+
+        // Create multiple ledgers for adding entries to multiple journals
+        for (int i = 0; i < journalDirs.length; i++) {
+            LedgerHandle lh = bkClient.createLedger(1, 1, 1, DigestType.CRC32, "passwd".getBytes());
+            long entryId = -1;
+            // Ensure that we have non-zero number of entries
+            long numOfEntries = new Random().nextInt(10) + 3;
+            for (int j = 0; j < numOfEntries; j++) {
+                entryId = lh.addEntry("data".getBytes());
+            }
+            assertEquals(entryId, (numOfEntries - 1));
+            lh.close();
+        }
+
+        for (int i = 0; i < journalDirs.length; i++) {
+            Journal journal = server.getBookie().journals.get(i);
+            // In-memory LastLogMark should be updated with every write to journal
+            assertTrue(journal.getLastLogMark().getCurMark().compare(lastLogMarkList.get(i).getCurMark()) > 0);
+            lastLogMarkList.set(i, journal.getLastLogMark().markLog());
+        }
+
+        // Kill Bookie abruptly before entries are flushed to disk
+        server.shutdown();
+
+        conf.setDiskUsageThreshold(0.001f)
+                .setDiskUsageWarnThreshold(0.0f).setReadOnlyModeEnabled(true).setIsForceGCAllowWhenNoSpace(true)
+                .setMinUsableSizeForIndexFileCreation(5 * 1024);
+
+        server = new BookieServer(conf);
+
+        for (int i = 0; i < journalDirs.length; i++) {
+            Journal journal = server.getBookie().journals.get(i);
+            // LastLogMark should be (0, 0) before bookie restart since bookie crashed before persisting lastMark
+            assertEquals(0, journal.getLastLogMark().getCurMark().compare(new LogMark(0, 0)));
+        }
+
+        int numOfRestarts = 3;
+        // Restart server multiple times to ensure that logs are never replayed and new files are not generated
+        for (int i = 0; i < numOfRestarts; i++) {
+
+            int txnBefore = countNumOfFiles(conf.getJournalDirs(), "txn");
+            int logBefore = countNumOfFiles(conf.getLedgerDirs(), "log");
+            int idxBefore = countNumOfFiles(conf.getLedgerDirs(), "idx");
+
+            server.start();
+
+            for (int j = 0; j < journalDirs.length; j++) {
+                Journal journal = server.getBookie().journals.get(j);
+                assertTrue(journal.getLastLogMark().getCurMark().compare(lastLogMarkList.get(j).getCurMark()) >= 0);
+                lastLogMarkList.set(j, journal.getLastLogMark().markLog());
+            }
+
+            server.shutdown();
+
+            // Every bookie restart initiates a new journal file
+            // Journals should not be replayed everytime since lastMark gets updated everytime
+            // New EntryLog files should not be generated.
+            assertEquals(journalDirs.length, (countNumOfFiles(conf.getJournalDirs(), "txn") - txnBefore));
+
+            // First restart should replay journal and generate new log/index files
+            // Subsequent runs should not generate new files (but can delete older ones)
+            if (i == 0) {
+                assertTrue((countNumOfFiles(conf.getLedgerDirs(), "log") - logBefore) > 0);
+                assertTrue((countNumOfFiles(conf.getLedgerDirs(), "idx") - idxBefore) > 0);
+            } else {
+                assertTrue((countNumOfFiles(conf.getLedgerDirs(), "log") - logBefore) <= 0);
+                assertTrue((countNumOfFiles(conf.getLedgerDirs(), "idx") - idxBefore) <= 0);
+            }
+
+            server = new BookieServer(conf);
+        }
+        bkClient.close();
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -23,6 +23,7 @@ package org.apache.bookkeeper.bookie;
 import static com.google.common.base.Charsets.UTF_8;
 import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.BOOKIE_STATUS_FILENAME;
+import static org.apache.bookkeeper.util.TestUtils.countNumOfFiles;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -143,12 +144,12 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
     }
 
     @Test
-    public void testFourJournalReplayForBookieRestartInReadOnlyMode() throws Exception {
+    public void testMultipleJournalReplayForBookieRestartInReadOnlyMode() throws Exception {
         testJournalReplayForBookieRestartInReadOnlyMode(4);
     }
 
     /**
-     * Tests that journal replay works correctly when bookie crashes and starts up in RO mode
+     * Tests that journal replay works correctly when bookie crashes and starts up in RO mode.
      */
     private void testJournalReplayForBookieRestartInReadOnlyMode(int numOfJournalDirs) throws Exception {
         File tmpLedgerDir = createTempDir("DiskCheck", "test");
@@ -231,7 +232,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
 
             for (int j = 0; j < journalDirs.length; j++) {
                 Journal journal = server.getBookie().journals.get(j);
-                assertTrue(journal.getLastLogMark().getCurMark().compare(lastLogMarkList.get(j).getCurMark()) >= 0);
+                assertTrue(journal.getLastLogMark().getCurMark().compare(lastLogMarkList.get(j).getCurMark()) > 0);
                 lastLogMarkList.set(j, journal.getLastLogMark().markLog());
             }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
+import org.apache.bookkeeper.bookie.Journal.LastLogMark;
 import org.apache.bookkeeper.client.ClientUtil;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -350,8 +351,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = new Bookie(conf);
-        b.readJournal();
+        Bookie b = startBookieReadJournal(conf);
 
         b.readEntry(1, 100);
         try {
@@ -379,8 +379,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = new Bookie(conf);
-        b.readJournal();
+        Bookie b = startBookieReadJournal(conf);
 
         b.readEntry(1, 100);
         try {
@@ -410,8 +409,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = new Bookie(conf);
-        b.readJournal();
+        Bookie b = startBookieReadJournal(conf);
 
         for (int i = 1; i <= 2 * JournalChannel.SECTOR_SIZE; i++) {
             b.readEntry(1, i);
@@ -570,8 +568,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = new Bookie(conf);
-        b.readJournal();
+        Bookie b = startBookieReadJournal(conf);
 
         b.readEntry(1, 99);
 
@@ -614,8 +611,8 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = new Bookie(conf);
-        b.readJournal();
+        Bookie b = startBookieReadJournal(conf);
+
         b.readEntry(1, 99);
 
         // still able to read last entry, but it's junk
@@ -638,6 +635,15 @@ public class BookieJournalTest {
         } catch (Bookie.NoEntryException e) {
             // correct behaviour
         }
+    }
+
+    private Bookie startBookieReadJournal(ServerConfiguration conf) throws IOException, InterruptedException, BookieException {
+        Bookie b = new Bookie(conf);
+        Journal journal = b.journals.get(0);
+        LastLogMark lastLogMark = journal.getLastLogMark().markLog();
+        b.readJournal();
+        assertTrue(journal.getLastLogMark().getCurMark().compare(lastLogMark.getCurMark()) > 0);
+        return b;
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -351,7 +351,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = startBookieReadJournal(conf);
+        Bookie b = createBookieAndReadJournal(conf);
 
         b.readEntry(1, 100);
         try {
@@ -379,7 +379,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = startBookieReadJournal(conf);
+        Bookie b = createBookieAndReadJournal(conf);
 
         b.readEntry(1, 100);
         try {
@@ -409,7 +409,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = startBookieReadJournal(conf);
+        Bookie b = createBookieAndReadJournal(conf);
 
         for (int i = 1; i <= 2 * JournalChannel.SECTOR_SIZE; i++) {
             b.readEntry(1, i);
@@ -568,7 +568,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = startBookieReadJournal(conf);
+        Bookie b = createBookieAndReadJournal(conf);
 
         b.readEntry(1, 99);
 
@@ -611,7 +611,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = startBookieReadJournal(conf);
+        Bookie b = createBookieAndReadJournal(conf);
 
         b.readEntry(1, 99);
 
@@ -637,12 +637,13 @@ public class BookieJournalTest {
         }
     }
 
-    private Bookie startBookieReadJournal(ServerConfiguration conf) throws IOException, InterruptedException, BookieException {
+    private Bookie createBookieAndReadJournal(ServerConfiguration conf) throws Exception {
         Bookie b = new Bookie(conf);
-        Journal journal = b.journals.get(0);
-        LastLogMark lastLogMark = journal.getLastLogMark().markLog();
-        b.readJournal();
-        assertTrue(journal.getLastLogMark().getCurMark().compare(lastLogMark.getCurMark()) > 0);
+        for (Journal journal : b.journals) {
+            LastLogMark lastLogMark = journal.getLastLogMark().markLog();
+            b.readJournal();
+            assertTrue(journal.getLastLogMark().getCurMark().compare(lastLogMark.getCurMark()) > 0);
+        }
         return b;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
@@ -28,7 +28,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import io.netty.buffer.ByteBuf;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
@@ -28,11 +28,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +64,19 @@ public class BookieWriteToJournalTest {
 
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
+
+    class NoOpJournalReplayBookie extends Bookie {
+
+        public NoOpJournalReplayBookie(ServerConfiguration conf)
+                throws IOException, InterruptedException, BookieException {
+            super(conf);
+        }
+
+        @Override
+        void readJournal() throws IOException, BookieException {
+            // Should be no-op since journal objects are mocked
+        }
+    }
 
     /**
      * test that Bookie calls correctly Journal.logAddEntry about "ackBeforeSync" parameter.
@@ -102,7 +117,7 @@ public class BookieWriteToJournalTest {
 
         whenNew(Journal.class).withAnyArguments().thenReturn(journal);
 
-        Bookie b = new Bookie(conf);
+        Bookie b = new NoOpJournalReplayBookie(conf);
         b.start();
 
         long ledgerId = 1;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -123,7 +123,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     public BookKeeperClusterTestCase(int numBookies, int testTimeoutSecs) {
-        this(numBookies, 1, 120);
+        this(numBookies, 1, testTimeoutSecs);
     }
 
     public BookKeeperClusterTestCase(int numBookies, int numOfZKNodes, int testTimeoutSecs) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -32,6 +32,7 @@ import io.netty.buffer.ByteBufAllocator;
 import java.io.File;
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -831,6 +832,15 @@ public abstract class BookKeeperClusterTestCase {
 
     public TestStatsProvider getStatsProvider(int index) throws Exception {
         return getStatsProvider(bs.get(index).getLocalAddress());
+    }
+
+    public static int countNumOfFiles(File[] folderNames, String... extensions) {
+        int count = 0;
+        for (int i = 0; i < folderNames.length; i++) {
+            Collection<File> filesCollection = FileUtils.listFiles(folderNames[i], extensions, true);
+            count += filesCollection.size();
+        }
+        return count;
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -32,7 +32,6 @@ import io.netty.buffer.ByteBufAllocator;
 import java.io.File;
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -832,15 +831,6 @@ public abstract class BookKeeperClusterTestCase {
 
     public TestStatsProvider getStatsProvider(int index) throws Exception {
         return getStatsProvider(bs.get(index).getLocalAddress());
-    }
-
-    public static int countNumOfFiles(File[] folderNames, String... extensions) {
-        int count = 0;
-        for (int i = 0; i < folderNames.length; i++) {
-            Collection<File> filesCollection = FileUtils.listFiles(folderNames[i], extensions, true);
-            count += filesCollection.size();
-        }
-        return count;
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestUtils.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestUtils.java
@@ -22,6 +22,7 @@
 package org.apache.bookkeeper.util;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +33,7 @@ import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.ReadHandle;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 
 /**
@@ -92,4 +94,14 @@ public final class TestUtils {
         }
         Assert.assertTrue(description, predicate.getAsBoolean());
     }
+
+    public static int countNumOfFiles(File[] folderNames, String... extensions) {
+        int count = 0;
+        for (int i = 0; i < folderNames.length; i++) {
+            Collection<File> filesCollection = FileUtils.listFiles(folderNames[i], extensions, true);
+            count += filesCollection.size();
+        }
+        return count;
+    }
+
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Update `lastLogMark` in memory after replaying each journal
Check for writable ledger dirs with `minUsableSizeForEntryLogCreation` to flush the `lastMark` file for bookies in ReadOnlyMode
Log line changes

### Motivation

Master Issue: #2087 
