### PR TITLE
[bookie] provide option to skip adding entry to journal

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -135,6 +135,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String NUM_JOURNAL_CALLBACK_THREADS = "numJournalCallbackThreads";
     protected static final String JOURNAL_FORMAT_VERSION_TO_WRITE = "journalFormatVersionToWrite";
     protected static final String JOURNAL_QUEUE_SIZE = "journalQueueSize";
+    protected static final String JOURNAL_SKIP_ENTRY_ENABLE = "journalSkipEntryEnable";
     // backpressure control
     protected static final String MAX_ADDS_IN_PROGRESS_LIMIT = "maxAddsInProgressLimit";
     protected static final String MAX_READS_IN_PROGRESS_LIMIT = "maxReadsInProgressLimit";
@@ -784,6 +785,29 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setJournalFormatVersionToWrite(int version) {
         this.setProperty(JOURNAL_FORMAT_VERSION_TO_WRITE, version);
+        return this;
+    }
+
+    /**
+     * Is bookie enable to skip adding entry to journal and acknowledge
+     * immediately once written to ledger cache.
+     *
+     * @return journal format version to write.
+     */
+    public boolean getJournalSkipEntryEnable() {
+        return this.getBoolean(JOURNAL_SKIP_ENTRY_ENABLE, false);
+    }
+
+    /**
+     * Enable skip add-entry to journal and acknowledge immediately once written
+     * to ledger cache.
+     *
+     * @param journalSkipEntryEnable
+     *            flag to skip adding entry to journal
+     * @return server configuration.
+     */
+    public ServerConfiguration setJournalSkipEntryEnable(boolean journalSkipEntryEnable) {
+        this.setProperty(JOURNAL_SKIP_ENTRY_ENABLE, journalSkipEntryEnable);
         return this;
     }
 

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -294,6 +294,10 @@ journalDirectories=/tmp/bk-txn
 # and onward versions.
 # journalFormatVersionToWrite=6
 
+# Enable skip add-entry to journal and acknowledge immediately once written
+# to ledger cache.
+# journalSkipEntryEnable=false
+
 # Max file size of journal file, in mega bytes
 # A new journal file will be created when the old one reaches the file size limitation
 # journalMaxSizeMB=2048


### PR DESCRIPTION
### Motivation
As described at : https://github.com/apache/pulsar/issues/5128

Right now, bookie serves WAL and provides durability by writing entry to journal before acking the message and it persist the entry to entry log file. bookie also provides below options to improve throughput
- to persist entry with fsync disable 
- writing entry to separate devices for journal and ledger. 

So, persisting entry to journal before acking gives durability but sometimes it becomes bottleneck (mostly due to number of io ops) when user wants to achieve higher throughput in system.

Few users have usecase to achieve high throughput with low publish latency, can compromise with durability and mostly reads from the cache. In that case, if we skip adding entry to journal and acks the message as soon as it's added to ledger cache then user can achieve comparatively very high writes in bookie. and it also helps in pulsar to reduce footprints of bookie while serving such usecases.

So, we want to add option to skip adding entry to journal. We also want to make sure that bookie should be able to handle change in this configuration and should come back gracefully whenever this configuration has been changed.

### Changes
Provide option `journalSkipEntryEnable` using which bookie can skip adding entry to journal while serving addEntry request.

