### PR TITLE
fix maven-javadoc-plugin configuration.

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -233,7 +233,7 @@
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>
           <!-- Avoid for missing javadoc comments to be marked as errors -->
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <doclint>-Xdoclint:none</doclint>
           <subpackages>org.apache.bookkeeper.client:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature</subpackages>
           <groups>
             <group>

--- a/bookkeeper-stats/pom.xml
+++ b/bookkeeper-stats/pom.xml
@@ -34,7 +34,7 @@
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>
           <!-- Avoid for missing javadoc comments to be marked as errors -->
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <doclint>-Xdoclint:none</doclint>
           <subpackages>org.apache.bookkeeper.stats</subpackages>
           <groups>
             <group>

--- a/pom.xml
+++ b/pom.xml
@@ -870,7 +870,7 @@
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>
           <!-- Prevent missing javadoc comments from being marked as errors -->
-          <additionalparam>-Xdoclint:none -notimestamp</additionalparam>
+          <doclint>-Xdoclint:none -notimestamp</doclint>
           <additionalOptions>
             <additionalOption>-Xdoclint:none -notimestamp</additionalOption>
           </additionalOptions>

--- a/stream/distributedlog/pom.xml
+++ b/stream/distributedlog/pom.xml
@@ -45,7 +45,7 @@
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>
           <!-- Avoid for missing javadoc comments to be marked as errors -->
-          <additionalparam>-Xdoclint:none -notimestamp</additionalparam>
+          <doclint>-Xdoclint:none -notimestamp</doclint>
           <groups>
             <group>
               <title>Core Library</title>


### PR DESCRIPTION
Descriptions of the changes in this PR:

change the doclint configuration in pom.xml 



### Motivation

when you clone the project there is always warning in IntelliJ IDEA

### Changes

change the doclint configuration in pom.xml  according to https://stackoverflow.com/questions/52547306/maven-javadoc-plugin-not-accepting-additionalparam-xdoclintnone-additionalpa

