### PR TITLE
[BUG] Fix avoid invoke init drivers repeatedly

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MetadataDrivers.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MetadataDrivers.java
@@ -91,27 +91,18 @@ public final class MetadataDrivers {
     private static final ConcurrentMap<String, MetadataClientDriverInfo> clientDrivers;
     @Getter(AccessLevel.PACKAGE)
     private static final ConcurrentMap<String, MetadataBookieDriverInfo> bookieDrivers;
-    private static boolean initialized = false;
 
     static {
         clientDrivers = new ConcurrentHashMap<>();
         bookieDrivers = new ConcurrentHashMap<>();
-        initialize();
-    }
-
-    static void initialize() {
-        if (initialized) {
-            return;
-        }
         loadInitialDrivers();
-        initialized = true;
-        log.info("BookKeeper metadata driver manager initialized");
     }
 
     @VisibleForTesting
     static void loadInitialDrivers() {
         loadInitialClientDrivers();
         loadInitialBookieDrivers();
+        log.info("BookKeeper metadata driver manager initialized");
     }
 
     private static void loadInitialClientDrivers() {
@@ -183,10 +174,6 @@ public final class MetadataDrivers {
     public static void registerClientDriver(String metadataBackendScheme,
                                             Class<? extends MetadataClientDriver> driver,
                                             boolean allowOverride) {
-        if (!initialized) {
-            initialize();
-        }
-
         String scheme = metadataBackendScheme.toLowerCase();
         MetadataClientDriverInfo oldDriverInfo = clientDrivers.get(scheme);
         if (null != oldDriverInfo && !allowOverride) {
@@ -218,10 +205,6 @@ public final class MetadataDrivers {
     public static void registerBookieDriver(String metadataBackendScheme,
                                             Class<? extends MetadataBookieDriver> driver,
                                             boolean allowOverride) {
-        if (!initialized) {
-            initialize();
-        }
-
         String scheme = metadataBackendScheme.toLowerCase();
         MetadataBookieDriverInfo oldDriverInfo = bookieDrivers.get(scheme);
         if (null != oldDriverInfo && !allowOverride) {
@@ -247,9 +230,6 @@ public final class MetadataDrivers {
      */
     public static MetadataClientDriver getClientDriver(String scheme) {
         checkNotNull(scheme, "Client Driver Scheme is null");
-        if (!initialized) {
-            initialize();
-        }
         MetadataClientDriverInfo driverInfo = clientDrivers.get(scheme.toLowerCase());
         if (null == driverInfo) {
             throw new IllegalArgumentException("Unknown backend " + scheme);
@@ -287,9 +267,6 @@ public final class MetadataDrivers {
      */
     public static MetadataBookieDriver getBookieDriver(String scheme) {
         checkNotNull(scheme, "Bookie Driver Scheme is null");
-        if (!initialized) {
-            initialize();
-        }
         MetadataBookieDriverInfo driverInfo = bookieDrivers.get(scheme.toLowerCase());
         if (null == driverInfo) {
             throw new IllegalArgumentException("Unknown backend " + scheme);


### PR DESCRIPTION
### Motivation

static code blocks are always invoked when the class is initialized, when client connect to bookkeeper server, output repeat init log

```
2020-06-04 10:10:24,751 INFO  org.apache.bookkeeper.meta.MetadataDrivers                    - BookKeeper metadata driver manager initialized
2020-06-04 10:10:24,753 INFO  org.apache.bookkeeper.meta.MetadataDrivers                    - BookKeeper metadata driver manager initialized
2020-06-04 10:10:24,753 INFO  org.apache.bookkeeper.meta.MetadataDrivers                    - BookKeeper metadata driver manager initialized
```

### Changes

Remove redundant initialization code.