### PR TITLE
[bookie] auto refresh tls cert at bookie-server

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -788,7 +788,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      *
      * @param certFilesRefreshSec
      *            tls certificate files refresh duration in seconds (set 0 to
-     *            check on every new connection)
+     *            disable auto refresh)
      * @return current configuration
      */
     public T setTLSCertFilesRefreshDurationSeconds(long certFilesRefreshSec) {
@@ -799,12 +799,12 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     /**
      * Get tls certificate files refresh duration in seconds.
      *
-     * @return tls certificate files refresh duration in seconds. Default 5
-     *         minutes. (set 0 to check on every new connection)
+     * @return tls certificate files refresh duration in seconds. Default 0
+     *         to disable auto refresh.
      *
      */
     public long getTLSCertFilesRefreshDurationSeconds() {
-        return getLong(TLS_CERT_FILES_REFRESH_DURATION_SECONDS, 300);
+        return getLong(TLS_CERT_FILES_REFRESH_DURATION_SECONDS, 0);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -117,6 +117,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     protected static final Class<? extends LedgerIdFormatter> DEFAULT_LEDGERID_FORMATTER =
             LedgerIdFormatter.LongLedgerIdFormatter.class;
 
+    protected static final String TLS_CERT_FILES_REFRESH_DURATION_SECONDS = "tlsCertFilesRefreshDurationSeconds";
     /**
      * This list will be passed to {@link SSLEngine#setEnabledCipherSuites(java.lang.String[]) }.
      * Please refer to official JDK JavaDocs
@@ -780,6 +781,30 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     public T setTLSClientAuthentication(boolean enabled) {
         setProperty(TLS_CLIENT_AUTHENTICATION, enabled);
         return getThis();
+    }
+
+    /**
+     * Set tls certificate files refresh duration in seconds.
+     *
+     * @param certFilesRefreshSec
+     *            tls certificate files refresh duration in seconds (set 0 to
+     *            check on every new connection)
+     * @return current configuration
+     */
+    public T setTLSCertFilesRefreshDurationSeconds(long certFilesRefreshSec) {
+        setProperty(TLS_CERT_FILES_REFRESH_DURATION_SECONDS, certFilesRefreshSec);
+        return getThis();
+    }
+
+    /**
+     * Get tls certificate files refresh duration in seconds.
+     *
+     * @return tls certificate files refresh duration in seconds. Default 5
+     *         minutes. (set 0 to check on every new connection)
+     *
+     */
+    public long getTLSCertFilesRefreshDurationSeconds() {
+        return getLong(TLS_CERT_FILES_REFRESH_DURATION_SECONDS, 300);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/FileModifiedTimeUpdater.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/FileModifiedTimeUpdater.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.tls;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import lombok.Getter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Holder class to validate file modification.
+ */
+public class FileModifiedTimeUpdater {
+    @Getter
+    String fileName;
+    @Getter
+    FileTime lastModifiedTime;
+
+    public FileModifiedTimeUpdater(String fileName) {
+        this.fileName = fileName;
+        this.lastModifiedTime = updateLastModifiedTime();
+    }
+
+    private FileTime updateLastModifiedTime() {
+        if (fileName != null) {
+            Path p = Paths.get(fileName);
+            try {
+                return Files.getLastModifiedTime(p);
+            } catch (IOException e) {
+                LOG.error("Unable to fetch lastModified time for file {}: ", fileName, e);
+            }
+        }
+        return null;
+    }
+
+    public boolean checkAndRefresh() {
+        FileTime newLastModifiedTime = updateLastModifiedTime();
+        if (newLastModifiedTime != null && !newLastModifiedTime.equals(lastModifiedTime)) {
+            this.lastModifiedTime = newLastModifiedTime;
+            return true;
+        }
+        return false;
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileModifiedTimeUpdater.class);
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
@@ -284,7 +284,7 @@ public class TLSContextFactory implements SecurityHandlerFactory {
 
     private SslContext getSSLContext() {
         long now = System.currentTimeMillis();
-        if (isServerCtx && (certRefreshTime <= 0 || now > (certLastRefreshTime + certRefreshTime))) {
+        if (isServerCtx && (certRefreshTime > 0 && now > (certLastRefreshTime + certRefreshTime))) {
             if (tTLSCertificatePath.checkAndRefresh() || tLSKeyStoreFilePath.checkAndRefresh()
                     || tLSKeyStorePasswordFilePath.checkAndRefresh() || tLSTrustStoreFilePath.checkAndRefresh()
                     || tLSTrustStorePasswordFilePath.checkAndRefresh()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
@@ -282,7 +282,7 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         updateServerContext();
     }
 
-    private SslContext getSSLContext() {
+    private synchronized SslContext getSSLContext() {
         long now = System.currentTimeMillis();
         if (isServerCtx && (certRefreshTime > 0 && now > (certLastRefreshTime + certRefreshTime))) {
             if (tTLSCertificatePath.checkAndRefresh() || tLSKeyStoreFilePath.checkAndRefresh()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
@@ -40,6 +40,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -79,8 +80,14 @@ public class TLSContextFactory implements SecurityHandlerFactory {
     private static final String TLSCONTEXT_HANDLER_NAME = "tls";
     private String[] protocols;
     private String[] ciphers;
-    private SslContext sslContext;
+    private volatile SslContext sslContext;
     private ByteBufAllocator allocator;
+    private AbstractConfiguration config;
+    private FileModifiedTimeUpdater tTLSCertificatePath, tLSKeyStoreFilePath, tLSKeyStorePasswordFilePath,
+            tLSTrustStoreFilePath, tLSTrustStorePasswordFilePath;
+    private long certRefreshTime;
+    private volatile long certLastRefreshTime;
+    private boolean isServerCtx;
 
     private String getPasswordFromFile(String path) throws IOException {
         byte[] pwd;
@@ -173,7 +180,7 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         return SslProvider.JDK;
     }
 
-    private void createClientContext(AbstractConfiguration conf)
+    private void createClientContext()
             throws SecurityException, KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException,
             UnrecoverableKeyException, InvalidKeySpecException, NoSuchProviderException {
         final SslContextBuilder sslContextBuilder;
@@ -182,11 +189,11 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         final boolean clientAuthentication;
 
         // get key-file and trust-file locations and passwords
-        if (!(conf instanceof ClientConfiguration)) {
+        if (!(config instanceof ClientConfiguration)) {
             throw new SecurityException("Client configruation not provided");
         }
 
-        clientConf = (ClientConfiguration) conf;
+        clientConf = (ClientConfiguration) config;
         provider = getTLSProvider(clientConf.getTLSProvider());
         clientAuthentication = clientConf.getTLSClientAuthentication();
 
@@ -262,7 +269,36 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         sslContext = sslContextBuilder.build();
     }
 
-    private void createServerContext(AbstractConfiguration conf) throws SecurityException, KeyStoreException,
+    private void createServerContext()
+            throws SecurityException, KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException,
+            UnrecoverableKeyException, InvalidKeySpecException, IllegalArgumentException {
+        isServerCtx = true;
+        ServerConfiguration serverConf = (ServerConfiguration) config;
+        tTLSCertificatePath = new FileModifiedTimeUpdater(serverConf.getTLSCertificatePath());
+        tLSKeyStoreFilePath = new FileModifiedTimeUpdater(serverConf.getTLSKeyStore());
+        tLSKeyStorePasswordFilePath = new FileModifiedTimeUpdater(serverConf.getTLSKeyStorePasswordPath());
+        tLSTrustStoreFilePath = new FileModifiedTimeUpdater(serverConf.getTLSTrustStore());
+        tLSTrustStorePasswordFilePath = new FileModifiedTimeUpdater(serverConf.getTLSTrustStorePasswordPath());
+        updateServerContext();
+    }
+
+    private SslContext getSSLContext() {
+        long now = System.currentTimeMillis();
+        if (isServerCtx && (certRefreshTime <= 0 || now > (certLastRefreshTime + certRefreshTime))) {
+            if (tTLSCertificatePath.checkAndRefresh() || tLSKeyStoreFilePath.checkAndRefresh()
+                    || tLSKeyStorePasswordFilePath.checkAndRefresh() || tLSTrustStoreFilePath.checkAndRefresh()
+                    || tLSTrustStorePasswordFilePath.checkAndRefresh()) {
+                try {
+                    updateServerContext();
+                } catch (Exception e) {
+                    LOG.info("Failed to refresh tls certs", e);
+                }
+            }
+        }
+        return sslContext;
+    }
+
+    private synchronized void updateServerContext() throws SecurityException, KeyStoreException,
             NoSuchAlgorithmException, CertificateException, IOException, UnrecoverableKeyException,
             InvalidKeySpecException, IllegalArgumentException {
         final SslContextBuilder sslContextBuilder;
@@ -271,11 +307,11 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         final boolean clientAuthentication;
 
         // get key-file and trust-file locations and passwords
-        if (!(conf instanceof ServerConfiguration)) {
+        if (!(config instanceof ServerConfiguration)) {
             throw new SecurityException("Server configruation not provided");
         }
 
-        serverConf = (ServerConfiguration) conf;
+        serverConf = (ServerConfiguration) config;
         provider = getTLSProvider(serverConf.getTLSProvider());
         clientAuthentication = serverConf.getTLSClientAuthentication();
 
@@ -349,14 +385,17 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         }
 
         sslContext = sslContextBuilder.build();
+        certLastRefreshTime = System.currentTimeMillis();
     }
 
     @Override
     public synchronized void init(NodeType type, AbstractConfiguration conf, ByteBufAllocator allocator)
             throws SecurityException {
         this.allocator = allocator;
+        this.config = conf;
         final String enabledProtocols;
         final String enabledCiphers;
+        certRefreshTime = TimeUnit.SECONDS.toMillis(conf.getTLSCertFilesRefreshDurationSeconds());
 
         enabledCiphers = conf.getTLSEnabledCipherSuites();
         enabledProtocols = conf.getTLSEnabledProtocols();
@@ -364,10 +403,10 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         try {
             switch (type) {
             case Client:
-                createClientContext(conf);
+                createClientContext();
                 break;
             case Server:
-                createServerContext(conf);
+                createServerContext();
                 break;
             default:
                 throw new SecurityException(new IllegalArgumentException("Invalid NodeType"));
@@ -401,7 +440,7 @@ public class TLSContextFactory implements SecurityHandlerFactory {
 
     @Override
     public SslHandler newTLSHandler() {
-        SslHandler sslHandler = sslContext.newHandler(allocator);
+        SslHandler sslHandler = getSSLContext().newHandler(allocator);
 
         if (protocols != null && protocols.length != 0) {
             sslHandler.engine().setEnabledProtocols(protocols);

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -258,7 +258,7 @@ httpServerClass=org.apache.bookkeeper.http.vertx.VertxHttpServer
 # tlsTrustStorePasswordPath=null
 
 # Tls certificate files refresh duration in seconds.
-# tlsCertFilesRefreshDurationSeconds=300
+# tlsCertFilesRefreshDurationSeconds=0
 
 ############################################## Bookie Storage ##############################################
 

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -257,6 +257,8 @@ httpServerClass=org.apache.bookkeeper.http.vertx.VertxHttpServer
 # Bookie Truststore password path, if the trust store is protected by a password.
 # tlsTrustStorePasswordPath=null
 
+# Tls certificate files refresh duration in seconds.
+# tlsCertFilesRefreshDurationSeconds=300
 
 ############################################## Bookie Storage ##############################################
 


### PR DESCRIPTION
### Motivation

Right now, if certs are rotated then bookie doesn't pick up refresh cert and we have to restart the bookie. So, we need a way to auto refresh certs into bookie.

### Modification

- add configuration `tlsCertFilesRefreshDurationSeconds` to auto refresh cert
- bookie checks last modified date of the cert after auto-refresh duration and refresh certs if requires

### Result

- Bookie can refresh certs without restart.