### PR TITLE
fix some stats monitor metrics

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1090,7 +1090,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                 } else if (qe.entryId != Bookie.METAENTRY_ID_FORCE_LEDGER) {
                     int entrySize = qe.entry.readableBytes();
                     journalStats.getJournalWriteBytes().add(entrySize);
-                    journalStats.getJournalQueueSize().dec();
 
                     batchSize += (4 + entrySize);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
@@ -87,12 +87,12 @@ class DbLedgerStorageStats {
     )
     private final OpStatsLogger readAheadBatchCountStats;
     @StatsDoc(
-        name = READAHEAD_BATCH_COUNT,
+        name = READAHEAD_BATCH_SIZE,
         help = "the distribution of num of bytes to read in one readahead batch"
     )
     private final OpStatsLogger readAheadBatchSizeStats;
     @StatsDoc(
-        name = FLUSH_SIZE,
+        name = FLUSH,
         help = "operation stats of flushing write cache to entry log files"
     )
     private final OpStatsLogger flushStats;


### PR DESCRIPTION
Descriptions of the changes in this PR:

The journalStats.getJournalQueueSize increase once and decrease twice, so this stat metric will be negative.

It increases in `logAddEntry` function and decrease in `QueueEntry recall` methord and Journal main thread run methord.

so we should delete the decrease in journal main thread run methord.

```
queue.put(QueueEntry.create(
                entry, ackBeforeSync,  ledgerId, entryId, cb, ctx, MathUtils.nowInNano(),
                journalStats.getJournalAddEntryStats(),
                journalStats.getJournalQueueSize()))
```