### PR TITLE
ISSUE #1979 Metrics link missing

### DIFF
--- a/site/docs/4.10.0/admin/metrics.md
+++ b/site/docs/4.10.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.10.0/admin/metrics.md
+++ b/site/docs/4.10.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.10.0/admin/metrics.md
+++ b/site/docs/4.10.0/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.11.0/admin/metrics.md
+++ b/site/docs/4.11.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -19,7 +19,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.11.0/admin/metrics.md
+++ b/site/docs/4.11.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -19,7 +19,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.11.0/admin/metrics.md
+++ b/site/docs/4.11.0/admin/metrics.md
@@ -4,7 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -19,7 +18,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.11.1/admin/metrics.md
+++ b/site/docs/4.11.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -19,7 +19,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.11.1/admin/metrics.md
+++ b/site/docs/4.11.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -19,7 +19,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.11.1/admin/metrics.md
+++ b/site/docs/4.11.1/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for these sinks:
@@ -19,7 +17,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.5.0/admin/metrics.md
+++ b/site/docs/4.5.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.5.0/admin/metrics.md
+++ b/site/docs/4.5.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.5.0/admin/metrics.md
+++ b/site/docs/4.5.0/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.5.1/admin/metrics.md
+++ b/site/docs/4.5.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.5.1/admin/metrics.md
+++ b/site/docs/4.5.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.5.1/admin/metrics.md
+++ b/site/docs/4.5.1/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.0/admin/metrics.md
+++ b/site/docs/4.6.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.0/admin/metrics.md
+++ b/site/docs/4.6.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.0/admin/metrics.md
+++ b/site/docs/4.6.0/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.1/admin/metrics.md
+++ b/site/docs/4.6.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.1/admin/metrics.md
+++ b/site/docs/4.6.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.1/admin/metrics.md
+++ b/site/docs/4.6.1/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.2/admin/metrics.md
+++ b/site/docs/4.6.2/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.2/admin/metrics.md
+++ b/site/docs/4.6.2/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.6.2/admin/metrics.md
+++ b/site/docs/4.6.2/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.0/admin/metrics.md
+++ b/site/docs/4.7.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.0/admin/metrics.md
+++ b/site/docs/4.7.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.0/admin/metrics.md
+++ b/site/docs/4.7.0/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.1/admin/metrics.md
+++ b/site/docs/4.7.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.1/admin/metrics.md
+++ b/site/docs/4.7.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.1/admin/metrics.md
+++ b/site/docs/4.7.1/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.2/admin/metrics.md
+++ b/site/docs/4.7.2/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.2/admin/metrics.md
+++ b/site/docs/4.7.2/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.2/admin/metrics.md
+++ b/site/docs/4.7.2/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.3/admin/metrics.md
+++ b/site/docs/4.7.3/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.3/admin/metrics.md
+++ b/site/docs/4.7.3/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.7.3/admin/metrics.md
+++ b/site/docs/4.7.3/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.0/admin/metrics.md
+++ b/site/docs/4.8.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.0/admin/metrics.md
+++ b/site/docs/4.8.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.0/admin/metrics.md
+++ b/site/docs/4.8.0/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.1/admin/metrics.md
+++ b/site/docs/4.8.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.1/admin/metrics.md
+++ b/site/docs/4.8.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.1/admin/metrics.md
+++ b/site/docs/4.8.1/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.2/admin/metrics.md
+++ b/site/docs/4.8.2/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.2/admin/metrics.md
+++ b/site/docs/4.8.2/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.8.2/admin/metrics.md
+++ b/site/docs/4.8.2/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.0/admin/metrics.md
+++ b/site/docs/4.9.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.0/admin/metrics.md
+++ b/site/docs/4.9.0/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.0/admin/metrics.md
+++ b/site/docs/4.9.0/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.1/admin/metrics.md
+++ b/site/docs/4.9.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.1/admin/metrics.md
+++ b/site/docs/4.9.1/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.1/admin/metrics.md
+++ b/site/docs/4.9.1/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.2/admin/metrics.md
+++ b/site/docs/4.9.2/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.2/admin/metrics.md
+++ b/site/docs/4.9.2/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -22,7 +22,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/4.9.2/admin/metrics.md
+++ b/site/docs/4.9.2/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for four five sinks:
@@ -22,7 +20,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/latest/admin/metrics.md
+++ b/site/docs/latest/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](../../reference/metrics) reference doc.
+> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
 
 ## Stats providers
 
@@ -19,7 +19,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config#statistics) available for bookies:
+There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/latest/admin/metrics.md
+++ b/site/docs/latest/admin/metrics.md
@@ -4,7 +4,7 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the [Metrics](https://bookkeeper.apache.org/docs/4.9.0/admin/metrics/) reference doc.
+> For a full listing of available metrics, see the Metrics reference doc.
 
 ## Stats providers
 
@@ -19,7 +19,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](https://bookkeeper.apache.org/docs/4.9.0/reference/config/) available for bookies:
+There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------

--- a/site/docs/latest/admin/metrics.md
+++ b/site/docs/latest/admin/metrics.md
@@ -4,8 +4,6 @@ title: Metric collection
 
 BookKeeper enables metrics collection through a variety of [stats providers](#stats-providers).
 
-> For a full listing of available metrics, see the Metrics reference doc.
-
 ## Stats providers
 
 BookKeeper has stats provider implementations for these sinks:
@@ -19,7 +17,7 @@ Provider | Provider class name
 
 ## Enabling stats providers in bookies
 
-There are two stats-related [configuration parameters](../../reference/config/) available for bookies:
+Two stats-related [configuration parameters](../../reference/config/) are available for bookies:
 
 Parameter | Description | Default
 :---------|:------------|:-------


### PR DESCRIPTION
Fixes #1979 

The link for `Metrics` is broken. However, the `Metrics` file is empty. Therefore, I temporarily removed the link in all versions. The same problem happened to `configuration parameters`.

I closed pr #2386 as it brought changes from the master instead of a new branch.