### PR TITLE
Issue 2170: Cleaned up error message for NoNodeException for lostBook…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
@@ -811,6 +811,9 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             LOG.info("lostBookieRecoveryDelay Znode is already present, so using "
                     + "existing lostBookieRecoveryDelay Znode value");
             return false;
+        } catch (KeeperException.NoNodeException nne) {
+            LOG.error("lostBookieRecoveryDelay Znode not found. Please verify if Auditor has been initialized.", nne);
+            return false;
         } catch (KeeperException ke) {
             LOG.error("Error while initializing LostBookieRecoveryDelay", ke);
             throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);


### PR DESCRIPTION
…ieRecoveryDelay when Auditor is not initialized.

### Motivation

If Auditor has not been initialized, running `lostBookieRecoveryDelay` from bookie shell will result in a stack trace and `NoNodeException`.

### Changes

Added a catch clause which:
* Cleans up stack trace
* Explains that the Auditor is not up yet, which means the znode for `lostbookierecoverydelay` has not been created yet.
* Prints exception

Master Issue: #2170 

