### PR TITLE
fix readlogmetadata failed bug and export entrylog file usage to output

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -982,10 +982,11 @@ public class BookieShell implements Tool {
 
             long logId;
             try {
-                logId = Long.parseLong(leftArgs[0]);
+                logId = Long.parseLong(leftArgs[0], 16);
                 flags.logId(logId);
             } catch (NumberFormatException nfe) {
                 flags.logFilename(leftArgs[0]);
+                flags.logId(-1);
             }
             cmd.apply(bkConf, flags);
             return 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
@@ -130,6 +130,9 @@ public class ReadLogMetadataCommand extends BookieCommand<ReadLogMetadataFlags> 
         LOG.info("Print entryLogMetadata of entrylog {} ({}.log)", logId, Long.toHexString(logId));
         initEntryLogger(conf);
         EntryLogMetadata entryLogMetadata = entryLogger.getEntryLogMetadata(logId);
+        LOG.info("entryLogId: {}, remaining size: {}, total size: {}, usage: {}", entryLogMetadata.getEntryLogId(),
+                entryLogMetadata.getRemainingSize(), entryLogMetadata.getTotalSize(), entryLogMetadata.getUsage());
+
         entryLogMetadata.getLedgersMap().forEach((ledgerId, size) -> {
             LOG.info("--------- Lid={}, TotalSizeOfEntriesOfLedger={}  ---------",
                      ledgerIdFormatter.formatLedgerId(ledgerId), size);


### PR DESCRIPTION
### Motivation
When i use `bookkeeper shell readlogmetadata`  to get an entrylog file's metadata info, i encountered the following exception:
```
19:51:11.282 [main] INFO  org.apache.bookkeeper.bookie.EntryLogger - Failed to get ledgers map index from: 0.log : No file for log 0
19:51:11.284 [main] WARN  org.apache.bookkeeper.bookie.EntryLogger - Failed to get channel to scan entry log: 0.log
Exception in thread "main" com.google.common.util.concurrent.UncheckedExecutionException: No file for log 0
	at org.apache.bookkeeper.tools.cli.commands.bookie.ReadLogMetadataCommand.apply(ReadLogMetadataCommand.java:106)
	at org.apache.bookkeeper.bookie.BookieShell$ReadLogMetadataCmd.runCmd(BookieShell.java:988)
	at org.apache.bookkeeper.bookie.BookieShell$MyCommand.runCmd(BookieShell.java:223)
	at org.apache.bookkeeper.bookie.BookieShell.run(BookieShell.java:1976)
	at org.apache.bookkeeper.bookie.BookieShell.main(BookieShell.java:2067)
Caused by: java.io.FileNotFoundException: No file for log 0
	at org.apache.bookkeeper.bookie.EntryLogger.findFile(EntryLogger.java:960)
	at org.apache.bookkeeper.bookie.EntryLogger.getChannelForLogId(EntryLogger.java:895)
	at org.apache.bookkeeper.bookie.EntryLogger.scanEntryLog(EntryLogger.java:976)
	at org.apache.bookkeeper.bookie.EntryLogger.extractEntryLogMetadataByScanning(EntryLogger.java:1132)
	at org.apache.bookkeeper.bookie.EntryLogger.getEntryLogMetadata(EntryLogger.java:1041)
	at org.apache.bookkeeper.tools.cli.commands.bookie.ReadLogMetadataCommand.printEntryLogMetadata(ReadLogMetadataCommand.java:132)
	at org.apache.bookkeeper.tools.cli.commands.bookie.ReadLogMetadataCommand.readLogMetadata(ReadLogMetadataCommand.java:125)
	at org.apache.bookkeeper.tools.cli.commands.bookie.ReadLogMetadataCommand.apply(ReadLogMetadataCommand.java:104)

```

In the source code, it parse the entry log id with 10 radix, however, the entry log file name is 16 radix entry log id and parse failed. Then parsing it with entry log file name, and set the log file name into flags. When parse the flags in `ReadLogMetadataCommand` class, it first check
```
private static final long DEFAULT_LOGID = -1L
if (flags.logId != DEFAULT_LOGID) {
     logid = flags.logId;
}
```
the default flag.logid is 0, so the `logid` will be set to 0.

### Changes
1. using `16 radix` to parse entry log id
2. when using entry log file name to get entry log metatdata, set the flags.logid to `-1`
3. export entry log usage to the output