### PR TITLE
[CI] Prune networks older than 12h

### DIFF
--- a/.test-infra/scripts/pre-docker-tests.sh
+++ b/.test-infra/scripts/pre-docker-tests.sh
@@ -28,6 +28,6 @@ ps -eo euser,pid,ppid,pgid,start,pcpu,pmem,cmd
 docker info
 docker system prune -f
 # clean up any dangling networks from previous runs
-docker network prune -f --filter name=testnetwork_*
+docker network prune -f --filter "until=12h"
 docker system events > docker.debug-info & echo $! > docker-log.pid
 docker pull quay.io/coreos/etcd:v3.3


### PR DESCRIPTION
Previously we were using a filter which matched on the network name of
the networks we create. However, docker seems to have removed this
functionality, so now we just prune all unused networks which are more
than 12h old (no CI job should be taking more than 12h).
