### PR TITLE
[doc] Improve the Manual deployment document.

### DIFF
--- a/site/docs/latest/deployment/manual.md
+++ b/site/docs/latest/deployment/manual.md
@@ -11,9 +11,9 @@ The easiest way to deploy BookKeeper is using schedulers like [DC/OS](../dcos), 
 
 We won't provide a full guide to setting up a ZooKeeper cluster here. We recommend that you consult [this guide](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html) in the official ZooKeeper documentation.
 
-## Starting up bookies
+## Cluster metadata setup
 
-Once your ZooKeeper cluster is up and running, you can start up as many {% pop bookies %} as you'd like to form a cluster. Before starting up each bookie, you need to modify the bookie's configuration to make sure that it points to the right ZooKeeper cluster.
+Once your ZooKeeper cluster is up and running, there is some metadata that needs to be written to ZooKeeper, so you need to modify the bookie's configuration to make sure that it points to the right ZooKeeper cluster.
 
 On each bookie host, you need to [download](../../getting-started/installation#download) the BookKeeper package as a tarball. Once you've done that, you need to configure the bookie by setting values in the `bookkeeper-server/conf/bk_server.conf` config file. The one parameter that you will absolutely need to change is the [`zkServers`](../../config#zkServers) parameter, which you will need to set to the ZooKeeper connection string for your ZooKeeper cluster. Here's an example:
 
@@ -23,24 +23,10 @@ zkServers=100.0.0.1:2181,100.0.0.2:2181,100.0.0.3:2181
 
 > A full listing of configurable parameters available in `bookkeeper-server/conf/bk_server.conf` can be found in the [Configuration](../../reference/config) reference manual.
 
-Once the bookie's configuration is set, you can start it up using the [`bookie`](../../reference/cli#bookkeeper-bookie) command of the [`bookkeeper`](../../reference/cli#bookkeeper) CLI tool:
+Once the bookie's configuration is set, you can set up cluster metadata for the cluster by running the following command from any bookie in the cluster:
 
 ```shell
-$ bin/bookkeeper bookie
-```
-
-> You can also build BookKeeper [by cloning it from source](../../getting-started/installation#clone) or [using Maven](../../getting-started/installation#build-using-maven).
-
-### System requirements
-
-{% include system-requirements.md %}
-
-## Cluster metadata setup
-
-Once you've started up a cluster of bookies, you need to set up cluster metadata for the cluster by running the following command from any bookie in the cluster:
-
-```shell
-$ bin/bookkeeper shell metaformat
+$ bookkeeper-server/bin/bookkeeper shell metaformat
 ```
 
 You can run in the formatting 
@@ -48,6 +34,22 @@ You can run in the formatting
 > The `metaformat` command performs all the necessary ZooKeeper cluster metadata tasks and thus only needs to be run *once* and from *any* bookie in the BookKeeper cluster.
 
 Once cluster metadata formatting has been completed, your BookKeeper cluster is ready to go!
+
+## Starting up bookies
+
+  
+
+Before you start up your bookies, you should make sure that all bookie hosts have the correct configuration, then you can start up as many {% pop bookies %} as you'd like to form a cluster by using the [`bookie`](../../reference/cli#bookkeeper-bookie) command of the [`bookkeeper`](../../reference/cli#bookkeeper) CLI tool:
+
+```shell
+$ bookkeeper-server/bin/bookkeeper bookie
+```
+
+
+### System requirements
+
+{% include system-requirements.md %}
+
 
 <!--
 ## AutoRecovery


### PR DESCRIPTION
### Motivation
Following the [Manual deployment](https://bookkeeper.apache.org/docs/latest/deployment/manual/), startup bookie may have failure since there is no znode(e.g. /ledger) about bookie in zookeeper. 

### Changes

Modify the site/docs/latest/deployment/manual.md, set up cluster metadata before startup of bookie.