### PR TITLE
(WIP) Have min time interval for force compaction

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -212,7 +212,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
             @Override
             public void diskAlmostFull(File disk) {
                 if (gcThread.isForceGCAllowWhenNoSpace) {
-                    gcThread.enableForceGC();
+                    gcThread.enableForceGCIfMinIntervalElapsed();
                 } else {
                     gcThread.suspendMajorGC();
                 }
@@ -221,7 +221,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
             @Override
             public void diskFull(File disk) {
                 if (gcThread.isForceGCAllowWhenNoSpace) {
-                    gcThread.enableForceGC();
+                    gcThread.enableForceGCIfMinIntervalElapsed();
                 } else {
                     gcThread.suspendMajorGC();
                     gcThread.suspendMinorGC();
@@ -231,7 +231,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
             @Override
             public void allDisksFull(boolean highPriorityWritesAllowed) {
                 if (gcThread.isForceGCAllowWhenNoSpace) {
-                    gcThread.enableForceGC();
+                    gcThread.enableForceGCIfMinIntervalElapsed();
                 } else {
                     gcThread.suspendMajorGC();
                     gcThread.suspendMinorGC();
@@ -255,7 +255,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
             public void diskJustWritable(File disk) {
                 if (gcThread.isForceGCAllowWhenNoSpace) {
                     // if a disk is just writable, we still need force gc.
-                    gcThread.enableForceGC();
+                    gcThread.enableForceGCIfMinIntervalElapsed();
                 } else {
                     // still under warn threshold, only resume minor compaction.
                     gcThread.resumeMinorGC();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
@@ -194,7 +194,8 @@ class LedgerDirsMonitor {
                 .setNameFormat("LedgerDirsMonitorThread")
                 .setDaemon(true)
                 .build());
-        this.checkTask = this.executor.scheduleAtFixedRate(this::check, interval, interval, TimeUnit.MILLISECONDS);
+        this.checkTask = this.executor.scheduleWithFixedDelay(() -> check(),
+                interval, interval, TimeUnit.MILLISECONDS);
     }
 
     // shutdown disk monitoring daemon

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -92,6 +92,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
     protected static final String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";
     protected static final String MAJOR_COMPACTION_THRESHOLD = "majorCompactionThreshold";
+    protected static final String FORCE_COMPACTION_INTERVAL = "forceCompactionInterval";
     protected static final String IS_THROTTLE_BY_BYTES = "isThrottleByBytes";
     protected static final String COMPACTION_MAX_OUTSTANDING_REQUESTS = "compactionMaxOutstandingRequests";
     protected static final String COMPACTION_RATE = "compactionRate";
@@ -1478,6 +1479,43 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setMajorCompactionInterval(long interval) {
         setProperty(MAJOR_COMPACTION_INTERVAL, interval);
+        return this;
+    }
+
+    /**
+     * Get the minimum interval needed to trigger force compaction by
+     * LedgerDirsListener, since the last main compaction. Main compaction will
+     * be Major compaction, if majorcompaction is disabled/suspended then it
+     * will be minorcompaction. If both major and minor are disabled/suspended
+     * then it will be just gc run.
+     *
+     * <p>If it is set to zero, then it wont check for time gap before force
+     * compacting. Default value is GcWaitTime/2.
+     *
+     * @return high water mark
+     */
+    public long getForceCompactionInterval() {
+        return getLong(FORCE_COMPACTION_INTERVAL, getGcWaitTime() / 2);
+    }
+
+    /**
+     * Set the minimum interval needed to force compaction by LedgerDirsListener,
+     * since the last main compaction. Main compaction will be Major compaction,
+     * if majorcompaction is disabled/suspended then it will be minorcompaction.
+     * If both major and minor are disabled/suspended then it will be just gc
+     * run.
+     *
+     * <p>If it is set to zero, then it wont check for time gap before force
+     * compacting.
+     *
+     * @see #getForceCompactionInterval()
+     *
+     * @param interval
+     *            Interval to run major compaction
+     * @return server configuration
+     */
+    public ServerConfiguration setForceCompactionInterval(long interval) {
+        setProperty(FORCE_COMPACTION_INTERVAL, interval);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
@@ -161,7 +161,7 @@ public class DiskChecker {
             // Warn should be triggered only if disk usage threshold doesn't trigger first.
             if (used > diskUsageWarnThreshold) {
                 LOG.warn("Space left on device {} : {}, Used space fraction: {} > WarnThreshold {}.",
-                        dir, usableSpace, used, diskUsageThreshold);
+                        dir, usableSpace, used, diskUsageWarnThreshold);
                 throw new DiskWarnThresholdException("Space left on device:"
                         + usableSpace + " Used space fraction:" + used + " > WarnThreshold:" + diskUsageWarnThreshold,
                         used);

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -353,6 +353,9 @@ groups:
   - param: majorCompactionInterval
     description: Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled.
     default: 86400
+  - param: forceCompactionInterval
+    description: The minimum interval needed to trigger force compaction by LedgerDirsListener, since the last main compaction. Main compaction will be Major compaction, if majorcompaction is disabled/suspended then it will be minorcompaction. If both major and minor are disabled/suspended then it will be just gc run. If it is set to zero, then it wont check for time gap before force compacting. Default value is GcWaitTime/2.
+    default: 300000
   - param: isThrottleByBytes
     description: Throttle compaction by bytes or by entries.
     default: 'false'
@@ -372,8 +375,8 @@ groups:
 - name: Garbage collection settings
   params:
   - param: gcWaitTime
-    description: How long the interval to trigger next garbage collection, in milliseconds. Since garbage collection is running in background, too frequent gc will heart performance. It is better to give a higher number of gc interval if there is enough disk capacity.
-    default: 1000
+    description: How long the interval to trigger next garbage collection, in milliseconds. Since garbage collection is running in background, too frequent gc will hurt performance. It is better to give a higher number of gc interval if there is enough disk capacity.
+    default: 600000
   - param: gcOverreplicatedLedgerWaitTime
     description: How long the interval to trigger next garbage collection of overreplicated ledgers, in milliseconds. This should not be run very frequently since we read the metadata for all the ledgers on the bookie from zk.
     default: 86400000


### PR DESCRIPTION
Descriptions of the changes in this PR:

Work continued from https://github.com/apache/bookkeeper/pull/1946

Descriptions of the changes in this PR (WIP):

- Added support for scheduling tasks with fixed delay in `MockExecutorController`
  - Can be used for adding unit tests for GC threads, LedgerDirsMonitor threads etc
- Fixed some broken tests
- Re-based the PR

Descriptions of the changes in PR 1946:

- minimum interval needed to trigger force compaction by LedgerDirsListener, 
since the last main compaction. Otherwise if isForceGCAllowWhenNoSpace is enabled
and when disk reaches storage threshold, it will do busy force gc for every
'diskCheckInterval' (10 secs) untill the disk/bookie becomes writable again.
gc operation is an expensive operation and it puts load on metadataserver for
iterating over all ledgers metadata. So we should call forcegc judiciously when
disk/bookie reaches storage threshold.

- here main compaction will be Major compaction, if majorcompaction is 
disabled/suspended then it will be minorcompaction. If both major and minor are
disabled/suspended then it will be just gc run.

- in LedgerDirsMonitor and in GarbageCollectorThread we should schedule tasks 
with fixed delay instead of at fixed rate. This would ensure that there would be
uniform delay between executions.