### PR TITLE
Fix flaky testIOVertexHTTPServerEndpointForARWithPrometheusProvider test

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -1196,7 +1196,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         String metrics = metricsStringBuilder.toString();
         // do primitive checks if metrics string contains some stats
         assertTrue("Metrics should contain basic counters",
-                metrics.contains(ReplicationStats.NUM_UNDER_REPLICATED_LEDGERS));
+                metrics.contains(ReplicationStats.NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED));
 
         // Now, hit the rest endpoint for configs
         url = new URL("http://localhost:" + nextFreePort + HttpRouter.SERVER_CONFIG);


### PR DESCRIPTION
Descriptions of the changes in this PR:

- in testIOVertexHTTPServerEndpointForARWithPrometheusProvider test
it is not correct to assume that Auditor would have been created and
started completely when we complete AutoRecoveryMain.start and see it
status as started. It would make sure AuditorElector.submitElectionTask
has submitted election task but not the completion of Auditor.start.
So instead of relying on Auditor metric (NUM_UNDER_REPLICATED_LEDGERS),
use ReplicationWorker metric - NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED.
