### PR TITLE
Fix firstStoredEntryId logic in LedgerFragment

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
@@ -134,11 +134,12 @@ public class LedgerFragment {
         Long firstEntry = LedgerHandle.INVALID_ENTRY_ID;
         for (int bookieIndex : bookieIndexes) {
             Long firstStoredEntryForBookie = getFirstStoredEntryId(bookieIndex);
-            if ((firstEntry != LedgerHandle.INVALID_ENTRY_ID)
-                    && (firstStoredEntryForBookie != LedgerHandle.INVALID_ENTRY_ID)) {
-                firstEntry = Math.min(firstEntry, firstStoredEntryForBookie);
-            } else if (firstStoredEntryForBookie != LedgerHandle.INVALID_ENTRY_ID) {
-                firstEntry = firstStoredEntryForBookie;
+            if (firstStoredEntryForBookie != LedgerHandle.INVALID_ENTRY_ID) {
+                if (firstEntry == LedgerHandle.INVALID_ENTRY_ID) {
+                    firstEntry = firstStoredEntryForBookie;
+                } else {
+                    firstEntry = Math.min(firstEntry, firstStoredEntryForBookie);
+                }
             }
         }
         return firstEntry;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
@@ -131,7 +131,7 @@ public class LedgerFragment {
      * @return entryId
      */
     public long getFirstStoredEntryId() {
-        Long firstEntry = LedgerHandle.INVALID_ENTRY_ID;
+        long firstEntry = LedgerHandle.INVALID_ENTRY_ID;
         for (int bookieIndex : bookieIndexes) {
             Long firstStoredEntryForBookie = getFirstStoredEntryId(bookieIndex);
             if (firstStoredEntryForBookie != LedgerHandle.INVALID_ENTRY_ID) {
@@ -171,7 +171,7 @@ public class LedgerFragment {
      * @return entryId
      */
     public long getLastStoredEntryId() {
-        Long lastEntry = LedgerHandle.INVALID_ENTRY_ID;
+        long lastEntry = LedgerHandle.INVALID_ENTRY_ID;
         for (int bookieIndex : bookieIndexes) {
             Long lastStoredEntryIdForBookie = getLastStoredEntryId(bookieIndex);
             if (lastStoredEntryIdForBookie != LedgerHandle.INVALID_ENTRY_ID) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
@@ -171,16 +171,18 @@ public class LedgerFragment {
      * @return entryId
      */
     public long getLastStoredEntryId() {
-        Long lastEntry = null;
+        Long lastEntry = LedgerHandle.INVALID_ENTRY_ID;
         for (int bookieIndex : bookieIndexes) {
             Long lastStoredEntryIdForBookie = getLastStoredEntryId(bookieIndex);
-            if (null == lastEntry) {
-                lastEntry = lastStoredEntryIdForBookie;
-            } else if (null != lastStoredEntryIdForBookie) {
-                lastEntry = Math.max(lastEntry, lastStoredEntryIdForBookie);
+            if (lastStoredEntryIdForBookie != LedgerHandle.INVALID_ENTRY_ID) {
+                if (lastEntry == LedgerHandle.INVALID_ENTRY_ID) {
+                    lastEntry = lastStoredEntryIdForBookie;
+                } else {
+                    lastEntry = Math.max(lastEntry, lastStoredEntryIdForBookie);
+                }
             }
         }
-        return null == lastEntry ? LedgerHandle.INVALID_ENTRY_ID : lastEntry;
+        return lastEntry;
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
@@ -131,16 +131,17 @@ public class LedgerFragment {
      * @return entryId
      */
     public long getFirstStoredEntryId() {
-        Long firstEntry = null;
+        Long firstEntry = LedgerHandle.INVALID_ENTRY_ID;
         for (int bookieIndex : bookieIndexes) {
             Long firstStoredEntryForBookie = getFirstStoredEntryId(bookieIndex);
-            if (null == firstEntry) {
-                firstEntry = firstStoredEntryForBookie;
-            } else if (null != firstStoredEntryForBookie) {
+            if ((firstEntry != LedgerHandle.INVALID_ENTRY_ID)
+                    && (firstStoredEntryForBookie != LedgerHandle.INVALID_ENTRY_ID)) {
                 firstEntry = Math.min(firstEntry, firstStoredEntryForBookie);
+            } else if (firstStoredEntryForBookie != LedgerHandle.INVALID_ENTRY_ID) {
+                firstEntry = firstStoredEntryForBookie;
             }
         }
-        return null == firstEntry ? LedgerHandle.INVALID_ENTRY_ID : firstEntry;
+        return firstEntry;
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -121,17 +121,13 @@ public class LedgerFragmentReplicator {
         }
         Long startEntryId = lf.getFirstStoredEntryId();
         Long endEntryId = lf.getLastStoredEntryId();
-        if (endEntryId == null) {
-            /*
-             * Ideally this should never happen if bookie failure is taken care
-             * of properly. Nothing we can do though in this case.
-             */
-            LOG.warn("Dead bookie (" + lf.getAddresses()
-                    + ") is still part of the current"
-                    + " active ensemble for ledgerId: " + lh.getId());
-            ledgerFragmentMcb.processResult(BKException.Code.OK, null, null);
-            return;
-        }
+
+        /*
+         * if startEntryId is INVALID_ENTRY_ID then endEntryId should be
+         * endEntryId and viceversa.
+         */
+        assert !(startEntryId == INVALID_ENTRY_ID ^ endEntryId == INVALID_ENTRY_ID);
+
         if (startEntryId > endEntryId || endEntryId <= INVALID_ENTRY_ID) {
             // for open ledger which there is no entry, the start entry id is 0,
             // the end entry id is -1.
@@ -248,6 +244,13 @@ public class LedgerFragmentReplicator {
 
         long firstEntryId = ledgerFragment.getFirstStoredEntryId();
         long lastEntryId = ledgerFragment.getLastStoredEntryId();
+
+        /*
+         * if startEntryId is INVALID_ENTRY_ID then endEntryId should be
+         * endEntryId and viceversa.
+         */
+        assert !(firstEntryId == INVALID_ENTRY_ID ^ lastEntryId == INVALID_ENTRY_ID);
+
         long numberOfEntriesToReplicate = (lastEntryId - firstEntryId) + 1;
         long splitsWithFullEntries = numberOfEntriesToReplicate
                 / rereplicationEntryBatchSize;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -127,8 +127,8 @@ public class LedgerFragmentReplicator {
          * INVALID_ENTRY_ID and viceversa.
          */
         if (startEntryId == INVALID_ENTRY_ID ^ endEntryId == INVALID_ENTRY_ID) {
-            LOG.error("For LedgerFragment: {}, seeing inconsistent startEntryId: {} and endEntryId: {}", lf,
-                    startEntryId, endEntryId);
+            LOG.error("For LedgerFragment: {}, seeing inconsistent firstStoredEntryId: {} and lastStoredEntryId: {}",
+                    lf, startEntryId, endEntryId);
             assert false;
         }
 
@@ -250,10 +250,14 @@ public class LedgerFragmentReplicator {
         long lastEntryId = ledgerFragment.getLastStoredEntryId();
 
         /*
-         * if startEntryId is INVALID_ENTRY_ID then endEntryId should be
-         * endEntryId and viceversa.
+         * if firstEntryId is INVALID_ENTRY_ID then lastEntryId should be
+         * INVALID_ENTRY_ID and viceversa.
          */
-        assert !(firstEntryId == INVALID_ENTRY_ID ^ lastEntryId == INVALID_ENTRY_ID);
+        if (firstEntryId == INVALID_ENTRY_ID ^ lastEntryId == INVALID_ENTRY_ID) {
+            LOG.error("For LedgerFragment: {}, seeing inconsistent firstStoredEntryId: {} and lastStoredEntryId: {}",
+                    ledgerFragment, firstEntryId, lastEntryId);
+            assert false;
+        }
 
         long numberOfEntriesToReplicate = (lastEntryId - firstEntryId) + 1;
         long splitsWithFullEntries = numberOfEntriesToReplicate

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -124,9 +124,13 @@ public class LedgerFragmentReplicator {
 
         /*
          * if startEntryId is INVALID_ENTRY_ID then endEntryId should be
-         * endEntryId and viceversa.
+         * INVALID_ENTRY_ID and viceversa.
          */
-        assert !(startEntryId == INVALID_ENTRY_ID ^ endEntryId == INVALID_ENTRY_ID);
+        if (startEntryId == INVALID_ENTRY_ID ^ endEntryId == INVALID_ENTRY_ID) {
+            LOG.error("For LedgerFragment: {}, seeing inconsistent startEntryId: {} and endEntryId: {}", lf,
+                    startEntryId, endEntryId);
+            assert false;
+        }
 
         if (startEntryId > endEntryId || endEntryId <= INVALID_ENTRY_ID) {
             // for open ledger which there is no entry, the start entry id is 0,


### PR DESCRIPTION
Descriptions of the changes in this PR:

- firstStoredEntryId logic in LedgerFragment should return '-1'
only if no bookie contains any entry of that LedgerFragment.

This is a serious issue, in our cluster we observed for a particular ledger, which is marked under replicated, it is returning -1 for firstStoredEntryId and 10 for lastStoredEntryId. Because of that the ReplicationWorker, tries to replicate entryId ‘-1’ and as expected it keeps failing while reading it. So ledger remains under replicated for ever.