### PR TITLE
The latency of BenchThroughputLatency may be wrong due to Integer overflow when we do a large scale benchmark test 

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
@@ -419,7 +419,8 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
 
     private static double percentile(long[] latency, int percentile) {
         int size = latency.length;
-        int sampleSize = (size * percentile) / 100;
+        double percent = (double) percentile / 100;
+        int sampleSize = (int) (size * percent);
         long total = 0;
         int count = 0;
         for (int i = 0; i < sampleSize; i++) {


### PR DESCRIPTION
- When` latency.size` is  is more than `20,000,000`(e.g, `25000000`),
`(size * percentile) / 100` will be a negative number due to Integer overflow and the latency will be wrong.
- For example: `size `= 25000000, `percentile `= 99, `sampleSize `= -18199672