### PR TITLE
Do not log WARNING about PlacementPolicy for tests and simple setups

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
@@ -238,7 +238,7 @@ class BookieWatcherImpl implements BookieWatcher {
         long startTime = MathUtils.nowInNano();
         EnsemblePlacementPolicy.PlacementResult<List<BookieSocketAddress>> newEnsembleResponse;
         List<BookieSocketAddress> socketAddresses;
-        PlacementPolicyAdherence isEnsembleAdheringToPlacementPolicy = PlacementPolicyAdherence.FAIL;
+        PlacementPolicyAdherence isEnsembleAdheringToPlacementPolicy;
         try {
             Set<BookieSocketAddress> quarantinedBookiesSet = quarantinedBookies.asMap().keySet();
             newEnsembleResponse = placementPolicy.newEnsemble(ensembleSize, writeQuorumSize, ackQuorumSize,
@@ -247,8 +247,10 @@ class BookieWatcherImpl implements BookieWatcher {
             isEnsembleAdheringToPlacementPolicy = newEnsembleResponse.isAdheringToPolicy();
             if (isEnsembleAdheringToPlacementPolicy == PlacementPolicyAdherence.FAIL) {
                 ensembleNotAdheringToPlacementPolicy.inc();
-                log.warn("New ensemble: {} is not adhering to Placement Policy. quarantinedBookies: {}",
-                        socketAddresses, quarantinedBookiesSet);
+                if (ensembleSize > 1) {
+                    log.warn("New ensemble: {} is not adhering to Placement Policy. quarantinedBookies: {}",
+                            socketAddresses, quarantinedBookiesSet);
+                }
             }
             // we try to only get from the healthy bookies first
             newEnsembleTimer.registerSuccessfulEvent(MathUtils.nowInNano() - startTime, TimeUnit.NANOSECONDS);


### PR DESCRIPTION

Descriptions of the changes in this PR:
Do not log 'New ensemble: {} is not adhering to Placement Policy. quarantinedBookies' in case of ensembleSize = 1


### Motivation
In tests cases and in simple demos it is very annoying to see that log line at "WARNING" level.
If we are requiring only 1 bookie it is not a big deal to WARN that the placement policy is not "adhering"
