### PR TITLE
 Fix distributedlog Maven reactor module

### DIFF
--- a/stream/distributedlog/core/pom.xml
+++ b/stream/distributedlog/core/pom.xml
@@ -112,7 +112,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <suppressionsLocation>buildtools/src/main/resources/distributedlog/suppressions.xml</suppressionsLocation>
+          <suppressionsLocation>../../buildtools/src/main/resources/distributedlog/suppressions.xml</suppressionsLocation>
+          <configLocation>../../buildtools/src/main/resources/bookkeeper/checkstyle.xml</configLocation>
           <excludes>**/thrift/**/*</excludes>
         </configuration>
       </plugin>

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
@@ -17,9 +17,9 @@
  */
 package org.apache.distributedlog.impl.metadata;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.distributedlog.DistributedLogConstants.EMPTY_BYTES;
 import static org.apache.distributedlog.DistributedLogConstants.UNASSIGNED_LOGSEGMENT_SEQNO;
 import static org.apache.distributedlog.metadata.LogMetadata.ALLOCATION_PATH;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/subscription/ZKSubscriptionStateStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/subscription/ZKSubscriptionStateStore.java
@@ -17,8 +17,8 @@
  */
 package org.apache.distributedlog.impl.subscription;
 
-import java.nio.charset.StandardCharsets;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;

--- a/stream/pom.xml
+++ b/stream/pom.xml
@@ -29,6 +29,7 @@
   <name>Apache BookKeeper :: Stream Storage :: Parent</name>
 
   <modules>
+    <module>distributedlog</module>
     <module>common</module>
     <module>tests-common</module>
     <module>statelib</module>


### PR DESCRIPTION
    - add explicitly distributedlog to the modules of Stream project
    - fix checkstyle on distributedlog, it wasn't executed
