### PR TITLE
Issue #2106: Update ZookKeeper dependency to 3.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <testcontainers.version>1.8.3</testcontainers.version>
     <twitter-server.version>1.29.0</twitter-server.version>
     <vertx.version>3.4.1</vertx.version>
-    <zookeeper.version>3.4.13</zookeeper.version>
+    <zookeeper.version>3.5.5</zookeeper.version>
     <jctools.version>2.1.2</jctools.version>
     <!-- plugin dependencies -->
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
@@ -496,7 +496,7 @@
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
+            <artifactId>netty-all</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -520,7 +520,7 @@
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
+            <artifactId>netty-all</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/shaded/distributedlog-core-shaded/pom.xml
+++ b/shaded/distributedlog-core-shaded/pom.xml
@@ -82,8 +82,8 @@
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.protobuf:protobuf-java</include>
-                  <!-- netty 3 (included from zookeeper) -->
-                  <include>io.netty:netty</include>
+                  <!-- netty (included from zookeeper) -->
+                  <include>io.netty:netty-all</include>
                   <include>net.java.dev.jna:jna</include>
                   <include>net.jpountz.lz4:lz4</include>
                   <include>org.apache.bookkeeper:bookkeeper-common</include>
@@ -104,6 +104,7 @@
                   <include>org.apache.httpcomponents:httpcore</include>
                   <include>org.apache.thrift:libthrift</include>
                   <include>org.apache.zookeeper:zookeeper</include>
+                  <include>org.apache.zookeeper:zookeeper-jute</include>
                   <include>org.rocksdb:rocksdbjni</include>
                 </includes>
               </artifactSet>


### PR DESCRIPTION
Descriptions of the changes in this PR:
Updated ZooKeeper dependency from 3.4.13 to 3.5.5.
Excluded transitive dependency to netty-all. 
Updated maven-shade-pluging configuration in 'distributedlog-core-shaded' project. Package 'org.apache.jute' was moved to a ZooKeeper dependency (org.apache.zookeeper:zookeeper-jute), so i added the artifact to the artifactSet.

Master Issue: #2106 

> - [X] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [X] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [X] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [X] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [X] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
