### PR TITLE
Simplify if statements

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/annotation/InterfaceAudience.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/annotation/InterfaceAudience.java
@@ -34,7 +34,7 @@ public class InterfaceAudience {
      */
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
-    public @interface Public {};
+    public @interface Public {}
 
     /**
      * Intended for use only within the project(s) specified in the annotation.
@@ -42,14 +42,14 @@ public class InterfaceAudience {
      */
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
-    public @interface LimitedPrivate {};
+    public @interface LimitedPrivate {}
 
     /**
      * Intended for use only within bookkeeper itself.
      */
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
-    public @interface Private {};
+    public @interface Private {}
 
     private InterfaceAudience() {} // Audience can't exist on its own
 

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/annotation/InterfaceStability.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/annotation/InterfaceStability.java
@@ -32,20 +32,20 @@ public class InterfaceStability {
    * can break compatibility only at major release (ie. at m.0).
    */
   @Documented
-  public @interface Stable {};
+  public @interface Stable {}
 
   /**
    * Evolving, but can break compatibility at minor release (i.e. m.x)
    */
   @Documented
-  public @interface Evolving {};
+  public @interface Evolving {}
 
   /**
    * No guarantee is provided as to reliability or stability across any
    * level of release granularity.
    */
   @Documented
-  public @interface Unstable {};
+  public @interface Unstable {}
 
   private InterfaceStability() {}
 }

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/validators/RangeValidator.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/validators/RangeValidator.java
@@ -68,10 +68,8 @@ public class RangeValidator implements Validator {
             Number n = (Number) value;
             if (min != null && n.doubleValue() < min.doubleValue()) {
                 return false;
-            } else if (max != null && n.doubleValue() > max.doubleValue()) {
-                return false;
             } else {
-                return true;
+                return max == null || !(n.doubleValue() > max.doubleValue());
             }
         } else {
             return false;

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
@@ -377,6 +377,6 @@ public class OrderedScheduler extends OrderedExecutor implements ScheduledExecut
             public void execute(Runnable command) {
                 super.execute(timedRunnable(command));
             }
-        };
+        }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/auth/BookKeeperPrincipal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/auth/BookKeeperPrincipal.java
@@ -63,10 +63,7 @@ public class BookKeeperPrincipal {
             return false;
         }
         final BookKeeperPrincipal other = (BookKeeperPrincipal) obj;
