### PR TITLE
Rerun the failed tests by comments

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1,0 +1,21 @@
+name: Bot tests
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  bot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bot actions
+        uses: zymap/bot@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT }}
+        with:
+          repo_owner: apache
+          repo_name: bookkeeper
+          rerun_cmd: rerun failure checks
+          comment: ${{ github.event.comment.body }}

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Bot actions
         uses: zymap/bot@v1.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT }}
+          GITHUB_TOKEN: ${{ secrets.BKBOT_TOKEN }}
         with:
           repo_owner: apache
           repo_name: bookkeeper


### PR DESCRIPTION
---

*Motivation*

Currently, non-committers cannot rerun the failure tests, we need to
provide the ability to let non-committer to rerun the failed tests.
I wrote a Github Actions that can rerun the failed test by comments
`rerun failure tests` and add it to the bookkeeper ci process.

