### PR TITLE
Allow build on JDK14 - upgrade Groovy compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
-    <dockerfile-maven-plugin.version>1.3.7</dockerfile-maven-plugin.version>
+    <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <license-maven-plugin.version>1.6</license-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>

--- a/tests/docker-images/all-released-versions-image/pom.xml
+++ b/tests/docker-images/all-released-versions-image/pom.xml
@@ -39,7 +39,7 @@
           <plugin>
             <groupId>com.spotify</groupId>
             <artifactId>dockerfile-maven-plugin</artifactId>
-            <version>1.3.7</version>
+            <version>1.4.13</version>
             <executions>
               <execution>
                 <id>default</id>

--- a/tests/integration-tests-base-groovy/pom.xml
+++ b/tests/integration-tests-base-groovy/pom.xml
@@ -31,8 +31,8 @@
   <name>Apache BookKeeper :: Tests :: Base module for Arquillian based integration tests using groovy</name>
 
   <properties>
-    <groovy-eclipse-compiler.version>3.4.0-01</groovy-eclipse-compiler.version>
-    <groovy-eclipse-batch.version>2.5.8-01</groovy-eclipse-batch.version>
+    <groovy-eclipse-compiler.version>3.6.0-03</groovy-eclipse-compiler.version>
+    <groovy-eclipse-batch.version>3.0.2-02</groovy-eclipse-batch.version>
   </properties>
 
   <build>


### PR DESCRIPTION
### Motivation

Current version of Groovy compiler for integration tests do not support JDK14

### Changes

Update Groovy Compiler
Update dockerfile-maven-plugin as well

