### PR TITLE
Journal scan should throw IOException when it reads negative length

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -797,8 +797,8 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     break;
                 }
                 boolean isPaddingRecord = false;
-                if (len == PADDING_MASK) {
-                    if (journalVersion >= JournalChannel.V5) {
+                if (len < 0) {
+                    if (len == PADDING_MASK && journalVersion >= JournalChannel.V5) {
                         // skip padding bytes
                         lenBuff.clear();
                         fullRead(recLog, lenBuff);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -812,7 +812,8 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                         }
                         isPaddingRecord = true;
                     } else {
-                        throw new IOException("Invalid record found with negative length : " + len);
+                        LOG.error("Invalid record found with negative length: {}", len);
+                        throw new IOException();
                     }
                 }
                 recBuff.clear();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -813,7 +813,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                         isPaddingRecord = true;
                     } else {
                         LOG.error("Invalid record found with negative length: {}", len);
-                        throw new IOException();
+                        throw new IOException("Invalid record found with negative length " + len);
                     }
                 }
                 recBuff.clear();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -290,7 +290,13 @@ public class BookieJournalTest {
         return jc;
     }
 
-    static JournalChannel writeV5Journal(File journalDir, int numEntries, byte[] masterKey) throws Exception {
+    static JournalChannel writeV5Journal(File journalDir, int numEntries,
+                                         byte[] masterKey) throws Exception {
+        return writeV5Journal(journalDir, numEntries, masterKey, false);
+    }
+
+    static JournalChannel writeV5Journal(File journalDir, int numEntries,
+                                         byte[] masterKey, boolean corruptLength) throws Exception {
         long logId = System.currentTimeMillis();
         JournalChannel jc = new JournalChannel(journalDir, logId);
 
@@ -312,7 +318,11 @@ public class BookieJournalTest {
             lastConfirmed = i;
             length += i;
             ByteBuf lenBuff = Unpooled.buffer();
-            lenBuff.writeInt(packet.readableBytes());
+            if (corruptLength) {
+                lenBuff.writeInt(-1);
+            } else {
+                lenBuff.writeInt(packet.readableBytes());
+            }
             bc.write(lenBuff);
             bc.write(packet);
             packet.release();


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

During journal replay, we can encounter negative length value if there is journal corruption. Currently, due to this bug, we pass negative length to limit a buffer, which throws IllegalArgumentException.

### Changes

Updated the Journal class to throw `IOException` with a clear message, instead of unclear `IllegalArgumentException`.

Master Issue: #2176
