### PR TITLE
Make bookkeeper script work on Git Bash on Windows

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -169,7 +169,6 @@ elif [ "${COMMAND}" == "localbookie" ]; then
   NUMBER=$1
   shift
   $EXECCMD ${JAVA} ${OPTS} ${JMX_ARGS} '-Dzookeeper.4lw.commands.whitelist=*' org.apache.bookkeeper.util.LocalBookKeeper ${NUMBER} ${BOOKIE_CONF} $@
-  ${JAVA} ${OPTS}  org.apache.bookkeeper.util.LocalBookKeeper ${NUMBER} ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "standalone" ]; then
   $EXECCMD ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.stream.cluster.StandaloneStarter --conf ${BK_HOME}/conf/standalone.conf $@
 elif [ ${COMMAND} == "upgrade" ]; then

--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -140,6 +140,12 @@ BOOKIE_ROOT_LOGGER=${BOOKIE_ROOT_LOGGER:-"INFO,CONSOLE"}
 BOOKIE_CLASSPATH="$BOOKIE_JAR:$BOOKIE_CLASSPATH:$BOOKIE_EXTRA_CLASSPATH"
 BOOKIE_CLASSPATH="`dirname $BOOKIE_LOG_CONF`:$BOOKIE_CLASSPATH"
 
+EXECCMD="exec "
+if [[ "$OSTYPE" == "msys" ]]; then
+    BOOKIE_CLASSPATH=$(echo "$BOOKIE_CLASSPATH" | sed "s/::/:/g")
+    EXECCMD=""
+fi
+
 # Build the OPTS
 BOOKIE_OPTS=$(build_bookie_opts)
 GC_OPTS=$(build_bookie_jvm_opts ${BOOKIE_LOG_DIR} "gc_%p.log")
@@ -156,26 +162,27 @@ fi
 #Change to BK_HOME to support relative paths
 cd "$BK_HOME"
 if [ ${COMMAND} == "bookie" ]; then
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.Main --conf ${BOOKIE_CONF} $@
+  $EXECCMD ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.Main --conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "autorecovery" ]; then
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.replication.AutoRecoveryMain --conf ${BOOKIE_CONF} $@
-elif [ ${COMMAND} == "localbookie" ]; then
+  $EXECCMD ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.replication.AutoRecoveryMain --conf ${BOOKIE_CONF} $@
+elif [ "${COMMAND}" == "localbookie" ]; then
   NUMBER=$1
   shift
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.util.LocalBookKeeper ${NUMBER} ${BOOKIE_CONF} $@
+  $EXECCMD ${JAVA} ${OPTS} ${JMX_ARGS} '-Dzookeeper.4lw.commands.whitelist=*' org.apache.bookkeeper.util.LocalBookKeeper ${NUMBER} ${BOOKIE_CONF} $@
+  ${JAVA} ${OPTS}  org.apache.bookkeeper.util.LocalBookKeeper ${NUMBER} ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "standalone" ]; then
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.stream.cluster.StandaloneStarter --conf ${BK_HOME}/conf/standalone.conf $@
+  $EXECCMD ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.stream.cluster.StandaloneStarter --conf ${BK_HOME}/conf/standalone.conf $@
 elif [ ${COMMAND} == "upgrade" ]; then
-  exec ${JAVA} ${OPTS} org.apache.bookkeeper.bookie.FileSystemUpgrade --conf ${BOOKIE_CONF} $@
+  $EXECCMD ${JAVA} ${OPTS} org.apache.bookkeeper.bookie.FileSystemUpgrade --conf ${BOOKIE_CONF} $@
 elif [ $COMMAND == "zookeeper" ]; then
     BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"zookeeper.log"}
-    exec $JAVA $OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE org.apache.zookeeper.server.quorum.QuorumPeerMain $BOOKIE_ZK_CONF $@
+    $EXECCMD $JAVA $OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE org.apache.zookeeper.server.quorum.QuorumPeerMain $BOOKIE_ZK_CONF $@
 elif [ ${COMMAND} == "shell" ]; then
   ENTRY_FORMATTER_ARG="-DentryFormatterClass=${ENTRY_FORMATTER_CLASS:-org.apache.bookkeeper.util.StringEntryFormatter}"
-  exec ${JAVA} ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
+  $EXECDMD ${JAVA} ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@ > command.txt
 elif [ ${COMMAND} == "help" ]; then
   bookkeeper_help;
 else
-  exec ${JAVA} ${OPTS} ${COMMAND} $@
+  $EXECMD ${JAVA} ${OPTS} ${COMMAND} $@
 fi
 


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Add the ability to run "bookkeeper" in a Windows environment with "Git Bash" tool.
This patch is not supposed to enable the execution of BookKeeper server in Production.
With this patch is is possible to run  "bookkeeper localbookie" and "bookkeeper standalone" in a Windows environment, to ease development of client applications.

You will need to change bk_server.conf paths com /tmp to another path.
You have to use a JDK runtime installed in a path that does not contain spaces.
Just download JDK runtime in some folder like c:\java

### Changes
Handle CLASSPATH, dropping double colon (::) separators.
Do not use 'exec' to start the commands.

Master Issue: #2267 

