### PR TITLE
Update to OpenJDK11 in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@
 FROM centos:7
 MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
 
-ARG BK_VERSION=4.9.0
+ARG BK_VERSION=4.11.0
 ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
 ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
 
@@ -28,12 +28,12 @@ ENV BOOKIE_PORT=3181
 EXPOSE $BOOKIE_PORT
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11
 
 # Download Apache Bookkeeper, untar and clean up
 RUN set -x \
     && adduser "${BK_USER}" \
-    && yum install -y java-1.8.0-openjdk-headless wget bash python sudo\
+    && yum install -y java-11-openjdk wget bash python sudo\
     && mkdir -pv /opt \
     && cd /opt \
     && wget -q "${DISTRO_URL}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ ENV BOOKIE_PORT=3181
 EXPOSE $BOOKIE_PORT
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11
+ENV JAVA_HOME=/usr/lib/jvm/jre-11
 
 # Download Apache Bookkeeper, untar and clean up
 RUN set -x \
@@ -52,7 +52,8 @@ RUN set -x \
     && pip install zk-shell \
     && rm -rf get-pip.py \
     && yum remove -y wget \
-    && yum clean all
+    && yum clean all \
+    && ls /usr/lib/jvm
 
 WORKDIR /opt/bookkeeper
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,12 +28,12 @@ ENV BOOKIE_PORT=3181
 EXPOSE $BOOKIE_PORT
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/jre-11
+ENV JAVA_HOME=/usr/lib/jvm/jdk-11
 
 # Download Apache Bookkeeper, untar and clean up
 RUN set -x \
     && adduser "${BK_USER}" \
-    && yum install -y java-11-openjdk wget bash python sudo\
+    && yum install -y java-11-openjdk-devel wget bash python sudo\
     && mkdir -pv /opt \
     && cd /opt \
     && wget -q "${DISTRO_URL}" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ Bookkeeper needs [Zookeeper](https://zookeeper.apache.org/) in order to preserve
 Just like running a BookKeeper cluster in one machine(http://bookkeeper.apache.org/docs/latest/getting-started/run-locally/), you can run a standalone BookKeeper in one docker container, the command is:
 ```
 docker run -it \
-     --env JAVA_HOME=/usr/lib/jvm/jre-11 \
+     --env JAVA_HOME=/usr/lib/jvm/jdk-11 \
      --entrypoint "/bin/bash" \
      apache/bookkeeper \
      -c "/opt/bookkeeper/bin/bookkeeper localbookie 3"

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ Bookkeeper needs [Zookeeper](https://zookeeper.apache.org/) in order to preserve
 Just like running a BookKeeper cluster in one machine(http://bookkeeper.apache.org/docs/latest/getting-started/run-locally/), you can run a standalone BookKeeper in one docker container, the command is:
 ```
 docker run -it \
-     --env JAVA_HOME=/usr/lib/jvm/jre-1.8.0 \
+     --env JAVA_HOME=/usr/lib/jvm/jre-11 \
      --entrypoint "/bin/bash" \
      apache/bookkeeper \
      -c "/opt/bookkeeper/bin/bookkeeper localbookie 3"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jre-11
+      - JAVA_HOME=/usr/lib/jvm/jdk-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 
@@ -38,7 +38,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jre-11
+      - JAVA_HOME=/usr/lib/jvm/jdk-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 
@@ -48,7 +48,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jre-11
+      - JAVA_HOME=/usr/lib/jvm/jdk-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+      - JAVA_HOME=/usr/lib/jvm/jre-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 
@@ -38,7 +38,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+      - JAVA_HOME=/usr/lib/jvm/jre-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 
@@ -48,7 +48,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+      - JAVA_HOME=/usr/lib/jvm/jre-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -21,7 +21,7 @@
 # */
 
 export PATH=$PATH:/opt/bookkeeper/bin
-export JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+export JAVA_HOME=/usr/lib/jvm/jre-11
 
 BK_HOME=/opt/bookkeeper
 BINDIR=${BK_HOME}/bin

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -21,7 +21,7 @@
 # */
 
 export PATH=$PATH:/opt/bookkeeper/bin
-export JAVA_HOME=/usr/lib/jvm/jre-11
+export JAVA_HOME=/usr/lib/jvm/jdk-11
 
 BK_HOME=/opt/bookkeeper
 BINDIR=${BK_HOME}/bin

--- a/docker/scripts/healthcheck.sh
+++ b/docker/scripts/healthcheck.sh
@@ -24,7 +24,7 @@
 
 set -x -e -u
 
-export JAVA_HOME=/usr/lib/jvm/jre-11
+export JAVA_HOME=/usr/lib/jvm/jdk-11
 
 # Sanity check that creates a ledger, writes a few entries, reads them and deletes the ledger.
 DEFAULT_HEALTH_CHECK_CMD="/opt/bookkeeper/bin/bookkeeper shell bookiesanity"

--- a/docker/scripts/healthcheck.sh
+++ b/docker/scripts/healthcheck.sh
@@ -24,7 +24,7 @@
 
 set -x -e -u
 
-export JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+export JAVA_HOME=/usr/lib/jvm/jre-11
 
 # Sanity check that creates a ledger, writes a few entries, reads them and deletes the ledger.
 DEFAULT_HEALTH_CHECK_CMD="/opt/bookkeeper/bin/bookkeeper shell bookiesanity"

--- a/tests/docker-images/current-version-image/Dockerfile
+++ b/tests/docker-images/current-version-image/Dockerfile
@@ -30,13 +30,13 @@ ENV BOOKIE_GRPC_PORT=4181
 EXPOSE ${BOOKIE_PORT} ${BOOKIE_HTTP_PORT} ${BOOKIE_GRPC_PORT}
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11
 
 # prepare utils
 RUN set -x \
     && adduser "${BK_USER}" \
     && yum install -y epel-release \
-    && yum install -y java-1.8.0-openjdk-headless wget bash python-pip python-devel sudo netcat gcc gcc-c++ \
+    && yum install -y java-11-openjdk wget bash python-pip python-devel sudo netcat gcc gcc-c++ \
     && mkdir -pv /opt \
     && cd /opt \
     # install zookeeper shell

--- a/tests/docker-images/current-version-image/Dockerfile
+++ b/tests/docker-images/current-version-image/Dockerfile
@@ -30,13 +30,13 @@ ENV BOOKIE_GRPC_PORT=4181
 EXPOSE ${BOOKIE_PORT} ${BOOKIE_HTTP_PORT} ${BOOKIE_GRPC_PORT}
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11
+ENV JAVA_HOME=/usr/lib/jvm/jdk-11
 
 # prepare utils
 RUN set -x \
     && adduser "${BK_USER}" \
     && yum install -y epel-release \
-    && yum install -y java-11-openjdk wget bash python-pip python-devel sudo netcat gcc gcc-c++ \
+    && yum install -y java-11-openjdk-devel wget bash python-pip python-devel sudo netcat gcc gcc-c++ \
     && mkdir -pv /opt \
     && cd /opt \
     # install zookeeper shell


### PR DESCRIPTION
Descriptions of the changes in this PR:
- Update "master" docker image to BK 4.11.0
- Update to OpenJDK11 the main Docker image and the Docker image used for integration tests
- We are not using "JRE" because it does not bundle jshell and our script detects the presence of JDK11+ from the presence of file "jshell"

Master Issue: #2387
