### PR TITLE
Update Copyright year to 2020 in NOTICE files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache BookKeeper
-Copyright 2011-2018 The Apache Software Foundation
+Copyright 2011-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -1,5 +1,5 @@
 Apache BookKeeper
-Copyright 2011-2018 The Apache Software Foundation
+Copyright 2011-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -1,5 +1,5 @@
 Apache BookKeeper
-Copyright 2011-2018 The Apache Software Foundation
+Copyright 2011-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -1,5 +1,5 @@
 Apache BookKeeper
-Copyright 2011-2018 The Apache Software Foundation
+Copyright 2011-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Changes:
- update Copyright reference year to 2020 in main NOTICE file and in templates for the binary distributions