### PR TITLE
Handle NPE when inet address is not able to resolve network address

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -776,7 +776,7 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements
     }
 
     protected String resolveNetworkLocation(BookieSocketAddress addr) {
-        return NetUtils.resolveNetworkLocation(dnsResolver, addr.getSocketAddress());
+        return NetUtils.resolveNetworkLocation(dnsResolver, addr);
     }
 
     protected Set<Node> convertBookiesToNodes(Collection<BookieSocketAddress> excludeBookies) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
@@ -68,13 +68,20 @@ public class NetUtils {
         return hostNames;
     }
 
-    public static String resolveNetworkLocation(DNSToSwitchMapping dnsResolver, InetSocketAddress addr) {
+    public static String resolveNetworkLocation(DNSToSwitchMapping dnsResolver,
+                                                BookieSocketAddress addr) {
         List<String> names = new ArrayList<String>(1);
 
+        InetSocketAddress inetSocketAddress = addr.getSocketAddress();
         if (dnsResolver.useHostName()) {
             names.add(addr.getHostName());
         } else {
-            names.add(addr.getAddress().getHostAddress());
+            InetAddress inetAddress = inetSocketAddress.getAddress();
+            if (null == inetAddress) {
+                addr.getHostName();
+            } else {
+                names.add(inetAddress.getHostAddress());
+            }
         }
 
         // resolve network addresses

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
@@ -78,7 +78,7 @@ public class NetUtils {
         } else {
             InetAddress inetAddress = inetSocketAddress.getAddress();
             if (null == inetAddress) {
-                addr.getHostName();
+                names.add(addr.getHostName());
             } else {
                 names.add(inetAddress.getHostAddress());
             }


### PR DESCRIPTION


Descriptions of the changes in this PR:

*Motivation*

```
06:00:53.731 [BookKeeperClientScheduler-OrderedScheduler-0-0] ERROR org.apache.bookkeeper.client.TopologyAwareEnsemblePlacementPolicy - Unexpected exception while handling joining bookie pulsar-tls-bookie-0.pulsar-tls-bookie.pulsar.svc.cluster.local:3181
java.lang.NullPointerException: null
	at org.apache.bookkeeper.net.NetUtils.resolveNetworkLocation(NetUtils.java:77) ~[org.apache.bookkeeper-bookkeeper-server-4.10.0.jar:4.10.0]
```

*TEST*

The `getAddress` is final method. It is hard to mock.

The method has been covered by other tests.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
