### PR TITLE
2178: IOException Should Be Thrown When Journal Is Corrupted

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -160,7 +160,7 @@ class JournalChannel implements Closeable {
                         + " suddenly appeared, is another bookie process running?");
             }
             randomAccessFile = new RandomAccessFile(fn, "rw");
-            fc = randomAccessFile.getChannel();
+            fc = openFileChannel(randomAccessFile);
             formatVersion = formatVersionToWrite;
 
             int headerSize = (V4 == formatVersion) ? VERSION_HEADER_SIZE : HEADER_SIZE;
@@ -178,7 +178,7 @@ class JournalChannel implements Closeable {
             fc.write(zeros, nextPrealloc - journalAlignSize);
         } else {  // open an existing file
             randomAccessFile = new RandomAccessFile(fn, "r");
-            fc = randomAccessFile.getChannel();
+            fc = openFileChannel(randomAccessFile);
             bc = null; // readonly
 
             ByteBuffer bb = ByteBuffer.allocate(VERSION_HEADER_SIZE);
@@ -290,5 +290,13 @@ class JournalChannel implements Closeable {
             }
             this.lastDropPosition = newDropPos;
         }
+    }
+
+    public static FileChannel openFileChannel(RandomAccessFile randomAccessFile) {
+        if (randomAccessFile == null) {
+            throw new IllegalArgumentException("Input cannot be null");
+        }
+
+        return randomAccessFile.getChannel();
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -23,6 +23,8 @@ package org.apache.bookkeeper.bookie;
 
 import static com.google.common.base.Charsets.UTF_8;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
+
 import org.apache.bookkeeper.util.NativeIO;
 import org.apache.bookkeeper.util.ZeroBuffer;
 import org.slf4j.Logger;
@@ -292,6 +295,7 @@ class JournalChannel implements Closeable {
         }
     }
 
+    @VisibleForTesting
     public static FileChannel openFileChannel(RandomAccessFile randomAccessFile) {
         if (randomAccessFile == null) {
             throw new IllegalArgumentException("Input cannot be null");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -224,6 +224,7 @@ class JournalChannel implements Closeable {
                 }
             } catch (IOException e) {
                 LOG.error("Bookie journal file can seek to position :", e);
+                throw e;
             }
         }
         if (fRemoveFromPageCache) {


### PR DESCRIPTION
Fixes #2178 