### PR TITLE
Update maven version to 3.6.2 for Jenkins

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -179,7 +179,7 @@ class common_job_properties {
   }
 
   // Sets common config for Maven jobs.
-  static void setMavenConfig(context, mavenInstallation='Maven 3.6.0', mavenOpts='-Xmx4096m -Xms2048m') {
+  static void setMavenConfig(context, mavenInstallation='Maven 3.6.2', mavenOpts='-Xmx4096m -Xms2048m') {
     context.mavenInstallation(mavenInstallation)
     context.mavenOpts('-Dorg.slf4j.simpleLogger.showDateTime=true')
     context.mavenOpts('-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd\\\'T\\\'HH:mm:ss.SSS')


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Update maven version to 3.6.2 for Jenkins build environments, since maven 3.6.0 is no longer available in the environment.