### PR TITLE
Issue #2197: bkctl binary distribution needs a 'logs' directory

### DIFF
--- a/bin/bkctl
+++ b/bin/bkctl
@@ -22,6 +22,7 @@
 
 BINDIR=`dirname "$0"`
 BK_HOME=`cd ${BINDIR}/..;pwd`
+mkdir -p $BK_HOME/logs
 
 source ${BK_HOME}/bin/common.sh
 source ${BK_HOME}/conf/bk_cli_env.sh


### PR DESCRIPTION
Fix #2197

Create "logs" directory before run bkctl cli