### PR TITLE
Issue 2264: Bookie cannot perform Garbage Collection in case of corrupted EntryLogger file

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1011,6 +1011,11 @@ public class EntryLogger {
                 // read the entry
 
                 data.clear();
+                if (entrySize < 0) {
+                    LOG.warn("bad read for ledger entry from entryLog {}@{} (entry size {})",
+                            entryLogId, pos, entrySize);
+                    return;
+                }
                 data.capacity(entrySize);
                 int rc = readFromLogChannel(entryLogId, bc, data, pos);
                 if (rc != entrySize) {


### PR DESCRIPTION
- in case of corrupted entry log file the bookie cannot perform GC
- handle the case of an unexpected negative entrysize

### Changes

Stop scanning the file

Master Issue: #2264
