### PR TITLE
[hotfix] fix the http endpoint component count error

### DIFF
--- a/site/docs/4.10.0/admin/http.md
+++ b/site/docs/4.10.0/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.6.0/admin/http.md
+++ b/site/docs/4.6.0/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.6.1/admin/http.md
+++ b/site/docs/4.6.1/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.6.2/admin/http.md
+++ b/site/docs/4.6.2/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.7.0/admin/http.md
+++ b/site/docs/4.7.0/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.7.1/admin/http.md
+++ b/site/docs/4.7.1/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.7.2/admin/http.md
+++ b/site/docs/4.7.2/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.7.3/admin/http.md
+++ b/site/docs/4.7.3/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.8.0/admin/http.md
+++ b/site/docs/4.8.0/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.8.1/admin/http.md
+++ b/site/docs/4.8.1/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.8.2/admin/http.md
+++ b/site/docs/4.8.2/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.9.0/admin/http.md
+++ b/site/docs/4.9.0/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.9.1/admin/http.md
+++ b/site/docs/4.9.1/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/4.9.2/admin/http.md
+++ b/site/docs/4.9.2/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 

--- a/site/docs/latest/admin/http.md
+++ b/site/docs/latest/admin/http.md
@@ -7,12 +7,12 @@ To use this feature, set `httpServerEnabled` to `true` in file `conf/bk_server.c
 
 ## All the endpoints
 
-Currently all the HTTP endpoints could be divided into these 4 components:
+Currently all the HTTP endpoints could be divided into these 5 components:
 1. Heartbeat: heartbeat for a specific bookie.
-1. Config: doing the server configuration for a specific bookie.
-1. Ledger: HTTP endpoints related to ledgers.
-1. Bookie: HTTP endpoints related to bookies.
-1. AutoRecovery: HTTP endpoints related to auto recovery.
+2. Config: doing the server configuration for a specific bookie.
+3. Ledger: HTTP endpoints related to ledgers.
+4. Bookie: HTTP endpoints related to bookies.
+5. AutoRecovery: HTTP endpoints related to auto recovery.
 
 ## Heartbeat
 


### PR DESCRIPTION
This PR is a hotfix for "BookKeeper Admin REST API" document, the compoent of HTTP endpoints should be 5, but it's 4 in the doc.