### PR TITLE
[code-style] fix build failure for check-style

### DIFF
--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterInitializer.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterInitializer.java
@@ -19,7 +19,7 @@
 package org.apache.bookkeeper.stream.storage.impl.cluster;
 
 import static org.apache.bookkeeper.stream.storage.StorageConstants.ZK_METADATA_ROOT_PATH;
-
+import static org.apache.bookkeeper.stream.storage.StorageConstants.getSegmentsRootPath;
 import com.google.common.base.Strings;
 import java.net.URI;
 import java.util.Optional;
@@ -32,7 +32,6 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.KeeperException;
-import static org.apache.bookkeeper.stream.storage.StorageConstants.getSegmentsRootPath;
 
 /**
  * ZooKeeper Based Cluster Initializer.


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

PR Validation build is failing with below exception:
```
[ERROR] src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterInitializer.java:[35] (imports) ImportOrder: Import org.apache.bookkeeper.stream.storage.StorageConstants.getSegmentsRootPath appears after other imports that it should precede
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check (default-cli) on project stream-storage-service-impl: You have 1 Checkstyle violation. -> [Help 1]
```