### PR TITLE
Add forkCount option to parallelize build and tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
     <protobuf-maven-plugin.version>0.5.0</protobuf-maven-plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
+    <forkCount.variable>5</forkCount.variable>
   </properties>
 
   <!-- dependency definitions -->
@@ -838,7 +839,7 @@
         <configuration>
           <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true -Dio.netty.leakDetection.level=paranoid</argLine>
           <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
-          <forkCount>5</forkCount>
+          <forkCount>${forkCount.variable}</forkCount>
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
           <rerunFailingTestsCount>${testRetryCount}</rerunFailingTestsCount>
@@ -1000,7 +1001,7 @@
               <!-- @{argLine} is a variable injected by JaCoCo-->
               <argLine>@{argLine} -Xmx2G -Djava.net.preferIPv4Stack=true</argLine>
               <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
-              <forkCount>5</forkCount>
+              <forkCount>${forkCount.variable}</forkCount>
               <reuseForks>false</reuseForks>
               <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
               <!-- we want build to complete even in case of failures -->
@@ -1035,7 +1036,7 @@
             <configuration>
               <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true</argLine>
               <redirectTestOutputToFile>false</redirectTestOutputToFile>
-              <forkCount>5</forkCount>
+              <forkCount>${forkCount.variable}</forkCount>
               <reuseForks>false</reuseForks>
               <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
               <trimStackTrace>false</trimStackTrace>
@@ -1056,7 +1057,7 @@
             <configuration>
               <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true -Dbookkeeper.root.logger=DEBUG,CONSOLE</argLine>
               <redirectTestOutputToFile>false</redirectTestOutputToFile>
-              <forkCount>5</forkCount>
+              <forkCount>${forkCount.variable}</forkCount>
               <reuseForks>false</reuseForks>
               <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
               <trimStackTrace>false</trimStackTrace>

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
     <protobuf-maven-plugin.version>0.5.0</protobuf-maven-plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
-    <forkCount.variable>5</forkCount.variable>
+    <forkCount.variable>1</forkCount.variable>
   </properties>
 
   <!-- dependency definitions -->

--- a/pom.xml
+++ b/pom.xml
@@ -838,6 +838,7 @@
         <configuration>
           <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true -Dio.netty.leakDetection.level=paranoid</argLine>
           <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
+          <forkCount>5</forkCount>
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
           <rerunFailingTestsCount>${testRetryCount}</rerunFailingTestsCount>
@@ -999,6 +1000,7 @@
               <!-- @{argLine} is a variable injected by JaCoCo-->
               <argLine>@{argLine} -Xmx2G -Djava.net.preferIPv4Stack=true</argLine>
               <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
+              <forkCount>5</forkCount>
               <reuseForks>false</reuseForks>
               <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
               <!-- we want build to complete even in case of failures -->
@@ -1033,6 +1035,7 @@
             <configuration>
               <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true</argLine>
               <redirectTestOutputToFile>false</redirectTestOutputToFile>
+              <forkCount>5</forkCount>
               <reuseForks>false</reuseForks>
               <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
               <trimStackTrace>false</trimStackTrace>
@@ -1053,6 +1056,7 @@
             <configuration>
               <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true -Dbookkeeper.root.logger=DEBUG,CONSOLE</argLine>
               <redirectTestOutputToFile>false</redirectTestOutputToFile>
+              <forkCount>5</forkCount>
               <reuseForks>false</reuseForks>
               <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
               <trimStackTrace>false</trimStackTrace>


### PR DESCRIPTION
### Motivation
Current code forks a new JVM per module. (bookkeeper-server, bookkeeper-proto etc)
This means one fork per module for build and testing, no parallelism within the module where majority of the time goes.
We need parallelism within a module during the test execution so we can have the builds complete faster and have the artifacts shipped out quicker.

### Changes
We use the maven surefire plugin but don't define the `forkCount` and hence set it to default of 1.
This means it executes each module with one thread.
This change sets `forkCount` to 5, enabling parallelism in testing and drastically reducing total turnaround time. (by about 2/3rds!)

*Total build+test time without this change*
```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:06 h
[INFO] Finished at: 2020-03-05T02:01:29-08:00
[INFO] ------------------------------------------------------------------------
```
*Total build+test time with this change*
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18:23 min
[INFO] Finished at: 2020-03-05T02:38:22-08:00
[INFO] ------------------------------------------------------------------------
```

### Things to watch
Added parallelism may cause some flappers but with much trial and error I have come to the number `5`. The flappers are usually only from conflict in obtaining the same port number.
If needed, we can increase the retryCount, but as of now I consistently don't see any flappers at a `forkCount` of 5