### PR TITLE
Fixed  bin/bookkeeper shell readjournal

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadJournalCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadJournalCommand.java
@@ -156,7 +156,7 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
                 return false;
             }
             String idString = name.split("\\.")[0];
-            journalId = Long.parseLong(idString);
+            journalId = Long.parseLong(idString,16);
         }
         scanJournal(journal, journalId, cmd.msg);
         return true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadJournalCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadJournalCommand.java
@@ -156,7 +156,7 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
                 return false;
             }
             String idString = name.split("\\.")[0];
-            journalId = Long.parseLong(idString,16);
+            journalId = Long.parseLong(idString, 16);
         }
         scanJournal(journal, journalId, cmd.msg);
         return true;


### PR DESCRIPTION
### Motivation
An error occurred while executing `bin/bookkeeper shell readjournal`,
![image](https://user-images.githubusercontent.com/42792537/70305222-d80d2300-183e-11ea-8759-88dfcc90b5be.png)
 the journal file name is hexadecimal, but when readjournal is executed, the journal name is resolved in base 10