### PR TITLE
 [CLEAN] Replace com.google.common.base.Optional with java.util.Optional

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
@@ -20,8 +20,7 @@
  */
 package org.apache.bookkeeper.client;
 
-import com.google.common.base.Optional;
-
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -92,7 +91,7 @@ class ClientInternalConf {
                                         conf.getMaxSpeculativeReadTimeout(),
                                         conf.getSpeculativeReadTimeoutBackoffMultiplier()));
         } else {
-            this.readSpeculativeRequestPolicy = Optional.<SpeculativeRequestExecutionPolicy>absent();
+            this.readSpeculativeRequestPolicy = Optional.<SpeculativeRequestExecutionPolicy>empty();
         }
         if (conf.getFirstSpeculativeReadLACTimeout() > 0) {
             this.readLACSpeculativeRequestPolicy =
@@ -101,7 +100,7 @@ class ClientInternalConf {
                         conf.getMaxSpeculativeReadLACTimeout(),
                         conf.getSpeculativeReadLACTimeoutBackoffMultiplier()));
         } else {
-            this.readLACSpeculativeRequestPolicy = Optional.<SpeculativeRequestExecutionPolicy>absent();
+            this.readLACSpeculativeRequestPolicy = Optional.<SpeculativeRequestExecutionPolicy>empty();
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3.java
@@ -17,12 +17,12 @@
  */
 package org.apache.bookkeeper.proto;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Stopwatch;
 import io.netty.channel.Channel;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -44,7 +44,7 @@ class LongPollReadEntryProcessorV3 extends ReadEntryProcessorV3 implements Watch
     private static final Logger logger = LoggerFactory.getLogger(LongPollReadEntryProcessorV3.class);
 
     private final Long previousLAC;
-    private Optional<Long> lastAddConfirmedUpdateTime = Optional.absent();
+    private Optional<Long> lastAddConfirmedUpdateTime = Optional.empty();
 
     // long poll execution state
     private final ExecutorService longPollThreadPool;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLastConfirmedAndEntryContext.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLastConfirmedAndEntryContext.java
@@ -17,7 +17,7 @@
  */
 package org.apache.bookkeeper.proto;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallbackCtx;
@@ -30,7 +30,7 @@ public class ReadLastConfirmedAndEntryContext implements ReadEntryCallbackCtx {
     final int bookieIndex;
     final BookieSocketAddress bookie;
     long lac = LedgerHandle.INVALID_ENTRY_ID;
-    Optional<Long> lacUpdateTimestamp = Optional.absent();
+    Optional<Long> lacUpdateTimestamp = Optional.empty();
 
     public ReadLastConfirmedAndEntryContext(int bookieIndex, BookieSocketAddress bookie) {
         this.bookieIndex = bookieIndex;

--- a/site/docs/latest/api/distributedlog-api.md
+++ b/site/docs/latest/api/distributedlog-api.md
@@ -222,7 +222,7 @@ logConf.setRetentionPeriodHours(12);
 DistributedLogManager logManager = namespace.openLog(
         "test-log",
         Optional.of(logConf),
-        Optional.absent()
+        Optional.empty()
 );
 ```
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogReader.java
@@ -18,12 +18,12 @@
 package org.apache.distributedlog;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledFuture;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKDistributedLogManager.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKDistributedLogManager.java
@@ -22,11 +22,11 @@ import static org.apache.distributedlog.namespace.NamespaceDriver.Role.READER;
 import static org.apache.distributedlog.namespace.NamespaceDriver.Role.WRITER;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -291,7 +291,7 @@ class BKDistributedLogManager implements DistributedLogManager {
     // Create Read Handler
 
     synchronized BKLogReadHandler createReadHandler() {
-        Optional<String> subscriberId = Optional.absent();
+        Optional<String> subscriberId = Optional.empty();
         return createReadHandler(subscriberId, false);
     }
 
@@ -634,7 +634,7 @@ class BKDistributedLogManager implements DistributedLogManager {
 
     @Override
     public LogReader openLogReader(DLSN fromDLSN) throws IOException {
-        return getInputStreamInternal(fromDLSN, Optional.<Long>absent());
+        return getInputStreamInternal(fromDLSN, Optional.<Long>empty());
     }
 
     @Override
@@ -704,7 +704,7 @@ class BKDistributedLogManager implements DistributedLogManager {
 
     @Override
     public CompletableFuture<AsyncLogReader> openAsyncLogReader(DLSN fromDLSN) {
-        Optional<String> subscriberId = Optional.absent();
+        Optional<String> subscriberId = Optional.empty();
         AsyncLogReader reader = new BKAsyncLogReader(
                 this,
                 scheduler,
@@ -722,7 +722,7 @@ class BKDistributedLogManager implements DistributedLogManager {
      */
     @Override
     public CompletableFuture<AsyncLogReader> getAsyncLogReaderWithLock(final DLSN fromDLSN) {
-        Optional<String> subscriberId = Optional.absent();
+        Optional<String> subscriberId = Optional.empty();
         return getAsyncLogReaderWithLock(Optional.of(fromDLSN), subscriberId);
     }
 
@@ -733,7 +733,7 @@ class BKDistributedLogManager implements DistributedLogManager {
 
     @Override
     public CompletableFuture<AsyncLogReader> getAsyncLogReaderWithLock(String subscriberId) {
-        Optional<DLSN> fromDLSN = Optional.absent();
+        Optional<DLSN> fromDLSN = Optional.empty();
         return getAsyncLogReaderWithLock(fromDLSN, Optional.of(subscriberId));
     }
 
@@ -1068,7 +1068,7 @@ class BKDistributedLogManager implements DistributedLogManager {
         CompletableFuture<Void> closeResult = Utils.closeSequence(null, true,
                 readHandlerToClose,
                 pendingReaders,
-                resourcesCloseable.or(AsyncCloseable.NULL));
+                resourcesCloseable.orElse(AsyncCloseable.NULL));
         FutureUtils.proxyTo(closeResult, closeFuture);
         return closeFuture;
     }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKDistributedLogNamespace.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKDistributedLogNamespace.java
@@ -154,7 +154,7 @@ public class BKDistributedLogNamespace implements Namespace {
             throws InvalidStreamNameException, LogNotFoundException, IOException {
         checkState();
         logName = validateAndNormalizeName(logName);
-        com.google.common.base.Optional<URI> uri = Utils.ioResult(driver.getLogMetadataStore().getLogLocation(logName));
+        Optional<URI> uri = Utils.ioResult(driver.getLogMetadataStore().getLogLocation(logName));
         if (!uri.isPresent()) {
             throw new LogNotFoundException("Log " + logName + " isn't found.");
         }
@@ -183,7 +183,7 @@ public class BKDistributedLogNamespace implements Namespace {
             throws InvalidStreamNameException, IOException {
         checkState();
         logName = validateAndNormalizeName(logName);
-        com.google.common.base.Optional<URI> uri = Utils.ioResult(driver.getLogMetadataStore().getLogLocation(logName));
+        Optional<URI> uri = Utils.ioResult(driver.getLogMetadataStore().getLogLocation(logName));
         if (!uri.isPresent()) {
             throw new LogNotFoundException("Log " + logName + " isn't found.");
         }
@@ -220,7 +220,7 @@ public class BKDistributedLogNamespace implements Namespace {
     public boolean logExists(String logName)
         throws IOException, IllegalArgumentException {
         checkState();
-        com.google.common.base.Optional<URI> uri = Utils.ioResult(driver.getLogMetadataStore().getLogLocation(logName));
+        Optional<URI> uri = Utils.ioResult(driver.getLogMetadataStore().getLogLocation(logName));
         if (uri.isPresent()) {
             try {
                 Utils.ioResult(driver.getLogStreamMetadataStore(WRITER)
@@ -309,8 +309,7 @@ public class BKDistributedLogNamespace implements Namespace {
                 failureInjector,                    /* Failure Injector */
                 statsLogger,                        /* Stats Logger */
                 perLogStatsLogger,                  /* Per Log Stats Logger */
-                com.google.common.base.Optional.absent()
-                                                    /* shared resources, we don't need to close any resources in dlm */
+                Optional.empty()                    /* shared resources, we don't need to close any resources in dlm */
         );
     }
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogReadHandler.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogReadHandler.java
@@ -18,11 +18,11 @@
 package org.apache.distributedlog;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKSyncLogReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKSyncLogReader.java
@@ -18,11 +18,11 @@
 package org.apache.distributedlog;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.base.Ticker;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -70,7 +70,7 @@ class BKSyncLogReader implements LogReader, AsyncNotification {
                     StatsLogger statsLogger) throws IOException {
         this.bkdlm = bkdlm;
         this.readHandler = bkdlm.createReadHandler(
-                Optional.<String>absent(),
+                Optional.<String>empty(),
                 this,
                 true);
         this.maxReadAheadWaitTime = conf.getReadAheadWaitTime();

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BookKeeperClient.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BookKeeperClient.java
@@ -19,11 +19,11 @@ package org.apache.distributedlog;
 
 import static com.google.common.base.Charsets.UTF_8;
 
-import com.google.common.base.Optional;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BKException;
@@ -117,7 +117,7 @@ public class BookKeeperClient {
                 .setStatsLogger(statsLogger)
                 .dnsResolver(dnsResolver)
                 .requestTimer(requestTimer)
-                .featureProvider(featureProvider.orNull())
+                .featureProvider(featureProvider.orElse(null))
                 .build();
         } catch (BKException bke) {
             throw new IOException(bke);

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BookKeeperClientBuilder.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BookKeeperClientBuilder.java
@@ -20,9 +20,9 @@ package org.apache.distributedlog;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Optional;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.HashedWheelTimer;
+import java.util.Optional;
 import org.apache.bookkeeper.feature.FeatureProvider;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -59,7 +59,7 @@ public class BookKeeperClientBuilder {
     // request timer
     private HashedWheelTimer requestTimer = null;
     // feature provider
-    private Optional<FeatureProvider> featureProvider = Optional.absent();
+    private Optional<FeatureProvider> featureProvider = Optional.empty();
 
     // Cached BookKeeper Client
     private BookKeeperClient cachedClient = null;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/DistributedLogConfiguration.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/DistributedLogConfiguration.java
@@ -19,11 +19,11 @@ package org.apache.distributedlog;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.bookkeeper.common.util.ReflectionUtils;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -539,22 +539,8 @@ public class DistributedLogConfiguration extends CompositeConfiguration {
      * Load whitelisted stream configuration from another configuration object.
      *
      * @param streamConfiguration stream configuration overrides
-     * @Deprecated since 0.5.0, in favor of using {@link #loadStreamConf(java.util.Optional)}
      */
     public void loadStreamConf(Optional<DistributedLogConfiguration> streamConfiguration) {
-        if (streamConfiguration.isPresent()) {
-            loadStreamConf(java.util.Optional.of(streamConfiguration.get()));
-        } else {
-            loadStreamConf(java.util.Optional.empty());
-        }
-    }
-
-    /**
-     * Load whitelisted stream configuration from another configuration object.
-     *
-     * @param streamConfiguration stream configuration overrides
-     */
-    public void loadStreamConf(java.util.Optional<DistributedLogConfiguration> streamConfiguration) {
         if (!streamConfiguration.isPresent()) {
             return;
         }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/LocalDLMEmulator.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/LocalDLMEmulator.java
@@ -17,13 +17,13 @@
  */
 package org.apache.distributedlog;
 
-import com.google.common.base.Optional;
 import java.io.File;
 import java.io.IOException;
 import java.net.BindException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -78,7 +78,7 @@ public class LocalDLMEmulator {
         private int zkPort = DEFAULT_ZK_PORT;
         private int initialBookiePort = DEFAULT_BOOKIE_INITIAL_PORT;
         private boolean shouldStartZK = true;
-        private Optional<ServerConfiguration> serverConf = Optional.absent();
+        private Optional<ServerConfiguration> serverConf = Optional.empty();
 
         public Builder numBookies(int numBookies) {
             this.numBookies = numBookies;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadUtils.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadUtils.java
@@ -17,10 +17,10 @@
  */
 package org.apache.distributedlog;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -497,7 +497,7 @@ public class ReadUtils {
             if (segment.getLastTxId() < transactionId) {
                 // all log records whose transaction id is less than provided transactionId
                 // then return none
-                Optional<LogRecordWithDLSN> noneRecord = Optional.absent();
+                Optional<LogRecordWithDLSN> noneRecord = Optional.empty();
                 return FutureUtils.value(noneRecord);
             }
         }
@@ -513,7 +513,7 @@ public class ReadUtils {
                     if (lastEntryId < 0) {
                         // it means that the log segment is created but not written yet or an empty log segment.
                         //it is equivalent to 'all log records whose transaction id is less than provided transactionId'
-                        Optional<LogRecordWithDLSN> nonRecord = Optional.absent();
+                        Optional<LogRecordWithDLSN> nonRecord = Optional.empty();
                         promise.complete(nonRecord);
                         return;
                     }
@@ -550,7 +550,7 @@ public class ReadUtils {
                             reader,
                             Lists.newArrayList(0L, lastEntryId),
                             nWays,
-                            Optional.<LogRecordWithDLSN>absent(),
+                            Optional.<LogRecordWithDLSN>empty(),
                             promise);
                 }
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/config/DynamicConfigurationFactory.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/config/DynamicConfigurationFactory.java
@@ -19,7 +19,6 @@ package org.apache.distributedlog.config;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.MalformedURLException;
@@ -27,6 +26,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.ConfigurationException;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/BKNamespaceDriver.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/BKNamespaceDriver.java
@@ -21,7 +21,6 @@ import static org.apache.distributedlog.util.DLUtils.isReservedStreamName;
 import static org.apache.distributedlog.util.DLUtils.validateAndNormalizeName;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -32,6 +31,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -293,7 +293,7 @@ public class BKNamespaceDriver implements NamespaceDriver {
                     bkdlConfig.getBkLedgersPath(),
                     eventLoopGroup,
                     requestTimer,
-                    Optional.<FeatureProvider>absent(),
+                    Optional.<FeatureProvider>empty(),
                     statsLogger);
         }
         this.readerBKC = this.sharedReaderBKCBuilder.build();

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/ZKLogMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/ZKLogMetadataStore.java
@@ -19,11 +19,11 @@ package org.apache.distributedlog.impl;
 
 import static org.apache.distributedlog.util.DLUtils.isReservedStreamName;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/federated/FederatedZKLogMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/federated/FederatedZKLogMetadataStore.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Charsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -31,6 +30,7 @@ import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -641,7 +641,7 @@ public class FederatedZKLogMetadataStore
             return postStateCheck(FutureUtils.value(Optional.of(location)));
         }
         if (!forceCheckLogExistence) {
-            Optional<URI> result = Optional.absent();
+            Optional<URI> result = Optional.empty();
             return FutureUtils.value(result);
         }
         return postStateCheck(fetchLogLocation(logName).thenApply((uriOptional) -> {
@@ -663,7 +663,7 @@ public class FederatedZKLogMetadataStore
         FutureUtils.collect(fetchFutures).whenComplete(new FutureEventListener<List<Optional<URI>>>() {
             @Override
             public void onSuccess(List<Optional<URI>> fetchResults) {
-                Optional<URI> result = Optional.absent();
+                Optional<URI> result = Optional.empty();
                 for (Optional<URI> fetchResult : fetchResults) {
                     if (result.isPresent()) {
                         if (fetchResult.isPresent()) {
@@ -701,7 +701,7 @@ public class FederatedZKLogMetadataStore
                     if (Code.OK.intValue() == rc) {
                         fetchPromise.complete(Optional.of(uri));
                     } else if (Code.NONODE.intValue() == rc) {
-                        fetchPromise.complete(Optional.<URI>absent());
+                        fetchPromise.complete(Optional.<URI>empty());
                     } else {
                         fetchPromise.completeExceptionally(KeeperException.create(Code.get(rc)));
                     }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
@@ -31,13 +31,13 @@ import static org.apache.distributedlog.metadata.LogMetadata.READ_LOCK_PATH;
 import static org.apache.distributedlog.metadata.LogMetadata.VERSION_PATH;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/metadata/LogMetadataForReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/metadata/LogMetadataForReader.java
@@ -17,8 +17,8 @@
  */
 package org.apache.distributedlog.metadata;
 
-import com.google.common.base.Optional;
 import java.net.URI;
+import java.util.Optional;
 
 /**
  * Log Metadata for Reader.

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/metadata/LogMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/metadata/LogMetadataStore.java
@@ -18,9 +18,9 @@
 package org.apache.distributedlog.metadata;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Optional;
 import java.net.URI;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.distributedlog.callback.NamespaceListener;
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/metadata/LogStreamMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/metadata/LogStreamMetadataStore.java
@@ -18,9 +18,9 @@
 package org.apache.distributedlog.metadata;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Optional;
 import java.io.Closeable;
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.distributedlog.common.util.PermitManager;
 import org.apache.distributedlog.lock.DistributedLock;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/util/CommandLineUtils.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/util/CommandLineUtils.java
@@ -17,7 +17,7 @@
  */
 package org.apache.distributedlog.util;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.apache.commons.cli.CommandLine;
 
 /**
@@ -29,7 +29,7 @@ public class CommandLineUtils {
         if (cmdline.hasOption(arg)) {
             return Optional.of(cmdline.getOptionValue(arg));
         } else {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -37,7 +37,7 @@ public class CommandLineUtils {
         if (cmdline.hasOption(arg)) {
             return Optional.of(true);
         } else {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -47,7 +47,7 @@ public class CommandLineUtils {
             if (cmdline.hasOption(arg)) {
                 return Optional.of(Integer.parseInt(cmdline.getOptionValue(arg)));
             } else {
-                return Optional.absent();
+                return Optional.empty();
             }
         } catch (NumberFormatException ex) {
             throw new IllegalArgumentException(arg + " is not a number");

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/util/Utils.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/util/Utils.java
@@ -18,12 +18,12 @@
 package org.apache.distributedlog.util;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -216,7 +216,7 @@ public class Utils {
         final byte[] data,
         final List<ACL> acl,
         final CreateMode createMode) {
-        Optional<String> parentPathShouldNotCreate = Optional.absent();
+        Optional<String> parentPathShouldNotCreate = Optional.empty();
         return zkAsyncCreateFullPathOptimistic(
                 zkc,
                 pathToCreate,
@@ -282,7 +282,7 @@ public class Utils {
                         return;
                     }
 
-                    Optional<String> parentPathShouldNotCreate = Optional.absent();
+                    Optional<String> parentPathShouldNotCreate = Optional.empty();
                     zkAsyncCreateFullPathOptimisticRecursive(zkc, pathToCreate, parentPathShouldNotCreate,
                             data, acl, createMode, new AsyncCallback.StringCallback() {
                         @Override

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKLogReadHandler.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKLogReadHandler.java
@@ -22,9 +22,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.base.Optional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
@@ -19,13 +19,13 @@ package org.apache.distributedlog;
 
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Ticker;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.LedgerHandle;

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogConfiguration.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogConfiguration.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.base.Optional;
 import java.util.List;
+import java.util.Optional;
 import org.apache.bookkeeper.net.DNSToSwitchMapping;
 import org.apache.commons.configuration.StrictConfigurationComparator;
 import org.apache.distributedlog.net.DNSResolverForRacks;
@@ -88,7 +88,7 @@ public class TestDistributedLogConfiguration {
     public void loadStreamConfNullOverrides() throws Exception {
         DistributedLogConfiguration conf = new DistributedLogConfiguration();
         DistributedLogConfiguration confClone = new DistributedLogConfiguration();
-        Optional<DistributedLogConfiguration> streamConfiguration = Optional.absent();
+        Optional<DistributedLogConfiguration> streamConfiguration = Optional.empty();
         conf.loadStreamConf(streamConfiguration);
 
         StrictConfigurationComparator comp = new StrictConfigurationComparator();

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestReadAheadEntryReader.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestReadAheadEntryReader.java
@@ -24,10 +24,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Ticker;
 import com.google.common.collect.Lists;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -116,7 +116,7 @@ public class TestReadAheadEntryReader extends TestDistributedLogBase {
                                                    DistributedLogConfiguration conf)
             throws Exception {
         BKLogReadHandler readHandler = dlm.createReadHandler(
-                Optional.<String>absent(),
+                Optional.<String>empty(),
                 true);
         LogSegmentEntryStore entryStore = new BKLogSegmentEntryStore(
                 conf,

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestReadUtils.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestReadUtils.java
@@ -21,9 +21,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/config/TestDynamicConfigurationFactory.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/config/TestDynamicConfigurationFactory.java
@@ -20,8 +20,8 @@ package org.apache.distributedlog.config;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import java.io.File;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/impl/TestZKLogMetadataStore.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/impl/TestZKLogMetadataStore.java
@@ -20,9 +20,9 @@ package org.apache.distributedlog.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import java.net.URI;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.distributedlog.DistributedLogConfiguration;

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/impl/federated/TestFederatedZKLogMetadataStore.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/impl/federated/TestFederatedZKLogMetadataStore.java
@@ -22,13 +22,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/util/TestUtils.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/util/TestUtils.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
@@ -64,7 +64,7 @@ public class TestUtils extends ZooKeeperClusterTestCase {
     @Test(timeout = 60000)
     public void testZkAsyncCreateFulPathOptimisticRecursive() throws Exception {
         String path1 = "/a/b/c/d";
-        Optional<String> parentPathShouldNotCreate = Optional.absent();
+        Optional<String> parentPathShouldNotCreate = Optional.empty();
         final CountDownLatch doneLatch1 = new CountDownLatch(1);
         Utils.zkAsyncCreateFullPathOptimisticRecursive(zkc, path1, parentPathShouldNotCreate,
                 new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,


### PR DESCRIPTION
### Motivation

`com.google.common.base.Optional` and `java.util.Optional` exist in the code base at the same time.

### Changes
Replace `com.google.common.base.Optional` with `java.util.Optional`.
