### PR TITLE
Issue 2310: Adds the autorecovery status service.

### DIFF
--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
@@ -50,6 +50,7 @@ public abstract class HttpRouter<Handler> {
     public static final String BOOKIE_STATE                 = "/api/v1/bookie/state";
     public static final String BOOKIE_IS_READY              = "/api/v1/bookie/is_ready";
     // autorecovery
+    public static final String AUTORECOVERY_STATUS          = "/api/v1/autorecovery/status";
     public static final String RECOVERY_BOOKIE              = "/api/v1/autorecovery/bookie";
     public static final String LIST_UNDER_REPLICATED_LEDGER = "/api/v1/autorecovery/list_under_replicated_ledger";
     public static final String WHO_IS_AUDITOR               = "/api/v1/autorecovery/who_is_auditor";
@@ -83,6 +84,8 @@ public abstract class HttpRouter<Handler> {
         this.endpointHandlers.put(BOOKIE_IS_READY, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_IS_READY));
 
         // autorecovery
+        this.endpointHandlers.put(AUTORECOVERY_STATUS, handlerFactory
+                .newHandler(HttpServer.ApiType.AUTORECOVERY_STATUS));
         this.endpointHandlers.put(RECOVERY_BOOKIE, handlerFactory.newHandler(HttpServer.ApiType.RECOVERY_BOOKIE));
         this.endpointHandlers.put(LIST_UNDER_REPLICATED_LEDGER,
             handlerFactory.newHandler(HttpServer.ApiType.LIST_UNDER_REPLICATED_LEDGER));

--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
@@ -33,6 +33,7 @@ public interface HttpServer {
     enum StatusCode {
         OK(200),
         REDIRECT(302),
+        BAD_REQUEST(400),
         FORBIDDEN(403),
         NOT_FOUND(404),
         INTERNAL_ERROR(500),

--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
@@ -84,6 +84,7 @@ public interface HttpServer {
         BOOKIE_IS_READY,
 
         // autorecovery
+        AUTORECOVERY_STATUS,
         RECOVERY_BOOKIE,
         LIST_UNDER_REPLICATED_LEDGER,
         WHO_IS_AUDITOR,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/BKHttpServiceProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/BKHttpServiceProvider.java
@@ -40,6 +40,7 @@ import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.Auditor;
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
+import org.apache.bookkeeper.server.http.service.AutoRecoveryStatusService;
 import org.apache.bookkeeper.server.http.service.BookieIsReadyService;
 import org.apache.bookkeeper.server.http.service.BookieStateService;
 import org.apache.bookkeeper.server.http.service.ConfigurationService;
@@ -199,7 +200,7 @@ public class BKHttpServiceProvider implements HttpServiceProvider {
                 return new DeleteLedgerService(configuration);
             case LIST_LEDGER:
                 return new ListLedgerService(configuration, bookieServer);
-            case GET_LEDGER_META:
+            case  GET_LEDGER_META:
                 return new GetLedgerMetaService(configuration, bookieServer);
             case READ_LEDGER_ENTRY:
                 return new ReadLedgerEntryService(configuration, bka);
@@ -225,6 +226,8 @@ public class BKHttpServiceProvider implements HttpServiceProvider {
                 return new BookieIsReadyService(bookieServer.getBookie());
 
             // autorecovery
+            case AUTORECOVERY_STATUS:
+                return new AutoRecoveryStatusService(configuration);
             case RECOVERY_BOOKIE:
                 return new RecoveryBookieService(configuration, bka, executor);
             case LIST_UNDER_REPLICATED_LEDGER:

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/BKHttpServiceProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/BKHttpServiceProvider.java
@@ -200,7 +200,7 @@ public class BKHttpServiceProvider implements HttpServiceProvider {
                 return new DeleteLedgerService(configuration);
             case LIST_LEDGER:
                 return new ListLedgerService(configuration, bookieServer);
-            case  GET_LEDGER_META:
+            case GET_LEDGER_META:
                 return new GetLedgerMetaService(configuration, bookieServer);
             case READ_LEDGER_ENTRY:
                 return new ReadLedgerEntryService(configuration, bka);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
@@ -87,7 +87,7 @@ public class AutoRecoveryStatusService implements HttpEndpointService {
         String enabled = params.get("enabled");
         if (enabled == null) {
             return new HttpServiceResponse("Param 'enabled' not found in " + params,
-                    HttpServer.StatusCode.INTERNAL_ERROR);
+                    HttpServer.StatusCode.BAD_REQUEST);
         }
         if (Boolean.parseBoolean(enabled)) {
             if (!ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.bookkeeper.server.http.service;
 
 import com.google.common.collect.ImmutableMap;
@@ -15,6 +33,16 @@ import org.apache.commons.lang3.ObjectUtils;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * HttpEndpointService that handles Autorecovery status related http requests.
+ *
+ * <p></p>The GET method returns the current status of Autorecovery. The output would be like {"enabled" : true}.
+ *
+ * <p>The PUT method requires a parameter 'enabled', and enables Autorecovery if its value is 'true',
+ * and disables Autorecovery otherwise. The behaviour is idempotent if Autorecovery status is already
+ * the same as desired. The output would be the current status after the action.
+ *
+ */
 public class AutoRecoveryStatusService implements HttpEndpointService {
     protected final ServerConfiguration conf;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
@@ -1,0 +1,80 @@
+package org.apache.bookkeeper.server.http.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.apache.bookkeeper.common.util.JsonUtil;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpEndpointService;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.MetadataDrivers;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class AutoRecoveryStatusService implements HttpEndpointService {
+    protected final ServerConfiguration conf;
+
+    public AutoRecoveryStatusService(ServerConfiguration conf) {
+        this.conf = conf;
+    }
+
+    @Override
+    public HttpServiceResponse handle(HttpServiceRequest request) throws Exception {
+        return MetadataDrivers.runFunctionWithLedgerManagerFactory(conf,
+                ledgerManagerFactory -> {
+                    try (LedgerUnderreplicationManager ledgerUnderreplicationManager = ledgerManagerFactory
+                            .newLedgerUnderreplicationManager()) {
+                        switch (request.getMethod()) {
+                            case GET:
+                                return handleGetStatus(ledgerUnderreplicationManager);
+                            case PUT:
+                                return handlePutStatus(request, ledgerUnderreplicationManager);
+                            default:
+                                return new HttpServiceResponse("Not found method. Should be GET or PUT method",
+                                        HttpServer.StatusCode.NOT_FOUND);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new UncheckedExecutionException(e);
+                    } catch (Exception e) {
+                        throw new UncheckedExecutionException(e);
+                    }
+                });
+    }
+
+    private HttpServiceResponse handleGetStatus(LedgerUnderreplicationManager ledgerUnderreplicationManager)
+            throws Exception {
+        String body = JsonUtil.toJson(ImmutableMap.of("enabled",
+                ledgerUnderreplicationManager.isLedgerReplicationEnabled()));
+        return new HttpServiceResponse(body, HttpServer.StatusCode.OK);
+    }
+
+    private HttpServiceResponse handlePutStatus(HttpServiceRequest request,
+                                                LedgerUnderreplicationManager ledgerUnderreplicationManager)
+            throws Exception {
+        Map<String, String> params = ObjectUtils.defaultIfNull(request.getParams(), Collections.emptyMap());
+        String enabled = params.get("enabled");
+        if (enabled == null) {
+            return new HttpServiceResponse("Param 'enabled' not found in " + params,
+                    HttpServer.StatusCode.INTERNAL_ERROR);
+        }
+        if (Boolean.parseBoolean(enabled)) {
+            if (!ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {
+                ledgerUnderreplicationManager.enableLedgerReplication();
+            }
+        } else {
+            if (ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {
+                ledgerUnderreplicationManager.disableLedgerReplication();
+            }
+        }
+
+        // use the current status as the response
+        String body = JsonUtil.toJson(ImmutableMap.of("enabled",
+                ledgerUnderreplicationManager.isLedgerReplicationEnabled()));
+        return new HttpServiceResponse(body, HttpServer.StatusCode.OK);
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
@@ -20,6 +20,8 @@ package org.apache.bookkeeper.server.http.service;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.util.Collections;
+import java.util.Map;
 import org.apache.bookkeeper.common.util.JsonUtil;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
@@ -29,9 +31,6 @@ import org.apache.bookkeeper.http.service.HttpServiceResponse;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
 import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.commons.lang3.ObjectUtils;
-
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * HttpEndpointService that handles Autorecovery status related http requests.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusServiceTest.java
@@ -94,7 +94,7 @@ public class AutoRecoveryStatusServiceTest extends BookKeeperClusterTestCase {
         Map<String, String> params = ImmutableMap.of("enable", "false");
         HttpServiceRequest request = new HttpServiceRequest(null, HttpServer.Method.PUT, params);
         HttpServiceResponse response = autoRecoveryStatusService.handle(request);
-        assertEquals(HttpServer.StatusCode.INTERNAL_ERROR.getValue(), response.getStatusCode());
+        assertEquals(HttpServer.StatusCode.BAD_REQUEST.getValue(), response.getStatusCode());
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusServiceTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class AutoRecoveryStatusServiceTest extends BookKeeperClusterTestCase {
     private final ObjectMapper mapper = new ObjectMapper();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusServiceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.server.http.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class AutoRecoveryStatusServiceTest extends BookKeeperClusterTestCase {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private AutoRecoveryStatusService autoRecoveryStatusService;
+    public AutoRecoveryStatusServiceTest() {
+        super(1);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        autoRecoveryStatusService = new AutoRecoveryStatusService(baseConf);
+    }
+
+    @Test
+    public void testGetStatus() throws Exception {
+        HttpServiceRequest request = new HttpServiceRequest(null, HttpServer.Method.GET, null);
+        HttpServiceResponse response = autoRecoveryStatusService.handle(request);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        JsonNode json = mapper.readTree(response.getBody());
+        assertEquals(Boolean.TRUE, json.get("enabled").asBoolean());
+    }
+
+    @Test
+    public void testEnableStatus() throws Exception {
+        Map<String, String> params = ImmutableMap.of("enabled", "true");
+        HttpServiceRequest request = new HttpServiceRequest(null, HttpServer.Method.PUT, params);
+        HttpServiceResponse response = autoRecoveryStatusService.handle(request);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        JsonNode json = mapper.readTree(response.getBody());
+        assertEquals(Boolean.TRUE, json.get("enabled").asBoolean());
+
+        request = new HttpServiceRequest(null, HttpServer.Method.GET, params);
+        response = autoRecoveryStatusService.handle(request);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        json = mapper.readTree(response.getBody());
+        assertEquals(Boolean.TRUE, json.get("enabled").asBoolean());
+    }
+
+    @Test
+    public void testDisableStatus() throws Exception {
+        Map<String, String> params = ImmutableMap.of("enabled", "false");
+        HttpServiceRequest request = new HttpServiceRequest(null, HttpServer.Method.PUT, params);
+        HttpServiceResponse response = autoRecoveryStatusService.handle(request);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        JsonNode json = mapper.readTree(response.getBody());
+        assertEquals(Boolean.FALSE, json.get("enabled").asBoolean());
+
+        request = new HttpServiceRequest(null, HttpServer.Method.GET, params);
+        response = autoRecoveryStatusService.handle(request);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response.getStatusCode());
+        json = mapper.readTree(response.getBody());
+        assertEquals(Boolean.FALSE, json.get("enabled").asBoolean());
+    }
+
+    @Test
+    public void testInvalidParams() throws Exception {
+        Map<String, String> params = ImmutableMap.of("enable", "false");
+        HttpServiceRequest request = new HttpServiceRequest(null, HttpServer.Method.PUT, params);
+        HttpServiceResponse response = autoRecoveryStatusService.handle(request);
+        assertEquals(HttpServer.StatusCode.INTERNAL_ERROR.getValue(), response.getStatusCode());
+    }
+
+    @Test
+    public void testInvalidMethod() throws Exception {
+        HttpServiceRequest request = new HttpServiceRequest(null, HttpServer.Method.POST, null);
+        HttpServiceResponse response = autoRecoveryStatusService.handle(request);
+        assertEquals(HttpServer.StatusCode.NOT_FOUND.getValue(), response.getStatusCode());
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusServiceTest.java
@@ -18,9 +18,12 @@
 
 package org.apache.bookkeeper.server.http.service;
 
+import static org.junit.Assert.assertEquals;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.apache.bookkeeper.http.HttpServer;
 import org.apache.bookkeeper.http.service.HttpServiceRequest;
 import org.apache.bookkeeper.http.service.HttpServiceResponse;
@@ -28,10 +31,9 @@ import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-
+/**
+ * Unit tests for {@link AutoRecoveryStatusService}.
+ */
 public class AutoRecoveryStatusServiceTest extends BookKeeperClusterTestCase {
     private final ObjectMapper mapper = new ObjectMapper();
     private AutoRecoveryStatusService autoRecoveryStatusService;


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

It would be convenient to support enable, disable, or check the status of autorecovery with REST API, just like what does in the toggle command.

### Changes

Adds an API to enable, disable, and get the current status of autorecovery at `/api/v1/autorecovery/status`.

Master Issue: #2310 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [x] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [x] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
