### PR TITLE
[conf] minorCompactionInterval should be greater than gcWaitTime

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -224,7 +224,7 @@ public class GarbageCollectorThread extends SafeRunnable {
                 throw new IOException("Invalid minor compaction threshold "
                                     + minorCompactionThreshold);
             }
-            if (minorCompactionInterval <= gcWaitTime) {
+            if (minorCompactionInterval < gcWaitTime) {
                 throw new IOException("Too short minor compaction interval : "
                                     + minorCompactionInterval);
             }
@@ -245,7 +245,7 @@ public class GarbageCollectorThread extends SafeRunnable {
                 throw new IOException("Invalid major compaction threshold "
                                     + majorCompactionThreshold);
             }
-            if (majorCompactionInterval <= gcWaitTime) {
+            if (majorCompactionInterval < gcWaitTime) {
                 throw new IOException("Too short major compaction interval : "
                                     + majorCompactionInterval);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -3131,8 +3131,11 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
             throw new ConfigurationException("For persisiting explicitLac, journalFormatVersionToWrite should be >= 6"
                     + "and FileInfoFormatVersionToWrite should be >= 1");
         }
-        if (getMinorCompactionInterval() <= getGcWaitTime()) {
-            throw new ConfigurationException("minorCompactionInterval should be greater than gcWaitTime.");
+        if (getMinorCompactionInterval() < getGcWaitTime()) {
+            throw new ConfigurationException("minorCompactionInterval should be >= gcWaitTime.");
+        }
+        if (getMajorCompactionInterval() < getGcWaitTime()) {
+            throw new ConfigurationException("majorCompactionInterval should be >= gcWaitTime.");
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -54,6 +54,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class ServerConfiguration extends AbstractConfiguration<ServerConfiguration> {
 
+    private static final int SECOND = 1000;
     // Ledger Storage Settings
 
     private static final ConfigKeyGroup GROUP_LEDGER_STORAGE = ConfigKeyGroup.builder("ledgerstorage")
@@ -3131,10 +3132,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
             throw new ConfigurationException("For persisiting explicitLac, journalFormatVersionToWrite should be >= 6"
                     + "and FileInfoFormatVersionToWrite should be >= 1");
         }
-        if (getMinorCompactionInterval() < getGcWaitTime()) {
+        if (getMinorCompactionInterval() * SECOND < getGcWaitTime()) {
             throw new ConfigurationException("minorCompactionInterval should be >= gcWaitTime.");
         }
-        if (getMajorCompactionInterval() < getGcWaitTime()) {
+        if (getMajorCompactionInterval() * SECOND < getGcWaitTime()) {
             throw new ConfigurationException("majorCompactionInterval should be >= gcWaitTime.");
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -3131,6 +3131,9 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
             throw new ConfigurationException("For persisiting explicitLac, journalFormatVersionToWrite should be >= 6"
                     + "and FileInfoFormatVersionToWrite should be >= 1");
         }
+        if (getMinorCompactionInterval() <= getGcWaitTime()) {
+            throw new ConfigurationException("minorCompactionInterval should be greater than gcWaitTime.");
+        }
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
@@ -155,7 +155,7 @@ public class TestServerConfiguration {
     }
 
     @Test
-    public void testCompactionSettings() {
+    public void testCompactionSettings() throws ConfigurationException {
         ServerConfiguration conf = new ServerConfiguration();
         long major, minor;
 
@@ -198,6 +198,26 @@ public class TestServerConfiguration {
         minor = conf.getMinorCompactionInterval();
         Assert.assertEquals(900, minor);
         Assert.assertEquals(21700, major);
+
+        conf.setMinorCompactionInterval(500);
+        try {
+            conf.validate();
+            fail();
+        } catch (ConfigurationException ignore) {
+        }
+
+        conf.setMinorCompactionInterval(600);
+        conf.validate();
+
+        conf.setMajorCompactionInterval(550);
+        try {
+            conf.validate();
+            fail();
+        } catch (ConfigurationException ignore) {
+        }
+
+        conf.setMajorCompactionInterval(600);
+        conf.validate();
 
         // Default Values
         double majorThreshold, minorThreshold;

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -568,6 +568,7 @@ ledgerDirectories=/tmp/bk-data
 
 # Interval to run major compaction, in seconds
 # If it is set to less than zero, the major compaction is disabled.
+# Note: should be greater than gcWaitTime.
 # majorCompactionInterval=86400
 
 # Maximum milliseconds to run major Compaction. Defaults to -1 run indefinitely.

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -542,6 +542,7 @@ ledgerDirectories=/tmp/bk-data
 
 # Interval to run minor compaction, in seconds
 # If it is set to less than zero, the minor compaction is disabled.
+# Note: should be greater than gcWaitTime.
 # minorCompactionInterval=3600
 
 # Maximum milliseconds to run minor Compaction. Defaults to -1 run indefinitely.


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Fix #2115 

### Changes

Add more instructions to note that `minorCompactionInterval` should be greater than `gcWaitTime`.
