### PR TITLE
[CI] Using master action code for checking rerun commands

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Bot actions
-        uses: zymap/bot@v1.0.0
+        uses: zymap/bot@master
         env:
           GITHUB_TOKEN: ${{ secrets.BKBOT_TOKEN }}
         with:

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Bot actions
-        uses: zymap/bot@master
+        uses: zymap/bot@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.BKBOT_TOKEN }}
         with:


### PR DESCRIPTION
 The rerun checks CI can not use ref to get all failure test actions. So I change to use sha of the commits to get all failure test actions to rerun. https://github.com/zymap/bot/pull/3/files