### PR TITLE
Fix log statements with incorrect placeholders

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -637,7 +637,7 @@ public class EntryLogger {
             if (compactionLogChannel != null) {
                 compactionLogChannel.appendLedgersMap();
                 compactionLogChannel.flushAndForceWrite(false);
-                LOG.info("Flushed compaction log file {} with logId.",
+                LOG.info("Flushed compaction log file {} with logId {}.",
                     compactionLogChannel.getLogFile(),
                     compactionLogChannel.getLogId());
                 // since this channel is only used for writing, after flushing the channel,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -451,7 +451,6 @@ public class IndexPersistenceMgr {
         try {
             fi = getFileInfo(ledgerId, null);
             fi.setExplicitLac(lac);
-            return;
         } finally {
             if (null != fi) {
                 fi.release();
@@ -465,7 +464,7 @@ public class IndexPersistenceMgr {
             fi = getFileInfo(ledgerId, null);
             return fi.getExplicitLac();
         } catch (IOException e) {
-            LOG.error("Exception during getLastAddConfirmed: {}", e);
+            LOG.error("Exception during getLastAddConfirmed", e);
             return null;
         } finally {
             if (null != fi) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -194,7 +194,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             }
         } catch (Throwable t) {
             // ignore exception, collecting garbage next time
-            LOG.warn("Exception when iterating over the metadata {}", t);
+            LOG.warn("Exception when iterating over the metadata", t);
         } finally {
             if (zk != null) {
                 try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -96,7 +96,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
     public boolean compact(EntryLogMetadata metadata) {
         if (metadata != null) {
             LOG.info("Compacting entry log {} with usage {}.",
-                new Object[]{metadata.getEntryLogId(), metadata.getUsage()});
+                metadata.getEntryLogId(), metadata.getUsage());
             CompactionPhase scanEntryLog = new ScanEntryLogPhase(metadata);
             if (!scanEntryLog.run()) {
                 LOG.info("Compaction for entry log {} end in ScanEntryLogPhase.", metadata.getEntryLogId());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
@@ -112,7 +112,7 @@ class PendingWriteLacOp implements WriteLacCallback {
                 return;
             }
         } else {
-            LOG.warn("WriteLac did not succeed: Ledger {} on {}", new Object[] { ledgerId, addr });
+            LOG.warn("WriteLac did not succeed: Ledger {} on {}", ledgerId, addr);
         }
 
         if (receivedResponseSet.isEmpty()){

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -290,7 +290,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                                 // and then it got removed.  I'd argue that returning an error here is the right
                                 // path since recreating it is likely to cause problems.
                                 LOG.warn("Ledger {} appears to have already existed and then been removed, failing"
-                                        + " with LedgerExistException");
+                                        + " with LedgerExistException", ledgerId);
                                 promise.completeExceptionally(new BKException.BKLedgerExistException());
                             } else {
                                 LOG.error("Could not validate node for ledger {} after LedgerExistsException", ledgerId,
@@ -355,7 +355,7 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                         if (LOG.isDebugEnabled()) {
                             LOG.debug(
                                     "Remove registered ledger metadata listeners on ledger {} after ledger is deleted.",
-                                    ledgerId, listenerSet);
+                                    ledgerId);
                         }
                     } else {
                         if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/BookieSocketAddress.java
@@ -117,9 +117,7 @@ public class BookieSocketAddress {
     // Return the String "serialized" version of this object.
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(hostname).append(COLON).append(port);
-        return sb.toString();
+        return hostname + COLON + port;
     }
 
     // Implement an equals method comparing two BookiSocketAddress objects.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
@@ -94,7 +94,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles()
                 .get(0L).get(0);
 
-        LOG.info("Killing Bookie", replicaToKill);
+        LOG.info("Killing Bookie : {}", replicaToKill);
         killBookie(replicaToKill);
 
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
@@ -149,7 +149,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
                 .get(0L).get(0);
 
         startNewBookie();
-        LOG.info("Killing Bookie", replicaToKill);
+        LOG.info("Killing Bookie : {}", replicaToKill);
         killBookie(replicaToKill);
 
         // Lets reform ensemble
@@ -163,7 +163,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
         LOG.info("New Bookie addr : {}", newBkAddr);
 
-        LOG.info("Killing Bookie", replicaToKill2);
+        LOG.info("Killing Bookie : {}", replicaToKill2);
         killBookie(replicaToKill2);
 
         Set<LedgerFragment> result = getFragmentsToReplicate(lh);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -140,7 +140,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
         BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
-        LOG.info("Killing Bookie", replicaToKill);
+        LOG.info("Killing Bookie : {}", replicaToKill);
         killBookie(replicaToKill);
 
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
@@ -187,7 +187,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
         lh.close();
         BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
-        LOG.info("Killing Bookie", replicaToKill);
+        LOG.info("Killing Bookie : {}", replicaToKill);
         ServerConfiguration killedBookieConfig = killBookie(replicaToKill);
 
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
@@ -236,7 +236,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
         lh.close();
         BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
-        LOG.info("Killing Bookie", replicaToKill);
+        LOG.info("Killing Bookie : {}", replicaToKill);
         ServerConfiguration killedBookieConfig = killBookie(replicaToKill);
 
         killAllBookies(lh, null);
@@ -292,7 +292,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
         lh.close();
         BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
-        LOG.info("Killing Bookie", replicaToKill);
+        LOG.info("Killing Bookie : {}", replicaToKill);
         killBookie(replicaToKill);
 
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
@@ -327,7 +327,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
         BookieSocketAddress replicaToKillFromFirstLedger = lh1.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
-        LOG.info("Killing Bookie", replicaToKillFromFirstLedger);
+        LOG.info("Killing Bookie : {}", replicaToKillFromFirstLedger);
 
         // Ledger2
         LedgerHandle lh2 = bkc.createLedger(3, 3, BookKeeper.DigestType.CRC32,
@@ -338,7 +338,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
         BookieSocketAddress replicaToKillFromSecondLedger = lh2.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
-        LOG.info("Killing Bookie", replicaToKillFromSecondLedger);
+        LOG.info("Killing Bookie : {}", replicaToKillFromSecondLedger);
 
         // Kill ledger1
         killBookie(replicaToKillFromFirstLedger);
@@ -397,7 +397,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
         BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
-        LOG.info("Killing Bookie", replicaToKill);
+        LOG.info("Killing Bookie : {}", replicaToKill);
         killBookie(replicaToKill);
 
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();
@@ -464,7 +464,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         for (int i = 0; i < ensembleSize; i++) {
             bookiesKilled[i] = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(i);
             killedBookiesConfig[i] = getBkConf(bookiesKilled[i]);
-            LOG.info("Killing Bookie", bookiesKilled[i]);
+            LOG.info("Killing Bookie : {}", bookiesKilled[i]);
             killBookie(bookiesKilled[i]);
         }
 
@@ -583,7 +583,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
         BookieSocketAddress replicaToKill = lh.getLedgerMetadata().getAllEnsembles().get(0L).get(0);
 
-        LOG.info("Killing Bookie", replicaToKill);
+        LOG.info("Killing Bookie : {}", replicaToKill);
         killBookie(replicaToKill);
 
         BookieSocketAddress newBkAddr = startNewBookieAndReturnAddress();

--- a/stream/distributedlog/common/src/main/java/org/apache/distributedlog/common/config/ConfigurationSubscription.java
+++ b/stream/distributedlog/common/src/main/java/org/apache/distributedlog/common/config/ConfigurationSubscription.java
@@ -99,7 +99,7 @@ public class ConfigurationSubscription {
                 }
             } catch (ConfigurationException ex) {
                 if (!fileNotFound(ex)) {
-                    LOG.error("Config init failed {}", ex);
+                    LOG.error("Config init failed", ex);
                 }
             }
         }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/LocalDLMEmulator.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/LocalDLMEmulator.java
@@ -145,7 +145,7 @@ public class LocalDLMEmulator {
                     LOG.info("Starting {} bookies : allowLoopback = {}", numBookies, serverConf.getAllowLoopback());
                     LocalBookKeeper.startLocalBookies(zkHost, zkPort,
                             numBookies, shouldStartZK, initialBookiePort, serverConf);
-                    LOG.info("{} bookies are started.");
+                    LOG.info("{} bookies are started.", numBookies);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     // go away quietly

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/bk/SimpleLedgerAllocator.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/bk/SimpleLedgerAllocator.java
@@ -314,7 +314,7 @@ public class SimpleLedgerAllocator implements LedgerAllocator, FutureEventListen
     private synchronized void setPhase(Phase phase) {
         this.phase = phase;
         LOG.info("Ledger allocator {} moved to phase {} : version = {}.",
-                new Object[] { allocatePath, phase, version });
+            allocatePath, phase, version);
     }
 
     private synchronized void allocateLedger() {
@@ -371,11 +371,11 @@ public class SimpleLedgerAllocator implements LedgerAllocator, FutureEventListen
         Version.Occurred occurred = newVersion.compare(version);
         if (occurred == Version.Occurred.AFTER) {
             LOG.info("Ledger allocator for {} moved version from {} to {}.",
-                    new Object[] { allocatePath, version, newVersion });
+                allocatePath, version, newVersion);
             version = newVersion;
         } else {
             LOG.warn("Ledger allocator for {} received an old version {}, current version is {}.",
-                    new Object[] { allocatePath, newVersion , version });
+                allocatePath, newVersion, version);
         }
     }
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/BKDLConfig.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/BKDLConfig.java
@@ -60,9 +60,9 @@ public class BKDLConfig implements DLConfig {
         }
         LOG.info("Propagate BKDLConfig to DLConfig : encodeRegionID = {},"
                         + " firstLogSegmentSequenceNumber = {}, createStreamIfNotExists = {}, isFederated = {}.",
-                new Object[] { dlConf.getEncodeRegionIDInLogSegmentMetadata(),
-                        dlConf.getFirstLogSegmentSequenceNumber(), dlConf.getCreateStreamIfNotExists(),
-                        bkdlConfig.isFederatedNamespace() });
+            dlConf.getEncodeRegionIDInLogSegmentMetadata(),
+            dlConf.getFirstLogSegmentSequenceNumber(), dlConf.getCreateStreamIfNotExists(),
+            bkdlConfig.isFederatedNamespace());
     }
 
     public static BKDLConfig resolveDLConfig(ZooKeeperClient zkc, URI uri) throws IOException {

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/net/DNSResolver.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/net/DNSResolver.java
@@ -66,7 +66,7 @@ public abstract class DNSResolver implements DNSToSwitchMapping {
             for (String override : overrides) {
                 String[] parts = override.split(":");
                 if (parts.length != 2) {
-                    LOG.warn("Incorrect override specified", override);
+                    LOG.warn("Incorrect override specified : {}", override);
                 } else {
                     hostNameToRegion.putIfAbsent(parts[0], parts[1]);
                 }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKDistributedLogNamespace.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKDistributedLogNamespace.java
@@ -183,7 +183,7 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
 
         try {
             namespace.openLog("/ test2");
-            fail("should fail to create invalid stream / test2");
+            fail("Should fail to create invalid stream / test2");
         } catch (InvalidStreamNameException isne) {
             // expected
         }
@@ -196,7 +196,7 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
             chars[0] = 0;
             String streamName = new String(chars);
             namespace.openLog(streamName);
-            fail("should fail to create invalid stream " + streamName);
+            fail("Should fail to create invalid stream " + streamName);
         } catch (InvalidStreamNameException isne) {
             // expected
         }
@@ -209,7 +209,7 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
             chars[3] = '\u0010';
             String streamName = new String(chars);
             namespace.openLog(streamName);
-            fail("should fail to create invalid stream " + streamName);
+            fail("Should fail to create invalid stream " + streamName);
         } catch (InvalidStreamNameException isne) {
             // expected
         }
@@ -344,13 +344,13 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
         try {
             // Reopening and writing again with a different un will fail.
             initDlogMeta("/" + runtime.getMethodName(), "not-test-un", streamName);
-            fail("write should have failed due to perms");
+            fail("Write should have failed due to perms");
         } catch (ZKException ex) {
-            LOG.info("caught exception trying to write with no perms {}", ex);
+            LOG.info("Caught exception trying to write with no perms", ex);
             assertEquals(KeeperException.Code.NOAUTH, ex.getKeeperExceptionCode());
         } catch (Exception ex) {
-            LOG.info("caught wrong exception trying to write with no perms {}", ex);
-            fail("wrong exception " + ex.getClass().getName() + " expected " + LockingException.class.getName());
+            LOG.info("Caught wrong exception trying to write with no perms", ex);
+            fail("Wrong exception " + ex.getClass().getName() + " expected " + LockingException.class.getName());
         }
 
         // Should work again.

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestLogSegmentCreation.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestLogSegmentCreation.java
@@ -103,7 +103,7 @@ public class TestLogSegmentCreation extends TestDistributedLogBase {
         assertFalse(hasDuplicatedSegment);
 
         LOG.info("Segments : duplicated = {}, inprogress = {}, {}",
-                 new Object[] { hasDuplicatedSegment, hasInprogress, segments });
+            hasDuplicatedSegment, hasInprogress, segments);
 
         dlm1.close();
         dlm2.close();

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestReader.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestReader.java
@@ -152,7 +152,7 @@ public class TestReader implements FutureEventListener<LogRecordWithDLSN> {
         try {
             assertTrue(value.getDlsn().compareTo(nextDLSN) >= 0);
             LOG.info("Received record {} from log {} for reader {}",
-                    new Object[] { value.getDlsn(), dlm.getStreamName(), readerName });
+                value.getDlsn(), dlm.getStreamName(), readerName);
             assertFalse(value.isControl());
             assertEquals(0, value.getDlsn().getSlotId());
             DLMTestUtil.verifyLargeLogRecord(value);

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestRollLogSegments.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestRollLogSegments.java
@@ -279,7 +279,7 @@ public class TestRollLogSegments extends TestDistributedLogBase {
                 }
                 @Override
                 public void onFailure(Throwable cause) {
-                    logger.error("Failed to write entries : {}", cause);
+                    logger.error("Failed to write entries", cause);
                 }
             });
             if (i == 1) {

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocatorPool.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocatorPool.java
@@ -289,8 +289,7 @@ public class TestLedgerAllocatorPool extends TestDistributedLogBase {
                             Utils.ioResult(txn.execute());
                             lh.close();
                             allocatedLedgers.putIfAbsent(lh.getId(), lh);
-                            logger.info("[thread {}] allocate {}th ledger {}",
-                                    new Object[] { tid, i, lh.getId() });
+                            logger.info("[thread {}] allocate {}th ledger {}", tid, i, lh.getId());
                         }
                     } catch (Exception ioe) {
                         numFailures.incrementAndGet();

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
@@ -55,13 +55,11 @@ public class BookieService extends AbstractLifecycleComponent<BookieConfiguratio
         }
         log.info("Hello, I'm your bookie, listening on port {} :"
                 + " metadata service uri = {}, journals = {}, ledgers = {}, index = {}",
-            new Object[]{
-                serverConf.getBookiePort(),
-                serverConf.getMetadataServiceUriUnchecked(),
-                Arrays.asList(serverConf.getJournalDirNames()),
-                Arrays.asList(serverConf.getLedgerDirs()),
-                indexDirs
-            });
+            serverConf.getBookiePort(),
+            serverConf.getMetadataServiceUriUnchecked(),
+            Arrays.asList(serverConf.getJournalDirNames()),
+            Arrays.asList(serverConf.getLedgerDirs()),
+            indexDirs);
         try {
             this.bs = new BookieServer(serverConf, statsLogger);
             bs.start();


### PR DESCRIPTION
### Changes

The following changes were made:

- remove unused placeholders in the log statements
- add missing placeholders to the log strings to show the complete information
- remove unnecessary initialization of object arrays in the log statements 