### PR TITLE
ISSUE-2224: Config ServerConfiguration with setAllowLoopback(true) for Unit Tests

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
@@ -55,7 +55,7 @@ public class GarbageCollectorThreadTest {
     @Mock
     private ScheduledExecutorService gcExecutor;
 
-    private ServerConfiguration conf = spy(new ServerConfiguration());
+    private ServerConfiguration conf = spy(new ServerConfiguration().setAllowLoopback(true));
     private CompactableLedgerStorage ledgerStorage = mock(CompactableLedgerStorage.class);
 
     @Before


### PR DESCRIPTION
### Motivation

Unit test fails when build master branch

### Changes

Config ServerConfiguration with setAllowLoopback(true) in the class GarbageCollectorThreadTest

Master Issue: #2224 
