### PR TITLE
[bookie-mTLS] add support of hostname verification

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -282,8 +282,8 @@ Apache Software License, Version 2.
 - lib/com.google.errorprone-error_prone_annotations-2.1.2.jar [40]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [41]
 - lib/org.jctools-jctools-core-2.1.2.jar [42]
-- lib/org.apache.httpcomponents-httpclient-4.4.1.jar [43]
-- lib/org.apache.httpcomponents-httpcore-4.4.1.jar [44]
+- lib/org.apache.httpcomponents-httpclient-4.5.5.jar [43]
+- lib/org.apache.httpcomponents-httpcore-4.4.9.jar [44]
 - lib/org.apache.thrift-libthrift-0.9.3.jar [45]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.9.7

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -259,8 +259,8 @@ Apache Software License, Version 2.
 - lib/com.google.errorprone-error_prone_annotations-2.1.2.jar [35]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [36]
 - lib/org.jctools-jctools-core-2.1.2.jar [37]
-- lib/org.apache.httpcomponents-httpclient-4.4.1.jar [38]
-- lib/org.apache.httpcomponents-httpcore-4.4.1.jar [39]
+- lib/org.apache.httpcomponents-httpclient-4.5.5.jar [38]
+- lib/org.apache.httpcomponents-httpcore-4.4.9.jar [39]
 - lib/org.apache.thrift-libthrift-0.9.3.jar [40]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.8.9

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -279,8 +279,8 @@ Apache Software License, Version 2.
 - lib/com.google.errorprone-error_prone_annotations-2.1.2.jar [35]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [36]
 - lib/org.jctools-jctools-core-2.1.2.jar [37]
-- lib/org.apache.httpcomponents-httpclient-4.4.1.jar [38]
-- lib/org.apache.httpcomponents-httpcore-4.4.1.jar [39]
+- lib/org.apache.httpcomponents-httpclient-4.5.5.jar [38]
+- lib/org.apache.httpcomponents-httpcore-4.4.9.jar [39]
 - lib/org.apache.thrift-libthrift-0.9.3.jar [40]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.8.9

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -116,6 +116,10 @@
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
     <!-- testing dependencies -->
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -146,6 +146,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
         "bookieMaxMultipleForWeightBasedPlacement";
     protected static final String GET_BOOKIE_INFO_TIMEOUT_SECS = "getBookieInfoTimeoutSecs";
     protected static final String START_TLS_TIMEOUT_SECS = "startTLSTimeoutSecs";
+    protected static final String TLS_HOSTNAME_VERIFICATION_ENABLED = "tlsHostnameVerificationEnabled";
 
     // Number of Threads
     protected static final String NUM_WORKER_THREADS = "numWorkerThreads";
@@ -1523,6 +1524,27 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
      */
     public ClientConfiguration setStartTLSTimeout(int timeoutSecs) {
         setProperty(START_TLS_TIMEOUT_SECS, timeoutSecs);
+        return this;
+    }
+
+    /**
+     * Whether hostname verification enabled?
+     *
+     * @return true if hostname verification enabled, otherwise false.
+     */
+    public boolean getHostnameVerificationEnabled() {
+        return getBoolean(TLS_HOSTNAME_VERIFICATION_ENABLED, false);
+    }
+
+    /**
+     * Enable/Disable hostname verification for tls connection.
+     *
+     * @param enabled
+     *            flag to enable/disable tls hostname verification.
+     * @return client configuration.
+     */
+    public ClientConfiguration setHostnameVerificationEnabled(boolean enabled) {
+        setProperty(TLS_HOSTNAME_VERIFICATION_ENABLED, enabled);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
@@ -457,8 +457,8 @@ class AuthHandler {
                 return true;
             }
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Verifying HostName for {}, Cipher {}, Protocols {}, on {}", hostname, sslSession.getCipherSuite(),
-                        sslSession.getProtocol(), channel);
+                LOG.debug("Verifying HostName for {}, Cipher {}, Protocols {}, on {}", hostname,
+                        sslSession.getCipherSuite(), sslSession.getProtocol(), channel);
             }
             boolean verification = HOSTNAME_VERIFIER.verify(hostname, sslSession);
             if (!verification) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
@@ -29,12 +29,16 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.ssl.SslHandler;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
+
+import javax.net.ssl.SSLSession;
 
 import org.apache.bookkeeper.auth.AuthCallbacks;
 import org.apache.bookkeeper.auth.AuthToken;
