### PR TITLE
Update Prometheus library to 0.8.1

### DIFF
--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -61,10 +61,10 @@ License for the specific language governing permissions and limitations
 under the License.
 
 ------------------------------------------------------------------------------------
-- lib/io.prometheus-simpleclient-0.0.21.jar
-- lib/io.prometheus-simpleclient_common-0.0.21.jar
-- lib/io.prometheus-simpleclient_hotspot-0.0.21.jar
-- lib/io.prometheus-simpleclient_servlet-0.0.21.jar
+- lib/io.prometheus-simpleclient-0.8.1.jar
+- lib/io.prometheus-simpleclient_common-0.8.1.jar
+- lib/io.prometheus-simpleclient_hotspot-0.8.1.jar
+- lib/io.prometheus-simpleclient_servlet-0.8.1.jar
 
 Prometheus instrumentation library for JVM applications
 Copyright 2012-2015 The Prometheus Authors

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -44,10 +44,10 @@ License for the specific language governing permissions and limitations
 under the License.
 
 ------------------------------------------------------------------------------------
-- lib/io.prometheus-simpleclient-0.0.21.jar
-- lib/io.prometheus-simpleclient_common-0.0.21.jar
-- lib/io.prometheus-simpleclient_hotspot-0.0.21.jar
-- lib/io.prometheus-simpleclient_servlet-0.0.21.jar
+- lib/io.prometheus-simpleclient-0.8.1.jar
+- lib/io.prometheus-simpleclient_common-0.8.1.jar
+- lib/io.prometheus-simpleclient_hotspot-0.8.1.jar
+- lib/io.prometheus-simpleclient_servlet-0.8.1.jar
 
 Prometheus instrumentation library for JVM applications
 Copyright 2012-2015 The Prometheus Authors

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <netty-boringssl.version>2.0.20.Final</netty-boringssl.version>
     <ostrich.version>9.1.3</ostrich.version>
     <powermock.version>2.0.2</powermock.version>
-    <prometheus.version>0.0.21</prometheus.version>
+    <prometheus.version>0.8.1</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
     <protobuf.version>3.5.1</protobuf.version>
     <protoc3.version>3.5.1-1</protoc3.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:
Update Prometheus library to 0.8.1

### Motivation

We have an obsolete version

### Changes

Update Prometheus library to latest version 0.8.1 and update NOTICE files
