### PR TITLE
ISSUE-2341 Load bookkeeper parameters from environment variables

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -170,11 +170,6 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -170,6 +170,11 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -236,7 +236,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
                 String name = entry.getKey().substring(ENV_PREFIX.length());
                 String value = entry.getValue();
                 log.info("load environment {}={}", name, value);
-                setProperty(name,value);
+                setProperty(name, value);
             });
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -72,6 +72,9 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
         DEFAULT_LOADER = loader;
     }
 
+    // Environment Parameters Prefix
+    protected static final String ENV_PREFIX = "BK_";
+
     // Zookeeper Parameters
     protected static final String ZK_TIMEOUT = "zkTimeout";
     protected static final String ZK_SERVERS = "zkServers";
@@ -222,6 +225,19 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
             String key = iter.next();
             setProperty(key, loadedConf.getProperty(key));
         }
+    }
+
+    /**
+     * Load configurations from environment variables prefixed with BK_.
+     */
+    public void loadEnv() {
+        System.getenv().entrySet().stream().filter(entry -> entry.getKey().startsWith(ENV_PREFIX))
+            .forEach(entry -> {
+                String name = entry.getKey().substring(ENV_PREFIX.length());
+                String value = entry.getValue();
+                log.info("load environment {}={}", name, value);
+                setProperty(name,value);
+            });
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -113,7 +113,7 @@ public class Main {
     }
 
     private static void loadConfEnv(ServerConfiguration conf) throws IllegalArgumentException {
-        try{
+        try {
             conf.loadEnv();
             conf.validate();
         } catch (ConfigurationException e) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -112,6 +112,16 @@ public class Main {
         log.info("Using configuration file {}", confFile);
     }
 
+    private static void loadConfEnv(ServerConfiguration conf) throws IllegalArgumentException {
+        try{
+            conf.loadEnv();
+            conf.validate();
+        } catch (ConfigurationException e) {
+            log.error("Malformed configuration file: {}", e);
+            throw new IllegalArgumentException();
+        }
+    }
+
     @SuppressWarnings("deprecation")
     private static ServerConfiguration parseArgs(String[] args)
         throws IllegalArgumentException {
@@ -124,6 +134,8 @@ public class Main {
             }
 
             ServerConfiguration conf = new ServerConfiguration();
+
+            loadConfEnv(conf);
 
             if (cmdLine.hasOption('c')) {
                 String confFile = cmdLine.getOptionValue("c");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfigurationWithEnvironment.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfigurationWithEnvironment.java
@@ -64,8 +64,8 @@ public class TestServerConfigurationWithEnvironment {
         assertEquals(1000, serverConf.getDeathWatchInterval());
         assertEquals(0.95, serverConf.getDiskUsageWarnThreshold(), 0.2);
         assertEquals(0.2, serverConf.getMinorCompactionThreshold(), 0.1);
-        assertEquals(1000l, serverConf.getGcWaitTime());
-        assertEquals(10000l, serverConf.getFlushInterval());
+        assertEquals(1000L, serverConf.getGcWaitTime());
+        assertEquals(10000L, serverConf.getFlushInterval());
         assertArrayEquals(new String[]{"test1", "test2", "test3"},
             serverConf.getExtraServerComponents());
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfigurationWithEnvironment.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfigurationWithEnvironment.java
@@ -1,0 +1,72 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.conf;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+/**
+ * Unit test for load bookkeeper configuration from environment {@link AbstractConfiguration}.
+ */
+public class TestServerConfigurationWithEnvironment {
+
+    private final ServerConfiguration serverConf;
+
+    public TestServerConfigurationWithEnvironment() {
+        serverConf = new ServerConfiguration();
+    }
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    @Before
+    public void setup() throws Exception {
+        environmentVariables.set("BK_bookiePort", "3182");
+        environmentVariables.set("BK_allowLoopback", "true");
+        environmentVariables.set("BK_bookieDeathWatchInterval", "1000");
+        environmentVariables.set("BK_extraServerComponents", "test1,test2,test3");
+        environmentVariables.set("BK_diskUsageWarnThreshold", "0.95");
+        environmentVariables.set("BK_minorCompactionThreshold", "0.2");
+        environmentVariables.set("BK_gcWaitTime", "1000");
+        serverConf.loadEnv();
+    }
+
+    @Test
+    public void testEnvironmentVariables() throws ConfigurationException {
+        serverConf.validate();
+        assertEquals(3182, serverConf.getBookiePort());
+        assertEquals(true, serverConf.getAllowLoopback());
+        assertEquals(1000, serverConf.getDeathWatchInterval());
+        assertEquals(0.95, serverConf.getDiskUsageWarnThreshold(), 0.2);
+        assertEquals(0.2, serverConf.getMinorCompactionThreshold(), 0.1);
+        assertEquals(1000l, serverConf.getGcWaitTime());
+        assertEquals(10000l, serverConf.getFlushInterval());
+        assertArrayEquals(new String[]{"test1", "test2", "test3"},
+            serverConf.getExtraServerComponents());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -789,6 +789,11 @@
       <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
     <vertx.version>3.4.1</vertx.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <jctools.version>2.1.2</jctools.version>
+    <system-rules.version>1.19.0</system-rules.version>
     <!-- plugin dependencies -->
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
@@ -712,6 +713,11 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers</artifactId>
         <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.stefanbirkner</groupId>
+        <artifactId>system-rules</artifactId>
+        <version>${system-rules.version}</version>
       </dependency>
 
       <!-- benchmark dependencies -->


### PR DESCRIPTION
Load bookkeeper parameters from environment variables prefixed with BK_

### Motivation

Add the way to configure bookkeeper through environment variables to simplify deployment

### Changes

Load bookkeeper parameters from environment variables with the prefix BK_ before load bk_server.conf

Master Issue: #2341 