### PR TITLE
Issue 2425: Typo for method name

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -447,7 +448,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                 conf,
                 scheduler,
                 rootStatsLogger,
-                java.util.Optional.ofNullable(zkc));
+                Optional.ofNullable(zkc));
         } catch (ConfigurationException ce) {
             LOG.error("Failed to initialize metadata client driver using invalid metadata service uri", ce);
             throw new IOException("Failed to initialize metadata client driver", ce);
@@ -569,7 +570,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         throws IOException {
         try {
             Class<? extends EnsemblePlacementPolicy> policyCls = conf.getEnsemblePlacementPolicy();
-            return ReflectionUtils.newInstance(policyCls).initialize(conf, java.util.Optional.ofNullable(dnsResolver),
+            return ReflectionUtils.newInstance(policyCls).initialize(conf, Optional.ofNullable(dnsResolver),
                     timer, featureProvider, statsLogger, bookieAddressResolver);
         } catch (ConfigurationException e) {
             throw new IOException("Failed to initialize ensemble placement policy : ", e);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -107,7 +107,7 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
             if (ackSet.completeBookieAndCheck(bookieIndex)) {
                 completed = true;
                 // we are able to say that every bookie sync'd its own journal
-                // for every ackknowledged entry before issuing the force() call
+                // for every acknowledged entry before issuing the force() call
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("After force on ledger {} updating LastAddConfirmed to {} ",
                               ledgerId, currentNonDurableLastAddConfirmed);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -120,7 +120,7 @@ public class LedgerHandle implements WriteHandle {
 
      /**
       * Next entryId which is expected to move forward during {@link #sendAddSuccessCallbacks() }. This is important
-      * in order to have an ordered sequence of addEntry ackknowledged to the writer
+      * in order to have an ordered sequence of addEntry acknowledged to the writer
       */
     volatile long pendingAddsSequenceHead;
 
@@ -1212,7 +1212,7 @@ public class LedgerHandle implements WriteHandle {
         doAsyncAddEntry(op);
     }
 
-    private boolean isWritesetWritable(DistributionSchedule.WriteSet writeSet,
+    private boolean isWriteSetWritable(DistributionSchedule.WriteSet writeSet,
                                        long key, int allowedNonWritableCount) {
         if (allowedNonWritableCount < 0) {
             allowedNonWritableCount = 0;
@@ -1246,14 +1246,14 @@ public class LedgerHandle implements WriteHandle {
         }
 
         final long startTime = MathUtils.nowInNano();
-        boolean success = isWritesetWritable(writeSet, key, allowedNonWritableCount);
+        boolean success = isWriteSetWritable(writeSet, key, allowedNonWritableCount);
 
         if (!success && durationMs > 0) {
             int backoff = 1;
             final int maxBackoff = 4;
             final long deadline = startTime + TimeUnit.MILLISECONDS.toNanos(durationMs);
 
-            while (!isWritesetWritable(writeSet, key, allowedNonWritableCount)) {
+            while (!isWriteSetWritable(writeSet, key, allowedNonWritableCount)) {
                 if (MathUtils.nowInNano() < deadline) {
                     long maxSleep = MathUtils.elapsedMSec(startTime);
                     if (maxSleep < 0) {
@@ -1265,7 +1265,7 @@ public class LedgerHandle implements WriteHandle {
                         TimeUnit.MILLISECONDS.sleep(sleepMs);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        success = isWritesetWritable(writeSet, key, allowedNonWritableCount);
+                        success = isWriteSetWritable(writeSet, key, allowedNonWritableCount);
                         break;
                     }
                     if (backoff <= maxBackoff) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -267,7 +267,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         payload = null;
 
         // We are about to send. Check if we need to make an ensemble change
-        // becasue of delayed write errors
+        // because of delayed write errors
         lh.maybeHandleDelayedWriteBookieFailure();
 
         // Iterate over set and trigger the sendWriteRequests

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerLayout.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerLayout.java
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 @ToString
 public class LedgerLayout {
 
-    // version of compability layout version
+    // version of compatibility layout version
     public static final int LAYOUT_MIN_COMPAT_VERSION = 1;
     // version of ledger layout metadata
     public static final int LAYOUT_FORMAT_VERSION = 2;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -214,7 +214,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
                 if (null == oldClientPool) {
                     clientPool = newClientPool;
                     // initialize the pool only after we put the pool into the map
-                    clientPool.intialize();
+                    clientPool.initialize();
                 } else {
                     clientPool = oldClientPool;
                     newClientPool.close(false);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/DefaultPerChannelBookieClientPool.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/DefaultPerChannelBookieClientPool.java
@@ -87,7 +87,7 @@ class DefaultPerChannelBookieClientPool implements PerChannelBookieClientPool,
     }
 
     @Override
-    public void intialize() {
+    public void initialize() {
         for (PerChannelBookieClient pcbc : this.clients) {
             pcbc.connectIfNeededAndDoOp(this);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClientPool.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClientPool.java
@@ -28,9 +28,9 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 public interface PerChannelBookieClientPool {
 
     /**
-     * intialize the pool. the implementation should not be blocked.
+     * initialize the pool. the implementation should not be blocked.
      */
-    void intialize();
+    void initialize();
 
     /**
      * Obtain a channel from channel pool to execute operations.

--- a/site/docs/4.10.0/api/ledger-api.md
+++ b/site/docs/4.10.0/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/4.11.0/api/ledger-api.md
+++ b/site/docs/4.11.0/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/4.11.1/api/ledger-api.md
+++ b/site/docs/4.11.1/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/4.8.0/api/ledger-api.md
+++ b/site/docs/4.8.0/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/4.8.1/api/ledger-api.md
+++ b/site/docs/4.8.1/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/4.8.2/api/ledger-api.md
+++ b/site/docs/4.8.2/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/4.9.0/api/ledger-api.md
+++ b/site/docs/4.9.0/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/4.9.1/api/ledger-api.md
+++ b/site/docs/4.9.1/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/4.9.2/api/ledger-api.md
+++ b/site/docs/4.9.2/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 

--- a/site/docs/latest/api/ledger-api.md
+++ b/site/docs/latest/api/ledger-api.md
@@ -810,7 +810,7 @@ writing the entry to SO buffers without waiting for an fsync.
 In this case the LastAddConfirmed pointer is not advanced to the writer side neither is updated on the reader's side, this is because **there is some chance to lose the entry**.
 Such entries will be still readable using readUnconfirmed() API, but they won't be readable using Long Poll reads or regular read() API.
 
-In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble ackknowledge the call after
+In order to get guarantees of durability the writer must use explicitly the [force()](../javadoc/org/apache/bookkeeper/client/api/ForceableHandle) API which will return only after all the bookies in the ensemble acknowledge the call after
 performing an fsync to the disk which is storing the journal.
 This way the LastAddConfirmed pointer is advanced on the writer side and it will be eventually available to the readers.
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Rename the method name:
```
PerChannelBookieClientPool#initialize
LedgerHandle#isWriteSetWritable
```
And some typos.

