### PR TITLE
Detect Java 11 JRE and not only JDK

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -72,7 +72,7 @@ source ${BK_CONFDIR}/bk_cli_env.sh
 
 detect_jdk8() {
 
-  if [ -f "$JAVA_HOME/bin/jshell" ]; then
+  if [ -f "$JAVA_HOME/lib/modules" ]; then
      echo "0"
   else
      echo "1"


### PR DESCRIPTION
- Use 'lib/modules' in order to detect a modern JDK
- With this change we can detect both JDK and JRE
