### PR TITLE
[BUG] Fix wrong jdk version on install doc page

### DIFF
--- a/site/bps/BP-34-cluster-metadata-checker.md
+++ b/site/bps/BP-34-cluster-metadata-checker.md
@@ -1,5 +1,5 @@
 ---
-title: "BP-34: Cluster Metadata Checker“
+title: "BP-34: Cluster Metadata Checker"
 issue: https://github.com/apache/bookkeeper/issues/1602
 state: Accepted
 release: N/A

--- a/site/docs/latest/getting-started/installation.md
+++ b/site/docs/latest/getting-started/installation.md
@@ -11,7 +11,7 @@ You can install BookKeeper either by [downloading](#download) a [GZipped](http:/
 ## Requirements
 
 * [Unix environment](http://www.opengroup.org/unix)
-* [Java Development Kit 1.6](http://www.oracle.com/technetwork/java/javase/downloads/index.html) or later
+* [Java Development Kit 1.8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) or later
 * [Maven 3.0](https://maven.apache.org/install.html) or later
 
 ## Download


### PR DESCRIPTION
### Motivation

We have adopted `lamada expression` and `stream api` in code base, it needs jdk1.8 at least.

e.g org.apache.bookkeeper.meta.zk.ZKMetadataClientDriver
```
@Override
public void setSessionStateListener(SessionStateListener sessionStateListener) {
    zk.register((event) -> {
        // Check for expired connection.
        if (event.getType().equals(EventType.None) && event.getState().equals(KeeperState.Expired)) {
            sessionStateListener.onSessionExpired();
        }
    });
}
```

![image](https://user-images.githubusercontent.com/20113411/82619119-a4b12b80-9c07-11ea-92e5-a1e3f5f9ff6b.png)

### Changes

Update `Java Development Kit 1.6` to `Java Development Kit 1.8`
