### PR TITLE
Fix JAVA_HOME in Dockerimage and allow it to be overwritten

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ ENV BOOKIE_PORT=3181
 EXPOSE $BOOKIE_PORT
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/jdk-11
+ENV JAVA_HOME=/usr/lib/jvm/java-11
 
 # Download Apache Bookkeeper, untar and clean up
 RUN set -x \

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ Bookkeeper needs [Zookeeper](https://zookeeper.apache.org/) in order to preserve
 Just like running a BookKeeper cluster in one machine(http://bookkeeper.apache.org/docs/latest/getting-started/run-locally/), you can run a standalone BookKeeper in one docker container, the command is:
 ```
 docker run -it \
-     --env JAVA_HOME=/usr/lib/jvm/jdk-11 \
+     --env JAVA_HOME=/usr/lib/jvm/java-11 \
      --entrypoint "/bin/bash" \
      apache/bookkeeper \
      -c "/opt/bookkeeper/bin/bookkeeper localbookie 3"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jdk-11
+      - JAVA_HOME=/usr/lib/jvm/java-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 
@@ -38,7 +38,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jdk-11
+      - JAVA_HOME=/usr/lib/jvm/java-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 
@@ -48,7 +48,7 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/jdk-11
+      - JAVA_HOME=/usr/lib/jvm/java-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 # When we build 'latest' tag we want to not override BK_VERSION variable
 if [[ "$DOCKER_TAG" = "latest" ]]
 then

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -21,7 +21,6 @@
 # */
 
 export PATH=$PATH:/opt/bookkeeper/bin
-export JAVA_HOME=/usr/lib/jvm/jdk-11
 
 BK_HOME=/opt/bookkeeper
 BINDIR=${BK_HOME}/bin

--- a/docker/scripts/healthcheck.sh
+++ b/docker/scripts/healthcheck.sh
@@ -24,8 +24,6 @@
 
 set -x -e -u
 
-export JAVA_HOME=/usr/lib/jvm/jdk-11
-
 # Sanity check that creates a ledger, writes a few entries, reads them and deletes the ledger.
 DEFAULT_HEALTH_CHECK_CMD="/opt/bookkeeper/bin/bookkeeper shell bookiesanity"
 


### PR DESCRIPTION
- Fix Java 11 Path in Dockerfile
- Allow to overwrite JAVA_HOME in entrypoint.sh and healthcheck.sh