### PR TITLE
Call exceptionHandler if Bookie.start fails with exception.

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
@@ -47,7 +47,7 @@ public class ComponentStarter {
                 component.close();
                 log.info("Closed component {} in shutdown hook successfully. Exiting.", component.getName());
                 FutureUtils.complete(future, null);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 log.error("Failed to close component {} in shutdown hook gracefully, Exiting anyway",
                     component.getName(), e);
                 future.completeExceptionally(e);

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.common.component;
 
 import java.util.concurrent.CompletableFuture;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 
@@ -72,6 +73,8 @@ public class ComponentStarter {
 
         // register a component exception handler
         component.setExceptionHandler((t, e) -> {
+            log.error("Triggered exceptionHandler of Component: {} because of Exception in Thread: {}",
+                    component.getName(), t, e);
             // start the shutdown hook when an uncaught exception happen in the lifecycle component.
             shutdownHookThread.start();
         });

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -39,7 +39,6 @@ import org.apache.bookkeeper.bookie.BookieCriticalThread;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.ExitCode;
 import org.apache.bookkeeper.bookie.ReadOnlyBookie;
-import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.common.allocator.ByteBufAllocatorBuilder;
 import org.apache.bookkeeper.common.util.JsonUtil.ParseJsonException;
 import org.apache.bookkeeper.conf.ServerConfiguration;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -137,7 +137,7 @@ public class BookieServer {
             : new Bookie(conf, statsLogger.scope(BOOKIE_SCOPE), allocator);
     }
 
-    public void start() throws IOException, UnavailableException, InterruptedException, BKException {
+    public void start() throws InterruptedException {
         this.bookie.start();
         // fail fast, when bookie startup is not successful
         if (!this.bookie.isRunning()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -116,7 +116,7 @@ public class AutoRecoveryMain {
     /*
      * Start daemons
      */
-    public void start() throws UnavailableException {
+    public void start() {
         auditorElector.start();
         replicationWorker.start();
         if (null != uncaughtExceptionHandler) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/AutoRecoveryService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/AutoRecoveryService.java
@@ -25,8 +25,6 @@ import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.server.component.ServerLifecycleComponent;
 import org.apache.bookkeeper.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A {@link ServerLifecycleComponent} that runs autorecovery.
@@ -34,7 +32,6 @@ import org.slf4j.LoggerFactory;
 public class AutoRecoveryService extends ServerLifecycleComponent {
 
     public static final String NAME = "autorecovery";
-    private static final Logger LOG = LoggerFactory.getLogger(AutoRecoveryService.class);
 
     private final AutoRecoveryMain main;
 
@@ -57,17 +54,7 @@ public class AutoRecoveryService extends ServerLifecycleComponent {
 
     @Override
     protected void doStart() {
-        try {
-            this.main.start();
-        } catch (Throwable exc) {
-            LOG.error("Got unexpected exception while starting AutoRecoveryMain", exc);
-            if (uncaughtExceptionHandler != null) {
-                LOG.error("Calling uncaughtExceptionHandler");
-                uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), exc);
-            } else {
-                throw new RuntimeException("Failed to start AutoRecoveryMain", exc);
-            }
-        }
+        this.main.start();
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/AutoRecoveryService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/AutoRecoveryService.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
 
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
-import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.server.component.ServerLifecycleComponent;
 import org.apache.bookkeeper.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/BookieService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/BookieService.java
@@ -24,8 +24,6 @@ import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.server.component.ServerLifecycleComponent;
 import org.apache.bookkeeper.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A {@link ServerLifecycleComponent} that starts the core bookie server.
@@ -35,8 +33,6 @@ public class BookieService extends ServerLifecycleComponent {
     public static final String NAME = "bookie-server";
 
     private final BookieServer server;
-    //private UncaughtExceptionHandler uncaughtExceptionHandler = null;
-    private static final Logger LOG = LoggerFactory.getLogger(BookieService.class);
 
     public BookieService(BookieConfiguration conf,
                          StatsLogger statsLogger)
@@ -59,14 +55,8 @@ public class BookieService extends ServerLifecycleComponent {
     protected void doStart() {
         try {
             this.server.start();
-        } catch (Throwable exc) {
-            LOG.error("Got unexpected exception while starting BookieServer", exc);
-            if (uncaughtExceptionHandler != null) {
-                LOG.error("Calling uncaughtExceptionHandler");
-                uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), exc);
-            } else {
-                throw new RuntimeException("Failed to start bookie server", exc);
-            }
+        } catch (InterruptedException exc) {
+            throw new RuntimeException("Failed to start bookie server", exc);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/BookieService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/BookieService.java
@@ -20,9 +20,7 @@ package org.apache.bookkeeper.server.service;
 
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
-import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.proto.BookieServer;
-import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
 import org.apache.bookkeeper.server.component.ServerLifecycleComponent;
 import org.apache.bookkeeper.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -44,6 +44,7 @@ import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.util.IOUtils;
+import org.apache.commons.collections4.map.StaticBucketMap;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Test;
@@ -111,7 +112,7 @@ public class BookieJournalTest {
     /**
      * Generate fence entry.
      */
-    private ByteBuf generateFenceEntry(long ledgerId) {
+    private static ByteBuf generateFenceEntry(long ledgerId) {
         ByteBuf bb = Unpooled.buffer();
         bb.writeLong(ledgerId);
         bb.writeLong(Bookie.METAENTRY_ID_FENCE_KEY);
@@ -121,7 +122,7 @@ public class BookieJournalTest {
     /**
      * Generate meta entry with given master key.
      */
-    private ByteBuf generateMetaEntry(long ledgerId, byte[] masterKey) {
+    private static ByteBuf generateMetaEntry(long ledgerId, byte[] masterKey) {
         ByteBuf bb = Unpooled.buffer();
         bb.writeLong(ledgerId);
         bb.writeLong(Bookie.METAENTRY_ID_LEDGER_KEY);
@@ -290,7 +291,7 @@ public class BookieJournalTest {
         return jc;
     }
 
-    private JournalChannel writeV5Journal(File journalDir, int numEntries, byte[] masterKey) throws Exception {
+    static JournalChannel writeV5Journal(File journalDir, int numEntries, byte[] masterKey) throws Exception {
         long logId = System.currentTimeMillis();
         JournalChannel jc = new JournalChannel(journalDir, logId);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -44,7 +44,6 @@ import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.util.IOUtils;
-import org.apache.commons.collections4.map.StaticBucketMap;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Test;


### PR DESCRIPTION

Descriptions of the changes in this PR:

When main thread of Bookie/BookieServer has exited with exception while starting Bookie,
Bookie process shouldn't be alive because of any non-daemon thread that has already
started.
