### PR TITLE
ISSUE 2377 : Relax grpcio requirement for python client to support python3.8 on mac os

### DIFF
--- a/stream/clients/python/bookkeeper/common/router/router.py
+++ b/stream/clients/python/bookkeeper/common/router/router.py
@@ -27,4 +27,4 @@ class BytesHashRouter(object):
         return
 
     def getRoutingKey(self, key):
-        return mmh3.hash64(key, seed=__SEED__, signed=True)[0]
+        return mmh3.hash64(key, seed=__SEED__)[0]

--- a/stream/clients/python/scripts/test.sh
+++ b/stream/clients/python/scripts/test.sh
@@ -19,6 +19,7 @@ set -e -x -u
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+PY_VERSION="3.8" NOXSESSION="unit" ${SCRIPT_DIR}/docker_tests.sh
 PY_VERSION="3.7" NOXSESSION="lint,lint_setup_py,unit" ${SCRIPT_DIR}/docker_tests.sh
 PY_VERSION="3.6" NOXSESSION="unit" ${SCRIPT_DIR}/docker_tests.sh
 PY_VERSION="3.5" NOXSESSION="unit" ${SCRIPT_DIR}/docker_tests.sh

--- a/stream/clients/python/setup.py
+++ b/stream/clients/python/setup.py
@@ -33,7 +33,7 @@ dependencies = [
     'pytz',
     'futures>=3.2.0;python_version<"3.2"',
     'grpcio<1.28,>=1.8.2',
-    'pymmh3>=0.0.3'
+    'pymmh3>=0.0.5'
 ]
 extras = {
 }

--- a/stream/clients/python/setup.py
+++ b/stream/clients/python/setup.py
@@ -32,7 +32,7 @@ dependencies = [
     'six>=1.10.0',
     'pytz',
     'futures>=3.2.0;python_version<"3.2"',
-    'grpcio<1.26.0,>=1.8.2',
+    'grpcio<1.28,>=1.8.2',
     'pymmh3>=0.0.3'
 ]
 extras = {


### PR DESCRIPTION


Descriptions of the changes in this PR:

Require a grpcio version that is minor of 1.28. This allow to install the 1.27.2 that has a pre-compiled wheel for python 3.8 on mac os.
Add tests for python 3.8


### Motivation

grpcio 1.25.0 does not allow the installation using python 3.8 on mac os x. This is due to the fact that the pre-compiled wheels have not been published before 1.26.0

### Changes


Updated the setup.py to relax a bit the requirement for grpcio
Add python3.8 as tested version
Updated the setup.py to install the latest pymmh3 version. **Note**: master tests are broken, I've updated the library and removed the 'signed' parameter that does not exists not anymore.

Master Issue: #<master-issue-number>

cc @eolivelli 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
