### PR TITLE
[LOG] Change ERROR to INFO log level

### DIFF
--- a/conf/log4j.shell.properties
+++ b/conf/log4j.shell.properties
@@ -25,7 +25,7 @@
 
 # DEFAULT: console appender only
 # Define some default values that can be overridden by system properties
-bookkeeper.root.logger=ERROR,CONSOLE
+bookkeeper.root.logger=INFO,CONSOLE
 
 log4j.rootLogger=${bookkeeper.root.logger}
 
@@ -37,15 +37,8 @@ log4j.appender.CONSOLE.Threshold=INFO
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ABSOLUTE} %-5p %m%n
 
-# verbose console logging
-log4j.appender.VERBOSECONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.VERBOSECONSOLE.Threshold=INFO
-log4j.appender.VERBOSECONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.VERBOSECONSOLE.layout.ConversionPattern=%m%n
-
-log4j.logger.verbose=INFO,VERBOSECONSOLE
-log4j.logger.org.apache.zookeeper=ERROR
-log4j.logger.org.apache.bookkeeper=ERROR
+log4j.logger.org.apache.zookeeper=INFO
+log4j.logger.org.apache.bookkeeper=INFO
 log4j.logger.org.apache.bookkeeper.bookie.BookieShell=INFO
 log4j.logger.org.apache.bookkeeper.client.BookKeeperAdmin=INFO
 log4j.logger.org.apache.bookkeeper.bookie.InterleavedStorageRegenerateIndexOp=INFO


### PR DESCRIPTION
### Motivation

When use shell command, it output nothing caused by `ERROR` level.

**OLD** (output nothing)
```
bin/bookkeeper shell readlogmetadata 0
```
**FIX**
```
bin/bookkeeper shell readlogmetadata 0

06:58:01,364 INFO  Print entryLogMetadata of entrylog 0 (0.log)
06:58:01,467 INFO  Failed to get ledgers map index from: 0.log : No ledgers map index found on entryLogId0
06:58:01,471 INFO  --------- Lid=0, TotalSizeOfEntriesOfLedger=59  ---------
```

### Changes

- Remove duplicate definition `VERBOSECONSOLE `
- Change `ERROR` to `INFO`
