### PR TITLE
[bookie-server-config] Avoid considering empty journalDirectories

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -41,6 +41,7 @@ import org.apache.bookkeeper.discover.ZKRegistrationManager;
 import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Configuration manages server-side settings.
@@ -1096,8 +1097,9 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public String[] getJournalDirNames() {
         String[] journalDirs = this.getStringArray(JOURNAL_DIRS);
-        if (journalDirs == null || journalDirs.length == 0) {
-            return new String[] {getJournalDirName()};
+        if (journalDirs == null || journalDirs.length == 0
+                || (journalDirs.length == 1 && StringUtils.isEmpty(journalDirs[0]))) {
+            return new String[] { getJournalDirName() };
         }
         return journalDirs;
     }


### PR DESCRIPTION
As discussed at : https://github.com/apache/pulsar/issues/6042

### Issue
We have config management tool which manages bookie-server configuration and sets empty value of `journalDirectories` if bookie-server is still wants to use single journal dir: `journalDirectory`. In this case, bookie-server doesn't consider `journalDirectory` value and keeps empty list of `journalDirectories` which stats bookie with invalid configuration.

### Expected behavior
Bookie-server should parse empty configuration `journalDirectories=` properly and avoid picking up empty value of `journalDirectories` and in that case, bookie-server should fallback to `journalDirectory` config.