### PR TITLE
Use https for Twitter maven repo

### DIFF
--- a/bookkeeper-stats-providers/twitter-science-provider/pom.xml
+++ b/bookkeeper-stats-providers/twitter-science-provider/pom.xml
@@ -78,7 +78,7 @@
       <id>twitter</id>
       <name>Twitter repo</name>
       <layout>default</layout>
-      <url>http://maven.twttr.com</url>
+      <url>https://maven.twttr.com</url>
     </repository>
   </repositories>
 </project> 


### PR DESCRIPTION
### Motivation

Fetch the maven dependencies through HTTPs 