@@ -42,11 +46,13 @@ import org.apache.bookkeeper.auth.BookieAuthProvider;
 import org.apache.bookkeeper.auth.ClientAuthProvider;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class AuthHandler {
     static final Logger LOG = LoggerFactory.getLogger(AuthHandler.class);
+    private static final DefaultHostnameVerifier HOSTNAME_VERIFIER = new DefaultHostnameVerifier();
 
     static class ServerSideHandler extends ChannelInboundHandlerAdapter {
         volatile boolean authenticated = false;
@@ -430,6 +436,35 @@ class AuthHandler {
                     authenticationError(ctx, rc);
                 }
             }
+        }
+
+        public boolean verifyTlsHostName(Channel channel) {
+            SslHandler sslHandler = channel.pipeline().get(SslHandler.class);
+            if (sslHandler == null) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("can't perform hostname-verification on non-ssl channel {}", channel);
+                }
+                return true;
+            }
+            SSLSession sslSession = sslHandler.engine().getSession();
+            String hostname = null;
+            if (channel.remoteAddress() instanceof InetSocketAddress) {
+                hostname = ((InetSocketAddress) channel.remoteAddress()).getHostName();
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("can't get remote hostName on ssl session {}", channel);
+                }
+                return true;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Verifying HostName for {}, Cipher {}, Protocols {}, on {}", hostname, sslSession.getCipherSuite(),
+                        sslSession.getProtocol(), channel);
+            }
+            boolean verification = HOSTNAME_VERIFIER.verify(hostname, sslSession);
+            if (!verification) {
+                LOG.warn("Failed to validate hostname verification {} on {}", hostname, channel);
+            }
+            return verification;
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1485,8 +1485,12 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                             state = ConnectionState.CONNECTED;
                             AuthHandler.ClientSideHandler authHandler = future.get().pipeline()
                                     .get(AuthHandler.ClientSideHandler.class);
-                            authHandler.authProvider.onProtocolUpgrade();
-                            activeTlsChannelCounter.inc();
+                        if (conf.getHostnameVerificationEnabled() && !authHandler.verifyTlsHostName(channel)) {
+                                rc = BKException.Code.UnauthorizedAccessException; //add HostnameVerification or private classes  not for validation
+                            } else {
+                                authHandler.authProvider.onProtocolUpgrade();
+                                activeTlsChannelCounter.inc();
+                            }
                         } else if (future.isSuccess()
                                 && (state == ConnectionState.CLOSED || state == ConnectionState.DISCONNECTED)) {
                             LOG.warn("Closed before TLS handshake completed, clean up: {}, current state {}",
@@ -2427,8 +2431,12 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                     state = ConnectionState.CONNECTED;
                     AuthHandler.ClientSideHandler authHandler = future.channel().pipeline()
                             .get(AuthHandler.ClientSideHandler.class);
-                    authHandler.authProvider.onProtocolUpgrade();
-                    activeTlsChannelCounter.inc();
+                    if (conf.getHostnameVerificationEnabled() && !authHandler.verifyTlsHostName(channel)) {
+                        rc = BKException.Code.UnauthorizedAccessException;
+                    } else {
+                        authHandler.authProvider.onProtocolUpgrade();
+                        activeTlsChannelCounter.inc();
+                    }
                 } else if (future.isSuccess() && (state == ConnectionState.CLOSED
                     || state == ConnectionState.DISCONNECTED)) {
                     LOG.warn("Closed before connection completed, clean up: {}, current state {}",

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1486,8 +1486,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                             AuthHandler.ClientSideHandler authHandler = future.get().pipeline()
                                     .get(AuthHandler.ClientSideHandler.class);
                         if (conf.getHostnameVerificationEnabled() && !authHandler.verifyTlsHostName(channel)) {
-                                rc = BKException.Code.UnauthorizedAccessException; //add HostnameVerification or private classes  not for validation
-                            } else {
+                            // add HostnameVerification or private classes not
+                            // for validation
+                            rc = BKException.Code.UnauthorizedAccessException;
+                        } else {
                                 authHandler.authProvider.onProtocolUpgrade();
                                 activeTlsChannelCounter.inc();
                             }

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
     <powermock.version>2.0.2</powermock.version>
     <prometheus.version>0.8.1</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
+    <httpclient.version>4.5.5</httpclient.version>
     <protobuf.version>3.5.1</protobuf.version>
     <protoc3.version>3.5.1-1</protoc3.version>
     <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
@@ -622,6 +623,13 @@
         <groupId>com.yahoo.datasketches</groupId>
         <artifactId>sketches-core</artifactId>
         <version>${datasketches.version}</version>
+      </dependency>
+      
+      <!-- http-client -->
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
       </dependency>
 
       <!-- tools dependencies -->


### PR DESCRIPTION
### Motivation

Right now, bookkeeper-client is not able to perform [hostname-verification](https://tersesystems.com/blog/2014/03/23/fixing-hostname-verification/) when it connects to broker over tls. Hostname-verification feature is already implemented in almost all [http-client](https://github.com/apache/httpcomponents-client/blob/master/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultHostnameVerifier.java) but it's not supported by [netty](https://stackoverflow.com/questions/13315623/netty-ssl-hostname-verification-support) yet. therefore, client should be able to perform hostname-verification as per [RFC-2181](https://tools.ietf.org/html/rfc2818#section-3.1)

### Modifications

- added client configuration to enable hostname-verification (default disable)
- use [http-client](https://github.com/apache/httpcomponents-client/blob/master/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultHostnameVerifier.java) but it's not supported by [netty](https://stackoverflow.com/questions/13315623/netty-ssl-hostname-verification-support) to perform hostname-validation rather adding custom logic.
- add httpclient-apache dependency into LICENSE and NOTICE files.

### Result

Bookkeeper client will be able to perform hostname verification while creating ssl session with bookie.