### PR TITLE
Issue #2385: NullPointerException in Zookeeper multiple operations execution with 3.6.1

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogWriteHandler.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogWriteHandler.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import jdk.internal.org.jline.utils.Log;
 import org.apache.bookkeeper.common.concurrent.FutureEventListener;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
@@ -1085,8 +1086,10 @@ class BKLogWriteHandler extends BKLogHandler {
 
     private CompletableFuture<List<LogSegmentMetadata>> setLogSegmentsOlderThanDLSNTruncated(
             List<LogSegmentMetadata> logSegments, final DLSN dlsn) {
-        LOG.debug("Setting truncation status on logs older than {} from {} for {}",
-            dlsn, logSegments, getFullyQualifiedName());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Setting truncation status on logs older than {} from {} for {}",
+                    dlsn, logSegments, getFullyQualifiedName());
+        }
         List<LogSegmentMetadata> truncateList = new ArrayList<LogSegmentMetadata>(logSegments.size());
         LogSegmentMetadata partialTruncate = null;
         LOG.info("{}: Truncating log segments older than {}", getFullyQualifiedName(), dlsn);

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogWriteHandler.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogWriteHandler.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import jdk.internal.org.jline.utils.Log;
 import org.apache.bookkeeper.common.concurrent.FutureEventListener;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/zk/ZKTransaction.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/zk/ZKTransaction.java
@@ -44,7 +44,7 @@ public class ZKTransaction implements Transaction<Object>, AsyncCallback.MultiCa
         this.zkc = zkc;
         this.ops = Lists.newArrayList();
         this.zkOps = Lists.newArrayList();
-        this.result = new CompletableFuture<Void>();
+        this.result = new CompletableFuture<>();
     }
 
     @Override
@@ -63,13 +63,15 @@ public class ZKTransaction implements Transaction<Object>, AsyncCallback.MultiCa
         if (!done.compareAndSet(false, true)) {
             return result;
         }
-        try {
-            zkc.get().multi(zkOps, this, result);
-        } catch (ZooKeeperClient.ZooKeeperConnectionException e) {
-            result.completeExceptionally(Utils.zkException(e, ""));
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            result.completeExceptionally(Utils.zkException(e, ""));
+        if (!zkOps.isEmpty()) {
+            try {
+                zkc.get().multi(zkOps, this, result);
+            } catch (ZooKeeperClient.ZooKeeperConnectionException e) {
+                result.completeExceptionally(Utils.zkException(e, ""));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                result.completeExceptionally(Utils.zkException(e, ""));
+            }
         }
         return result;
     }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/zk/ZKTransaction.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/zk/ZKTransaction.java
@@ -61,7 +61,6 @@ public class ZKTransaction implements Transaction<Object>, AsyncCallback.MultiCa
 
     @Override
     public CompletableFuture<Void> execute() {
-        System.out.println("eccoqui");
         if (!done.compareAndSet(false, true)) {
             return result;
         }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/zk/ZKTransaction.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/zk/ZKTransaction.java
@@ -18,6 +18,7 @@
 package org.apache.distributedlog.zk;
 
 import com.google.common.collect.Lists;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -60,10 +61,13 @@ public class ZKTransaction implements Transaction<Object>, AsyncCallback.MultiCa
 
     @Override
     public CompletableFuture<Void> execute() {
+        System.out.println("eccoqui");
         if (!done.compareAndSet(false, true)) {
             return result;
         }
-        if (!zkOps.isEmpty()) {
+        if (zkOps.isEmpty()) {
+            this.processResult(KeeperException.Code.OK.intValue(), null, null, Collections.emptyList());
+        } else {
             try {
                 zkc.get().multi(zkOps, this, result);
             } catch (ZooKeeperClient.ZooKeeperConnectionException e) {

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestZooKeeperClient.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestZooKeeperClient.java
@@ -461,7 +461,7 @@ public class TestZooKeeperClient extends ZooKeeperClusterTestCase {
         }
         assertEquals(ZooKeeper.States.CONNECTED, newZk.getState());
     }
-    
+
     @Test(timeout = 60000)
     public void testZKTransactionEmptyOps() throws Exception {
         Utils.ioResult(new ZKTransaction(zkc).execute());

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestZooKeeperClient.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestZooKeeperClient.java
@@ -33,6 +33,8 @@ import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.zookeeper.BoundExponentialBackoffRetryPolicy;
 import org.apache.distributedlog.ZooKeeperClient.Credentials;
 import org.apache.distributedlog.ZooKeeperClient.DigestCredentials;
+import org.apache.distributedlog.util.Utils;
+import org.apache.distributedlog.zk.ZKTransaction;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -458,5 +460,10 @@ public class TestZooKeeperClient extends ZooKeeperClusterTestCase {
             TimeUnit.MILLISECONDS.sleep(sessionTimeoutMs / 2);
         }
         assertEquals(ZooKeeper.States.CONNECTED, newZk.getState());
+    }
+    
+    @Test(timeout = 60000)
+    public void testZKTransactionEmptyOps() throws Exception {
+        Utils.ioResult(new ZKTransaction(zkc).execute());
     }
 }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestZooKeeperClient.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestZooKeeperClient.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -33,7 +34,6 @@ import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.zookeeper.BoundExponentialBackoffRetryPolicy;
 import org.apache.distributedlog.ZooKeeperClient.Credentials;
 import org.apache.distributedlog.ZooKeeperClient.DigestCredentials;
-import org.apache.distributedlog.util.Utils;
 import org.apache.distributedlog.zk.ZKTransaction;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -464,6 +464,7 @@ public class TestZooKeeperClient extends ZooKeeperClusterTestCase {
 
     @Test(timeout = 60000)
     public void testZKTransactionEmptyOps() throws Exception {
-        Utils.ioResult(new ZKTransaction(zkc).execute());
+        CompletableFuture<Void> future = new ZKTransaction(zkc).execute();
+        assertTrue(future.isDone());
     }
 }


### PR DESCRIPTION
Fix for #2385

Now we avoid to send out multiple operations request to ZooKeeper when there are not operations to execute