### PR TITLE
Make the project buildable with JDK12 and JDK13

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -123,13 +123,13 @@ BOOKIE_GC_LOGGING_OPTS=${BOOKIE_GC_LOGGING_OPTS:-"${DEFAULT_BOOKIE_GC_LOGGING_OP
 DEFAULT_CLI_GC_OPTS="-XX:+UseG1GC \
     -XX:MaxGCPauseMillis=10"
 if [ "$USING_JDK8" -ne "1" ]; then
+  DEFAULT_CLI_GC_LOGGING_OPTS=""
+else
   DEFAULT_CLI_GC_LOGGING_OPTS="-XX:+PrintGCDetails \
     -XX:+PrintGCApplicationStoppedTime  \
     -XX:+UseGCLogFileRotation \
     -XX:NumberOfGCLogFiles=5 \
     -XX:GCLogFileSize=64m"
-else
-  DEFAULT_CLI_GC_LOGGING_OPTS=""
 fi
 
 CLI_MAX_HEAP_MEMORY=${CLI_MAX_HEAP_MEMORY:-"512M"}

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <junit.version>4.12</junit.version>
     <libthrift5.version>0.5.0-1</libthrift5.version>
     <libthrift9.version>0.9.3</libthrift9.version>
-    <lombok.version>1.16.22</lombok.version>
+    <lombok.version>1.18.10</lombok.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>2.22.0</mockito.version>
     <netty.version>4.1.32.Final</netty.version>
@@ -183,7 +183,7 @@
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>2.5</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
@@ -703,6 +703,7 @@
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
         <version>${groovy.version}</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/tests/integration-tests-base-groovy/pom.xml
+++ b/tests/integration-tests-base-groovy/pom.xml
@@ -31,8 +31,8 @@
   <name>Apache BookKeeper :: Tests :: Base module for Arquillian based integration tests using groovy</name>
 
   <properties>
-    <groovy-eclipse-compiler.version>2.9.2-04</groovy-eclipse-compiler.version>
-    <groovy-eclipse-batch.version>2.4.13-02</groovy-eclipse-batch.version>
+    <groovy-eclipse-compiler.version>3.4.0-01</groovy-eclipse-compiler.version>
+    <groovy-eclipse-batch.version>2.5.8-01</groovy-eclipse-batch.version>
   </properties>
 
   <build>
@@ -73,6 +73,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
+            <type>pom</type>
           </dependency>
         </dependencies>
       </plugin>
@@ -101,6 +102,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
+      <type>pom</type>
     </dependency>
   </dependencies>
   <pluginRepositories>

--- a/tests/integration-tests-utils/pom.xml
+++ b/tests/integration-tests-utils/pom.xml
@@ -57,6 +57,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
+      <type>pom</type>
     </dependency>
 
   </dependencies>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -28,7 +28,7 @@
   <name>Apache BookKeeper :: Tests</name>
 
   <properties>
-    <groovy.version>2.4.13</groovy.version>
+    <groovy.version>2.5.8</groovy.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Upgrade Lombok to 1.18.10
Upgrade Groovy and Groovy Compiler and Maven Compiler plugin
Fix an inverted if that prevented **bkctl** to work with JDK11+ and it made GC LOGGING opts not applied with JDK8 (in bkctl command), a regression introduced by #2132