### PR TITLE
[CLEAN] Fix missing Override annotation

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchBookie.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchBookie.java
@@ -83,6 +83,7 @@ public class BenchBookie {
     static class ThroughputCallback implements WriteCallback {
         int count;
         int waitingCount = Integer.MAX_VALUE;
+        @Override
         public synchronized void writeComplete(int rc, long ledgerId, long entryId,
                 BookieSocketAddress addr, Object ctx) {
             if (rc != 0) {

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
@@ -134,6 +134,7 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
         return duration;
     }
 
+    @Override
     public void run() {
         LOG.info("Running...");
         long start = previous = System.currentTimeMillis();
@@ -141,6 +142,7 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
         int sent = 0;
 
         Thread reporter = new Thread() {
+                @Override
                 public void run() {
                     try {
                         while (true) {
@@ -290,6 +292,7 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
             final long timeout = Long.parseLong(cmd.getOptionValue("timeout", "360")) * 1000;
 
             timeouter.schedule(new TimerTask() {
+                    @Override
                     public void run() {
                         System.err.println("Timing out benchmark after " + timeout + "ms");
                         System.exit(-1);

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/TestClient.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/TestClient.java
@@ -103,6 +103,7 @@ public class TestClient {
             final long timeout = Long.parseLong(cmd.getOptionValue("timeout", "360")) * 1000;
 
             timeouter.schedule(new TimerTask() {
+                    @Override
                     public void run() {
                         System.err.println("Timing out benchmark after " + timeout + "ms");
                         System.exit(-1);
@@ -209,6 +210,7 @@ public class TestClient {
             this.r = new Random(System.identityHashCode(this));
         }
 
+        @Override
         public Long call() {
             try {
                 long count = 0;
@@ -253,6 +255,7 @@ public class TestClient {
             this.sync = sync;
         }
 
+        @Override
         public Long call() {
             try {
                 long start = System.currentTimeMillis();

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/LifecycleComponent.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/LifecycleComponent.java
@@ -37,6 +37,7 @@ public interface LifecycleComponent extends AutoCloseable {
 
     void stop();
 
+    @Override
     void close();
 
     /**

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/validators/RangeValidator.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/validators/RangeValidator.java
@@ -69,7 +69,7 @@ public class RangeValidator implements Validator {
             if (min != null && n.doubleValue() < min.doubleValue()) {
                 return false;
             } else {
-                return max == null || !(n.doubleValue() > max.doubleValue());
+                return max == null || n.doubleValue() <= max.doubleValue();
             }
         } else {
             return false;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/auth/AuthProviderFactoryFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/auth/AuthProviderFactoryFactory.java
@@ -75,6 +75,7 @@ public class AuthProviderFactoryFactory {
                                               AuthCallbacks.GenericCallback<Void> completeCb) {
             completeCb.operationComplete(BKException.Code.OK, null);
             return new BookieAuthProvider() {
+                @Override
                 public void process(AuthToken m, AuthCallbacks.GenericCallback<AuthToken> cb) {
                     // any request of authentication for clients is going to be answered with a standard response
                     // the client will d
@@ -100,7 +101,9 @@ public class AuthProviderFactoryFactory {
             addr.setAuthorizedId(BookKeeperPrincipal.ANONYMOUS);
             completeCb.operationComplete(BKException.Code.OK, null);
             return new ClientAuthProvider() {
+                @Override
                 public void init(AuthCallbacks.GenericCallback<AuthToken> cb) {}
+                @Override
                 public void process(AuthToken m, AuthCallbacks.GenericCallback<AuthToken> cb) {}
             };
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -210,6 +210,7 @@ public class BookieShell implements Tool {
             this.cmdName = cmdName;
         }
 
+        @Override
         public String description() {
             // we used the string returned by `getUsage` as description in showing the list of commands
             return getUsage();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -341,6 +341,7 @@ public class BookieStateManager implements StateManager {
             return;
         }
     }
+    @Override
     public void setShutdownHandler(ShutdownHandler handler){
         shutdownHandler = handler;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Cookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Cookie.java
@@ -151,6 +151,7 @@ public class Cookie {
         verifyInternal(c, true);
     }
 
+    @Override
     public String toString() {
         if (layoutVersion <= 3) {
             return toStringVersion3();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryKeyValue.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryKeyValue.java
@@ -109,6 +109,7 @@ public class EntryKeyValue extends EntryKey {
     /**
     * String representation.
     */
+    @Override
     public String toString() {
         return ledgerId + ":" + entryId;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
@@ -86,6 +86,7 @@ public class FileSystemUpgrade {
                 return false;
             }
 
+            @Override
             public boolean accept(File dir, String name) {
                 if (name.endsWith(".txn") || name.endsWith(".log")
                     || name.equals("lastId") || name.startsWith("lastMark")) {
@@ -195,6 +196,7 @@ public class FileSystemUpgrade {
                     c.writeToDirectory(tmpDir);
 
                     String[] files = d.list(new FilenameFilter() {
+                            @Override
                             public boolean accept(File dir, String name) {
                                 return bookieFilesFilter.accept(dir, name)
                                     && !(new File(dir, name).isDirectory());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexInMemPageMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexInMemPageMgr.java
@@ -608,14 +608,17 @@ class IndexInMemPageMgr {
             this.initEntry = initEntry;
         }
 
+        @Override
         public LedgerEntryPage getLEP() throws IOException {
             return getLedgerEntryPage(ledgerId, initEntry);
         }
 
+        @Override
         public long getFirstEntry() {
             return initEntry;
         }
 
+        @Override
         public long getLastEntry() {
             return initEntry + entriesPerPage;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -213,7 +213,7 @@ public class IndexPersistenceMgr {
             if (ee.getCause() instanceof IOException) {
                 throw (IOException) ee.getCause();
             } else {
-                throw new LedgerCache.NoIndexForLedger("Failed to load file info for ledger " + ledger, ee);
+                throw new LedgerCache.NoIndexForLedgerException("Failed to load file info for ledger " + ledger, ee);
             }
         } finally {
             persistenceMgrStats.getPendingGetFileInfoCounter().dec();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -342,6 +342,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         }
 
         private static final Recycler<QueueEntry> RECYCLER = new Recycler<QueueEntry>() {
+            @Override
             protected QueueEntry newObject(Recycler.Handle<QueueEntry> handle) {
                 return new QueueEntry(handle);
             }
@@ -448,6 +449,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
     }
 
     private final Recycler<ForceWriteRequest> forceWriteRequestsRecycler = new Recycler<ForceWriteRequest>() {
+                @Override
                 protected ForceWriteRequest newObject(
                         Recycler.Handle<ForceWriteRequest> handle) {
                     return new ForceWriteRequest(handle);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCache.java
@@ -66,8 +66,8 @@ public interface LedgerCache extends Closeable {
     /**
      * Specific exception to encode the case where the index is not present.
      */
-    class NoIndexForLedger extends IOException {
-        NoIndexForLedger(String reason, Exception cause) {
+    class NoIndexForLedgerException extends IOException {
+        NoIndexForLedgerException(String reason, Exception cause) {
             super(reason, cause);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerCacheImpl.java
@@ -159,10 +159,12 @@ public class LedgerCacheImpl implements LedgerCache {
         return indexPersistenceManager.isFenced(ledgerId);
     }
 
+    @Override
     public void setExplicitLac(long ledgerId, ByteBuf lac) throws IOException {
         indexPersistenceManager.setExplicitLac(ledgerId, lac);
     }
 
+    @Override
     public ByteBuf getExplicitLac(long ledgerId) {
         return indexPersistenceManager.getExplicitLac(ledgerId);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -87,6 +87,7 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
         return ledgerStorage.getExplicitLac(ledgerId);
     }
 
+    @Override
     synchronized SettableFuture<Boolean> fenceAndLogInJournal(Journal journal) throws IOException {
         boolean success = this.setFenced();
         if (success) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/AsyncCallback.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/AsyncCallback.java
@@ -87,6 +87,7 @@ public interface AsyncCallback {
          * @param ctx
          *          context object
          */
+        @Override
         default void addCompleteWithLatency(int rc, LedgerHandle lh, long entryId, long qwcLatency, Object ctx) {
             addComplete(rc, lh, entryId, ctx);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1335,6 +1335,7 @@ public class BookKeeperAdmin implements AutoCloseable {
     throws IOException {
         final LedgerRangeIterator iterator = bkc.getLedgerManager().getLedgerRanges(0);
         return new Iterable<Long>() {
+            @Override
             public Iterator<Long> iterator() {
                 return new Iterator<Long>() {
                     Iterator<Long> currentRange = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieInfoReader.java
@@ -79,6 +79,7 @@ public class BookieInfoReader {
         public long getWeight() {
             return freeDiskSpace;
         }
+        @Override
         public String toString() {
             return "FreeDiskSpace: " + this.freeDiskSpace + " TotalDiskCapacity: " + this.totalDiskSpace;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
@@ -83,6 +83,7 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
                     ListenableFuture<Boolean> issueNextRequest = requestExecutor.issueSpeculativeRequest();
                     Futures.addCallback(issueNextRequest, new FutureCallback<Boolean>() {
                         // we want this handler to run immediately after we push the big red button!
+                        @Override
                         public void onSuccess(Boolean issueNextRequest) {
                             if (issueNextRequest) {
                                 scheduleSpeculativeRead(scheduler, requestExecutor,
@@ -96,6 +97,7 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
                             }
                         }
 
+                        @Override
                         public void onFailure(Throwable thrown) {
                             LOG.warn("Failed to issue speculative request for {}, speculativeReadTimeout = {} : ",
                                     requestExecutor, speculativeRequestTimeout, thrown);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
@@ -72,6 +72,7 @@ public class LedgerChecker {
             this.cb = cb;
         }
 
+        @Override
         public void readEntryComplete(int rc, long ledgerId, long entryId,
                 ByteBuf buffer, Object ctx) {
             if (rc == BKException.Code.OK) {
@@ -262,6 +263,7 @@ public class LedgerChecker {
             this.cb = cb;
         }
 
+        @Override
         public void readEntryComplete(int rc, long ledgerId, long entryId,
                                       ByteBuf buffer, Object ctx) {
             if (BKException.Code.NoSuchEntryException != rc && BKException.Code.NoSuchLedgerExistsException != rc
@@ -293,6 +295,7 @@ public class LedgerChecker {
             this.cb = cb;
         }
 
+        @Override
         public void operationComplete(int rc, LedgerFragment result) {
             if (rc == BKException.Code.ClientClosedException) {
                 cb.operationComplete(BKException.Code.ClientClosedException, badFragments);
@@ -371,6 +374,7 @@ public class LedgerChecker {
 
                 final EntryExistsCallback eecb = new EntryExistsCallback(lh.getLedgerMetadata().getWriteQuorumSize(),
                                               new GenericCallback<Boolean>() {
+                                                  @Override
                                                   public void operationComplete(int rc, Boolean result) {
                                                       if (result) {
                                                           fragments.add(lastLedgerFragment);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -52,6 +52,7 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
     static final Logger LOG = LoggerFactory.getLogger(LedgerHandleAdv.class);
 
     static class PendingOpsComparator implements Comparator<PendingAddOp>, Serializable {
+        @Override
         public int compare(PendingAddOp o1, PendingAddOp o2) {
             return Long.compare(o1.entryId, o2.entryId);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -100,6 +100,7 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
                                                             lh.getCurrentEnsemble(),
                                                             lh.ledgerKey,
                 new ReadLastConfirmedOp.LastConfirmedDataCallback() {
+                    @Override
                     public void readLastConfirmedDataComplete(int rc, RecoveryData data) {
                         if (rc == BKException.Code.OK) {
                             synchronized (lh) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -245,6 +245,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
     /**
      * Initiate the add operation.
      */
+    @Override
     public void safeRun() {
         hasRun = true;
         if (callbackTriggered) {
@@ -457,6 +458,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
 
     private final Handle<PendingAddOp> recyclerHandle;
     private static final Recycler<PendingAddOp> RECYCLER = new Recycler<PendingAddOp>() {
+        @Override
         protected PendingAddOp newObject(Recycler.Handle<PendingAddOp> handle) {
             return new PendingAddOp(handle);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -108,6 +108,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
             }
         }
 
+        @Override
         public void close() {
             entryImpl.close();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
@@ -93,6 +93,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
             }
         }
 
+        @Override
         public void close() {
             entryImpl.close();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedOp.java
@@ -95,6 +95,7 @@ class ReadLastConfirmedOp implements ReadEntryCallback {
         }
     }
 
+    @Override
     public synchronized void readEntryComplete(final int rc, final long ledgerId, final long entryId,
             final ByteBuf buffer, final Object ctx) {
         int bookieIndex = (Integer) ctx;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
@@ -79,6 +79,7 @@ public class RoundRobinDistributionSchedule implements DistributionSchedule {
 
         private final Handle<WriteSetImpl> recyclerHandle;
         private static final Recycler<WriteSetImpl> RECYCLER = new Recycler<WriteSetImpl>() {
+                    @Override
                     protected WriteSetImpl newObject(
                             Recycler.Handle<WriteSetImpl> handle) {
                         return new WriteSetImpl(handle);
@@ -269,6 +270,7 @@ public class RoundRobinDistributionSchedule implements DistributionSchedule {
 
         private final Handle<AckSetImpl> recyclerHandle;
         private static final Recycler<AckSetImpl> RECYCLER = new Recycler<AckSetImpl>() {
+            @Override
             protected AckSetImpl newObject(Recycler.Handle<AckSetImpl> handle) {
                 return new AckSetImpl(handle);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -542,6 +542,7 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements
             this.failedToResolveNetworkLocationCounter = failedToResolveNetworkLocationCounter;
         }
 
+        @Override
         public List<String> resolve(List<String> names) {
             if (names == null) {
                 return Collections.emptyList();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/WeightedRandomSelectionImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/WeightedRandomSelectionImpl.java
@@ -56,6 +56,7 @@ class WeightedRandomSelectionImpl<T> implements WeightedRandomSelection<T> {
         Long totalWeight = 0L, min = Long.MAX_VALUE;
         List<WeightedObject> values = new ArrayList<WeightedObject>(map.values());
         Collections.sort(values, new Comparator<WeightedObject>() {
+            @Override
             public int compare(WeightedObject o1, WeightedObject o2) {
                 long diff = o1.getWeight() - o2.getWeight();
                 if (diff < 0L) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LastConfirmedAndEntry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LastConfirmedAndEntry.java
@@ -50,6 +50,7 @@ public interface LastConfirmedAndEntry extends AutoCloseable {
     /**
      * {@inheritDoc}
      */
+    @Override
     void close();
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntry.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerEntry.java
@@ -98,6 +98,7 @@ public interface LedgerEntry extends AutoCloseable {
     /**
      * {@inheritDoc}
      */
+    @Override
     void close();
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
@@ -115,6 +115,7 @@ public interface LedgerUnderreplicationManager extends AutoCloseable {
     /**
      * Release all resources held by the ledger underreplication manager.
      */
+    @Override
     void close()
             throws ReplicationException.UnavailableException;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
@@ -586,6 +586,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
         while (true) {
             final CountDownLatch changedLatch = new CountDownLatch(1);
             Watcher w = new Watcher() {
+                @Override
                 public void process(WatchedEvent e) {
                     if (e.getType() == Watcher.Event.EventType.NodeChildrenChanged
                             || e.getType() == Watcher.Event.EventType.NodeDeleted
@@ -741,6 +742,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             LOG.debug("notifyLedgerReplicationEnabled()");
         }
         Watcher w = new Watcher() {
+            @Override
             public void process(WatchedEvent e) {
                 if (e.getType() == Watcher.Event.EventType.NodeDeleted) {
                     LOG.info("LedgerReplication is enabled externally through Zookeeper, "
@@ -857,6 +859,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
     public void notifyLostBookieRecoveryDelayChanged(GenericCallback<Void> cb) throws UnavailableException {
         LOG.debug("notifyLostBookieRecoveryDelayChanged()");
         Watcher w = new Watcher() {
+            @Override
             public void process(WatchedEvent e) {
                 if (e.getType() == Watcher.Event.EventType.NodeDataChanged) {
                     cb.operationComplete(0, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
@@ -59,10 +59,12 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
         this.conf = conf;
     }
 
+    @Override
     public Configuration getConf() {
         return conf;
     }
 
+    @Override
     public void setConf(Configuration conf) {
         this.conf = conf;
         validateConf();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopologyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopologyImpl.java
@@ -399,6 +399,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
      * @exception IllegalArgumentException if add a node to a leave
                                            or node to be added is not a leaf
      */
+    @Override
     public void add(Node node) {
         if (node == null) {
             return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/processor/RequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/processor/RequestProcessor.java
@@ -30,6 +30,7 @@ public interface RequestProcessor extends AutoCloseable {
     /**
      * Close the request processor.
      */
+    @Override
     void close();
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
@@ -166,6 +166,7 @@ class AuthHandler {
                 this.channel = channel;
             }
 
+            @Override
             public void operationComplete(int rc, AuthToken newam) {
                 if (rc != BKException.Code.OK) {
                     LOG.error("Error processing auth message, closing connection");
@@ -189,6 +190,7 @@ class AuthHandler {
                 this.pluginName = pluginName;
             }
 
+            @Override
             public void operationComplete(int rc, AuthToken newam) {
                 BookkeeperProtocol.Response.Builder builder = BookkeeperProtocol.Response.newBuilder()
                         .setHeader(req.getHeader());
@@ -387,6 +389,7 @@ class AuthHandler {
                 this.pluginName = pluginName;
             }
 
+            @Override
             public void operationComplete(int rc, AuthToken newam) {
                 if (rc != BKException.Code.OK) {
                     authenticationError(ctx, rc);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -432,6 +432,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
 
         private static final Recycler<ChannelReadyForAddEntryCallback> RECYCLER =
             new Recycler<ChannelReadyForAddEntryCallback>() {
+                    @Override
                     protected ChannelReadyForAddEntryCallback newObject(
                             Recycler.Handle<ChannelReadyForAddEntryCallback> recyclerHandle) {
                         return new ChannelReadyForAddEntryCallback(recyclerHandle);
@@ -479,16 +480,19 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         }, ledgerId, useV3Enforced);
     }
 
+    @Override
     public void readEntry(BookieSocketAddress addr, long ledgerId, long entryId,
                           ReadEntryCallback cb, Object ctx, int flags) {
         readEntry(addr, ledgerId, entryId, cb, ctx, flags, null);
     }
 
+    @Override
     public void readEntry(final BookieSocketAddress addr, final long ledgerId, final long entryId,
                           final ReadEntryCallback cb, final Object ctx, int flags, byte[] masterKey) {
         readEntry(addr, ledgerId, entryId, cb, ctx, flags, masterKey, false);
     }
 
+    @Override
     public void readEntry(final BookieSocketAddress addr, final long ledgerId, final long entryId,
                           final ReadEntryCallback cb, final Object ctx, int flags, byte[] masterKey,
                           final boolean allowFastFail) {
@@ -509,6 +513,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
     }
 
 
+    @Override
     public void readEntryWaitForLACUpdate(final BookieSocketAddress addr,
                                           final long ledgerId,
                                           final long entryId,
@@ -534,6 +539,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         }, ledgerId);
     }
 
+    @Override
     public void getBookieInfo(final BookieSocketAddress addr, final long requested, final GetBookieInfoCallback cb,
             final Object ctx) {
         final PerChannelBookieClientPool client = lookupClient(addr);
@@ -564,10 +570,12 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         }
     }
 
+    @Override
     public boolean isClosed() {
         return closed;
     }
 
+    @Override
     public void close() {
         closeLock.writeLock().lock();
         try {
@@ -624,6 +632,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         }
         WriteCallback cb = new WriteCallback() {
 
+            @Override
             public void writeComplete(int rc, long ledger, long entry, BookieSocketAddress addr, Object ctx) {
                 Counter counter = (Counter) ctx;
                 counter.dec();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -282,6 +282,7 @@ public interface BookieProtocol {
         }
 
         private static final Recycler<AddRequest> RECYCLER = new Recycler<AddRequest>() {
+            @Override
             protected AddRequest newObject(Handle<AddRequest> handle) {
                 return new AddRequest(handle);
             }
@@ -336,6 +337,7 @@ public interface BookieProtocol {
         }
 
         private static final Recycler<ParsedAddRequest> RECYCLER = new Recycler<ParsedAddRequest>() {
+            @Override
             protected ParsedAddRequest newObject(Handle<ParsedAddRequest> handle) {
                 return new ParsedAddRequest(handle);
             }
@@ -486,6 +488,7 @@ public interface BookieProtocol {
         }
 
         private static final Recycler<AddResponse> RECYCLER = new Recycler<AddResponse>() {
+            @Override
             protected AddResponse newObject(Handle<AddResponse> handle) {
                 return new AddResponse(handle);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -43,6 +43,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
 
     long startTimeNanos;
 
+    @Override
     protected void reset() {
         super.reset();
         startTimeNanos = -1L;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -495,6 +495,7 @@ public class Auditor implements AutoCloseable {
                 return;
             }
             executor.submit(safeRun(new Runnable() {
+                @Override
                 public void run() {
                     synchronized (Auditor.this) {
                         LOG.info("Shutting down Auditor's Executor");
@@ -513,6 +514,7 @@ public class Auditor implements AutoCloseable {
             return f;
         }
         return executor.submit(safeRun(new Runnable() {
+                @Override
                 @SuppressWarnings("unchecked")
                 public void run() {
                     try {
@@ -569,6 +571,7 @@ public class Auditor implements AutoCloseable {
                         if (auditTask == null) {
                             // if there is no scheduled audit, schedule one
                             auditTask = executor.schedule(safeRun(new Runnable() {
+                                @Override
                                 public void run() {
                                     startAudit(false);
                                     auditTask = null;
@@ -599,6 +602,7 @@ public class Auditor implements AutoCloseable {
         }
         return executor.submit(safeRun(new Runnable() {
             int lostBookieRecoveryDelay = -1;
+            @Override
             public void run() {
                 try {
                     waitIfLedgerReplicationDisabled();
@@ -628,6 +632,7 @@ public class Auditor implements AutoCloseable {
                         LOG.info("lostBookieRecoveryDelay has been set to {}, so rescheduling AuditTask accordingly",
                                 lostBookieRecoveryDelay);
                         auditTask = executor.schedule(safeRun(new Runnable() {
+                            @Override
                             public void run() {
                                 startAudit(false);
                                 auditTask = null;
@@ -730,6 +735,7 @@ public class Auditor implements AutoCloseable {
                     checkAllLedgersLastExecutedCTime, durationSinceLastExecutionInSecs, initialDelay, interval);
 
             executor.scheduleAtFixedRate(safeRun(new Runnable() {
+                @Override
                 public void run() {
                     try {
                         if (!ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {
@@ -797,6 +803,7 @@ public class Auditor implements AutoCloseable {
                     placementPolicyCheckLastExecutedCTime, durationSinceLastExecutionInSecs, initialDelay, interval);
 
             executor.scheduleAtFixedRate(safeRun(new Runnable() {
+                @Override
                 public void run() {
                     try {
                         Stopwatch stopwatch = Stopwatch.createStarted();
@@ -918,6 +925,7 @@ public class Auditor implements AutoCloseable {
                 replicasCheckLastExecutedCTime, durationSinceLastExecutionInSecs, initialDelay, interval);
 
         executor.scheduleAtFixedRate(safeRun(new Runnable() {
+            @Override
             public void run() {
                 try {
                     Stopwatch stopwatch = Stopwatch.createStarted();
@@ -1141,6 +1149,7 @@ public class Auditor implements AutoCloseable {
             this.callback = callback;
         }
 
+        @Override
         public void operationComplete(int rc, Set<LedgerFragment> fragments) {
             if (rc == BKException.Code.OK) {
                 Set<BookieSocketAddress> bookies = Sets.newHashSet();
@@ -1958,6 +1967,7 @@ public class Auditor implements AutoCloseable {
     }
 
     private final Runnable bookieCheck = new Runnable() {
+            @Override
             public void run() {
                 if (auditTask == null) {
                     startAudit(true);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
@@ -252,6 +252,7 @@ public class AuditorElector {
      */
     private void submitShutdownTask() {
         executor.submit(new Runnable() {
+                @Override
                 public void run() {
                     if (!running.compareAndSet(true, false)) {
                         return;
@@ -281,6 +282,7 @@ public class AuditorElector {
     Future<?> submitElectionTask() {
 
         Runnable r = new Runnable() {
+                @Override
                 public void run() {
                     if (!running.get()) {
                         return;
@@ -425,6 +427,7 @@ public class AuditorElector {
          * Return -1 if the first vote is less than second. Return 1 if the
          * first vote is greater than second. Return 0 if the votes are equal.
          */
+        @Override
         public int compare(String vote1, String vote2) {
             long voteSeqId1 = getVoteSequenceId(vote1);
             long voteSeqId2 = getVoteSequenceId(vote2);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/TLSContextFactory.java
@@ -118,6 +118,7 @@ public class TLSContextFactory implements SecurityHandlerFactory {
         return ks;
     }
 
+    @Override
     public String getHandlerName() {
         return TLSCONTEXT_HANDLER_NAME;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DaemonThreadFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DaemonThreadFactory.java
@@ -33,6 +33,7 @@ public class DaemonThreadFactory implements ThreadFactory {
         assert priority >= Thread.MIN_PRIORITY && priority <= Thread.MAX_PRIORITY;
         this.priority = priority;
     }
+    @Override
     public Thread newThread(Runnable r) {
         Thread thread = defaultThreadFactory.newThread(r);
         thread.setDaemon(true);

--- a/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/CodahaleOpStatsLogger.java
+++ b/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/CodahaleOpStatsLogger.java
@@ -32,24 +32,29 @@ class CodahaleOpStatsLogger implements OpStatsLogger {
     }
 
     // OpStatsLogger functions
+    @Override
     public void registerFailedEvent(long eventLatency, TimeUnit unit) {
         fail.update(eventLatency, unit);
     }
 
+    @Override
     public void registerSuccessfulEvent(long eventLatency, TimeUnit unit) {
         success.update(eventLatency, unit);
     }
 
+    @Override
     public void registerSuccessfulValue(long value) {
         // Values are inserted as millis, which is the unit they will be presented, to maintain 1:1 scale
         success.update(value, TimeUnit.MILLISECONDS);
     }
 
+    @Override
     public void registerFailedValue(long value) {
         // Values are inserted as millis, which is the unit they will be presented, to maintain 1:1 scale
         fail.update(value, TimeUnit.MILLISECONDS);
     }
 
+    @Override
     public synchronized void clear() {
         // can't clear a timer
     }
@@ -57,6 +62,7 @@ class CodahaleOpStatsLogger implements OpStatsLogger {
     /**
      * This function should go away soon (hopefully).
      */
+    @Override
     public synchronized OpStatsData toOpStatsData() {
         long numFailed = fail.getCount();
         long numSuccess = success.getCount();

--- a/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleOpStatsLogger.java
+++ b/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleOpStatsLogger.java
@@ -33,24 +33,29 @@ class CodahaleOpStatsLogger implements OpStatsLogger {
     }
 
     // OpStatsLogger functions
+    @Override
     public void registerFailedEvent(long eventLatency, TimeUnit unit) {
         fail.update(eventLatency, unit);
     }
 
+    @Override
     public void registerSuccessfulEvent(long eventLatency, TimeUnit unit) {
         success.update(eventLatency, unit);
     }
 
+    @Override
     public void registerSuccessfulValue(long value) {
         // Values are inserted as millis, which is the unit they will be presented, to maintain 1:1 scale
         success.update(value, TimeUnit.MILLISECONDS);
     }
 
+    @Override
     public void registerFailedValue(long value) {
         // Values are inserted as millis, which is the unit they will be presented, to maintain 1:1 scale
         fail.update(value, TimeUnit.MILLISECONDS);
     }
 
+    @Override
     public synchronized void clear() {
         // can't clear a timer
     }
@@ -58,6 +63,7 @@ class CodahaleOpStatsLogger implements OpStatsLogger {
     /**
      * This function should go away soon (hopefully).
      */
+    @Override
     public synchronized OpStatsData toOpStatsData() {
         long numFailed = fail.getCount();
         long numSuccess = success.getCount();

--- a/circe-checksum/src/main/java/com/scurrilous/circe/impl/IntStatefulLongHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/impl/IntStatefulLongHash.java
@@ -39,70 +39,87 @@ public final class IntStatefulLongHash implements StatefulLongHash {
         this.intHash = intHash;
     }
 
+    @Override
     public StatelessLongHash asStateless() {
         return new IntStatelessLongHash(intHash.asStateless());
     }
 
+    @Override
     public String algorithm() {
         return intHash.algorithm();
     }
 
+    @Override
     public int length() {
         return intHash.length();
     }
 
+    @Override
     public StatefulHash createNew() {
         return intHash.createNew();
     }
 
+    @Override
     public boolean supportsUnsafe() {
         return intHash.supportsUnsafe();
     }
 
+    @Override
     public boolean supportsIncremental() {
         return intHash.supportsIncremental();
     }
 
+    @Override
     public void reset() {
         intHash.reset();
     }
 
+    @Override
     public void update(byte[] input) {
         intHash.update(input);
     }
 
+    @Override
     public void update(byte[] input, int index, int length) {
         intHash.update(input, index, length);
     }
 
+    @Override
     public void update(ByteBuffer input) {
         intHash.update(input);
     }
 
+    @Override
     public void update(long address, long length) {
         intHash.update(address, length);
     }
 
+    @Override
     public byte[] getBytes() {
         return intHash.getBytes();
     }
 
+    @Override
     public int getBytes(byte[] output, int index, int maxLength) {
         return intHash.getBytes(output, index, maxLength);
     }
 
+    @Override
     public byte getByte() {
         return intHash.getByte();
     }
 
+    @Override
     public short getShort() {
         return intHash.getShort();
     }
 
+    @Override
     public int getInt() {
         return intHash.getInt();
     }
 
+    @Override
     public long getLong() {
         return intHash.getLong();
     }

--- a/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/impl/internal/api/LocationClient.java
+++ b/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/impl/internal/api/LocationClient.java
@@ -37,6 +37,7 @@ public interface LocationClient extends AutoCloseable {
     CompletableFuture<List<OneStorageContainerEndpointResponse>> locateStorageContainers(
         List<Revisioned<Long>> storageContainerIds);
 
+    @Override
     void close();
 
 }

--- a/stream/common/src/main/java/org/apache/bookkeeper/common/util/AutoAsyncCloseable.java
+++ b/stream/common/src/main/java/org/apache/bookkeeper/common/util/AutoAsyncCloseable.java
@@ -33,6 +33,7 @@ public interface AutoAsyncCloseable extends AsyncCloseable, AutoCloseable {
      */
     boolean isClosed();
 
+    @Override
     default void close() {
         try {
             FutureUtils.result(closeAsync());

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/api/StateStore.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/api/StateStore.java
@@ -69,6 +69,7 @@ public interface StateStore extends AutoCloseable {
     /**
      * Close the state store.
      */
+    @Override
     void close();
 
 }

--- a/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/api/sc/StorageContainer.java
+++ b/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/api/sc/StorageContainer.java
@@ -59,6 +59,7 @@ public interface StorageContainer extends AutoCloseable {
     /**
      * Close a storage container.
      */
+    @Override
     void close();
 
 }

--- a/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/api/sc/StorageContainerRegistry.java
+++ b/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/api/sc/StorageContainerRegistry.java
@@ -74,5 +74,6 @@ public interface StorageContainerRegistry extends AutoCloseable {
     /**
      * Close the registry.
      */
+    @Override
     void close();
 }

--- a/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/api/sc/StorageContainerServiceFactory.java
+++ b/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/api/sc/StorageContainerServiceFactory.java
@@ -34,6 +34,7 @@ public interface StorageContainerServiceFactory extends AutoCloseable {
     /**
      * {@inheritDoc}
      */
+    @Override
     void close();
 
 }

--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/service/RangeStoreServiceImpl.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/service/RangeStoreServiceImpl.java
@@ -167,6 +167,7 @@ class RangeStoreServiceImpl implements RangeStoreService, AutoCloseable {
         });
     }
 
+    @Override
     public CompletableFuture<Void> start() {
         List<CompletableFuture<Void>> futures = Lists.newArrayList(
             startRootRangeStore(),
@@ -175,6 +176,7 @@ class RangeStoreServiceImpl implements RangeStoreService, AutoCloseable {
         return FutureUtils.collect(futures).thenApply(ignored -> null);
     }
 
+    @Override
     public CompletableFuture<Void> stop() {
         return storeFactory.closeStores(scId);
     }

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/MavenClassLoader.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/MavenClassLoader.java
@@ -183,6 +183,7 @@ public class MavenClassLoader implements AutoCloseable {
         throw new ClassNotFoundException("No such digest type " + type);
     }
 
+    @Override
     public void close() throws Exception {
         classloader.close();
     }


### PR DESCRIPTION
### Motivation

**Code clean**

- An overridden method should be marked with @Override annotation, once the method signature in the abstract class is changed, the implementation class will report a compile-time error immediately.

- Exception class names must be ended with Exception

- The negation operator is not easy to be quickly understood

### Changes

- Fix missing `@Override` annotation
- `NoIndexForLedger` to `NoIndexForLedgerException` 
- `!(n.doubleValue() > max.doubleValue())` to `(n.doubleValue() <= max.doubleValue())`

