### PR TITLE
bin/bookkeeper shell supports the -conf

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -108,16 +108,30 @@ shift
 LOCALBOOKIES_CONFIG_DIR="${LOCALBOOKIES_CONFIG_DIR:-/tmp/localbookies-config}"
 if [ ${COMMAND} == "shell" ]; then
   DEFAULT_LOG_CONF=${BK_HOME}/conf/log4j.shell.properties
-  if [[ $1 == "-localbookie"  ]]; then
-    if [[ $2 == *:* ]];
-    then
-      BOOKIE_CONF=${LOCALBOOKIES_CONFIG_DIR}/$2.conf
-      shift 2
-    else
-      BOOKIE_CONF=${LOCALBOOKIES_CONFIG_DIR}/baseconf.conf
-      shift
-    fi
-  fi
+  LOCALBOOKIE=0
+   while [ $# -gt 0 ]
+    do
+       opt="$1"
+       case $opt in
+         (-conf)
+            BOOKIE_CONF="$2"
+            shift 2
+         ;;
+         (-localbookie)
+            LOCALBOOKIE=1
+            if [[ $2 == *:* ]];
+            then
+               LOCALBOOKIE_CONF=${LOCALBOOKIES_CONFIG_DIR}/$2.conf
+               shift 2
+            else
+               LOCALBOOKIE_CONF=${LOCALBOOKIES_CONFIG_DIR}/baseconf.conf
+               shift
+            fi
+         ;;
+         (*)
+         ;;
+       esac
+    done
 fi
 
 if [ -z "$BOOKIE_ZK_CONF" ]; then
@@ -172,7 +186,11 @@ elif [ $COMMAND == "zookeeper" ]; then
     exec $JAVA $OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE org.apache.zookeeper.server.quorum.QuorumPeerMain $BOOKIE_ZK_CONF $@
 elif [ ${COMMAND} == "shell" ]; then
   ENTRY_FORMATTER_ARG="-DentryFormatterClass=${ENTRY_FORMATTER_CLASS:-org.apache.bookkeeper.util.StringEntryFormatter}"
-  exec ${JAVA} ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
+  if [ ${LOCALBOOKIE} == 1 ]; then
+             exec ${JAVA} ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${LOCALBOOKIE_CONF} $@
+     else
+             exec ${JAVA} ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
+     fi
 elif [ ${COMMAND} == "help" ]; then
   bookkeeper_help;
 else


### PR DESCRIPTION
### Motivation
`bin/bookkeeper shell ` support `-conf configuration`, but it doesn't work. bk_server.conf is loaded by default, even if the configuration is specified
![image](https://user-images.githubusercontent.com/42792537/70309755-2a534180-1849-11ea-96b0-bd5b07a6b717.png)
Modify `bin/bookkeeper` to specify the configuration file as an absolute path

