### PR TITLE
[bookie-mtls] add BouncyCastleProvider for security-provider to avoid InvalidKeyException

### DIFF
--- a/bookkeeper-dist/src/assemble/bin-all.xml
+++ b/bookkeeper-dist/src/assemble/bin-all.xml
@@ -58,6 +58,7 @@
         <include>google-auth-library-credentials-0.9.0/LICENSE</include>
         <include>javax.servlet-api-3.1.0/CDDL+GPL-1.1</include>
         <include>jline-2.11/LICENSE</include>
+        <include>bouncycastle-1.60/LICENSE.html</include>
         <include>jsr-305/LICENSE</include>
         <include>netty-3.10.1.Final/*</include>
         <include>netty-4.1.32.Final/*</include>

--- a/bookkeeper-dist/src/assemble/bin-server.xml
+++ b/bookkeeper-dist/src/assemble/bin-server.xml
@@ -55,6 +55,7 @@
         <include>netty-4.1.32.Final/*</include>
         <include>protobuf-3.0.0/LICENSE</include>
         <include>jline-2.11/LICENSE</include>
+        <include>bouncycastle-1.60/LICENSE.html</include>
         <include>protobuf-3.5.1/LICENSE</include>
         <include>slf4j-1.7.25/LICENSE.txt</include>
       </includes>

--- a/bookkeeper-dist/src/assemble/bkctl.xml
+++ b/bookkeeper-dist/src/assemble/bkctl.xml
@@ -69,6 +69,7 @@
         <include>netty-4.1.32.Final/*</include>
         <include>protobuf-3.0.0/LICENSE</include>
         <include>jline-2.11/LICENSE</include>
+        <include>bouncycastle-1.60/LICENSE.html</include>
         <include>protobuf-3.5.1/LICENSE</include>
         <include>slf4j-1.7.25/LICENSE.txt</include>
       </includes>

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -467,6 +467,14 @@ license. For details, see deps/jline-2.11/LICENSE
 Bundled as
   - lib/jline-jline-2.11.jar
 ------------------------------------------------------------------------------------
+This product bundles the bouncycastle Library. 
+For license details, see deps/bouncycastle-1.60/LICENSE.html
+
+Bundled as
+  - lib/org.bouncycastle-bcpkix-jdk15on-1.60.jar
+  - lib/org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
+  - lib/org.bouncycastle-bcprov-jdk15on-1.60.jar
+------------------------------------------------------------------------------------
 This product uses the annotations from The Checker Framework, which are licensed under
 MIT License. For details, see deps/checker-compat-qual-2.5.2/LICENSE
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -391,6 +391,15 @@ license. For details, see deps/jline-2.11/LICENSE
 Bundled as
   - lib/jline-jline-2.11.jar
 ------------------------------------------------------------------------------------
+This product bundles the bouncycastle Library. 
+For license details, see deps/bouncycastle-1.60/LICENSE.html
+
+Bundled as
+  - lib/org.bouncycastle-bcpkix-jdk15on-1.60.jar
+  - lib/org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
+  - lib/org.bouncycastle-bcprov-jdk15on-1.60.jar
+------------------------------------------------------------------------------------
+
 This product uses the annotations from The Checker Framework, which are licensed under
 MIT License. For details, see deps/checker-compat-qual-2.5.2/LICENSE
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -456,6 +456,14 @@ license. For details, see deps/jline-2.11/LICENSE
 Bundled as
   - lib/jline-jline-2.11.jar
 ------------------------------------------------------------------------------------
+This product bundles the bouncycastle Library. 
+For license details, see deps/bouncycastle-1.60/LICENSE.html
+
+Bundled as
+  - lib/org.bouncycastle-bcpkix-jdk15on-1.60.jar
+  - lib/org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
+  - lib/org.bouncycastle-bcprov-jdk15on-1.60.jar
+------------------------------------------------------------------------------------
 This product uses the annotations from The Checker Framework, which are licensed under
 MIT License. For details, see deps/checker-compat-qual-2.5.2/LICENSE
 

--- a/bookkeeper-dist/src/main/resources/deps/bouncycastle-1.60/LICENSE.html
+++ b/bookkeeper-dist/src/main/resources/deps/bouncycastle-1.60/LICENSE.html
@@ -1,0 +1,22 @@
+<html>
+<body bgcolor=#ffffff>
+
+Copyright (c) 2000-2019 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
+<p>
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+and associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+<p>
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+<p>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</body>
+</html>

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -101,6 +101,14 @@
       <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-ext-jdk15on</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
@@ -56,6 +56,12 @@ import org.slf4j.LoggerFactory;
  * A factory to manage TLS contexts.
  */
 public class TLSContextFactory implements SecurityHandlerFactory {
+
+    static {
+        // Fixes loading PKCS8Key file: https://stackoverflow.com/a/18912362
+        java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
+
     /**
      * Supported Key File Types.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.6</commons-lang3.version>
     <commons-io.version>2.4</commons-io.version>
+    <bouncycastle.version>1.60</bouncycastle.version>
     <curator.version>4.0.1</curator.version>
     <dropwizard.version>3.1.0</dropwizard.version>
     <etcd.version>0.0.2</etcd.version>
@@ -300,7 +301,17 @@
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
       </dependency>
-
+      <!-- bouncy -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-ext-jdk15on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
       <!-- reflection libs -->
       <dependency>
         <groupId>org.reflections</groupId>


### PR DESCRIPTION
### Motivation
As described at: https://github.com/apache/pulsar/issues/5047

### Issue

Sometimes user  sees `Invalid TLS configuration` at bookie while loading PKCS8Key file and that can be fixed by using Bouncycastle provider.: https://stackoverflow.com/questions/6559272/algid-parse-error-not-a-sequence/18912362#18912362

```
2019-08-26 16:16:51,983 - ERROR - [BookKeeperClientWorker-OrderedExecutor-0-0:BookieClient@179] - Security Exception in creating new default PCBC pool: 
org.apache.bookkeeper.tls.SecurityException: Invalid TLS configuration
	at org.apache.bookkeeper.tls.TLSContextFactory.init(TLSContextFactory.java:392)
	at org.apache.bookkeeper.proto.PerChannelBookieClient.<init>(PerChannelBookieClient.java:266)
	at org.apache.bookkeeper.proto.BookieClient.create(BookieClient.java:155)
	at org.apache.bookkeeper.proto.DefaultPerChannelBookieClientPool.<init>(DefaultPerChannelBookieClientPool.java:71)
	at org.apache.bookkeeper.proto.BookieClient.lookupClient(BookieClient.java:168)
	at org.apache.bookkeeper.proto.BookieClient.addEntry(BookieClient.java:245)
	at org.apache.bookkeeper.client.PendingAddOp.sendWriteRequest(PendingAddOp.java:131)
	at org.apache.bookkeeper.client.PendingAddOp.safeRun(PendingAddOp.java:240)
	at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalArgumentException: File does not contain valid private key: /my.key.pem
	at io.netty.handler.ssl.SslContextBuilder.keyManager(SslContextBuilder.java:267)
	at org.apache.bookkeeper.tls.TLSContextFactory.createClientContext(TLSContextFactory.java:244)
	at org.apache.bookkeeper.tls.TLSContextFactory.init(TLSContextFactory.java:363)
	... 12 more
Caused by: java.security.spec.InvalidKeySpecException: Neither RSA, DSA nor EC worked
	at io.netty.handler.ssl.SslContext.getPrivateKeyFromByteBuffer(SslContext.java:1045)
	at io.netty.handler.ssl.SslContext.toPrivateKey(SslContext.java:1014)
	at io.netty.handler.ssl.SslContextBuilder.keyManager(SslContextBuilder.java:265)
	... 14 more
Caused by: java.security.spec.InvalidKeySpecException: java.security.InvalidKeyException: IOException : algid parse error, not a sequence
	at sun.security.ec.ECKeyFactory.engineGeneratePrivate(ECKeyFactory.java:169)
	at java.security.KeyFactory.generatePrivate(KeyFactory.java:372)
	at io.netty.handler.ssl.SslContext.getPrivateKeyFromByteBuffer(SslContext.java:1043)
	... 16 more
Caused by: java.security.InvalidKeyException: IOException : algid parse error, not a sequence
	at sun.security.pkcs.PKCS8Key.decode(PKCS8Key.java:351)
	at sun.security.pkcs.PKCS8Key.decode(PKCS8Key.java:356)
	at sun.security.ec.ECPrivateKeyImpl.<init>(ECPrivateKeyImpl.java:73)
	at sun.security.ec.ECKeyFactory.implGeneratePrivate(ECKeyFactory.java:237)
	at sun.security.ec.ECKeyFactory.engineGeneratePrivate(ECKeyFactory.java:165)
	... 18 more
```