### PR TITLE
Upgrade the `vertx` version to 3.5.3

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -237,9 +237,9 @@ Apache Software License, Version 2.
 - lib/io.prometheus-simpleclient_common-0.0.21.jar [17]
 - lib/io.prometheus-simpleclient_hotspot-0.0.21.jar [17]
 - lib/io.prometheus-simpleclient_servlet-0.0.21.jar [17]
-- lib/io.vertx-vertx-auth-common-3.4.1.jar [18]
-- lib/io.vertx-vertx-core-3.4.1.jar [19]
-- lib/io.vertx-vertx-web-3.4.1.jar [20]
+- lib/io.vertx-vertx-auth-common-3.5.3.jar [18]
+- lib/io.vertx-vertx-core-3.5.3.jar [19]
+- lib/io.vertx-vertx-web-3.5.3.jar [20]
 - lib/log4j-log4j-1.2.17.jar [21]
 - lib/net.java.dev.jna-jna-3.2.7.jar [22]
 - lib/org.apache.commons-commons-collections4-4.1.jar [23]
@@ -301,9 +301,9 @@ Apache Software License, Version 2.
 [14] Source available at https://github.com/dropwizard/metrics/tree/v3.1.0
 [16] Source available at https://github.com/netty/netty/tree/netty-4.1.32.Final
 [17] Source available at https://github.com/prometheus/client_java/tree/parent-0.0.21
-[18] Source available at https://github.com/vert-x3/vertx-auth/tree/3.4.1
-[19] Source available at https://github.com/eclipse/vert.x/tree/3.4.1
-[20] Source available at https://github.com/vert-x3/vertx-web/tree/3.4.1
+[18] Source available at https://github.com/vert-x3/vertx-auth/tree/3.5.3
+[19] Source available at https://github.com/eclipse/vert.x/tree/3.5.3
+[20] Source available at https://github.com/vert-x3/vertx-web/tree/3.5.3
 [21] Source available at http://logging.apache.org/log4j/1.2/download.html
 [22] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [23] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -234,9 +234,9 @@ Apache Software License, Version 2.
 - lib/io.prometheus-simpleclient_common-0.0.21.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.0.21.jar [12]
 - lib/io.prometheus-simpleclient_servlet-0.0.21.jar [12]
-- lib/io.vertx-vertx-auth-common-3.4.1.jar [13]
-- lib/io.vertx-vertx-core-3.4.1.jar [14]
-- lib/io.vertx-vertx-web-3.4.1.jar [15]
+- lib/io.vertx-vertx-auth-common-3.5.3.jar [13]
+- lib/io.vertx-vertx-core-3.5.3.jar [14]
+- lib/io.vertx-vertx-web-3.5.3.jar [15]
 - lib/log4j-log4j-1.2.17.jar [16]
 - lib/net.java.dev.jna-jna-3.2.7.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [18]
@@ -296,9 +296,9 @@ Apache Software License, Version 2.
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.32.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.0.21
-[13] Source available at https://github.com/vert-x3/vertx-auth/tree/3.4.1
-[14] Source available at https://github.com/eclipse/vert.x/tree/3.4.1
-[15] Source available at https://github.com/vert-x3/vertx-web/tree/3.4.1
+[13] Source available at https://github.com/vert-x3/vertx-auth/tree/3.5.3
+[14] Source available at https://github.com/eclipse/vert.x/tree/3.5.3
+[15] Source available at https://github.com/vert-x3/vertx-web/tree/3.5.3
 [16] Source available at http://logging.apache.org/log4j/1.2/download.html
 [17] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <javax-annotations-api.version>1.3.2</javax-annotations-api.version>
     <testcontainers.version>1.8.3</testcontainers.version>
-    <vertx.version>3.4.1</vertx.version>
+    <vertx.version>3.5.3</vertx.version>
     <zookeeper.version>3.5.7</zookeeper.version>
     <jctools.version>2.1.2</jctools.version>
     <!-- plugin dependencies -->


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Motivation

As the https://github.com/apache/pulsar/issues/7931 said, CVE-2018-12540 has been raised on vertx 3.4.1 which is found in the pulsar dependencies. 

### Changes

- Upgrade the vertx version from 3.4.1 to 3.5.3
- Update license files

