### PR TITLE
ZookeeperClient should retry instantly on zk session expiry

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ZooKeeperClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ZooKeeperClient.java
@@ -228,6 +228,9 @@ public class ZooKeeperClient extends ZooKeeper implements Watcher, AutoCloseable
             checkArgument(retryExecThreadCount > 0);
 
             if (null == connectRetryPolicy) {
+                // Session expiry event is received by client only when zk quorum is well established.
+                // All other connection loss retries happen at zk client library transparently.
+                // Hence, we don't need to wait before retrying.
                 connectRetryPolicy =
                         new BoundExponentialBackoffRetryPolicy(0, 0, Integer.MAX_VALUE);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ZooKeeperClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ZooKeeperClient.java
@@ -229,7 +229,7 @@ public class ZooKeeperClient extends ZooKeeper implements Watcher, AutoCloseable
 
             if (null == connectRetryPolicy) {
                 connectRetryPolicy =
-                        new BoundExponentialBackoffRetryPolicy(sessionTimeoutMs, sessionTimeoutMs, Integer.MAX_VALUE);
+                        new BoundExponentialBackoffRetryPolicy(0, 0, Integer.MAX_VALUE);
             }
             if (null == operationRetryPolicy) {
                 operationRetryPolicy =


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Currently, we wait for `sessionTimeoutMs` before initiating a new zk cnxn. Session expiry is recevied only
when zk quprum is in a healthy state and can acquire a quorum to expire a session.
All other connection loss retries happen at zk client library transparently.

There is not much benefit waiting at BK client level.

### Changes

Updated the values for backoff and maxbackoff to 0 seconds.
