### PR TITLE
Change Python client version to 4.10.0

### DIFF
--- a/stream/clients/python/setup.py
+++ b/stream/clients/python/setup.py
@@ -19,7 +19,7 @@ import setuptools
 
 name = 'apache-bookkeeper-client'
 description = 'Apache BookKeeper client library'
-version = '4.10.0-alpha-0'
+version = '4.10.0'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
According to the release guide, before cutting a release we have to remove the 'alpha' qualifier from Python client version