### PR TITLE
Add /api/v1/bookie/info REST API

### DIFF
--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
@@ -49,6 +49,7 @@ public abstract class HttpRouter<Handler> {
     public static final String GC_DETAILS                   = "/api/v1/bookie/gc_details";
     public static final String BOOKIE_STATE                 = "/api/v1/bookie/state";
     public static final String BOOKIE_IS_READY              = "/api/v1/bookie/is_ready";
+    public static final String BOOKIE_INFO                  = "/api/v1/bookie/info";
     // autorecovery
     public static final String RECOVERY_BOOKIE              = "/api/v1/autorecovery/bookie";
     public static final String LIST_UNDER_REPLICATED_LEDGER = "/api/v1/autorecovery/list_under_replicated_ledger";
@@ -81,6 +82,7 @@ public abstract class HttpRouter<Handler> {
         this.endpointHandlers.put(GC_DETAILS, handlerFactory.newHandler(HttpServer.ApiType.GC_DETAILS));
         this.endpointHandlers.put(BOOKIE_STATE, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_STATE));
         this.endpointHandlers.put(BOOKIE_IS_READY, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_IS_READY));
+        this.endpointHandlers.put(BOOKIE_INFO, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_INFO));
 
         // autorecovery
         this.endpointHandlers.put(RECOVERY_BOOKIE, handlerFactory.newHandler(HttpServer.ApiType.RECOVERY_BOOKIE));

--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
@@ -82,6 +82,7 @@ public interface HttpServer {
         GC_DETAILS,
         BOOKIE_STATE,
         BOOKIE_IS_READY,
+        BOOKIE_INFO,
 
         // autorecovery
         RECOVERY_BOOKIE,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/BKHttpServiceProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/BKHttpServiceProvider.java
@@ -40,6 +40,7 @@ import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.Auditor;
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
+import org.apache.bookkeeper.server.http.service.BookieInfoService;
 import org.apache.bookkeeper.server.http.service.BookieIsReadyService;
 import org.apache.bookkeeper.server.http.service.BookieStateService;
 import org.apache.bookkeeper.server.http.service.ConfigurationService;
@@ -223,6 +224,8 @@ public class BKHttpServiceProvider implements HttpServiceProvider {
                 return new BookieStateService(bookieServer.getBookie());
             case BOOKIE_IS_READY:
                 return new BookieIsReadyService(bookieServer.getBookie());
+            case BOOKIE_INFO:
+                return new BookieInfoService(bookieServer.getBookie());
 
             // autorecovery
             case RECOVERY_BOOKIE:

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieInfoService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieInfoService.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.server.http.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.common.util.JsonUtil;
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpEndpointService;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+
+/**
+ * HttpEndpointService that returns 200 if the bookie is ready.
+ */
+@AllArgsConstructor
+public class BookieInfoService implements HttpEndpointService {
+    @NonNull private final Bookie bookie;
+
+    /**
+     * POJO definition for the bookie state response.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BookieInfo {
+        private long freeSpace;
+        private long totalSpace;
+    }
+
+    @Override
+    public HttpServiceResponse handle(HttpServiceRequest request) throws Exception {
+        HttpServiceResponse response = new HttpServiceResponse();
+
+        if (HttpServer.Method.GET != request.getMethod()) {
+            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setBody("Only GET is supported.");
+            return response;
+        }
+
+        BookieInfo bi = new BookieInfo(bookie.getTotalFreeSpace(), bookie.getTotalDiskSpace());
+
+        String jsonResponse = JsonUtil.toJson(bi);
+        response.setBody(jsonResponse);
+        response.setCode(HttpServer.StatusCode.OK);
+        return response;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieInfoService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieInfoService.java
@@ -30,14 +30,23 @@ import org.apache.bookkeeper.http.service.HttpServiceRequest;
 import org.apache.bookkeeper.http.service.HttpServiceResponse;
 
 /**
- * HttpEndpointService that returns 200 if the bookie is ready.
+ * HttpEndpointService that exposes the current info of the bookie.
+ *
+ * <pre>
+ * <code>
+ * {
+ *  "freeSpace" : 0,
+ *  "totalSpace" : 0
+ * }
+ * </code>
+ * </pre>
  */
 @AllArgsConstructor
 public class BookieInfoService implements HttpEndpointService {
     @NonNull private final Bookie bookie;
 
     /**
-     * POJO definition for the bookie state response.
+     * POJO definition for the bookie info response.
      */
     @Data
     @NoArgsConstructor

--- a/site/docs/latest/admin/http.md
+++ b/site/docs/latest/admin/http.md
@@ -168,6 +168,24 @@ Currently all the HTTP endpoints could be divided into these 5 components:
 
 ## Bookie
 
+### Endpoint: /api/v1/bookie/info
+1. Method: GET
+   * Description:  Get bookie info
+   * Response:
+
+        | Code   | Description |
+        |:-------|:------------|
+        |200 | Successful operation |
+        |403 | Permission denied |
+        |501 | Not implemented |
+   * Body:
+      ```json
+      {
+         "freeSpace" : 0,
+         "totalSpace" : 0
+       }
+      ```
+
 ### Endpoint: /api/v1/bookie/list_bookies/?type=&lt;type&gt;&print_hostnames=&lt;hostnames&gt;
 1. Method: GET
     * Description:  Get all the available bookies.


### PR DESCRIPTION
Descriptions of the changes in this PR:

This adds an additional HTTP REST endpoint to expose the bookie's info (only storage numbers for now).

### Motivation

I was looking for an HTTP endpoint that returned the info of only the current bookie, but couldn't find one. The only similar API I've found was `/api/v1/bookie/list_bookie_info`, however it connects to all bookies and may take a long time to respond (plus its response format is difficult to parse).

### Changes

I've added a new API at `/api/v1/bookie/info` that returns a response like:
```json
{
  "freeSpace" : 0,
  "totalSpace" : 0
}
```
