### PR TITLE
[bk-server] Clean up over-replicated ledgers owned by different bookies

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -153,6 +153,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             long end = -1;
             boolean done = false;
             AtomicBoolean isBookieInEnsembles = new AtomicBoolean(false);
+            Versioned<LedgerMetadata> metadata = null;
             while (!done) {
                 start = end + 1;
                 if (ledgerRangeIterator.hasNext()) {
@@ -174,8 +175,8 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
                     if (!ledgersInMetadata.contains(bkLid)) {
                         if (verifyMetadataOnGc) {
                             isBookieInEnsembles.set(false);
+                            metadata = null;
                             int rc = BKException.Code.OK;
-                            Versioned<LedgerMetadata> metadata = null;
                             try {
                                 metadata = result(ledgerManager.readLedgerMetadata(bkLid), zkOpTimeoutMs,
                                         TimeUnit.MILLISECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -34,8 +34,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRange;
@@ -45,6 +47,7 @@ import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
@@ -149,6 +152,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             long start;
             long end = -1;
             boolean done = false;
+            AtomicBoolean isBookieInEnsembles = new AtomicBoolean(false);
             while (!done) {
                 start = end + 1;
                 if (ledgerRangeIterator.hasNext()) {
@@ -169,9 +173,12 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
                 for (Long bkLid : subBkActiveLedgers) {
                     if (!ledgersInMetadata.contains(bkLid)) {
                         if (verifyMetadataOnGc) {
+                            isBookieInEnsembles.set(false);
                             int rc = BKException.Code.OK;
+                            Versioned<LedgerMetadata> metadata = null;
                             try {
-                                result(ledgerManager.readLedgerMetadata(bkLid), zkOpTimeoutMs, TimeUnit.MILLISECONDS);
+                                metadata = result(ledgerManager.readLedgerMetadata(bkLid), zkOpTimeoutMs,
+                                        TimeUnit.MILLISECONDS);
                             } catch (BKException | TimeoutException e) {
                                 if (e instanceof BKException) {
                                     rc = ((BKException) e).getCode();
@@ -182,7 +189,19 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
                                     continue;
                                 }
                             }
-                            if (rc != BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
+                            // check bookie should be part of ensembles in one
+                            // of the segment else ledger should be deleted from
+                            // local storage
+                            if (metadata != null && metadata.getValue() != null) {
+                                metadata.getValue().getAllEnsembles().forEach((entryId, ensembles) -> {
+                                    if (ensembles != null && ensembles.contains(selfBookieAddress)) {
+                                        isBookieInEnsembles.set(true);
+                                    }
+                                });
+                                if (isBookieInEnsembles.get()) {
+                                    continue;
+                                }
+                            } else if (rc != BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                                 LOG.warn("Ledger {} Missing in metadata list, but ledgerManager returned rc: {}.",
                                         bkLid, rc);
                                 continue;


### PR DESCRIPTION
### Motivation
As described at: https://github.com/apache/pulsar/issues/4632
- Sometimes due to overreplication, bookie contains ledgers which are not owned by that bookie anymore and that bookie is not part of the ensemble-list of those ledgers. In this case, GC finds out those overreplicated ledgers and 
- deletes their index from dbStorage (rocksDB) and 
- tries to delete them from entrylog files.

However, bookie doesn't delete them from entry-log files due to change made in [#870](https://github.com/apache/bookkeeper/issues/870) where bookie avoids deleting ledger if znode of that ledger exists.

Because of that bookie ends up storing large number entrylog files with ledgers which are owned by different bookies. It also cause OOM when GC tries to deal with large number of entry log files.

### Modification

Delete the ledgers if bookie is not part of ensemble list of over-replicated ledgers