### PR TITLE
Issue #2152: Amend disk usage warn log

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
@@ -161,7 +161,7 @@ public class DiskChecker {
             // Warn should be triggered only if disk usage threshold doesn't trigger first.
             if (used > diskUsageWarnThreshold) {
                 LOG.warn("Space left on device {} : {}, Used space fraction: {} > WarnThreshold {}.",
-                        dir, usableSpace, used, diskUsageThreshold);
+                        dir, usableSpace, used, diskUsageWarnThreshold);
                 throw new DiskWarnThresholdException("Space left on device:"
                         + usableSpace + " Used space fraction:" + used + " > WarnThreshold:" + diskUsageWarnThreshold,
                         used);


### PR DESCRIPTION
### Motivation

Fixes #2152

### Changes

Replace `diskUsageThreshold` by `diskUsageWarnThreshold` when disk usage threshold doesn't trigger first.