### PR TITLE
[bookkeeper-tool] Fix update rate-limiting for update-ledger command

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1492,6 +1492,7 @@ public class BookieShell implements Tool {
             super(CMD_UPDATELEDGER);
             opts.addOption("b", "bookieId", true, "Bookie Id");
             opts.addOption("s", "updatespersec", true, "Number of ledgers updating per second (default: 5 per sec)");
+            opts.addOption("r", "maxOutstandingReads", true, "Max outstanding reads (default: 5 * updatespersec)");
             opts.addOption("l", "limit", true, "Maximum number of ledgers to update (default: no limit)");
             opts.addOption("v", "verbose", true, "Print status of the ledger updation (default: false)");
             opts.addOption("p", "printprogress", true,
@@ -1510,8 +1511,8 @@ public class BookieShell implements Tool {
 
         @Override
         String getUsage() {
-            return "updateledgers -bookieId <hostname|ip> [-updatespersec N] [-limit N] [-verbose true/false] "
-                    + "[-printprogress N]";
+            return "updateledgers -bookieId <hostname|ip> [-updatespersec N] [-maxOutstandingReads N] [-limit N] "
+                    + "[-verbose true/false] [-printprogress N]";
         }
 
         @Override
@@ -1532,6 +1533,7 @@ public class BookieShell implements Tool {
             }
             boolean useHostName = getOptionalValue(bookieId, "hostname");
             final int rate = getOptionIntValue(cmdLine, "updatespersec", 5);
+            final int maxOutstandingReads = getOptionIntValue(cmdLine, "maxOutstandingReads", (rate * 5));
             final int limit = getOptionIntValue(cmdLine, "limit", Integer.MIN_VALUE);
             final boolean verbose = getOptionBooleanValue(cmdLine, "verbose", false);
             final long printprogress;
@@ -1548,6 +1550,7 @@ public class BookieShell implements Tool {
             flags.printProgress(printprogress);
             flags.limit(limit);
             flags.updatePerSec(rate);
+            flags.maxOutstandingReads(maxOutstandingReads);
             flags.verbose(verbose);
 
             boolean result = cmd.apply(bkConf, flags);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/FlipBookieIdCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/FlipBookieIdCommand.java
@@ -77,6 +77,10 @@ public class FlipBookieIdCommand extends BookieCommand<FlipBookieIdCommand.FlipB
             description = "Number of ledgers updating per second (default: 5 per sec)")
         private int updatePerSec = 5;
 
+        @Parameter(names = { "-r",
+                "--maxOutstandingReads" }, description = "Max outstanding reads (default: 5 * updatespersec)")
+        private int maxOutstandingReads = updatePerSec * 5;
+
         @Parameter(names = {"-l", "--limit"},
             description = "Maximum number of ledgers of ledgers to update (default: no limit)")
         private int limit = Integer.MIN_VALUE;
@@ -112,6 +116,12 @@ public class FlipBookieIdCommand extends BookieCommand<FlipBookieIdCommand.FlipB
         final int rate = flags.updatePerSec;
         if (rate <= 0) {
             LOG.error("Invalid updatespersec {}, should be > 0", rate);
+            return false;
+        }
+
+        final int maxOutstandingReads = flags.maxOutstandingReads;
+        if (maxOutstandingReads <= 0) {
+            LOG.error("Invalid maxOutstandingReads {}, should be > 0", maxOutstandingReads);
             return false;
         }
 
@@ -154,7 +164,8 @@ public class FlipBookieIdCommand extends BookieCommand<FlipBookieIdCommand.FlipB
         };
 
         try {
-            updateLedgerOp.updateBookieIdInLedgers(oldBookieId, newBookieId, rate, limit, progressable);
+            updateLedgerOp.updateBookieIdInLedgers(oldBookieId, newBookieId, rate, maxOutstandingReads, limit,
+                    progressable);
         } catch (IOException e) {
             LOG.error("Failed to update ledger metadata", e);
             return false;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
@@ -108,7 +108,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
             BookieSocketAddress toBookieAddr = new BookieSocketAddress(curBookieId.getHostName() + ":"
                     + curBookieAddr.getPort());
             UpdateLedgerOp updateLedgerOp = new UpdateLedgerOp(bk, bkadmin);
-            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 5, Integer.MIN_VALUE, progressable);
+            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 5, 25, Integer.MIN_VALUE, progressable);
 
             for (LedgerHandle lh : ledgers) {
                 lh.close();
@@ -146,22 +146,22 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
             BookieSocketAddress toBookieAddr = new BookieSocketAddress(toBookieId.getHostName() + ":"
                     + curBookieAddr.getPort());
             UpdateLedgerOp updateLedgerOp = new UpdateLedgerOp(bk, bkadmin);
-            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 7, 4, progressable);
+            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 7, 35, 4, progressable);
             int updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
             assertEquals("Failed to update the ledger metadata to use bookie host name", 4, updatedLedgersCount);
 
             // next execution
