### PR TITLE
Force to use Python grpcio less then 1.26.0

### DIFF
--- a/stream/clients/python/setup.py
+++ b/stream/clients/python/setup.py
@@ -32,7 +32,7 @@ dependencies = [
     'six>=1.10.0',
     'pytz',
     'futures>=3.2.0;python_version<"3.2"',
-    'grpcio>=1.8.2',
+    'grpcio<1.26.0,>=1.8.2',
     'pymmh3>=0.0.3'
 ]
 extras = {


### PR DESCRIPTION
- it looks like a newer version of grpcio has been published and we were using open version range
- by forcing a closed ended range of version we workaround the error in integration tests