-        if (!Objects.equals(this.name, other.name)) {
-            return false;
-        }
-        return true;
+        return Objects.equals(this.name, other.name);
     }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -898,12 +898,8 @@ public class Bookie extends BookieCriticalThread {
      */
     private void replay(Journal journal, JournalScanner scanner) throws IOException {
         final LogMark markedLog = journal.getLastLogMark().getCurMark();
-        List<Long> logs = Journal.listJournalIds(journal.getJournalDirectory(), journalId -> {
-            if (journalId < markedLog.getLogFileId()) {
-                return false;
-            }
-            return true;
-        });
+        List<Long> logs = Journal.listJournalIds(journal.getJournalDirectory(), journalId ->
+            journalId >= markedLog.getLogFileId());
         // last log mark may be missed due to no sync up before
         // validate filtered log ids only when we have markedLogId
         if (markedLog.getLogFileId() > 0) {
@@ -1518,11 +1514,7 @@ public class Bookie extends BookieCriticalThread {
                     if (!isInteractive) {
                         // If non interactive and force is set, then delete old
                         // data.
-                        if (force) {
-                            confirm = true;
-                        } else {
-                            confirm = false;
-                        }
+                        confirm = force;
                     } else {
                         confirm = IOUtils
                                 .confirmPrompt("Are you sure to format Bookie data..?");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -2157,9 +2157,6 @@ public class BookieShell implements Tool {
     }
 
     private static boolean getOptionalValue(String optValue, String optName) {
-        if (StringUtils.equals(optValue, optName)) {
-            return true;
-        }
-        return false;
+        return StringUtils.equals(optValue, optName);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
@@ -91,10 +91,7 @@ public class FileSystemUpgrade {
                     || name.equals("lastId") || name.startsWith("lastMark")) {
                     return true;
                 }
-                if (containsIndexFiles(dir, name)) {
-                    return true;
-                }
-                return false;
+                return containsIndexFiles(dir, name);
             }
         };
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -273,11 +273,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
         @Override
         public boolean accept(long journalId) {
-            if (journalId < lastMark.getCurMark().getLogFileId()) {
-                return true;
-            } else {
-                return false;
-            }
+            return journalId < lastMark.getCurMark().getLogFileId();
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1168,7 +1168,7 @@ public class BookKeeperAdmin implements AutoCloseable {
                 if (ledgerRootExists) {
                     if (!isInteractive) {
                         // If non interactive and force is set, then delete old data.
-                      doFormat = force;
+                        doFormat = force;
                     } else {
                         // Confirm with the admin.
                         doFormat = IOUtils

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1168,11 +1168,7 @@ public class BookKeeperAdmin implements AutoCloseable {
                 if (ledgerRootExists) {
                     if (!isInteractive) {
                         // If non interactive and force is set, then delete old data.
-                        if (force) {
-                            doFormat = true;
-                        } else {
-                            doFormat = false;
-                        }
+                      doFormat = force;
                     } else {
                         // Confirm with the admin.
                         doFormat = IOUtils

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -107,7 +107,7 @@ public class LedgerHandle implements WriteHandle {
     private enum HandleState {
         OPEN,
         CLOSED
-    };
+    }
 
     private HandleState handleState = HandleState.OPEN;
     private final CompletableFuture<Void> closePromise = new CompletableFuture<>();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerMetadata.java
@@ -158,7 +158,7 @@ public interface LedgerMetadata {
         /** The ledger is closed. No new entries may be added to it.
             The length and lastEntryId are fixed. Ensembles may change, but only for rereplication.
         */
-        CLOSED;
+        CLOSED
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -574,18 +574,15 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
      *          Znode Name
      * @return true  if the znode is a special znode otherwise false
      */
-     public static boolean isSpecialZnode(String znode) {
-        if (BookKeeperConstants.AVAILABLE_NODE.equals(znode)
-                || BookKeeperConstants.COOKIE_NODE.equals(znode)
-                || BookKeeperConstants.LAYOUT_ZNODE.equals(znode)
-                || BookKeeperConstants.INSTANCEID.equals(znode)
-                || BookKeeperConstants.UNDER_REPLICATION_NODE.equals(znode)
-                || LegacyHierarchicalLedgerManager.IDGEN_ZNODE.equals(znode)
-                || LongHierarchicalLedgerManager.IDGEN_ZNODE.equals(znode)
-                || znode.startsWith(ZkLedgerIdGenerator.LEDGER_ID_GEN_PREFIX)) {
-            return true;
-        }
-        return false;
+    public static boolean isSpecialZnode(String znode) {
+        return BookKeeperConstants.AVAILABLE_NODE.equals(znode)
+            || BookKeeperConstants.COOKIE_NODE.equals(znode)
+            || BookKeeperConstants.LAYOUT_ZNODE.equals(znode)
+            || BookKeeperConstants.INSTANCEID.equals(znode)
+            || BookKeeperConstants.UNDER_REPLICATION_NODE.equals(znode)
+            || LegacyHierarchicalLedgerManager.IDGEN_ZNODE.equals(znode)
+            || LongHierarchicalLedgerManager.IDGEN_ZNODE.equals(znode)
+            || znode.startsWith(ZkLedgerIdGenerator.LEDGER_ID_GEN_PREFIX);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
@@ -653,16 +653,13 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
          *          Znode Name
          * @return true  if the znode is a special znode otherwise false
          */
-         public static boolean isSpecialZnode(String znode) {
-            if (BookKeeperConstants.AVAILABLE_NODE.equals(znode)
-                    || BookKeeperConstants.COOKIE_NODE.equals(znode)
-                    || BookKeeperConstants.LAYOUT_ZNODE.equals(znode)
-                    || BookKeeperConstants.INSTANCEID.equals(znode)
-                    || BookKeeperConstants.UNDER_REPLICATION_NODE.equals(znode)
-                    || MsLedgerManager.IDGEN_ZNODE.equals(znode)) {
-                return true;
-            }
-            return false;
+        public static boolean isSpecialZnode(String znode) {
+            return BookKeeperConstants.AVAILABLE_NODE.equals(znode)
+                || BookKeeperConstants.COOKIE_NODE.equals(znode)
+                || BookKeeperConstants.LAYOUT_ZNODE.equals(znode)
+                || BookKeeperConstants.INSTANCEID.equals(znode)
+                || BookKeeperConstants.UNDER_REPLICATION_NODE.equals(znode)
+                || MsLedgerManager.IDGEN_ZNODE.equals(znode);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
@@ -720,11 +720,8 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             LOG.debug("isLedgerReplicationEnabled()");
         }
         try {
-            if (null != zkc.exists(basePath + '/'
-                    + BookKeeperConstants.DISABLE_NODE, false)) {
-                return false;
-            }
-            return true;
+            return null == zkc.exists(basePath + '/'
+                + BookKeeperConstants.DISABLE_NODE, false);
         } catch (KeeperException ke) {
             LOG.error("Error while checking the state of "
                     + "ledger re-replication", ke);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopologyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopologyImpl.java
@@ -109,11 +109,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
             }
 
             Node firstChild = children.get(0);
-            if (firstChild instanceof InnerNode) {
-                return false;
-            }
-
-            return true;
+            return !(firstChild instanceof InnerNode);
         }
 
         /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/streaming/LedgerOutputStream.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/streaming/LedgerOutputStream.java
@@ -107,9 +107,7 @@ public class LedgerOutputStream extends OutputStream {
         if (bytebuff.remaining() < len) {
             flush();
             bytebuff.clear();
-            if (bytebuff.capacity() < len) {
-                return false;
-            }
+            return bytebuff.capacity() >= len;
         }
         return true;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LedgerCommand.java
@@ -94,9 +94,7 @@ public class LedgerCommand extends BookieCommand<LedgerCommand.LedgerFlags> {
         long ledgerId = cmdFlags.ledgerId;
         if (conf.getLedgerStorageClass().equals(DbLedgerStorage.class.getName())) {
             // dump ledger info
-            if (!dumpLedgerInfo(ledgerId, conf)) {
-                return false;
-            }
+            return dumpLedgerInfo(ledgerId, conf);
         } else if (conf.getLedgerStorageClass().equals(SortedLedgerStorage.class.getName())
                 || conf.getLedgerStorageClass().equals(InterleavedLedgerStorage.class.getName())) {
             ServerConfiguration tConf = new ServerConfiguration(conf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/auth/TestAuth.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/auth/TestAuth.java
@@ -100,7 +100,6 @@ public class TestAuth extends BookKeeperClusterTestCase {
                     PASSWD)) {
             ledgerWritten.set(l.getId());
             l.addEntry(ENTRY);
-            l.close();
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieDeferredSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieDeferredSyncTest.java
@@ -68,7 +68,7 @@ public class BookieDeferredSyncTest extends BookKeeperClusterTestCase {
                 .withLedgerId(ledgerId)
                 .withRecovery(true)
                 .withPassword(new byte[0])
-                .execute());) {
+                .execute())) {
 
             try (LedgerEntries entries = readLh.read(0, n - 1)) {
                 for (int i = 0; i < n; i++) {
@@ -121,7 +121,7 @@ public class BookieDeferredSyncTest extends BookKeeperClusterTestCase {
                     .withLedgerId(ledgerId)
                     .withRecovery(true)
                     .withPassword(new byte[0])
-                    .execute());) {
+                    .execute())) {
 
                 try (LedgerEntries entries = readLh.read(0, n - 1)) {
                     for (int i = 0; i < n; i++) {
@@ -143,7 +143,7 @@ public class BookieDeferredSyncTest extends BookKeeperClusterTestCase {
                     .withLedgerId(ledgerId)
                     .withRecovery(true)
                     .withPassword(new byte[0])
-                    .execute());) {
+                    .execute())) {
                 assertEquals(-1, readLh.getLastAddConfirmed());
 
                 // entry will be readable with readUnconfirmed
@@ -176,15 +176,13 @@ public class BookieDeferredSyncTest extends BookKeeperClusterTestCase {
                 .withWriteFlags(writeFlags)
                 .withDigestType(DigestType.CRC32C)
                 .withPassword(new byte[0])
-                .execute());) {
+                .execute())) {
             int n = 10;
             for (int i = 0; i < n; i++) {
                 lh.append(("entry-" + i).getBytes(UTF_8));
             }
             result(lh.force());
             assertEquals(n - 1, lh.getLastAddConfirmed());
-
-            lh.close();
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -793,7 +793,7 @@ public class LedgerCacheTest {
             public void writeComplete(int rc, long ledgerId, long entryId, BookieSocketAddress addr, Object ctx){
                 LOG.info("fail write to bk");
                 assertTrue(rc != OK);
-            };
+            }
 
         }, null, "passwd".getBytes());
         bookie.shutdown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -810,7 +810,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     public void testCannotUseWriteFlagsOnV2Protocol() throws Exception {
         ClientConfiguration conf = new ClientConfiguration(baseClientConf);
         conf.setUseV2WireProtocol(true);
-        try (BookKeeperTestClient bkc = new BookKeeperTestClient(conf);) {
+        try (BookKeeperTestClient bkc = new BookKeeperTestClient(conf)) {
             try (WriteHandle wh = result(bkc.newCreateLedgerOp()
                     .withEnsembleSize(3)
                     .withWriteQuorumSize(3)
@@ -827,7 +827,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     public void testCannotUseForceOnV2Protocol() throws Exception {
         ClientConfiguration conf = new ClientConfiguration(baseClientConf);
         conf.setUseV2WireProtocol(true);
-        try (BookKeeperTestClient bkc = new BookKeeperTestClient(conf);) {
+        try (BookKeeperTestClient bkc = new BookKeeperTestClient(conf)) {
             try (WriteHandle wh = result(bkc.newCreateLedgerOp()
                     .withEnsembleSize(3)
                     .withWriteQuorumSize(3)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MetadataUpdateLoopTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MetadataUpdateLoopTest.java
@@ -464,7 +464,7 @@ public class MetadataUpdateLoopTest {
                         }
                     });
             return promise;
-        };
+        }
     }
 
     @Data
@@ -509,6 +509,6 @@ public class MetadataUpdateLoopTest {
             } else {
                 return super.writeLedgerMetadata(ledgerId, metadata, currentVersion);
             }
-        };
+        }
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
@@ -93,11 +93,7 @@ public class RoundRobinDistributionScheduleTest {
     boolean[] buildAvailable(int ensemble, Set<Integer> responses) {
         boolean[] available = new boolean[ensemble];
         for (int i = 0; i < ensemble; i++) {
-            if (responses.contains(i)) {
-                available[i] = false;
-            } else {
-                available[i] = true;
-            }
+            available[i] = !responses.contains(i);
         }
         return available;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -292,13 +292,13 @@ public class TestTLS extends BookKeeperClusterTestCase {
         int numEntries = 100;
         long lid;
         byte[] testEntry = "testEntry".getBytes();
-        try (LedgerHandle lh = client.createLedger(clusterSize, clusterSize, DigestType.CRC32, passwd);) {
+        try (LedgerHandle lh = client.createLedger(clusterSize, clusterSize, DigestType.CRC32, passwd)) {
             for (int i = 0; i <= numEntries; i++) {
                 lh.addEntry(testEntry);
             }
             lid = lh.getId();
         }
-        try (LedgerHandle lh = client.openLedger(lid, DigestType.CRC32, passwd);) {
+        try (LedgerHandle lh = client.openLedger(lid, DigestType.CRC32, passwd)) {
             Enumeration<LedgerEntry> entries = lh.readEntries(0, numEntries);
             while (entries.hasMoreElements()) {
                 LedgerEntry e = entries.nextElement();
@@ -310,7 +310,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     private LedgerMetadata testClient(ClientConfiguration conf, int clusterSize) throws Exception {
-        try (BookKeeper client = new BookKeeper(conf);) {
+        try (BookKeeper client = new BookKeeper(conf)) {
             return testClient(client, clusterSize);
         }
     }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKDistributedLogManager.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKDistributedLogManager.java
@@ -1031,7 +1031,7 @@ class BKDistributedLogManager implements DistributedLogManager {
                         return null;
                     });
         }
-    };
+    }
 
     /**
      * Close the distributed log manager, freeing any resources it may hold.

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/DLSN.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/DLSN.java
@@ -225,11 +225,7 @@ public class DLSN implements Comparable<DLSN> {
         if (logSegmentSequenceNo != dlsn.logSegmentSequenceNo) {
             return false;
         }
-        if (slotId != dlsn.slotId) {
-            return false;
-        }
-
-        return true;
+        return slotId == dlsn.slotId;
     }
 
     @Override


### PR DESCRIPTION
### Changes

* Simplify `if` statements where it is possible (mainly for `if` statements returning boolean values)
* Remove redundant semicolons
* Remove the `close` method where the resource is used withing the try-with-resources block