### PR TITLE
Display filesystem and docker info for all jenkins runs

### DIFF
--- a/.test-infra/jenkins/job_bookkeeper_precommit_bookie_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_bookie_tests.groovy
@@ -50,7 +50,7 @@ freeStyleJob('bookkeeper_precommit_bookie_tests') {
     shell("id")
     shell("ulimit -a")
     shell("pwd")
-    shell("df -h")
+    shell("df -Th")
     shell("ps aux")
 
     // Build everything

--- a/.test-infra/jenkins/job_bookkeeper_precommit_client_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_client_tests.groovy
@@ -50,7 +50,7 @@ freeStyleJob('bookkeeper_precommit_client_tests') {
     shell("id")
     shell("ulimit -a")
     shell("pwd")
-    shell("df -h")
+    shell("df -Th")
     shell("ps aux")
 
     // Build everything

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java11.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java11.groovy
@@ -30,7 +30,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java11') {
     shell("id")
     shell("ulimit -a")
     shell("pwd")
-    shell("df -h")
+    shell("df -Th")
     shell("ps aux")
   }
 

--- a/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_java8.groovy
@@ -30,7 +30,7 @@ mavenJob('bookkeeper_precommit_pullrequest_java8') {
     shell("id")
     shell("ulimit -a")
     shell("pwd")
-    shell("df -h")
+    shell("df -Th")
     shell("ps aux")
   }
 

--- a/.test-infra/jenkins/job_bookkeeper_precommit_remaining_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_remaining_tests.groovy
@@ -54,7 +54,7 @@ freeStyleJob('bookkeeper_precommit_remaining_tests') {
     shell("id")
     shell("ulimit -a")
     shell("pwd")
-    shell("df -h")
+    shell("df -Th")
     shell("ps aux")
 
     // Build everything

--- a/.test-infra/jenkins/job_bookkeeper_precommit_replication_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_replication_tests.groovy
@@ -50,7 +50,7 @@ freeStyleJob('bookkeeper_precommit_replication_tests') {
     shell("id")
     shell("ulimit -a")
     shell("pwd")
-    shell("df -h")
+    shell("df -Th")
     shell("ps aux")
 
     // Build everything

--- a/.test-infra/jenkins/job_bookkeeper_precommit_tls_tests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_precommit_tls_tests.groovy
@@ -50,7 +50,7 @@ freeStyleJob('bookkeeper_precommit_tls_tests') {
     shell("id")
     shell("ulimit -a")
     shell("pwd")
-    shell("df -h")
+    shell("df -Th")
     shell("ps aux")
 
     // Build everything

--- a/.test-infra/jenkins/job_bookkeeper_release_branch_47_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_release_branch_47_integrationtests.groovy
@@ -40,7 +40,7 @@ freeStyleJob('bookkeeper_release_branch_47_integrationtests') {
         shell('id')
         shell('ulimit -a')
         shell('pwd')
-        shell('df -h')
+        shell('df -Th')
         shell('ps -eo euser,pid,ppid,pgid,start,pcpu,pmem,cmd')
         shell('docker network prune -f --filter name=testnetwork_*') // clean up any dangling networks from previous runs
         shell('docker system events > docker.log & echo $! > docker-log.pid')

--- a/.test-infra/jenkins/job_bookkeeper_release_branch_48_integrationtests.groovy
+++ b/.test-infra/jenkins/job_bookkeeper_release_branch_48_integrationtests.groovy
@@ -40,7 +40,7 @@ freeStyleJob('bookkeeper_release_branch_48_integrationtests') {
         shell('id')
         shell('ulimit -a')
         shell('pwd')
-        shell('df -h')
+        shell('df -Th')
         shell('ps -eo euser,pid,ppid,pgid,start,pcpu,pmem,cmd')
         shell('docker network prune -f --filter name=testnetwork_*') // clean up any dangling networks from previous runs
         shell('docker system events > docker.log & echo $! > docker-log.pid')

--- a/.test-infra/scripts/pre-docker-tests.sh
+++ b/.test-infra/scripts/pre-docker-tests.sh
@@ -23,8 +23,9 @@ set -ex
 id
 ulimit -a
 pwd
-df -h
+df -Th
 ps -eo euser,pid,ppid,pgid,start,pcpu,pmem,cmd
+docker info
 docker system prune -f
 # clean up any dangling networks from previous runs
 docker network prune -f --filter name=testnetwork_*


### PR DESCRIPTION
Descriptions of the changes in this PR:

Changes to shell commands in few scripts

### Motivation

It was difficult to reproduce jenkins test failures locally and the cause might be due to differences in underlying file system. These commands will output more information to spot the exact differences.

### Changes

Running `df` command with an additional `-T` parameter to output filesystem information
Added `docker info` command to print docker details before every test run

