### PR TITLE
[Bk-Client] Check empty ledger-parent node while deleting ledger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
@@ -134,8 +134,21 @@ public class ZkUtils {
             public void processResult(int rc, String path, Object ctx) {
                 if (rc == Code.OK.intValue()) {
                     String parent = new File(originalPath).getParent().replace("\\", "/");
-                    asyncDeleteFullPathOptimistic(zk, parent, -1, callback, leafNodePath);
+                    zk.getData(parent, false, (dRc, dPath, dCtx, data, stat) -> {
+                        if (Code.OK.intValue() == dRc && (stat != null && stat.getNumChildren() == 0)) {
+                            asyncDeleteFullPathOptimistic(zk, parent, -1, callback, leafNodePath);
+                        } else {
+                            // parent node is not empty so, complete the
+                            // callback
+                            if (path.equals(leafNodePath)) {
+                                callback.processResult(rc, path, leafNodePath);
+                            } else {
+                                callback.processResult(Code.OK.intValue(), path, leafNodePath);
+                            }
+                        }
+                    }, null);
                 } else {
+                    // parent node deletion fails.. so, complete the callback
                     if (path.equals(leafNodePath)) {
                         callback.processResult(rc, path, leafNodePath);
                     } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
@@ -140,11 +140,7 @@ public class ZkUtils {
                         } else {
                             // parent node is not empty so, complete the
                             // callback
-                            if (path.equals(leafNodePath)) {
-                                callback.processResult(rc, path, leafNodePath);
-                            } else {
-                                callback.processResult(Code.OK.intValue(), path, leafNodePath);
-                            }
+                            callback.processResult(Code.OK.intValue(), path, leafNodePath);
                         }
                     }, null);
                 } else {


### PR DESCRIPTION
### Motivation

As discussed at [#4276](https://github.com/apache/pulsar/issues/4276), while deleting ledger, bk-client should check parent node is empty before issuing delete request for parent znode.

