### PR TITLE
Make default Bookie scripts work on JDK11+

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#
 #/**
 # * Licensed to the Apache Software Foundation (ASF) under one
 # * or more contributor license agreements.  See the NOTICE file
@@ -71,13 +70,31 @@ source ${BK_CONFDIR}/nettyenv.sh
 source ${BK_CONFDIR}/bkenv.sh
 source ${BK_CONFDIR}/bk_cli_env.sh
 
+detect_jdk8() {
+
+  if [ -f "$JAVA_HOME/bin/jshell" ]; then
+     echo "0"
+  else
+     echo "1"
+  fi
+  return
+}
+
 # default netty settings
 NETTY_LEAK_DETECTION_LEVEL=${NETTY_LEAK_DETECTION_LEVEL:-"disabled"}
 NETTY_RECYCLER_MAXCAPACITY=${NETTY_RECYCLER_MAXCAPACITY:-"1000"}
 NETTY_RECYCLER_LINKCAPACITY=${NETTY_RECYCLER_LINKCAPACITY:-"1024"}
 
-# default bookie JVM settings
-DEFAULT_BOOKIE_GC_OPTS="-XX:+UseG1GC \
+USING_JDK8=$(detect_jdk8)
+
+if [ "$USING_JDK8" -ne "1" ]; then
+   DEFAULT_BOOKIE_GC_OPTS="-XX:+UseG1GC \
+    -XX:MaxGCPauseMillis=10 \
+    -XX:+ParallelRefProcEnabled \
+    -XX:+DisableExplicitGC"
+   DEFAULT_BOOKIE_GC_LOGGING_OPTS=""
+else
+  DEFAULT_BOOKIE_GC_OPTS="-XX:+UseG1GC \
     -XX:MaxGCPauseMillis=10 \
     -XX:+ParallelRefProcEnabled \
     -XX:+UnlockExperimentalVMOptions \
@@ -88,11 +105,13 @@ DEFAULT_BOOKIE_GC_OPTS="-XX:+UseG1GC \
     -XX:G1NewSizePercent=50 \
     -XX:+DisableExplicitGC \
     -XX:-ResizePLAB"
-DEFAULT_BOOKIE_GC_LOGGING_OPTS="-XX:+PrintGCDetails \
+  DEFAULT_BOOKIE_GC_LOGGING_OPTS="-XX:+PrintGCDetails \
     -XX:+PrintGCApplicationStoppedTime  \
     -XX:+UseGCLogFileRotation \
     -XX:NumberOfGCLogFiles=5 \
     -XX:GCLogFileSize=64m"
+fi
+
 BOOKIE_MAX_HEAP_MEMORY=${BOOKIE_MAX_HEAP_MEMORY:-"1g"}
 BOOKIE_MIN_HEAP_MEMORY=${BOOKIE_MIN_HEAP_MEMORY:-"1g"}
 BOOKIE_MAX_DIRECT_MEMORY=${BOOKIE_MAX_DIRECT_MEMORY:-"2g"}
@@ -103,11 +122,16 @@ BOOKIE_GC_LOGGING_OPTS=${BOOKIE_GC_LOGGING_OPTS:-"${DEFAULT_BOOKIE_GC_LOGGING_OP
 # default CLI JVM settings
 DEFAULT_CLI_GC_OPTS="-XX:+UseG1GC \
     -XX:MaxGCPauseMillis=10"
-DEFAULT_CLI_GC_LOGGING_OPTS="-XX:+PrintGCDetails \
+if [ "$USING_JDK8" -ne "1" ]; then
+  DEFAULT_CLI_GC_LOGGING_OPTS="-XX:+PrintGCDetails \
     -XX:+PrintGCApplicationStoppedTime  \
     -XX:+UseGCLogFileRotation \
     -XX:NumberOfGCLogFiles=5 \
     -XX:GCLogFileSize=64m"
+else
+  DEFAULT_CLI_GC_LOGGING_OPTS=""
+fi
+
 CLI_MAX_HEAP_MEMORY=${CLI_MAX_HEAP_MEMORY:-"512M"}
 CLI_MIN_HEAP_MEMORY=${CLI_MIN_HEAP_MEMORY:-"256M"}
 CLI_MEM_OPTS=${CLI_MEM_OPTS:-"-Xms${CLI_MIN_HEAP_MEMORY} -Xmx${CLI_MAX_HEAP_MEMORY}"}
@@ -241,15 +265,23 @@ set_module_classpath() {
 build_bookie_jvm_opts() {
   LOG_DIR=$1
   GC_LOG_FILENAME=$2
-
-  echo "$BOOKIE_MEM_OPTS $BOOKIE_GC_OPTS $BOOKIE_GC_LOGGING_OPTS $BOOKIE_PERF_OPTS -Xloggc:${LOG_DIR}/${GC_LOG_FILENAME}"
+  if [ "$USING_JDK8" -eq "1" ]; then
+    echo "$BOOKIE_MEM_OPTS $BOOKIE_GC_OPTS $BOOKIE_GC_LOGGING_OPTS $BOOKIE_PERF_OPTS -Xloggc:${LOG_DIR}/${GC_LOG_FILENAME}"
+  else
+    echo "$BOOKIE_MEM_OPTS $BOOKIE_GC_OPTS $BOOKIE_GC_LOGGING_OPTS $BOOKIE_PERF_OPTS -Xlog:gc=info:file=${LOG_DIR}/${GC_LOG_FILENAME}::filecount=5,filesize=64m"
+  fi
+  return
 }
 
 build_cli_jvm_opts() {
   LOG_DIR=$1
   GC_LOG_FILENAME=$2
-
-  echo "$CLI_MEM_OPTS $CLI_GC_OPTS $CLI_GC_LOGGING_OPTS -Xloggc:${LOG_DIR}/${GC_LOG_FILENAME}"
+  if [ "$USING_JDK8" -eq "1" ]; then
+    echo "$CLI_MEM_OPTS $CLI_GC_OPTS $CLI_GC_LOGGING_OPTS -Xloggc:${LOG_DIR}/${GC_LOG_FILENAME}"
+  else
+    echo "$CLI_MEM_OPTS $CLI_GC_OPTS $CLI_GC_LOGGING_OPTS -Xlog:gc=info:file=${LOG_DIR}/${GC_LOG_FILENAME}::filecount=5,filesize=64m"
+  fi
+  return
 }
 
 build_netty_opts() {


### PR DESCRIPTION
- detect new Java versions in bin/common.sh
- use different defaults on JDK8 vs JDK11+

Descriptions of the changes in this PR:
Change distribution scripts in order to detect a JDK newer then JDK8 and set default JVM options accordingly.

### Motivation

Because I want that BookKeeper tools run out of the box with JDK11

### Changes
1) detect a JDK newer then JDK8, but checking if exists $JAVA_HOME/bin/jshell (this is quite robust, better then parsing some Java version string)
2) use new defaults for JDK11, in particular do not enable experimental and deprecated options, use the new [Java Unified Logging](https://openjdk.java.net/jeps/158) log system for GC

Please note the output of "Java Unified Logging" is very different from the old pre-Java9 one and 
options are different, there is no simple port.

Master Issue: #1912

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java11]: skip build on java11. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