-            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 2, 10, progressable);
+            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 2, 10, 10, progressable);
             updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
             assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
 
             // no ledgers
-            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 3, 20, progressable);
+            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 3, 15, 20, progressable);
             updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
             assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
 
             // no ledgers
-            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 3, Integer.MIN_VALUE, progressable);
+            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 3, 15, Integer.MIN_VALUE, progressable);
             updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, toBookieAddr);
             assertEquals("Failed to update the ledger metadata to use bookie host name", 10, updatedLedgersCount);
         }
@@ -208,7 +208,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
             BookieSocketAddress toBookieAddr = new BookieSocketAddress(toBookieId.getHostName() + ":"
                     + curBookieAddr.getPort());
             UpdateLedgerOp updateLedgerOp = new UpdateLedgerOp(bk, bkadmin);
-            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 5, 100, progressable);
+            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 5, 25, 100, progressable);
 
             bookieServer.shutdown();
 
@@ -278,7 +278,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
             BookieSocketAddress curBookieAddr = ensemble.get(0);
             BookieSocketAddress toBookieAddr = new BookieSocketAddress("localhost:" + curBookieAddr.getPort());
             UpdateLedgerOp updateLedgerOp = new UpdateLedgerOp(bk, bkadmin);
-            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 5, 100, progressable);
+            updateLedgerOp.updateBookieIdInLedgers(curBookieAddr, toBookieAddr, 5, 25, 100, progressable);
 
             if (!latch.await(120, TimeUnit.SECONDS)) {
                 throw new Exception("Entries took too long to add");

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/FlipBookieIdCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/FlipBookieIdCommandTest.java
@@ -101,8 +101,8 @@ public class FlipBookieIdCommandTest extends BookieCommandTestBase {
         verifyNew(UpdateLedgerOp.class, times(1)).withArguments(eq(bookKeeper), eq(bookKeeperAdmin));
         verifyNew(ServerConfiguration.class, times(1)).withArguments(eq(conf));
         verify(serverConfiguration, times(1)).setUseHostNameAsBookieID(anyBoolean());
-        verify(updateLedgerOp, times(1))
-            .updateBookieIdInLedgers(eq(bookieSocketAddress), eq(bookieSocketAddress), anyInt(), anyInt(), any());
+        verify(updateLedgerOp, times(1)).updateBookieIdInLedgers(eq(bookieSocketAddress), eq(bookieSocketAddress),
+                anyInt(), anyInt(), anyInt(), any());
     }
 
 }


### PR DESCRIPTION
### Motivation
Right now, `UpdateLedgerCmd` provides option `updatespersec` to throttle number of writes on zk. However, it throttles number of reads instead writes. Because of that it takes long time to complete this command as it slows down the read instead applying throttling while writing to zk.

### Modification
- Apply throttling while updating zk.
- If writes are being throttled then we also want to avoid accumulating reads so, added `maxOutstandingReads` option to manage max concurrent reads.

**Note:** We also need this change for #2321 .. so, I will rebase #2321 once this PR is merged.