### PR TITLE
Avoid using directBuffer directly

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -1308,7 +1308,7 @@ public class Bookie extends BookieCriticalThread {
     }
 
     private ByteBuf createExplicitLACEntry(long ledgerId, ByteBuf explicitLac) {
-        ByteBuf bb = allocator.directBuffer(8 + 8 + 4 + explicitLac.capacity());
+        ByteBuf bb = allocator.buffer(8 + 8 + 4 + explicitLac.capacity());
         bb.writeLong(ledgerId);
         bb.writeLong(METAENTRY_ID_LEDGER_EXPLICITLAC);
         bb.writeInt(explicitLac.capacity());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -83,7 +83,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
         this.writeCapacity = writeCapacity;
         this.position = new AtomicLong(fc.position());
         this.writeBufferStartPosition.set(position.get());
-        this.writeBuffer = allocator.directBuffer(writeCapacity);
+        this.writeBuffer = allocator.buffer(writeCapacity);
         this.unpersistedBytes = new AtomicLong(0);
         this.unpersistedBytesBound = unpersistedBytesBound;
         this.doRegularFlushes = unpersistedBytesBound > 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -861,7 +861,7 @@ public class EntryLogger {
         BufferedReadChannel bc = getChannelForLogId(entryLogId);
 
         // Allocate buffer to read (version, ledgersMapOffset, ledgerCount)
-        ByteBuf headers = allocator.directBuffer(LOGFILE_HEADER_SIZE);
+        ByteBuf headers = allocator.buffer(LOGFILE_HEADER_SIZE);
         try {
             bc.read(headers, 0);
 
@@ -977,7 +977,7 @@ public class EntryLogger {
         long pos = LOGFILE_HEADER_SIZE;
 
         // Start with a reasonably sized buffer size
-        ByteBuf data = allocator.directBuffer(1024 * 1024);
+        ByteBuf data = allocator.buffer(1024 * 1024);
 
         try {
 
@@ -1059,7 +1059,7 @@ public class EntryLogger {
         EntryLogMetadata meta = new EntryLogMetadata(entryLogId);
 
         final int maxMapSize = LEDGERS_MAP_HEADER_SIZE + LEDGERS_MAP_ENTRY_SIZE * LEDGERS_MAP_MAX_BATCH_SIZE;
-        ByteBuf ledgersMap = allocator.directBuffer(maxMapSize);
+        ByteBuf ledgersMap = allocator.buffer(maxMapSize);
 
         try {
             while (offset < bc.size()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
@@ -73,7 +73,7 @@ public class ReadCache implements Closeable {
         cacheIndexes = new ArrayList<>();
 
         for (int i = 0; i < segmentsCount; i++) {
-            cacheSegments.add(Unpooled.buffer(segmentSize, segmentSize));
+            cacheSegments.add(allocator.buffer(segmentSize, segmentSize));
             cacheIndexes.add(new ConcurrentLongLongPairHashMap(4096, 2 * Runtime.getRuntime().availableProcessors()));
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
@@ -73,7 +73,7 @@ public class ReadCache implements Closeable {
         cacheIndexes = new ArrayList<>();
 
         for (int i = 0; i < segmentsCount; i++) {
-            cacheSegments.add(Unpooled.directBuffer(segmentSize, segmentSize));
+            cacheSegments.add(Unpooled.buffer(segmentSize, segmentSize));
             cacheIndexes.add(new ConcurrentLongLongPairHashMap(4096, 2 * Runtime.getRuntime().availableProcessors()));
         }
     }
@@ -142,7 +142,7 @@ public class ReadCache implements Closeable {
                     int entryOffset = (int) res.first;
                     int entryLen = (int) res.second;
 
-                    ByteBuf entry = allocator.directBuffer(entryLen, entryLen);
+                    ByteBuf entry = allocator.buffer(entryLen, entryLen);
                     entry.writeBytes(cacheSegments.get(segmentIdx), entryOffset, entryLen);
                     return entry;
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
@@ -24,7 +24,6 @@ import static org.apache.bookkeeper.bookie.storage.ldb.WriteCache.align64;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 
 import java.io.Closeable;
 import java.util.ArrayList;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
@@ -24,7 +24,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicLong;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
@@ -105,11 +105,11 @@ public class WriteCache implements Closeable {
 
         for (int i = 0; i < segmentsCount - 1; i++) {
             // All intermediate segments will be full-size
-            cacheSegments[i] = Unpooled.directBuffer(maxSegmentSize, maxSegmentSize);
+            cacheSegments[i] = allocator.buffer(maxSegmentSize, maxSegmentSize);
         }
 
         int lastSegmentSize = (int) (maxCacheSize % maxSegmentSize);
-        cacheSegments[segmentsCount - 1] = Unpooled.directBuffer(lastSegmentSize, lastSegmentSize);
+        cacheSegments[segmentsCount - 1] = allocator.buffer(lastSegmentSize, lastSegmentSize);
     }
 
     public void clear() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -306,7 +306,7 @@ public class ByteBufList extends AbstractReferenceCounted {
                     if (prependSize) {
                         // Prepend the frame size before writing the buffer list, so that we only have 1 single size
                         // header
-                        ByteBuf sizeBuffer = ctx.alloc().directBuffer(4, 4);
+                        ByteBuf sizeBuffer = ctx.alloc().buffer(4, 4);
                         sizeBuffer.writeInt(b.readableBytes());
                         ctx.write(sizeBuffer, ctx.voidPromise());
                     }


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Motivation*

We introduced a smart buffer allocator since 4.9.0. It falls back to allocate buffer
on heap when running out direct memory so that the bookie can run in a degraded mode
rather than crashes.

However if we use `directBuffer` directly, it bypasses the fallback mechanism. So
the bookie crashes when running out of direct memory.

*Modifications*

Use `buffer` instead of `directBuffer` and let the allocator decide what is the best
to use.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java11]: skip build on java11. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
