### PR TITLE
Active ledgers on entry log file

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -46,7 +46,6 @@ import org.apache.bookkeeper.tools.cli.commands.autorecovery.LostBookieRecoveryD
 import org.apache.bookkeeper.tools.cli.commands.autorecovery.ToggleCommand;
 import org.apache.bookkeeper.tools.cli.commands.autorecovery.TriggerAuditCommand;
 import org.apache.bookkeeper.tools.cli.commands.autorecovery.WhoIsAuditorCommand;
-import org.apache.bookkeeper.tools.cli.commands.bookie.ListActiveLedgersCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ConvertToDBStorageCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ConvertToInterleavedStorageCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.FlipBookieIdCommand;
@@ -54,6 +53,7 @@ import org.apache.bookkeeper.tools.cli.commands.bookie.FormatCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.InitCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LastMarkCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LedgerCommand;
+import org.apache.bookkeeper.tools.cli.commands.bookie.ListActiveLedgersCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ListFilesOnDiscCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.ListLedgersCommand;
 import org.apache.bookkeeper.tools.cli.commands.bookie.LocalConsistencyCheckCommand;
@@ -717,7 +717,7 @@ public class BookieShell implements Tool {
     }
 
     /**
-     * List active ledgers on entry log file
+     * List active ledgers on entry log file.
      **/
     class ListActiveLedgersCmd extends MyCommand {
         Options lOpts = new Options();
@@ -725,21 +725,23 @@ public class BookieShell implements Tool {
         ListActiveLedgersCmd() {
             super(CMD_ACTIVE_LEDGERS_ON_ENTRY_LOG_FILE);
             lOpts.addOption("l", "logId", true, "Entry log file id");
-            lOpts.addOption("t", "timeout",true, "Read timeout(ms)");
+            lOpts.addOption("t", "timeout", true, "Read timeout(ms)");
         }
 
         @Override
         public int runCmd(CommandLine cmdLine) throws Exception {
             final boolean hasTimeout = cmdLine.hasOption("t");
-            final boolean hasLogId=cmdLine.hasOption("l");
-            if(!hasLogId){
+            final boolean hasLogId = cmdLine.hasOption("l");
+            if (!hasLogId){
                 printUsage();
                 return -1;
             }
-            final long logId = Long.valueOf(cmdLine.getOptionValue("l"));
+            final long logId = Long.parseLong(cmdLine.getOptionValue("l"));
             ListActiveLedgersCommand.ActiveLedgerFlags flags = new ListActiveLedgersCommand.ActiveLedgerFlags();
             flags.logId(logId);
-            if(hasTimeout) flags.timeout(Long.valueOf(cmdLine.getOptionValue("t")));
+            if (hasTimeout){
+                flags.timeout(Long.parseLong(cmdLine.getOptionValue("t")));
+            }
             ListActiveLedgersCommand cmd = new ListActiveLedgersCommand(ledgerIdFormatter);
             cmd.apply(bkConf, flags);
             return 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1051,7 +1051,7 @@ public class EntryLogger {
 
         if (header.ledgersMapOffset == 0L) {
             // The index was not stored in the log file (possibly because the bookie crashed before flushing it)
-            throw new IOException("No ledgers map index found on entryLogId" + entryLogId);
+            throw new IOException("No ledgers map index found on entryLogId " + entryLogId);
         }
 
         if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
@@ -1,0 +1,146 @@
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithLedgerManagerFactory;
+
+import com.beust.jcommander.Parameter;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.bookkeeper.bookie.EntryLogMetadata;
+import org.apache.bookkeeper.bookie.EntryLogger;
+import org.apache.bookkeeper.bookie.ReadOnlyEntryLogger;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.exceptions.MetadataException;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.tools.cli.commands.bookie.ListActiveLedgersCommand.ActiveLedgerFlags;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
+import org.apache.bookkeeper.tools.framework.CliFlags;
+import org.apache.bookkeeper.tools.framework.CliSpec;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.apache.zookeeper.AsyncCallback.VoidCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+/**
+ *
+ *  List active(exist in metadata storage) ledgers in a entry log file
+ *
+ **/
+public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
+  static final Logger LOG = LoggerFactory.getLogger(ListActiveLedgersCommand.class);
+    private static final String NAME = "active ledger";
+    private static final String DESC = "Retrieve bookie active ledger info.";
+    private static final long  DEFAULT_TIME_OUT=1000;
+    private static final long  DEFAULT_LOG_ID=0;
+    private static final String DEFAULT_LEDGER_ID_FORMATTER = "";
+    private LedgerIdFormatter ledgerIdFormatter;
+
+  public ListActiveLedgersCommand(){
+    this(new ActiveLedgerFlags());
+  }
+    public ListActiveLedgersCommand(LedgerIdFormatter ledgerIdFormatter){
+        this(new ActiveLedgerFlags());
+        this.ledgerIdFormatter=ledgerIdFormatter;
+    }
+
+    public ListActiveLedgersCommand(ActiveLedgerFlags ledgerFlags){
+        super(CliSpec.<ActiveLedgerFlags>newBuilder().withName(NAME).withDescription(DESC).withFlags(ledgerFlags).build());
+    }
+
+    /**
+     * Flags for active ledger  command.
+     */
+    @Accessors(fluent = true)
+    @Setter
+    public static class ActiveLedgerFlags extends CliFlags {
+
+        @Parameter(names = { "-l", "--logid" }, description = "Entry log file id")
+        private long logId=DEFAULT_LOG_ID;
+        @Parameter(names = { "-t", "--timeout" }, description = "Read timeout(ms)")
+        private long timeout=DEFAULT_TIME_OUT;
+        @Parameter(names = { "-f", "--ledgerIdFormatter" }, description = "Ledger id formatter")
+        private String ledgerIdFormatter = DEFAULT_LEDGER_ID_FORMATTER;
+    }
+    @Override
+    public boolean apply(ServerConfiguration bkConf, ActiveLedgerFlags cmdFlags){
+      initLedgerFormatter(bkConf,cmdFlags);
+        try{
+          handler(bkConf,cmdFlags);
+        }catch (MetadataException| ExecutionException e) {
+          throw new UncheckedExecutionException(e.getMessage(), e);
+        }
+        return true;
+    }
+
+    private void initLedgerFormatter(ServerConfiguration conf, ActiveLedgerFlags cmdFlags) {
+      if (!cmdFlags.ledgerIdFormatter.equals(DEFAULT_LEDGER_ID_FORMATTER)) {
+        this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(cmdFlags.ledgerIdFormatter, conf);
+      } else if(ledgerIdFormatter==null){
+        this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(conf);
+      }
+    }
+
+    public void handler(ServerConfiguration bkConf, ActiveLedgerFlags cmdFlags) throws ExecutionException,MetadataException {
+      runFunctionWithLedgerManagerFactory(bkConf, mFactory -> {
+        try (LedgerManager ledgerManager = mFactory.newLedgerManager()) {
+          Set<Long> activeLedgersOnMetadata=new HashSet<Long>();
+          BookkeeperInternalCallbacks.Processor<Long> ledgerProcessor=(ledger,cb)->{
+            activeLedgersOnMetadata.add(ledger);
+            cb.processResult(BKException.Code.OK, null, null);
+          };
+          CountDownLatch done=new CountDownLatch(1);
+          AtomicInteger resultCode=new AtomicInteger(BKException.Code.OK);
+          VoidCallback endCallback=(rs,s,obj)->{
+            resultCode.set(rs);
+            done.countDown();
+          };
+          ledgerManager.asyncProcessLedgers(ledgerProcessor,endCallback,null,BKException.Code.OK,BKException.Code.ReadException);
+          done.await(cmdFlags.timeout,TimeUnit.MILLISECONDS);
+          if(resultCode.get()==BKException.Code.OK){
+            EntryLogger entryLogger = new ReadOnlyEntryLogger(bkConf);
+            EntryLogMetadata entryLogMetadata=entryLogger.getEntryLogMetadata(cmdFlags.logId);
+            List<Long> ledgersOnEntryLog=entryLogMetadata.getLedgersMap().keys();
+            if(ledgersOnEntryLog.size()==0){
+              LOG.info("Ledgers on log file {} is empty",cmdFlags.logId);
+            }
+            List<Long> activeLedgersOnEntryLog=new ArrayList<Long>(ledgersOnEntryLog.size());
+            for(long ledger:ledgersOnEntryLog){
+              if(activeLedgersOnMetadata.contains(ledger)){
+                activeLedgersOnEntryLog.add(ledger);
+              }
+            }printActiveLedgerOnEntryLog(cmdFlags.logId,activeLedgersOnEntryLog);
+          }else{
+            LOG.info("Read active ledgers id from metadata store,fail code {}",resultCode.get());
+            throw BKException.create(resultCode.get());
+          }
+        }catch (Exception e){
+          LOG.error("Received Exception while processing ledgers", e);
+          throw new UncheckedExecutionException(e);
+        }
+        return null;
+      });
+    }
+
+    public void printActiveLedgerOnEntryLog(long logId, List<Long> activeLedgers){
+      if(activeLedgers.size()==0){
+        System.out.println("No active ledgers on log file " +logId);
+      }else{
+        System.out.println("Active ledgers on entry log "+logId+" as follow:");
+      }
+      Collections.sort(activeLedgers);
+      for(long a:activeLedgers){
+        System.out.println(ledgerIdFormatter.formatLedgerId(a)+" ");
+      }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
@@ -1,16 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.bookkeeper.tools.cli.commands.bookie;
 
 import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithLedgerManagerFactory;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -26,23 +46,20 @@ import org.apache.bookkeeper.tools.cli.commands.bookie.ListActiveLedgersCommand.
 import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
 import org.apache.zookeeper.AsyncCallback.VoidCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 /**
- *
- *  List active(exist in metadata storage) ledgers in a entry log file
+ *  List active(exist in metadata storage) ledgers in a entry log file.
  *
  **/
 public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
   static final Logger LOG = LoggerFactory.getLogger(ListActiveLedgersCommand.class);
     private static final String NAME = "active ledger";
     private static final String DESC = "Retrieve bookie active ledger info.";
-    private static final long  DEFAULT_TIME_OUT=1000;
-    private static final long  DEFAULT_LOG_ID=0;
+    private static final long  DEFAULT_TIME_OUT = 1000;
+    private static final long  DEFAULT_LOG_ID = 0;
     private static final String DEFAULT_LEDGER_ID_FORMATTER = "";
     private LedgerIdFormatter ledgerIdFormatter;
 
@@ -51,11 +68,15 @@ public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
   }
     public ListActiveLedgersCommand(LedgerIdFormatter ledgerIdFormatter){
         this(new ActiveLedgerFlags());
-        this.ledgerIdFormatter=ledgerIdFormatter;
+        this.ledgerIdFormatter = ledgerIdFormatter;
     }
 
     public ListActiveLedgersCommand(ActiveLedgerFlags ledgerFlags){
-        super(CliSpec.<ActiveLedgerFlags>newBuilder().withName(NAME).withDescription(DESC).withFlags(ledgerFlags).build());
+        super(CliSpec.<ActiveLedgerFlags>newBuilder().
+                      withName(NAME).
+                      withDescription(DESC).
+                      withFlags(ledgerFlags).
+                      build());
     }
 
     /**
@@ -66,18 +87,18 @@ public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
     public static class ActiveLedgerFlags extends CliFlags {
 
         @Parameter(names = { "-l", "--logid" }, description = "Entry log file id")
-        private long logId=DEFAULT_LOG_ID;
+        private long logId = DEFAULT_LOG_ID;
         @Parameter(names = { "-t", "--timeout" }, description = "Read timeout(ms)")
-        private long timeout=DEFAULT_TIME_OUT;
+        private long timeout = DEFAULT_TIME_OUT;
         @Parameter(names = { "-f", "--ledgerIdFormatter" }, description = "Ledger id formatter")
         private String ledgerIdFormatter = DEFAULT_LEDGER_ID_FORMATTER;
     }
     @Override
     public boolean apply(ServerConfiguration bkConf, ActiveLedgerFlags cmdFlags){
-      initLedgerFormatter(bkConf,cmdFlags);
-        try{
-          handler(bkConf,cmdFlags);
-        }catch (MetadataException| ExecutionException e) {
+      initLedgerFormatter(bkConf, cmdFlags);
+        try {
+          handler(bkConf, cmdFlags);
+        } catch (MetadataException | ExecutionException e) {
           throw new UncheckedExecutionException(e.getMessage(), e);
         }
         return true;
@@ -86,45 +107,51 @@ public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
     private void initLedgerFormatter(ServerConfiguration conf, ActiveLedgerFlags cmdFlags) {
       if (!cmdFlags.ledgerIdFormatter.equals(DEFAULT_LEDGER_ID_FORMATTER)) {
         this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(cmdFlags.ledgerIdFormatter, conf);
-      } else if(ledgerIdFormatter==null){
+      } else if (ledgerIdFormatter == null){
         this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(conf);
       }
     }
 
-    public void handler(ServerConfiguration bkConf, ActiveLedgerFlags cmdFlags) throws ExecutionException,MetadataException {
+    public void handler(ServerConfiguration bkConf, ActiveLedgerFlags cmdFlags)
+      throws ExecutionException, MetadataException {
       runFunctionWithLedgerManagerFactory(bkConf, mFactory -> {
         try (LedgerManager ledgerManager = mFactory.newLedgerManager()) {
-          Set<Long> activeLedgersOnMetadata=new HashSet<Long>();
-          BookkeeperInternalCallbacks.Processor<Long> ledgerProcessor=(ledger,cb)->{
+          Set<Long> activeLedgersOnMetadata = new HashSet<Long>();
+          BookkeeperInternalCallbacks.Processor<Long> ledgerProcessor = (ledger, cb)->{
             activeLedgersOnMetadata.add(ledger);
             cb.processResult(BKException.Code.OK, null, null);
           };
-          CountDownLatch done=new CountDownLatch(1);
-          AtomicInteger resultCode=new AtomicInteger(BKException.Code.OK);
-          VoidCallback endCallback=(rs,s,obj)->{
+          CountDownLatch done = new CountDownLatch(1);
+          AtomicInteger resultCode = new AtomicInteger(BKException.Code.OK);
+          VoidCallback endCallback = (rs, s, obj)->{
             resultCode.set(rs);
             done.countDown();
           };
-          ledgerManager.asyncProcessLedgers(ledgerProcessor,endCallback,null,BKException.Code.OK,BKException.Code.ReadException);
-          done.await(cmdFlags.timeout,TimeUnit.MILLISECONDS);
-          if(resultCode.get()==BKException.Code.OK){
-            EntryLogger entryLogger = new ReadOnlyEntryLogger(bkConf);
-            EntryLogMetadata entryLogMetadata=entryLogger.getEntryLogMetadata(cmdFlags.logId);
-            List<Long> ledgersOnEntryLog=entryLogMetadata.getLedgersMap().keys();
-            if(ledgersOnEntryLog.size()==0){
-              LOG.info("Ledgers on log file {} is empty",cmdFlags.logId);
-            }
-            List<Long> activeLedgersOnEntryLog=new ArrayList<Long>(ledgersOnEntryLog.size());
-            for(long ledger:ledgersOnEntryLog){
-              if(activeLedgersOnMetadata.contains(ledger)){
-                activeLedgersOnEntryLog.add(ledger);
+          ledgerManager.asyncProcessLedgers(ledgerProcessor, endCallback, null,
+            BKException.Code.OK, BKException.Code.ReadException);
+          if (done.await(cmdFlags.timeout, TimeUnit.MILLISECONDS)){
+            if  (resultCode.get() == BKException.Code.OK) {
+              EntryLogger entryLogger = new ReadOnlyEntryLogger(bkConf);
+              EntryLogMetadata entryLogMetadata = entryLogger.getEntryLogMetadata(cmdFlags.logId);
+              List<Long> ledgersOnEntryLog = entryLogMetadata.getLedgersMap().keys();
+              if (ledgersOnEntryLog.size() == 0) {
+                LOG.info("Ledgers on log file {} is empty", cmdFlags.logId);
               }
-            }printActiveLedgerOnEntryLog(cmdFlags.logId,activeLedgersOnEntryLog);
-          }else{
-            LOG.info("Read active ledgers id from metadata store,fail code {}",resultCode.get());
-            throw BKException.create(resultCode.get());
+              List<Long> activeLedgersOnEntryLog = new ArrayList<Long>(ledgersOnEntryLog.size());
+              for (long ledger : ledgersOnEntryLog) {
+                if (activeLedgersOnMetadata.contains(ledger)) {
+                  activeLedgersOnEntryLog.add(ledger);
+                }
+              }
+              printActiveLedgerOnEntryLog(cmdFlags.logId, activeLedgersOnEntryLog);
+            } else {
+              LOG.info("Read active ledgers id from metadata store,fail code {}", resultCode.get());
+              throw BKException.create(resultCode.get());
+            }
+          } else {
+            LOG.info("Read active ledgers id from metadata store timeout");
           }
-        }catch (Exception e){
+        } catch (BKException | InterruptedException | IOException e){
           LOG.error("Received Exception while processing ledgers", e);
           throw new UncheckedExecutionException(e);
         }
@@ -133,14 +160,14 @@ public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
     }
 
     public void printActiveLedgerOnEntryLog(long logId, List<Long> activeLedgers){
-      if(activeLedgers.size()==0){
-        System.out.println("No active ledgers on log file " +logId);
-      }else{
-        System.out.println("Active ledgers on entry log "+logId+" as follow:");
+      if (activeLedgers.size() == 0){
+        System.out.println("No active ledgers on log file " + logId);
+      } else {
+        System.out.println("Active ledgers on entry log " + logId + " as follow:");
       }
       Collections.sort(activeLedgers);
-      for(long a:activeLedgers){
-        System.out.println(ledgerIdFormatter.formatLedgerId(a)+" ");
+      for (long a:activeLedgers){
+        System.out.println(ledgerIdFormatter.formatLedgerId(a) + " ");
       }
     }
 }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
@@ -17,9 +17,9 @@
  */
 package org.apache.distributedlog.impl.metadata;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.distributedlog.DistributedLogConstants.EMPTY_BYTES;
 import static org.apache.distributedlog.DistributedLogConstants.UNASSIGNED_LOGSEGMENT_SEQNO;
 import static org.apache.distributedlog.metadata.LogMetadata.ALLOCATION_PATH;
@@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/subscription/ZKSubscriptionStateStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/subscription/ZKSubscriptionStateStore.java
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 package org.apache.distributedlog.impl.subscription;
-
-import java.nio.charset.StandardCharsets;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

For troubleshooting bookkeeper disk usage issues, having a tool to list the ledgers that are still alive in the entry log file is super useful.

### Changes
  * Add ListActiveLedgerCommand on BookieShell

Master Issue: #2358 


