### PR TITLE
Issue #2145: Make ledgerDirs in Cookie consistent across generating a…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Cookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Cookie.java
@@ -82,7 +82,7 @@ public class Cookie {
         this.instanceId = instanceId;
     }
 
-    private static String encodeDirPaths(String[] dirs) {
+    public static String encodeDirPaths(String[] dirs) {
         StringBuilder b = new StringBuilder();
         b.append(dirs.length);
         for (String d : dirs) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommand.java
@@ -116,7 +116,7 @@ public class GenerateCookieCommand extends CookieCommand<Flags> {
             builder.setInstanceId(instanceId);
         }
         builder.setJournalDirs(cmdFlags.journalDirs);
-        builder.setLedgerDirs(Cookie.encodeDirPaths(new String[] { cmdFlags.ledgerDirs }));
+        builder.setLedgerDirs(Cookie.encodeDirPaths(cmdFlags.ledgerDirs.split(",")));
 
         Cookie cookie = builder.build();
         cookie.writeToFile(new File(cmdFlags.outputFile));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommand.java
@@ -116,7 +116,7 @@ public class GenerateCookieCommand extends CookieCommand<Flags> {
             builder.setInstanceId(instanceId);
         }
         builder.setJournalDirs(cmdFlags.journalDirs);
-        builder.setLedgerDirs(cmdFlags.ledgerDirs);
+        builder.setLedgerDirs(Cookie.encodeDirPaths(new String[] { cmdFlags.ledgerDirs }));
 
         Cookie cookie = builder.build();
         cookie.writeToFile(new File(cmdFlags.outputFile));

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
@@ -199,7 +199,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
     }
 
     /**
-     * A successful run with encoding multiple ledgers while generating cookie
+     * A successful run with encoding multiple ledgers while generating cookie.
      */
     @Test
     public void testGenerateCookieWithMultipleLedgerDirs() throws Exception {
@@ -228,7 +228,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
         for (String cookieField : cookieFields) {
             String[] fields = cookieField.split(" ");
             if (fields[0].equals("ledgerDirs:")) {
-                assertEquals(fields[1].charAt(1),'2');
+                assertEquals(fields[1].charAt(1), '2');
             }
         }
     }

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
@@ -136,7 +136,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
             .setBookieHost(BOOKIE_ID)
             .setInstanceId(instanceId)
             .setJournalDirs(journalDir)
-            .setLedgerDirs(ledgersDir)
+            .setLedgerDirs(Cookie.encodeDirPaths(new String[] {ledgersDir}))
             .build();
 
         when(rm.getClusterInstanceId()).thenReturn(instanceId);
@@ -172,7 +172,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
             .setBookieHost(BOOKIE_ID)
             .setInstanceId(instanceId)
             .setJournalDirs(journalDir)
-            .setLedgerDirs(ledgersDir)
+            .setLedgerDirs(Cookie.encodeDirPaths(new String[] {ledgersDir}))
             .build();
 
         when(rm.getClusterInstanceId()).thenReturn(instanceId);

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.tools.cli.commands.cookie;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
@@ -32,6 +33,8 @@ import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
+
 import org.apache.bookkeeper.bookie.Cookie;
 import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.tools.cli.helpers.CookieCommandTestBase;
@@ -136,7 +139,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
             .setBookieHost(BOOKIE_ID)
             .setInstanceId(instanceId)
             .setJournalDirs(journalDir)
-            .setLedgerDirs(Cookie.encodeDirPaths(new String[] {ledgersDir}))
+            .setLedgerDirs(Cookie.encodeDirPaths(ledgersDir.split(",")))
             .build();
 
         when(rm.getClusterInstanceId()).thenReturn(instanceId);
@@ -165,14 +168,14 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
     public void testGenerateCookieWithInstanceId() throws Exception {
         File cookieFile = testFolder.newFile("cookie-with-instance-id");
         String journalDir = "/path/to/journal";
-        String ledgersDir = "/path/to/ledgers,/path/to/more/ledgers";
+        String ledgersDir = "/path/to/ledgers";
         String instanceId = "test-instance-id";
 
         Cookie cookie = Cookie.newBuilder()
             .setBookieHost(BOOKIE_ID)
             .setInstanceId(instanceId)
             .setJournalDirs(journalDir)
-            .setLedgerDirs(Cookie.encodeDirPaths(new String[] {ledgersDir}))
+            .setLedgerDirs(Cookie.encodeDirPaths(ledgersDir.split(",")))
             .build();
 
         when(rm.getClusterInstanceId()).thenReturn(instanceId);
@@ -193,6 +196,41 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
 
         byte[] data = Files.readAllBytes(Paths.get(cookieFile.getPath()));
         assertArrayEquals(cookie.toString().getBytes(UTF_8), data);
+    }
+
+    /**
+     * A successful run with encoding multiple ledgers while generating cookie
+     */
+    @Test
+    public void testGenerateCookieWithMultipleLedgerDirs() throws Exception {
+        File cookieFile = testFolder.newFile("cookie-with-instance-id");
+        String journalDir = "/path/to/journal";
+        String ledgersDir = "/path/to/ledgers,/path/to/more/ledgers";
+        String instanceId = "test-instance-id";
+
+        when(rm.getClusterInstanceId()).thenReturn(instanceId);
+        assertTrue(
+                getConsoleOutput(),
+                runCommand(new String[] {
+                        "-l", ledgersDir,
+                        "-j", journalDir,
+                        "-o", cookieFile.getPath(),
+                        "-i", instanceId,
+                        BOOKIE_ID
+                }));
+        String consoleOutput = getConsoleOutput();
+        assertTrue(consoleOutput, consoleOutput.contains(
+                "Successfully saved the generated cookie to " + cookieFile.getPath()
+        ));
+        verify(rm, times(0)).getClusterInstanceId();
+
+        List<String> cookieFields = Files.readAllLines(Paths.get(cookieFile.getPath()));
+        for (String cookieField : cookieFields) {
+            String[] fields = cookieField.split(" ");
+            if (fields[0].equals("ledgerDirs:")) {
+                assertEquals(fields[1].charAt(1),'2');
+            }
+        }
     }
 
 }

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
@@ -165,7 +165,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
     public void testGenerateCookieWithInstanceId() throws Exception {
         File cookieFile = testFolder.newFile("cookie-with-instance-id");
         String journalDir = "/path/to/journal";
-        String ledgersDir = "/path/to/ledgers";
+        String ledgersDir = "/path/to/ledgers,/path/to/more/ledgers";
         String instanceId = "test-instance-id";
 
         Cookie cookie = Cookie.newBuilder()


### PR DESCRIPTION
…nd setting

Descriptions of the changes in this PR:

### Motivation

In PR #1794 we brought in a way to generate a cookie from command line.
However during generation, we have to also encode the ledger dirs by default.

### Changes

Added encoding of ledger dir paths while setting the ledger dirs in a generated cookie in `GenerateCookieCommand.java`.
Tweaked existing test to include more than one ledger path for test coverage.

Master Issue: #2145 