### PR TITLE
[hotfix][docs] remove redundant word in protocol documents

### DIFF
--- a/site/docs/4.10.0/development/protocol.md
+++ b/site/docs/4.10.0/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.5.0/development/protocol.md
+++ b/site/docs/4.5.0/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.5.1/development/protocol.md
+++ b/site/docs/4.5.1/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.6.0/development/protocol.md
+++ b/site/docs/4.6.0/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.6.1/development/protocol.md
+++ b/site/docs/4.6.1/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.6.2/development/protocol.md
+++ b/site/docs/4.6.2/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.7.0/development/protocol.md
+++ b/site/docs/4.7.0/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.7.1/development/protocol.md
+++ b/site/docs/4.7.1/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.7.2/development/protocol.md
+++ b/site/docs/4.7.2/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.7.3/development/protocol.md
+++ b/site/docs/4.7.3/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.8.0/development/protocol.md
+++ b/site/docs/4.8.0/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.8.1/development/protocol.md
+++ b/site/docs/4.8.1/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.8.2/development/protocol.md
+++ b/site/docs/4.8.2/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.9.0/development/protocol.md
+++ b/site/docs/4.9.0/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.9.1/development/protocol.md
+++ b/site/docs/4.9.1/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/4.9.2/development/protocol.md
+++ b/site/docs/4.9.2/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation

--- a/site/docs/latest/development/protocol.md
+++ b/site/docs/latest/development/protocol.md
@@ -124,7 +124,7 @@ In many cases, leader election is really leader suggestion. Multiple nodes could
 Once a node thinks it is leader for a particular log, it must take the following steps:
 
 1. Read the list of ledgers for the log
-1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
+1. {% pop Fence %} the last two ledgers in the list. Two ledgers are fenced because the writer may be writing to the second-to-last ledger while adding the last ledger to the list.
 1. Create a new ledger
 1. Add the new ledger to the ledger list
 1. Write the new ledger back to the datastore using a CAS operation


### PR DESCRIPTION
This PR removes redundant word  "because" in protocol documents.
