### PR TITLE
Issue #2148: Support shell subcommands to print usage when no args

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/BookieShellCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/BookieShellCommand.java
@@ -43,6 +43,10 @@ public class BookieShellCommand<CliFlagsT extends CliFlags> implements Command {
 
     @Override
     public int runCmd(String[] args) throws Exception {
+        if (args.length <= 0) {
+            printUsage();
+            return -1;
+        }
         return bkCmd.apply(
             shellCmdName,
             conf,


### PR DESCRIPTION
### Motivation

Fixes #2148

### Changes

Print usage when args is empty in shell command `BookieShellCommand`.