### PR TITLE
BP-42: new api list ledgers

### DIFF
--- a/site/bps/BP-42-new-api-list-ledgers.md
+++ b/site/bps/BP-42-new-api-list-ledgers.md
@@ -1,0 +1,93 @@
+---
+title: "BP-42: New Client API - list ledgers"
+issue: https://github.com/apache/bookkeeper/<issue-number>
+state: "Under Discussion"
+release: "N/A"
+---
+
+### Motivation
+
+The new Client API (`org.apache.bookkeeper.client.api.BookKeeper`) aims to replace obsolete BookKeeper API but some features are not implemented yet, like the functionalities provided by `BookKeeperAdmin`. 
+For example, it does not expose a method to list available ledgers, comparable to `BookKeeperAdmin#listLedgers()`.
+
+#### Ledgers listing 
+The goal here is to extends the Client API for listing ledgers. Moreover current method  `BookKeeperAdmin#listLedgers()` does not report errors from the metadata driver; for instance, if an IOException occurs during iterator flow, the error is not visible to the caller and the iteration is stopped (e.g. hasNext will return false). However there is no intention to change this behaviour in this proposal.
+
+#### Simpler access to LedgerMetadata
+The goal here is to streamline the access to `LedgerMetadata`, directly from BookKeeper interface.
+
+#### Ledger id inside LedgerMetadata
+Currently there is no `ledgerId` property inside `LedgerMetadata` interface, this can be helpful in some contexts.
+
+
+### Public Interfaces
+
+This proposal adds new interfaces to `org.apache.bookkeeper.client.api` package, similar to `org.apache.bookkeeper.client.api.BookKeeper` methods. 
+
+    // new interface
+    interface LedgersIterator {
+
+        boolean hasNext() throws IOException;
+
+        long next() throws IOException;
+    }
+
+    // new interface
+    interface ListLedgersResult extends AutoCloseable {
+
+        LedgersIterator iterator();
+
+        Iterable<Long> toIterable();
+    }
+
+    // new interface
+    interface ListLedgersResultBuilder extends OpBuilder<Void>{
+
+        // empty now, maybe some filters in future
+    }
+
+    interface BookKeeper {
+
+        ....
+
+        ListLedgersResultBuilder newListLedgersOp();
+
+        CompleatableFuture<LedgerMetadata> getLedgerMetadata(long ledgerId);
+
+    }
+
+    interface LedgerMetadata {
+        
+        ....
+
+        long getLedgerId();
+
+    }
+
+### Proposed Changes
+
+#### Ledgers listing
+
+The implementation is pretty similar to `BookKeeperAdmin#listLedgers()` but there are few enhancements:
+- Handle metadata driver errors, since the IOException is directly thrown up to caller, allowing user to handle network errors in a more suitable way.
+- Leave the possibility to restrict/filter returned ledgers in future, without API breaking changes   
+
+The implementation will be the same used in BookKeeperAdmin, iterating over `LedgerRangeIterator`, which already handles ledgers search properly.
+
+#### Simpler access to LedgerMetadata
+The implementation will use LedgerManager to retrieve metadata for a specified ledgerId.  
+
+#### Ledger id inside LedgerMetadata
+Each time a LedgerMetadata instance is created, the ledgerId is known, so it is trivial to set it in the instance.
+
+### Compatibility, Deprecation, and Migration Plan
+
+No impact for current API, the proposal does not aim to explicit deprecate `BookKeeperAdmin#listLedgers()` method.
+
+### Test Plan
+
+This proposal needs only new unit tests, other tests must continue pass without any changes.
+
+### Rejected Alternatives
+
+An alternative could be creates a new API similar to BookKeeperAdmin but it is better to invest enhancing `org.apache.bookkeeper.client.api.BookKeeper` API.

--- a/site/bps/BP-42-new-api-list-ledgers.md
+++ b/site/bps/BP-42-new-api-list-ledgers.md
@@ -1,6 +1,6 @@
 ---
 title: "BP-42: New Client API - list ledgers"
-issue: https://github.com/apache/bookkeeper/<issue-number>
+issue: https://github.com/apache/bookkeeper/issues/2422
 state: "Under Discussion"
 release: "N/A"
 ---

--- a/site/bps/BP-42-new-api-list-ledgers.md
+++ b/site/bps/BP-42-new-api-list-ledgers.md
@@ -11,7 +11,7 @@ The new Client API (`org.apache.bookkeeper.client.api.BookKeeper`) aims to repla
 For example, it does not expose a method to list available ledgers, comparable to `BookKeeperAdmin#listLedgers()`.
 
 #### Ledgers listing 
-The goal here is to extends the Client API for listing ledgers. Moreover current method  `BookKeeperAdmin#listLedgers()` does not report errors from the metadata driver; for instance, if an IOException occurs during iterator flow, the error is not visible to the caller and the iteration is stopped (e.g. hasNext will return false). However there is no intention to change this behaviour in this proposal.
+The goal here is to extend the Client API for listing ledgers. Moreover current method  `BookKeeperAdmin#listLedgers()` does not report errors from the metadata driver; for instance, if an IOException occurs during iterator flow, the error is not visible to the caller and the iteration is stopped (e.g. hasNext will return false). However there is no intention to change this behaviour in this proposal.
 
 #### Simpler access to LedgerMetadata
 The goal here is to streamline the access to `LedgerMetadata`, directly from BookKeeper interface.
@@ -71,6 +71,7 @@ This proposal adds new interfaces to `org.apache.bookkeeper.client.api` package,
 The implementation is pretty similar to `BookKeeperAdmin#listLedgers()` but there are few enhancements:
 - Handle metadata driver errors, since the IOException is directly thrown up to caller, allowing user to handle network errors in a more suitable way.
 - Leave the possibility to restrict/filter returned ledgers in future, without API breaking changes   
+- Dispose some resources needed to retrieve ledgers (`ListLedgersResult` extends `AutoCloseable`)) (will be empty for current implementations)
 
 The implementation will be the same used in BookKeeperAdmin, iterating over `LedgerRangeIterator`, which already handles ledgers search properly.
 


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation


The new Client API (org.apache.bookkeeper.client.api.BookKeeper) aims to replace obsolete BookKeeper API but some features are not implemented yet, like the functionalities provided by BookKeeperAdmin.
For example, it does not expose a method to list available ledgers, comparable to BookKeeperAdmin#listLedgers().
low.

### Changes

- Ledgers listing
- Simpler access to LedgerMetadata
- Ledger id inside LedgerMetadata

Master Issue: #2422

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
