### PR TITLE
[BUG] Fix flaky testLedgerOpenAfterBKCrashed

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieFailureTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieFailureTest.java
@@ -320,8 +320,20 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
 
         // try to open ledger with recovery
         LedgerHandle afterlh = bkc.openLedger(beforelh.getId(), digestType, "".getBytes());
-
         assertEquals(beforelh.getLastAddPushed(), afterlh.getLastAddConfirmed());
+
+        // try to open ledger no recovery
+        // bookies: 4, ensSize: 3, ackQuorumSize: 2
+        LedgerHandle beforelhWithNoRecovery = bkc.createLedger(numBookies - 1 , 2, digestType, "".getBytes());
+        for (int i = 0; i < numEntries; i++) {
+            beforelhWithNoRecovery.addEntry(tmp.getBytes());
+        }
+
+        // shutdown first bookie server
+        killBookie(0);
+
+        // try to open ledger no recovery, should be able to open ledger
+        bkc.openLedger(beforelhWithNoRecovery.getId(), digestType, "".getBytes());
     }
 
     /**


### PR DESCRIPTION
### Motivation

`BookieFailureTest#testLedgerOpenAfterBKCrashed` is a flaky test case, it cause some pr failed.

```
org.apache.bookkeeper.client.BKException$BKLedgerRecoveryException: Error while recovering ledger
  at org.apache.bookkeeper.client.SyncCallbackUtils.finish(SyncCallbackUtils.java:83)
  at org.apache.bookkeeper.client.SyncCallbackUtils$SyncOpenCallback.openComplete(SyncCallbackUtils.java:157)
  at org.apache.bookkeeper.client.LedgerOpenOp.openComplete(LedgerOpenOp.java:232)
  at org.apache.bookkeeper.client.LedgerOpenOp$1.safeOperationComplete(LedgerOpenOp.java:201)
  at org.apache.bookkeeper.client.LedgerOpenOp$1.safeOperationComplete(LedgerOpenOp.java:193)
  at org.apache.bookkeeper.util.OrderedGenericCallback.operationComplete(OrderedGenericCallback.java:62)
  at org.apache.bookkeeper.proto.BookkeeperInternalCallbacks$TimedGenericCallback.operationComplete(BookkeeperInternalCallbacks.java:189)
  at org.apache.bookkeeper.client.ReadOnlyLedgerHandle.lambda$recover$5(ReadOnlyLedgerHandle.java:295)
  at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760)
  at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736)
  at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474)
  at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977)
  at org.apache.bookkeeper.client.LedgerRecoveryOp.submitCallback(LedgerRecoveryOp.java:136)
  at org.apache.bookkeeper.client.LedgerRecoveryOp.onEntryComplete(LedgerRecoveryOp.java:202)
  at org.apache.bookkeeper.client.ListenerBasedPendingReadOp.submitCallback(ListenerBasedPendingReadOp.java:67)
  at org.apache.bookkeeper.client.PendingReadOp$LedgerEntryRequest.fail(PendingReadOp.java:170)
  at org.apache.bookkeeper.client.PendingReadOp$SequenceReadRequest.sendNextRead(PendingReadOp.java:392)
  at org.apache.bookkeeper.client.PendingReadOp$SequenceReadRequest.logErrorAndReattemptRead(PendingReadOp.java:435)
  at org.apache.bookkeeper.client.PendingReadOp.readEntryComplete(PendingReadOp.java:581)
  at org.apache.bookkeeper.proto.BookieClientImpl$2.safeRun(BookieClientImpl.java:369)
  at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
  at java.lang.Thread.run(Thread.java:748)
```

![image](https://user-images.githubusercontent.com/20113411/82434983-3add3880-9ac6-11ea-96a3-24fbd71d16d4.png)

### Changes

Test case should cover following situation, which shutdown any one of bookies, and try to open ledger with no bookie recovery. 
```
Bookies: 4
ensSize: 3
writeQuorumSize: 2
ackQuorumSize: 2
```

