### PR TITLE
 #2288: add metadata to StreamStorage ledgers

### DIFF
--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/Constants.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/Constants.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Constants {
 
+    public static final String LEDGER_METADATA_APPLICATION_STREAM_STORAGE = "bk-stream-storage-service";
     public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
     public static final byte[] NULL_START_KEY = EMPTY_BYTE_ARRAY;
     public static final byte[] NULL_END_KEY = new byte[] { 0 };

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/journal/AbstractStateStoreWithJournal.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/journal/AbstractStateStoreWithJournal.java
@@ -42,6 +42,7 @@ import org.apache.bookkeeper.statelib.api.StateStoreSpec;
 import org.apache.bookkeeper.statelib.api.exceptions.StateStoreClosedException;
 import org.apache.bookkeeper.statelib.api.exceptions.StateStoreException;
 import org.apache.bookkeeper.statelib.api.exceptions.StateStoreRuntimeException;
+import org.apache.bookkeeper.statelib.impl.Constants;
 import org.apache.distributedlog.DLSN;
 import org.apache.distributedlog.LogRecord;
 import org.apache.distributedlog.LogRecordWithDLSN;
@@ -49,6 +50,7 @@ import org.apache.distributedlog.api.AsyncLogReader;
 import org.apache.distributedlog.api.AsyncLogWriter;
 import org.apache.distributedlog.api.DistributedLogManager;
 import org.apache.distributedlog.api.namespace.Namespace;
+import org.apache.distributedlog.bk.LedgerMetadata;
 import org.apache.distributedlog.exceptions.LogEmptyException;
 import org.apache.distributedlog.exceptions.LogNotFoundException;
 import org.apache.distributedlog.util.Utils;
@@ -218,7 +220,10 @@ public abstract class AbstractStateStoreWithJournal<LocalStateStoreT extends Sta
         } catch (IOException e) {
             return FutureUtils.exception(e);
         }
-        return logManager.openAsyncLogWriter().thenComposeAsync(w -> {
+        LedgerMetadata metadata = new LedgerMetadata();
+        metadata.setApplication(Constants.LEDGER_METADATA_APPLICATION_STREAM_STORAGE);
+        metadata.setComponent("state-store");
+        return logManager.openAsyncLogWriter(metadata).thenComposeAsync(w -> {
             synchronized (this) {
                 writer = w;
                 nextRevision = writer.getLastTxId();
@@ -233,7 +238,10 @@ public abstract class AbstractStateStoreWithJournal<LocalStateStoreT extends Sta
     }
 
     private CompletableFuture<DLSN> writeCatchUpMarker() {
-        return logManager.openAsyncLogWriter().thenComposeAsync(w -> {
+        LedgerMetadata metadata = new LedgerMetadata();
+        metadata.setApplication(Constants.LEDGER_METADATA_APPLICATION_STREAM_STORAGE);
+        metadata.setComponent("state-store");
+        return logManager.openAsyncLogWriter(metadata).thenComposeAsync(w -> {
             synchronized (this) {
                 writer = w;
                 nextRevision = writer.getLastTxId();

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/dlog/DLCheckpointStore.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/dlog/DLCheckpointStore.java
@@ -103,7 +103,7 @@ public class DLCheckpointStore implements CheckpointStore {
             LedgerMetadata metadata = new LedgerMetadata();
             metadata.setApplication(Constants.LEDGER_METADATA_APPLICATION_STREAM_STORAGE);
             metadata.setComponent("checkpoint-store");
-            AsyncLogWriter writer = Utils.ioResult(dlm.openAsyncLogWriter());
+            AsyncLogWriter writer = Utils.ioResult(dlm.openAsyncLogWriter(metadata));
             return new BufferedOutputStream(
                 new DLOutputStream(dlm, writer), 128 * 1024);
         } catch (LogNotFoundException le) {

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/dlog/DLCheckpointStore.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/dlog/DLCheckpointStore.java
@@ -32,11 +32,13 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.statelib.api.checkpoint.CheckpointStore;
+import org.apache.bookkeeper.statelib.impl.Constants;
 import org.apache.distributedlog.DLSN;
 import org.apache.distributedlog.api.AsyncLogWriter;
 import org.apache.distributedlog.api.DistributedLogManager;
 import org.apache.distributedlog.api.LogReader;
 import org.apache.distributedlog.api.namespace.Namespace;
+import org.apache.distributedlog.bk.LedgerMetadata;
 import org.apache.distributedlog.exceptions.DLInterruptedException;
 import org.apache.distributedlog.exceptions.LogEmptyException;
 import org.apache.distributedlog.exceptions.LogExistsException;
@@ -98,6 +100,9 @@ public class DLCheckpointStore implements CheckpointStore {
         try {
             DistributedLogManager dlm = namespace.openLog(
                 filePath);
+            LedgerMetadata metadata = new LedgerMetadata();
+            metadata.setApplication(Constants.LEDGER_METADATA_APPLICATION_STREAM_STORAGE);
+            metadata.setComponent("checkpoint-store");
             AsyncLogWriter writer = Utils.ioResult(dlm.openAsyncLogWriter());
             return new BufferedOutputStream(
                 new DLOutputStream(dlm, writer), 128 * 1024);


### PR DESCRIPTION
Descriptions of the changes in this PR:

Added 'application' and 'component' metadata to StreamStorage ledgers.
application: bk-stream-storage-service
component: state-store / checkpoint-store

Master Issue: #2288 

> - [X] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [X] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [X] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [X] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [X] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java11]: skip build on java11. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
