### PR TITLE
Update distributedlog library to use NoSuchLedgerExistsOnMetadataServer

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BookKeeperClient.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BookKeeperClient.java
@@ -239,8 +239,7 @@ public class BookKeeperClient {
             public void deleteComplete(int rc, Object ctx) {
                 if (BKException.Code.OK == rc) {
                     promise.complete(null);
-                } else if (BKException.Code.NoSuchLedgerExistsException == rc
-                    || Code.NoSuchLedgerExistsOnMetadataServerException == rc) {
+                } else if (Code.NoSuchLedgerExistsOnMetadataServerException == rc) {
                     if (ignoreNonExistentLedger) {
                         promise.complete(null);
                     } else {

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BookKeeperClient.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BookKeeperClient.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy;
@@ -238,7 +239,8 @@ public class BookKeeperClient {
             public void deleteComplete(int rc, Object ctx) {
                 if (BKException.Code.OK == rc) {
                     promise.complete(null);
-                } else if (BKException.Code.NoSuchLedgerExistsException == rc) {
+                } else if (BKException.Code.NoSuchLedgerExistsException == rc
+                    || Code.NoSuchLedgerExistsOnMetadataServerException == rc) {
                     if (ignoreNonExistentLedger) {
                         promise.complete(null);
                     } else {

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryStore.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -134,7 +135,7 @@ public class BKLogSegmentEntryStore implements
     @Override
     public void deleteComplete(int rc, Object ctx) {
         DeleteLogSegmentRequest deleteRequest = (DeleteLogSegmentRequest) ctx;
-        if (BKException.Code.NoSuchLedgerExistsException == rc) {
+        if (Code.NoSuchLedgerExistsOnMetadataServerException == rc) {
             logger.warn("No ledger {} found to delete for {}.",
                     deleteRequest.segment.getLogSegmentId(), deleteRequest.segment);
         } else if (BKException.Code.OK != rc) {

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/tools/DistributedLogTool.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/tools/DistributedLogTool.java
@@ -1277,7 +1277,7 @@ import org.slf4j.LoggerFactory;
                                     if (numLedgersDeleted % 1000 == 0) {
                                         System.out.println("Deleted " + numLedgersDeleted + " ledgers.");
                                     }
-                                } catch (BKException.BKNoSuchLedgerExistsException e) {
+                                } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException e) {
                                     int numLedgersDeleted = numLedgers.incrementAndGet();
                                     if (numLedgersDeleted % 1000 == 0) {
                                         System.out.println("Deleted " + numLedgersDeleted + " ledgers.");

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKDistributedLogManager.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKDistributedLogManager.java
@@ -1237,7 +1237,7 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
             driver.getReaderBKC().get().openLedgerNoRecovery(ledgerId,
                 BookKeeper.DigestType.CRC32, conf.getBKDigestPW().getBytes(UTF_8));
             fail("Should fail to open ledger after we delete the log");
-        } catch (BKException.BKNoSuchLedgerExistsException e) {
+        } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException e) {
             // ignore
         }
         // delete again should not throw any exception


### PR DESCRIPTION
*Motivation*

Issue #2066 introduced `NoSuchLedgerExistsOnMetadataServer`. But the distributedlog
library is not updated to reflect to this change.

*Modifications*

Change to use `NoSuchLedgerExistsOnMetadataServer` in the right place.