### PR TITLE
Fix tests and upgrade libs to make tests pass on JDK13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,11 +149,11 @@
     <libthrift9.version>0.9.3</libthrift9.version>
     <lombok.version>1.18.10</lombok.version>
     <lz4.version>1.3.0</lz4.version>
-    <mockito.version>2.22.0</mockito.version>
+    <mockito.version>3.0.0</mockito.version>
     <netty.version>4.1.32.Final</netty.version>
     <netty-boringssl.version>2.0.20.Final</netty-boringssl.version>
     <ostrich.version>9.1.3</ostrich.version>
-    <powermock.version>2.0.0-beta.5</powermock.version>
+    <powermock.version>2.0.2</powermock.version>
     <prometheus.version>0.0.21</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
     <protobuf.version>3.5.1</protobuf.version>

--- a/tests/scripts/src/test/bash/bk_test_bin_common.sh
+++ b/tests/scripts/src/test/bash/bk_test_bin_common.sh
@@ -200,8 +200,12 @@ testBuildBookieJVMOpts() {
   TEST_LOG_DIR=${BK_TMPDIR}/logdir
   TEST_GC_LOG_FILENAME="test-gc.log"
   ACTUAL_JVM_OPTS=$(build_bookie_jvm_opts ${TEST_LOG_DIR} ${TEST_GC_LOG_FILENAME})
-  EXPECTED_JVM_OPTS="-Xms1g -Xmx1g -XX:MaxDirectMemorySize=2g ${DEFAULT_BOOKIE_GC_OPTS} ${DEFAULT_BOOKIE_GC_LOGGING_OPTS}  -Xloggc:${TEST_LOG_DIR}/${TEST_GC_LOG_FILENAME}"
-
+  USEJDK8=$(detect_jdk8)
+  if [ "$USING_JDK8" -ne "1" ]; then
+    EXPECTED_JVM_OPTS="-Xms1g -Xmx1g -XX:MaxDirectMemorySize=2g ${DEFAULT_BOOKIE_GC_OPTS} ${DEFAULT_BOOKIE_GC_LOGGING_OPTS}  -Xlog:gc=info:file=${TEST_LOG_DIR}/${TEST_GC_LOG_FILENAME}::filecount=5,filesize=64m"
+  else
+    EXPECTED_JVM_OPTS="-Xms1g -Xmx1g -XX:MaxDirectMemorySize=2g ${DEFAULT_BOOKIE_GC_OPTS} ${DEFAULT_BOOKIE_GC_LOGGING_OPTS}  -Xloggc:${TEST_LOG_DIR}/${TEST_GC_LOG_FILENAME}"
+  fi
   assertEquals "JVM OPTS is not set correctly" "${EXPECTED_JVM_OPTS}" "${ACTUAL_JVM_OPTS}"
 }
 
@@ -211,8 +215,12 @@ testBuildCLIJVMOpts() {
   TEST_LOG_DIR=${BK_TMPDIR}/logdir
   TEST_GC_LOG_FILENAME="test-gc.log"
   ACTUAL_JVM_OPTS=$(build_cli_jvm_opts ${TEST_LOG_DIR} ${TEST_GC_LOG_FILENAME})
-  EXPECTED_JVM_OPTS="-Xms256M -Xmx512M ${DEFAULT_CLI_GC_OPTS} ${DEFAULT_CLI_GC_LOGGING_OPTS} -Xloggc:${TEST_LOG_DIR}/${TEST_GC_LOG_FILENAME}"
-
+  USEJDK8=$(detect_jdk8)
+  if [ "$USING_JDK8" -ne "1" ]; then
+    EXPECTED_JVM_OPTS="-Xms256M -Xmx512M ${DEFAULT_CLI_GC_OPTS} ${DEFAULT_CLI_GC_LOGGING_OPTS} -Xlog:gc=info:file=${TEST_LOG_DIR}/${TEST_GC_LOG_FILENAME}::filecount=5,filesize=64m"
+  else
+    EXPECTED_JVM_OPTS="-Xms256M -Xmx512M ${DEFAULT_CLI_GC_OPTS} ${DEFAULT_CLI_GC_LOGGING_OPTS} -Xloggc:${TEST_LOG_DIR}/${TEST_GC_LOG_FILENAME}"
+  fi
   assertEquals "JVM OPTS is not set correctly" "${EXPECTED_JVM_OPTS}" "${ACTUAL_JVM_OPTS}"
 }
 


### PR DESCRIPTION
- Upgrade Mockito and PowerMock with a version that support JDK12+
- Fix bash script tests