### PR TITLE
Website: Update Release Management for new Time Based Release Plan

### DIFF
--- a/site/community/releases.md
+++ b/site/community/releases.md
@@ -4,7 +4,7 @@ title: Release Management
 
 > Apache BookKeeper community adopts [Time Based Release Plan](https://cwiki.apache.org/confluence/display/BOOKKEEPER/BP-13+-+Time+Based+Release+Plan) starting from 4.6.0.
 
-Apache BookKeeper community makes a feture release every 3 month.
+Apache BookKeeper community makes a feture release every 6 month (since `4.10.0`).
 
 - A month before the release date, the release manager will cut branches and also publish a list of features that will be included in the release. These features will typically
     be [BookKeeper Proposals](http://bookkeeper.apache.org/community/bookkeeper_proposals/), but not always.
@@ -15,19 +15,17 @@ Apache BookKeeper community makes a feture release every 3 month.
 
 ### Feature Release Window
 
-The next feature release is `4.10.0`. The release window is the following:
+The next feature release is `4.11.0`. The release window is the following:
 
 | **Date** | **Event** |
-| February 1, 2019 | Merge window opens on master branch |
-| March 12, 2019 | Major feature should be in, Cut release branch |
-| March 19, 2019 | Minor feature should be in, Stabilize release branch |
-| March 26, 2019 | Code freeze, Only accept fixes for blocking issues, Rolling out release candidates |
+| December 1, 2019 | Merge window opens on master branch |
+| April 6, 2020 | Major feature should be in, Cut release branch |
+| April 13, 2020 | Minor feature should be in, Stabilize release branch |
+| April 20, 2020 | Code freeze, Only accept fixes for blocking issues, Rolling out release candidates |
 
 ## Release Schedule
 
-- **4.10.0**: February 2019 - March 2019
-- **4.11.0**: April 2019 - May 2019
-- **4.12.0**: June 2019 - July 2019
-- **4.13.0**: August 2019 - September 2019
+- **4.11.0**: December 2019 - May 2020
+- **4.12.0**: June 2020 - November 2020
+- **4.13.0**: December 2020 - May 2021
 
-<iframe src="https://calendar.google.com/calendar/embed?src=aam1p2gcoa40n68a6duflnva7c%40group.calendar.google.com&ctz=America/Los_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
As discussed on the mailing list, I'm updating the BookKeeper website to reflect the new Time Based Release Plan.

You can find the staging website @ https://aluccaroni.github.io/bookkeeper-staging-site/community/releases/

Please note that I've removed the calendar since it was empty