### PR TITLE
Fix the log level of not support Sse42Crc32C

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
@@ -45,7 +45,7 @@ class CRC32CDigestManager extends DigestManager {
         super(ledgerId, useV2Protocol, allocator);
 
         if (!Sse42Crc32C.isSupported() && !nonSupportedMessagePrinted) {
-            log.error("Sse42Crc32C is not supported, will use a slower CRC32C implementation.");
+            log.warn("Sse42Crc32C is not supported, will use a slower CRC32C implementation.");
             nonSupportedMessagePrinted = true;
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
@@ -32,6 +32,8 @@ import org.apache.commons.lang3.mutable.MutableInt;
 @Slf4j
 class CRC32CDigestManager extends DigestManager {
 
+    private static boolean isSupported = true;
+
     private static final FastThreadLocal<MutableInt> currentCrc = new FastThreadLocal<MutableInt>() {
         @Override
         protected MutableInt initialValue() throws Exception {
@@ -41,8 +43,14 @@ class CRC32CDigestManager extends DigestManager {
 
     public CRC32CDigestManager(long ledgerId, boolean useV2Protocol, ByteBufAllocator allocator) {
         super(ledgerId, useV2Protocol, allocator);
+
+        if (!isSupported) {
+            return;
+        }
+
         if (!Sse42Crc32C.isSupported()) {
-            log.warn("Sse42Crc32C is not supported, will use a slower CRC32C implementation.");
+            log.error("Sse42Crc32C is not supported, will use a slower CRC32C implementation.");
+            isSupported = false;
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
@@ -42,7 +42,7 @@ class CRC32CDigestManager extends DigestManager {
     public CRC32CDigestManager(long ledgerId, boolean useV2Protocol, ByteBufAllocator allocator) {
         super(ledgerId, useV2Protocol, allocator);
         if (!Sse42Crc32C.isSupported()) {
-            log.error("Sse42Crc32C is not supported, will use a slower CRC32C implementation.");
+            log.warn("Sse42Crc32C is not supported, will use a slower CRC32C implementation.");
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.mutable.MutableInt;
 @Slf4j
 class CRC32CDigestManager extends DigestManager {
 
-    private static boolean isSupported = true;
+    private static boolean nonSupportedMessagePrinted = false;
 
     private static final FastThreadLocal<MutableInt> currentCrc = new FastThreadLocal<MutableInt>() {
         @Override
@@ -44,13 +44,9 @@ class CRC32CDigestManager extends DigestManager {
     public CRC32CDigestManager(long ledgerId, boolean useV2Protocol, ByteBufAllocator allocator) {
         super(ledgerId, useV2Protocol, allocator);
 
-        if (!isSupported) {
-            return;
-        }
-
-        if (!Sse42Crc32C.isSupported()) {
+        if (!Sse42Crc32C.isSupported() && !nonSupportedMessagePrinted) {
             log.error("Sse42Crc32C is not supported, will use a slower CRC32C implementation.");
-            isSupported = false;
+            nonSupportedMessagePrinted = true;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

When users are using Apache Pulsar, they will encounter the following error about `Sse42Crc32C`. But in fact it does not affect the correctness of Apache Pulsar use. But the error level log information will cause confusion for the user.
```
10:12:49.119 [pulsar-ordered-OrderedExecutor-0-0-EventThread] ERROR org.apache.bookkeeper.proto.checksum.CRC32CDigestManager - Sse42Crc32C is not supported, will use a slower CRC32C implementation.
```



### Changes

Replace the log level of `not support Sse42Crc32C` from error to warn.

