### PR TITLE
Entries must be acknowledged by bookies in multiple fault domains before being acknowledged to client

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperClientStats.java
@@ -97,6 +97,10 @@ public interface BookKeeperClientStats {
 
     // placementpolicy stats
     String NUM_WRITABLE_BOOKIES_IN_DEFAULT_RACK = "NUM_WRITABLE_BOOKIES_IN_DEFAULT_RACK";
+    String WRITE_DELAYED_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS = "WRITE_DELAYED_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS";
+    String WRITE_DELAYED_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS_LATENCY =
+            "WRITE_DELAYED_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS_LATENCY";
+    String WRITE_TIMED_OUT_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS = "WRITE_TIME_OUT_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS";
 
     OpStatsLogger getCreateOpLogger();
     OpStatsLogger getOpenOpLogger();
@@ -119,6 +123,9 @@ public interface BookKeeperClientStats {
     Counter getLacUpdateHitsCounter();
     Counter getLacUpdateMissesCounter();
     OpStatsLogger getClientChannelWriteWaitLogger();
+    OpStatsLogger getWriteDelayedDueToNotEnoughFaultDomainsLatency();
+    Counter getWriteDelayedDueToNotEnoughFaultDomains();
+    Counter getWriteTimedOutDueToNotEnoughFaultDomains();
     void registerPendingAddsGauge(Gauge<Integer> gauge);
 
     static BookKeeperClientStats newInstance(StatsLogger stats) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
@@ -49,6 +49,7 @@ class ClientInternalConf {
     final long timeoutMonitorIntervalSec;
     final boolean enableBookieFailureTracking;
     final boolean useV2WireProtocol;
+    final boolean enforceMinNumFaultDomainsForWrite;
 
     static ClientInternalConf defaultValues() {
         return fromConfig(new ClientConfiguration());
@@ -82,6 +83,7 @@ class ClientInternalConf {
         this.enableBookieFailureTracking = conf.getEnableBookieFailureTracking();
         this.useV2WireProtocol = conf.getUseV2WireProtocol();
         this.enableStickyReads = conf.isStickyReadsEnabled();
+        this.enforceMinNumFaultDomainsForWrite = conf.getEnforceMinNumFaultDomainsForWrite();
 
         if (conf.getFirstSpeculativeReadTimeout() > 0) {
             this.readSpeculativeRequestPolicy =

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
@@ -423,7 +423,9 @@ public interface EnsemblePlacementPolicy {
      *            list of BookieSocketAddress of bookies that have acknowledged a write.
      * @return
      */
-    default boolean areAckedBookiesAdheringToPlacementPolicy(Set<BookieSocketAddress> ackedBookies) {
+    default boolean areAckedBookiesAdheringToPlacementPolicy(Set<BookieSocketAddress> ackedBookies,
+                                                             int writeQuorumSize,
+                                                             int ackQuorumSize) {
         return true;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
@@ -415,6 +415,19 @@ public interface EnsemblePlacementPolicy {
     }
 
     /**
+     * Returns true if the bookies that have acknowledged a write adhere to the minimum fault domains as defined in the
+     * placement policy in use. Ex: In the case of RackawareEnsemblePlacementPolicy, bookies belong to at least
+     * 'minNumRacksPerWriteQuorum' number of racks.
+     *
+     * @param ackedBookies
+     *            list of BookieSocketAddress of bookies that have acknowledged a write.
+     * @return
+     */
+    default boolean areAckedBookiesAdheringToPlacementPolicy(Set<BookieSocketAddress> ackedBookies) {
+        return true;
+    }
+
+    /**
      * Result of a placement calculation against a placement policy.
      */
     final class PlacementResult<T> {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
@@ -421,6 +421,10 @@ public interface EnsemblePlacementPolicy {
      *
      * @param ackedBookies
      *            list of BookieSocketAddress of bookies that have acknowledged a write.
+     * @param writeQuorumSize
+     *            writeQuorumSize of the ensemble
+     * @param ackQuorumSize
+     *            ackQuorumSize of the ensemble
      * @return
      */
     default boolean areAckedBookiesAdheringToPlacementPolicy(Set<BookieSocketAddress> ackedBookies,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -381,7 +381,10 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
 
         if (ackQuorum && !completed) {
             if (clientCtx.getConf().enforceMinNumFaultDomainsForWrite
-                && !(clientCtx.getPlacementPolicy().areAckedBookiesAdheringToPlacementPolicy(addEntrySuccessBookies))) {
+                && !(clientCtx.getPlacementPolicy()
+                              .areAckedBookiesAdheringToPlacementPolicy(addEntrySuccessBookies,
+                                                                        lh.getLedgerMetadata().getWriteQuorumSize(),
+                                                                        lh.getLedgerMetadata().getAckQuorumSize()))) {
                 LOG.warn("Write success for entry ID {} delayed, not acknowledged by bookies in enough fault domains",
                          entryId);
                 // Increment to indicate write did not complete due to not enough fault domains

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -30,8 +30,10 @@ import io.netty.util.Recycler.Handle;
 import io.netty.util.ReferenceCountUtil;
 import java.util.EnumSet;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallbackWithLatency;
@@ -71,6 +73,8 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
     boolean isRecoveryAdd = false;
     long requestTimeNanos;
     long qwcLatency; // Quorum Write Completion Latency after response from quorum bookies.
+    Set<BookieSocketAddress> addEntrySuccessBookies;
+    long writeDelayedStartTime; // min fault domains completion latency after response from ack quorum bookies
 
     long currentLedgerLength;
     int pendingWriteRequests;
@@ -105,6 +109,13 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         op.allowFailFast = false;
         op.qwcLatency = 0;
         op.writeFlags = writeFlags;
+
+        if (op.addEntrySuccessBookies == null) {
+            op.addEntrySuccessBookies = new HashSet<>();
+        } else {
+            op.addEntrySuccessBookies.clear();
+        }
+        op.writeDelayedStartTime = -1;
 
         return op;
     }
@@ -159,6 +170,11 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
                 public void safeRun() {
                     if (completed) {
                         return;
+                    } else if (addEntrySuccessBookies.size() >= lh.getLedgerMetadata().getAckQuorumSize()) {
+                        // If ackQuorum number of bookies have acknowledged the write but still not complete, indicates
+                        // failures due to not having been written to enough fault domains. Increment corresponding
+                        // counter.
+                        clientCtx.getClientStats().getWriteTimedOutDueToNotEnoughFaultDomains().inc();
                     }
                     lh.handleUnrecoverableErrorDuringAdd(BKException.Code.AddEntryQuorumTimeoutException);
                 }
@@ -282,6 +298,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         boolean ackQuorum = false;
         if (BKException.Code.OK == rc) {
             ackQuorum = ackSet.completeBookieAndCheck(bookieIndex);
+            addEntrySuccessBookies.add(ensemble.get(bookieIndex));
         }
 
         if (completed) {
@@ -363,10 +380,30 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         }
 
         if (ackQuorum && !completed) {
-            completed = true;
-            this.qwcLatency = MathUtils.elapsedNanos(requestTimeNanos);
+            if (clientCtx.getConf().enforceMinNumFaultDomainsForWrite
+                && !(clientCtx.getPlacementPolicy().areAckedBookiesAdheringToPlacementPolicy(addEntrySuccessBookies))) {
+                LOG.warn("Write success for entry ID {} delayed, not acknowledged by bookies in enough fault domains",
+                         entryId);
+                // Increment to indicate write did not complete due to not enough fault domains
+                clientCtx.getClientStats().getWriteDelayedDueToNotEnoughFaultDomains().inc();
 
-            sendAddSuccessCallbacks();
+                // Only do this for the first time.
+                if (writeDelayedStartTime == -1) {
+                    writeDelayedStartTime = MathUtils.nowInNano();
+                }
+            } else {
+                completed = true;
+                this.qwcLatency = MathUtils.elapsedNanos(requestTimeNanos);
+
+                if (writeDelayedStartTime != -1) {
+                    clientCtx.getClientStats()
+                             .getWriteDelayedDueToNotEnoughFaultDomainsLatency()
+                             .registerSuccessfulEvent(MathUtils.elapsedNanos(writeDelayedStartTime),
+                                                      TimeUnit.NANOSECONDS);
+                }
+
+                sendAddSuccessCallbacks();
+            }
         }
     }
 
@@ -478,6 +515,8 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         hasRun = false;
         allowFailFast = false;
         writeFlags = null;
+        addEntrySuccessBookies.clear();
+        writeDelayedStartTime = -1;
 
         recyclerHandle.recycle(this);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -1063,8 +1063,11 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
     }
 
     @Override
-    public boolean areAckedBookiesAdheringToPlacementPolicy(Set<BookieSocketAddress> ackedBookies) {
+    public boolean areAckedBookiesAdheringToPlacementPolicy(Set<BookieSocketAddress> ackedBookies,
+                                                            int writeQuorumSize,
+                                                            int ackQuorumSize) {
         HashSet<String> rackCounter = new HashSet<>();
+        int minWriteQuorumNumRacksPerWriteQuorum = Math.min(writeQuorumSize, minNumRacksPerWriteQuorum);
 
         ReentrantReadWriteLock.ReadLock readLock = rwLock.readLock();
         readLock.lock();
@@ -1088,6 +1091,6 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
         } finally {
             readLock.unlock();
         }
-        return rackCounter.size() >= minNumRacksPerWriteQuorum;
+        return rackCounter.size() >= minWriteQuorumNumRacksPerWriteQuorum;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -1064,27 +1064,29 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
 
     @Override
     public boolean areAckedBookiesAdheringToPlacementPolicy(Set<BookieSocketAddress> ackedBookies) {
-        ReentrantReadWriteLock.ReadLock readLock = rwLock.readLock();
-
-        readLock.lock();
         HashSet<String> rackCounter = new HashSet<>();
-        for (BookieSocketAddress bookie : ackedBookies) {
-            try {
-                rackCounter.add(knownBookies.get(bookie).getNetworkLocation());
-            } catch (Exception e) {
-                LOG.warn("Received exception while trying to get network location of bookie: {}", bookie, e);
-            }
-        }
 
-        // Check to make sure that ensemble is writing to `minNumberOfRacks`'s number of racks at least.
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("areAckedBookiesAdheringToPlacementPolicy returning {} because number of racks = {} and "
-                      + "minNumRacksPerWriteQuorum = {}",
-                      rackCounter.size() >= minNumRacksPerWriteQuorum,
-                      rackCounter.size(),
-                      minNumRacksPerWriteQuorum);
+        ReentrantReadWriteLock.ReadLock readLock = rwLock.readLock();
+        readLock.lock();
+        try {
+            for (BookieSocketAddress bookie : ackedBookies) {
+                try {
+                    rackCounter.add(knownBookies.get(bookie).getNetworkLocation());
+                } catch (Exception e) {
+                    LOG.warn("Received exception while trying to get network location of bookie: {}", bookie, e);
+                }
+            }
+
+            // Check to make sure that ensemble is writing to `minNumberOfRacks`'s number of racks at least.
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("areAckedBookiesAdheringToPlacementPolicy returning {} because number of racks = {} and " + "minNumRacksPerWriteQuorum = {}",
+                          rackCounter.size() >= minNumRacksPerWriteQuorum,
+                          rackCounter.size(),
+                          minNumRacksPerWriteQuorum);
+            }
+        } finally {
+            readLock.unlock();
         }
-        readLock.unlock();
         return rackCounter.size() >= minNumRacksPerWriteQuorum;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -1079,7 +1079,8 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
 
             // Check to make sure that ensemble is writing to `minNumberOfRacks`'s number of racks at least.
             if (LOG.isDebugEnabled()) {
-                LOG.debug("areAckedBookiesAdheringToPlacementPolicy returning {} because number of racks = {} and " + "minNumRacksPerWriteQuorum = {}",
+                LOG.debug("areAckedBookiesAdheringToPlacementPolicy returning {} because number of racks = {} and "
+                          + "minNumRacksPerWriteQuorum = {}",
                           rackCounter.size() >= minNumRacksPerWriteQuorum,
                           rackCounter.size(),
                           minNumRacksPerWriteQuorum);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -1073,11 +1073,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
         readLock.lock();
         try {
             for (BookieSocketAddress bookie : ackedBookies) {
-                try {
-                    rackCounter.add(knownBookies.get(bookie).getNetworkLocation());
-                } catch (Exception e) {
-                    LOG.warn("Received exception while trying to get network location of bookie: {}", bookie, e);
-                }
+                rackCounter.add(knownBookies.get(bookie).getNetworkLocation());
             }
 
             // Check to make sure that ensemble is writing to `minNumberOfRacks`'s number of racks at least.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/BookKeeperClientStatsImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/BookKeeperClientStatsImpl.java
@@ -141,6 +141,24 @@ public class BookKeeperClientStatsImpl implements BookKeeperClientStats {
     )
     private final Counter speculativeReadCounter;
 
+    @StatsDoc(
+        name = WRITE_DELAYED_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS_LATENCY,
+        help = "The delay in write completion because min number of fault domains was not reached"
+    )
+    private final OpStatsLogger writeDelayedDueToNotEnoughFaultDomainsLatency;
+
+    @StatsDoc(
+        name = WRITE_DELAYED_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS,
+        help = "The number of times write completion was delayed because min number of fault domains was not reached"
+    )
+    private final Counter writeDelayedDueToNotEnoughFaultDomains;
+
+    @StatsDoc(
+        name = WRITE_TIMED_OUT_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS,
+        help = "The number of times write completion timed out because min number of fault domains was not reached"
+    )
+    private final Counter writeTimedOutDueToNotEnoughFaultDomains;
+
 
     public BookKeeperClientStatsImpl(StatsLogger stats) {
         this.stats = stats;
@@ -166,6 +184,12 @@ public class BookKeeperClientStatsImpl implements BookKeeperClientStats {
         this.clientChannelWriteWaitStats = stats.getOpStatsLogger(CLIENT_CHANNEL_WRITE_WAIT);
 
         speculativeReadCounter = stats.getCounter(SPECULATIVE_READ_COUNT);
+
+        this.writeDelayedDueToNotEnoughFaultDomainsLatency =
+                stats.getOpStatsLogger(WRITE_DELAYED_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS_LATENCY);
+        this.writeDelayedDueToNotEnoughFaultDomains = stats.getCounter(WRITE_DELAYED_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS);
+        this.writeTimedOutDueToNotEnoughFaultDomains =
+                stats.getCounter(WRITE_TIMED_OUT_DUE_TO_NOT_ENOUGH_FAULT_DOMAINS);
     }
 
     @Override
@@ -251,6 +275,18 @@ public class BookKeeperClientStatsImpl implements BookKeeperClientStats {
     @Override
     public Counter getEnsembleBookieDistributionCounter(String bookie) {
         return stats.getCounter(LEDGER_ENSEMBLE_BOOKIE_DISTRIBUTION + "-" + bookie);
+    }
+    @Override
+    public OpStatsLogger getWriteDelayedDueToNotEnoughFaultDomainsLatency() {
+        return writeDelayedDueToNotEnoughFaultDomainsLatency;
+    }
+    @Override
+    public Counter getWriteDelayedDueToNotEnoughFaultDomains() {
+        return writeDelayedDueToNotEnoughFaultDomains;
+    }
+    @Override
+    public Counter getWriteTimedOutDueToNotEnoughFaultDomains() {
+        return writeTimedOutDueToNotEnoughFaultDomains;
     }
     @Override
     public void registerPendingAddsGauge(Gauge<Integer> gauge) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -159,6 +159,9 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     // enforce minimum number of racks per write quorum
     public static final String ENFORCE_MIN_NUM_RACKS_PER_WRITE_QUORUM = "enforceMinNumRacksPerWriteQuorum";
 
+    // enforce minimum number of fault domains for write
+    public static final String ENFORCE_MIN_NUM_FAULT_DOMAINS_FOR_WRITE = "enforceMinNumFaultDomainsForWrite";
+
     // ignore usage of local node in the internal logic of placement policy
     public static final String IGNORE_LOCAL_NODE_IN_PLACEMENT_POLICY = "ignoreLocalNodeInPlacementPolicy";
 
@@ -844,6 +847,20 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      */
     public boolean getEnforceMinNumRacksPerWriteQuorum() {
         return getBoolean(ENFORCE_MIN_NUM_RACKS_PER_WRITE_QUORUM, false);
+    }
+
+    /**
+     * Set the flag to enforce minimum number of fault domains for write.
+     */
+    public void setEnforceMinNumFaultDomainsForWrite(boolean enforceMinNumFaultDomainsForWrite) {
+        setProperty(ENFORCE_MIN_NUM_FAULT_DOMAINS_FOR_WRITE, enforceMinNumFaultDomainsForWrite);
+    }
+
+    /**
+     * Get the flag to enforce minimum number of fault domains for write.
+     */
+    public boolean getEnforceMinNumFaultDomainsForWrite() {
+        return getBoolean(ENFORCE_MIN_NUM_FAULT_DOMAINS_FOR_WRITE, false);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -966,9 +966,9 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
      * Test to test the working of enforceMinNumFaultDomainsForWrite configuration. The test:
      * 1. Sets up the config to use a minimum of 2 racks per write quorum
      * 2. Enables both enforceMinNumRacksPerWriteQuorum and enforceMinNumFaultDomainsForWrite.
-     * 3. Starts up 4 bookies in default rack (`/default-region/default-rack`) and 1 in `/default-region/rack1`
+     * 3. Starts up 4 bookies in rack 0 (`/default-region/rack0`) and 1 in rack 1 `/default-region/rack1`
      * 4. Creates a ledger using ensembleSize=wqSize=3.
-     * 5. The non default rack bookie is put to sleep
+     * 5. The rack 1 bookie is put to sleep
      * 6. AddEntry is attempted.
      * 7. A separate thread countdowns 10 seconds and then awakens the sleeping bookie.
      * 8. Success of addEntry is checked.
@@ -998,7 +998,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
 
         // Assign all initial bookies started to the default rack by modifying the `localhost` in the StaticDNSResolver
         StaticDNSResolver.reset();
-        StaticDNSResolver.addNodeToRack("localhost", NetworkTopology.DEFAULT_REGION_AND_RACK);
+        StaticDNSResolver.addNodeToRack("localhost", NetworkTopology.DEFAULT_REGION + "/rack0");
 
         try (BookKeeperTestClient bk = new BookKeeperTestClient(conf)) {
             // Modify localhost in StaticDNSResolver to assign next started bookie to a different rack("/rack1")

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -1066,14 +1066,14 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
             writeToLedger.start();
 
             // Waiting and checking to make sure that write has not succeeded
-            countDownLatch.await(2, TimeUnit.SECONDS);
+            countDownLatch.await(conf.getAddEntryTimeout(), TimeUnit.SECONDS);
             assertEquals("Write succeeded but should not have", -1, lh.lastAddConfirmed);
 
             // Wake the bookie
             sleepLatchCase1.countDown();
 
             // Waiting and checking to make sure that write has succeeded
-            writeToLedger.join(1000);
+            writeToLedger.join(conf.getAddEntryTimeout() * 1000);
             assertEquals("Write did not succeed but should have", 0, lh.lastAddConfirmed);
 
             assertEquals(statsLogger
@@ -1100,7 +1100,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
             writeToLedger2.start();
 
             // Waiting and checking to make sure that write has failed
-            writeToLedger2.join(6000);
+            writeToLedger2.join((conf.getAddEntryQuorumTimeout() + 2) * 1000);
             assertEquals("Write succeeded but should not have", 0, lh.lastAddConfirmed);
 
             sleepLatchCase2.countDown();

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -891,6 +891,11 @@ zkEnableSecurity=false
 # bookie then it would throw BKNotEnoughBookiesException instead of picking random one.
 # enforceMinNumRacksPerWriteQuorum=false
 
+# Enforce write being acknowledged by bookies belonging to atleast minimum
+# number of fault domains(depending on the placement policy) before being
+# acknowledged by bookkeeper.
+# enforceMinNumFaultDomainsForWrite=true
+
 #############################################################################
 ## Auditor settings
 #############################################################################

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -894,7 +894,7 @@ zkEnableSecurity=false
 # Enforce write being acknowledged by bookies belonging to atleast minimum
 # number of fault domains(depending on the placement policy) before being
 # acknowledged by bookkeeper.
-# enforceMinNumFaultDomainsForWrite=true
+# enforceMinNumFaultDomainsForWrite=false
 
 #############################################################################
 ## Auditor settings

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -644,6 +644,9 @@ groups:
     description: |
       'ignoreLocalNodeInPlacementPolicy' specifies whether to ignore localnode in the internal logic of placement policy. If it is not possible or useful to use Bookkeeper client node's (or AutoReplicator) rack/region info. for placement policy then it is better to ignore localnode instead of false alarming with log lines and metrics.
     default: false
+  - param: enforceMinNumFaultDomainsForWrite
+      description: |
+        'enforceMinNumFaultDomainsForWrite' enforces EnsemblePlacementPolicy to check if a write has made it to bookies in 'minNumRacksPerWriteQuorum' number of fault domains, before acknowledging the write back.
 
 - name: AutoRecovery auditor settings
   params:

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -645,8 +645,8 @@ groups:
       'ignoreLocalNodeInPlacementPolicy' specifies whether to ignore localnode in the internal logic of placement policy. If it is not possible or useful to use Bookkeeper client node's (or AutoReplicator) rack/region info. for placement policy then it is better to ignore localnode instead of false alarming with log lines and metrics.
     default: false
   - param: enforceMinNumFaultDomainsForWrite
-      description: |
-        'enforceMinNumFaultDomainsForWrite' enforces EnsemblePlacementPolicy to check if a write has made it to bookies in 'minNumRacksPerWriteQuorum' number of fault domains, before acknowledging the write back.
+    description: |
+      'enforceMinNumFaultDomainsForWrite' enforces EnsemblePlacementPolicy to check if a write has made it to bookies in 'minNumRacksPerWriteQuorum' number of fault domains, before acknowledging the write back.
 
 - name: AutoRecovery auditor settings
   params:


### PR DESCRIPTION
Descriptions of the changes in this PR:

Bookkeeper write logic makes sure that there are at least ackQuorumSize
number of successful writes before sending ack back to the client. In
many cases these may fall into the same fault domain. A mechanism to
force bookkeeper to make sure that there are acks from at least
minNumRacksPerWriteQuorum number of fault domains and a configuration
to enforce this.

Signed-off-by: Ankit Jain <jain.a@salesforce.com>

Master Issue: #2095 