### PR TITLE
Bring back statslogger to BookKeeper client in ReplicationWorker process.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -36,6 +36,7 @@ import org.apache.bookkeeper.bookie.BookieCriticalThread;
 import org.apache.bookkeeper.bookie.ExitCode;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeperClientStats;
 import org.apache.bookkeeper.common.component.ComponentStarter;
 import org.apache.bookkeeper.common.component.LifecycleComponent;
 import org.apache.bookkeeper.common.component.LifecycleComponentStack;
@@ -91,7 +92,7 @@ public class AutoRecoveryMain {
             throws IOException, InterruptedException, KeeperException, UnavailableException,
             CompatibilityException {
         this.conf = conf;
-        this.bkc = Auditor.createBookKeeperClient(conf);
+        this.bkc = Auditor.createBookKeeperClient(conf, statsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE));
         MetadataClientDriver metadataClientDriver = bkc.getMetadataClientDriver();
         metadataClientDriver.setSessionStateListener(() -> {
             LOG.error("Client connection to the Metadata server has expired, so shutting down AutoRecoveryMain!");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -65,6 +65,7 @@ import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirExcepti
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.client.BookKeeperClientStats;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.common.component.ComponentStarter;
 import org.apache.bookkeeper.common.component.Lifecycle;
@@ -1319,6 +1320,8 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // do primitive checks if metrics string contains some stats
         assertTrue("Metrics should contain basic counters",
                 metrics.contains(ReplicationStats.NUM_FULL_OR_PARTIAL_LEDGERS_REPLICATED));
+        assertTrue("Metrics should contain basic counters from BookKeeper client",
+                metrics.contains(BookKeeperClientStats.CREATE_OP));
 
         // Now, hit the rest endpoint for configs
         url = new URL("http://localhost:" + nextFreePort + HttpRouter.SERVER_CONFIG);


### PR DESCRIPTION

Descriptions of the changes in this PR:

bd2b16e880d172d4761461fdbf85c1bd19b24e36 is supposed to fix this issue,
but it missed passing statsLogger to createBookKeeperClient method.

For more info. check desc. of bd2b16e880d172d4761461fdbf85c1bd19b24e36.
