### PR TITLE
Fix method order in order to make the execution of TestEntryLog predictable

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestEntryLog.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestEntryLog.java
@@ -67,13 +67,16 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Tests for EntryLog.
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestEntryLog {
     private static final Logger LOG = LoggerFactory.getLogger(TestEntryLog.class);
 


### PR DESCRIPTION
### Motivation

TestEntyLog reuses the entryLogger variable across test methods execution, resulting in an unpredictable execution.
We can at least make the test work consistently across environments using JUnit built-in FixMethodOrder annotation

### Changes
@FixMethodOrder(MethodSorters.NAME_ASCENDING)

Fixes #2260
