### PR TITLE
[Docs] Modify “Using Autoecovery”,recover does not support the specified target bookie

### DIFF
--- a/site/docs/latest/admin/autorecovery.md
+++ b/site/docs/latest/admin/autorecovery.md
@@ -12,24 +12,21 @@ When a {% pop bookie %} crashes, all {% pop ledgers %} on that bookie become und
 You can manually recover failed bookies using the [`bookkeeper`](../../reference/cli) command-line tool. You need to specify:
 
 * the `shell recover` option 
-* an IP and port for your BookKeeper cluster's ZooKeeper ensemble
 * the IP and port for the failed bookie
 
 Here's an example:
 
 ```bash
 $ bin/bookkeeper shell recover \
-  zk1.example.com:2181 \ # IP and port for ZooKeeper
   192.168.1.10:3181      # IP and port for the failed bookie
 ```
 
-If you wish, you can also specify which bookie you'd like to rereplicate to. Here's an example:
+If you wish, you can also specify which ledgers you'd like to recover. Here's an example:
 
 ```bash
 $ bin/bookkeeper shell recover \
-  zk1.example.com:2181 \ # IP and port for ZooKeeper
   192.168.1.10:3181 \    # IP and port for the failed bookie
-  192.168.1.11:3181      # IP and port for the bookie to rereplicate to
+  --ledger ledgerID      # ledgerID which you want to recover 
 ```
 
 ### The manual recovery process

--- a/site/docs/latest/admin/bookies.md
+++ b/site/docs/latest/admin/bookies.md
@@ -162,19 +162,13 @@ If the change was the result of an accidental configuration change, the change c
 1. Run the following command to re-replicate the data:
 
    ```bash
-   $ bin/bookkeeper shell recover \
-     <zkserver> \
-     <oldbookie> \
-     <newbookie>
+   $ bin/bookkeeper shell recover <oldbookie> 
    ```
 
    The ZooKeeper server, old bookie, and new bookie, are all identified by their external IP and `bookiePort` (3181 by default). Here's an example:
 
    ```bash
-   $ bin/bookkeeper shell recover \
-     zk1.example.com \
-     192.168.1.10:3181 \
-     192.168.1.10:3181
+   $ bin/bookkeeper shell recover  192.168.1.10:3181
    ```
 
    See the [AutoRecovery](../autorecovery) documentation for more info on the re-replication process.


### PR DESCRIPTION
### Motivation 
`bin/bookkeeper shell recover` only receives one parameter i.e. failed bookie. According to [recovery](https://bookkeeper.apache.org/docs/latest/admin/autorecovery/#manual-recovery) it is useless to specify ZooKeeper address and target bookie.
![image](https://user-images.githubusercontent.com/42792537/68930100-a3babf80-07c8-11ea-90e1-320cfac1b77b.png)