### PR TITLE
Issue #2305: Bookies should not be allowed to come up without a cookie in metadata store.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -467,6 +467,12 @@ public class Bookie extends BookieCriticalThread {
                               + "Empty directories are {}", missedCookieDirs);
                     throw new InvalidCookieException();
                 }
+            } else {
+                if (rmCookie == null) {
+                    // No corresponding cookie found in registration manager. The bookie should fail to come up.
+                    LOG.error("Cookie for this bookie is not stored in metadata store. Bookie failing to come up");
+                    throw new InvalidCookieException();
+                }
             }
         } catch (IOException ioe) {
             LOG.error("Error accessing cookie on disks", ioe);


### PR DESCRIPTION
### Motivation
Currently we allow bookies to come up even if they don't have a cookie in the metadata store.
The cookie is an identity of a registered bookie and a bookie should not be allowed to come up without it.

### Changes
Update handling of bookie boot up. Add test.
This scenario is rarely expected but can happen in case of corruption or errant deletion of znodes for cookies
