### PR TITLE
Issue 2274: The 'metaformat' command does not delete 'idgen' znode

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -580,7 +580,11 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
             || BookKeeperConstants.LAYOUT_ZNODE.equals(znode)
             || BookKeeperConstants.INSTANCEID.equals(znode)
             || BookKeeperConstants.UNDER_REPLICATION_NODE.equals(znode)
-            || LegacyHierarchicalLedgerManager.IDGEN_ZNODE.equals(znode)
+            || isLeadgerIdGeneratorZnode(znode);
+    }
+
+    public static boolean isLeadgerIdGeneratorZnode(String znode) {
+        return LegacyHierarchicalLedgerManager.IDGEN_ZNODE.equals(znode)
             || LongHierarchicalLedgerManager.IDGEN_ZNODE.equals(znode)
             || znode.startsWith(ZkLedgerIdGenerator.LEDGER_ID_GEN_PREFIX);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.bookkeeper.meta;
 
+import static org.apache.bookkeeper.meta.AbstractZkLedgerManager.isLeadgerIdGeneratorZnode;
+import static org.apache.bookkeeper.meta.AbstractZkLedgerManager.isSpecialZnode;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -48,7 +50,10 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
             String ledgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
             List<String> children = zk.getChildren(ledgersRootPath, false);
             for (String child : children) {
-                if (!AbstractZkLedgerManager.isSpecialZnode(child) && ledgerManager.isLedgerParentNode(child)) {
+                boolean lParentNode = !isSpecialZnode(child) && ledgerManager.isLedgerParentNode(child);
+                boolean lIdGenerator = isLeadgerIdGeneratorZnode(child);
+
+                if (lParentNode || lIdGenerator) {
                     ZKUtil.deleteRecursive(zk, ledgersRootPath + "/" + child);
                 }
             }


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

After `metaformat`, ledgerId does not count from 0 because，the `metaformat` command does not delete `idgen` znode.

### Changes

In the `AbstractZkLedgerManagerFactory` avoid skipping the igen and idgen-long nodes

Master Issue: #2274