### PR TITLE
[DLOG] LogReader shouldn't be added to pending if not locking

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKDistributedLogManager.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKDistributedLogManager.java
@@ -694,7 +694,6 @@ class BKDistributedLogManager implements DistributedLogManager {
                 subscriberId,
                 false,
                 statsLogger);
-        pendingReaders.add(reader);
         return FutureUtils.value(reader);
     }
 


### PR DESCRIPTION
The pendingReaders set in BKDistributedLogManager exists so that if
the manager is closed which the lock is being acquired for a reader,
that reader will be closed (even though it hasn't been returned to the
client).

In the case that the reader is opened without a lock, there
is not async action being performed. Previously we were also adding
these readers to the pendingReaders, but they were never being removed
from the pendingReaders, causing a memory leak. This change avoids
adding no-locking readers to pendingReaders.
