### PR TITLE
Removed mutex contention on BufferedChannel

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -172,7 +172,7 @@ public class BookieJournalTest {
 
     private static void moveToPosition(JournalChannel jc, long pos) throws IOException {
         jc.fc.position(pos);
-        jc.bc.position.set(pos);
+        jc.bc.position = pos;
         jc.bc.writeBufferStartPosition.set(pos);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BufferedChannelTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BufferedChannelTest.java
@@ -121,7 +121,9 @@ public class BufferedChannelTest {
             expectedNumOfUnpersistedBytes = (byteBufLength * numOfWrites) - unpersistedBytesBound;
         }
 
-        Assert.assertEquals("Unpersisted bytes", expectedNumOfUnpersistedBytes, logChannel.getUnpersistedBytes());
+        if (unpersistedBytesBound > 0) {
+            Assert.assertEquals("Unpersisted bytes", expectedNumOfUnpersistedBytes, logChannel.getUnpersistedBytes());
+        }
         logChannel.close();
         fileChannel.close();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -526,16 +526,20 @@ public class EntryLogTest {
 
         Assert.assertFalse("Exception happened in one of the operation", exceptionHappened.get());
 
-        /*
-         * if flush of the previous current channel is called then the
-         * unpersistedBytes should be less than what it was before, actually it
-         * would be close to zero (but when new log is created with addEntry
-         * call, ledgers map will be appended at the end of entry log)
-         */
-        Assert.assertTrue(
-                "previous currentChannel unpersistedBytes should be less than " + currentActiveChannelUnpersistedBytes
-                        + ", but it is actually " + currentActiveChannel.getUnpersistedBytes(),
-                currentActiveChannel.getUnpersistedBytes() < currentActiveChannelUnpersistedBytes);
+        if (conf.getFlushIntervalInBytes() > 0) {
+            /*
+             * if flush of the previous current channel is called then the
+             * unpersistedBytes should be less than what it was before, actually
+             * it would be close to zero (but when new log is created with
+             * addEntry call, ledgers map will be appended at the end of entry
+             * log)
+             */
+            Assert.assertTrue(
+                    "previous currentChannel unpersistedBytes should be less than "
+                            + currentActiveChannelUnpersistedBytes
+                            + ", but it is actually " + currentActiveChannel.getUnpersistedBytes(),
+                    currentActiveChannel.getUnpersistedBytes() < currentActiveChannelUnpersistedBytes);
+        }
         for (BufferedLogChannel rotatedLogChannel : rotatedLogChannels) {
             Assert.assertEquals("previous rotated entrylog should be flushandforcewritten", 0,
                     rotatedLogChannel.getUnpersistedBytes());


### PR DESCRIPTION
### Motivation

Contention on `BufferedChannel` between the journal thread and the ForceWriteThread was introduced in #1228.

`unpersistentBytes` is only used if `unpersistedBytesBound > 0`, which is not true by default. We shouldn't be paying the penalty if not needed.

Also `position` doesn't need to be `AtomicLong` since it's only updated while the mutex is taken. Using a volatile will have the same effect with less overhead.
