### PR TITLE
[CLEAN] remove duplicate property key in log4j.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ It is suitable for being used in following scenarios:
 
 ## Get Started
 
-* *Concepts*: Start with the [basic concepts](http://bookkeeper.apache.org/docs/master/bookkeeperOverview.html) of Apache BookKeeper.
+* *Concepts*: Start with the [basic concepts](https://bookkeeper.apache.org/docs/master/bookkeeperOverview.html) of Apache BookKeeper.
   This will help you to fully understand the other parts of the documentation.
-* [Getting Started](http://bookkeeper.apache.org/docs/master/bookkeeperStarted.html) to setup BookKeeper to write logs.
+* [Getting Started](https://bookkeeper.apache.org/docs/master/bookkeeperStarted.html) to setup BookKeeper to write logs.
 
 ## Documentation
 
@@ -30,17 +30,17 @@ It is suitable for being used in following scenarios:
 * [Tutorial](https://bookkeeper.apache.org/archives/docs/master/bookkeeperTutorial.html)
 * [Java API](https://bookkeeper.apache.org/archives/docs/master/apidocs/)
 
-You can also read [Turning Ledgers into Logs](http://bookkeeper.apache.org/docs/master/bookkeeperLedgers2Logs.html) to learn how to turn **ledgers** into continuous **log streams**.
+You can also read [Turning Ledgers into Logs](https://bookkeeper.apache.org/docs/master/bookkeeperLedgers2Logs.html) to learn how to turn **ledgers** into continuous **log streams**.
 If you are looking for a high level **log stream** API, you can checkout [DistributedLog](http://distributedlog.io).
 
 ### Administrators
 
-* [Admin Guide](http://bookkeeper.apache.org/docs/master/bookkeeperConfig.html)
-* [Configuration Parameters](http://bookkeeper.apache.org/docs/master/bookieConfigParams.html)
+* [Admin Guide](https://bookkeeper.apache.org/docs/master/bookkeeperConfig.html)
+* [Configuration Parameters](https://bookkeeper.apache.org/docs/master/bookieConfigParams.html)
 
 ### Contributors
 
-* [BookKeeper Internals](http://bookkeeper.apache.org/docs/master/bookkeeperInternals.html)
+* [BookKeeper Internals](https://bookkeeper.apache.org/docs/master/bookkeeperInternals.html)
 
 ## Get In Touch
 

--- a/bookkeeper-benchmark/conf/log4j.properties
+++ b/bookkeeper-benchmark/conf/log4j.properties
@@ -57,10 +57,6 @@ log4j.appender.ROLLINGFILE.MaxFileSize=10MB
 # uncomment the next line to limit number of backup files
 #log4j.appender.ROLLINGFILE.MaxBackupIndex=10
 
-log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
-log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n
-
-
 #
 # Add TRACEFILE to rootLogger to get log file output
 #    Log DEBUG level and above messages to a log file


### PR DESCRIPTION
### Motivation

1. Fix duplicate key in log4j.properties
2. `http` to `https` in `README`

### Changes

![image](https://user-images.githubusercontent.com/20113411/82162451-369ef880-98d7-11ea-9217-777721bba545.png)

![image](https://user-images.githubusercontent.com/20113411/82162816-d2c9ff00-98d9-11ea-967e-53646d351753.png)
