### PR TITLE
Testcase for limitStatsLogging.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -388,12 +388,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             shFactory.init(NodeType.Client, conf, allocator);
         }
 
-        StringBuilder nameBuilder = new StringBuilder();
-        nameBuilder.append(addr.getHostName().replace('.', '_').replace('-', '_'))
-            .append("_").append(addr.getPort());
-
         this.statsLogger = parentStatsLogger.scope(BookKeeperClientStats.CHANNEL_SCOPE)
-            .scope(nameBuilder.toString());
+            .scope(buildStatsLoggerScopeName(addr));
 
         readEntryOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_READ_OP);
         addEntryOpLogger = statsLogger.getOpStatsLogger(BookKeeperClientStats.CHANNEL_ADD_OP);
@@ -491,6 +487,12 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             }
 
         };
+    }
+
+    public static String buildStatsLoggerScopeName(BookieSocketAddress addr) {
+        StringBuilder nameBuilder = new StringBuilder();
+        nameBuilder.append(addr.getHostName().replace('.', '_').replace('-', '_')).append("_").append(addr.getPort());
+        return nameBuilder.toString();
     }
 
     private void completeOperation(GenericCallback<PerChannelBookieClient> op, int rc) {


### PR DESCRIPTION


Descriptions of the changes in this PR:

bd2b16e880d172d4761461fdbf85c1bd19b24e36 had introduced
'limitStatsLogging' feature, which would be used to limit statslogging,
where it is needed. eg - we would like to suppress logs from PCBC
in Auditor/ReplicationWorker process.

In this commit I'm adding testcases for this feature.