### PR TITLE
[BUG] Fix redundant statistics

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/InfoCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/InfoCommand.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -86,8 +87,19 @@ public class InfoCommand extends BookieCommand<CliFlags> {
                 System.out.println(CommandHelpers.getBookieSocketAddrStringRepresentation(bookieId)
                     + ":\tFree: " + bInfo.getFreeDiskSpace() + getReadable(bInfo.getFreeDiskSpace())
                     + "\tTotal: " + bInfo.getTotalDiskSpace() + getReadable(bInfo.getTotalDiskSpace()));
-                totalFree += bInfo.getFreeDiskSpace();
-                total += bInfo.getTotalDiskSpace();
+            }
+
+            // group by hostname
+            Map<String, BookieInfo> dedupedMap = map.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    entry -> entry.getKey().getHostName(),
+                    entry -> entry.getValue(),
+                    (key1, key2) -> key2
+                ));
+            for (BookieInfo bookieInfo : dedupedMap.values()) {
+                totalFree += bookieInfo.getFreeDiskSpace();
+                total += bookieInfo.getTotalDiskSpace();
             }
 
             System.out.println("Total free disk space in the cluster:\t" + totalFree + getReadable(totalFree));


### PR DESCRIPTION
### Motivation

Fix redundant statistics, run 5 bookies `bin/bookkeeper localbookie 10`, then show bookieinfo

```
./bin/bookkeeper shell bookieinfo
```

**Wrong result**
```
Free disk space info:
10.101.52.18(10.101.52.18):5004:        Free: 34930151424(34.93GB)      Total: 255850758144(255.85GB)
10.101.52.18(10.101.52.18):5003:        Free: 34930151424(34.93GB)      Total: 255850758144(255.85GB)
10.101.52.18(10.101.52.18):5002:        Free: 34930151424(34.93GB)      Total: 255850758144(255.85GB)
10.101.52.18(10.101.52.18):5000:        Free: 34930151424(34.93GB)      Total: 255850758144(255.85GB)
10.101.52.18(10.101.52.18):5005:        Free: 34930151424(34.93GB)      Total: 255850758144(255.85GB)
Total free disk space in the cluster:   174650757120(174.65GB)
Total disk capacity in the cluster:     1279253790720(1.279TB)
```

**Right result**
```
Free disk space info:
10.101.52.18(10.101.52.18):5004:        Free: 33172185088(33.172GB)     Total: 255850758144(255.85GB)
10.101.52.18(10.101.52.18):5003:        Free: 33172185088(33.172GB)     Total: 255850758144(255.85GB)
10.101.52.18(10.101.52.18):5002:        Free: 33172185088(33.172GB)     Total: 255850758144(255.85GB)
10.101.52.18(10.101.52.18):5006:        Free: 33172185088(33.172GB)     Total: 255850758144(255.85GB)
10.101.52.18(10.101.52.18):5005:        Free: 33172185088(33.172GB)     Total: 255850758144(255.85GB)
Total free disk space in the cluster:   33172185088(33.172GB)
Total disk capacity in the cluster:     255850758144(255.85GB)
```

