### PR TITLE
BP-41 Cleanup tools logs

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -47,7 +47,12 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
                 throw new Exception("bookie " + bookieId + " does not publish a bookie-rpc endpoint");
             }
             BookieSocketAddress res = new BookieSocketAddress(endpoint.getHost(), endpoint.getPort());
-            log.info("Resolved {} as {}", bookieId, res);
+            if (!bookieId.toString().equals(res.toString())) {
+                // only print if the information is useful
+                log.info("Resolved {} as {}", bookieId, res);
+            } else {
+                log.debug("Resolved {} as {}", bookieId, res);
+            }
             return res;
         } catch (BKException.BKBookieHandleNotAvailableException ex) {
             if (BookieSocketAddress.isDummyBookieIdForHostname(bookieId)) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -2441,15 +2441,15 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
 
             synchronized (PerChannelBookieClient.this) {
                 if (future.isSuccess() && state == ConnectionState.CONNECTING && future.channel().isActive()) {
-                    LOG.info("Successfully connected to bookie: {}", future.channel());
                     rc = BKException.Code.OK;
                     channel = future.channel();
                     if (shFactory != null) {
+                        LOG.info("Successfully connected to bookie: {} {} initiate TLS", bookieId, future.channel());
                         makeWritable();
                         initiateTLS();
                         return;
                     } else {
-                        LOG.info("Successfully connected to bookie: " + bookieId);
+                        LOG.info("Successfully connected to bookie: {} {}", bookieId, future.channel());
                         state = ConnectionState.CONNECTED;
                         activeNonTlsChannelCounter.inc();
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -254,23 +254,14 @@ public class Main {
             printUsage();
             throw iae;
         }
-
-        StringBuilder sb = new StringBuilder();
-        String[] ledgerDirNames = conf.getLedgerDirNames();
-        for (int i = 0; i < ledgerDirNames.length; i++) {
-            if (i != 0) {
-                sb.append(',');
-            }
-            sb.append(ledgerDirNames[i]);
-        }
-
         String hello = String.format(
-            "Hello, I'm your bookie, listening on port %1$s. Metadata service uri is %2$s."
-                + " Journals are in %3$s. Ledgers are stored in %4$s.",
+            "Hello, I'm your bookie, bookieId is %1$s, listening on port %2$s. Metadata service uri is %3$s."
+                + " Journals are in %4$s. Ledgers are stored in %5$s.",
+            conf.getBookieId() != null ? conf.getBookieId() : "<not-set>",
             conf.getBookiePort(),
             conf.getMetadataServiceUriUnchecked(),
             Arrays.asList(conf.getJournalDirNames()),
-            sb);
+            Arrays.asList(conf.getLedgerDirNames()));
         log.info(hello);
 
         return conf;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/CommandHelpers.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/CommandHelpers.java
@@ -40,9 +40,9 @@ public final class CommandHelpers {
      * When using hostname as bookie id, it's possible that the host is no longer valid and
      * can't get a ip from the hostname, so using UNKNOWN to indicate ip is unknown for the hostname
      */
-    public static String getBookieSocketAddrStringRepresentation(BookieId bookidId,
+    public static String getBookieSocketAddrStringRepresentation(BookieId bookieId,
                                                                  BookieAddressResolver bookieAddressResolver) {
-        BookieSocketAddress networkAddress = bookieAddressResolver.resolve(bookidId);
+        BookieSocketAddress networkAddress = bookieAddressResolver.resolve(bookieId);
         String hostname = networkAddress.getHostName();
         String realHostname;
         String ip;
@@ -58,7 +58,7 @@ public final class CommandHelpers {
            }
            realHostname = hostname;
         }
-        return formatBookieSocketAddress(bookidId, ip, networkAddress.getPort(), realHostname);
+        return formatBookieSocketAddress(bookieId, ip, networkAddress.getPort(), realHostname);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/CommandHelpers.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/CommandHelpers.java
@@ -44,9 +44,8 @@ public final class CommandHelpers {
                                                                  BookieAddressResolver bookieAddressResolver) {
         BookieSocketAddress networkAddress = bookieAddressResolver.resolve(bookidId);
         String hostname = networkAddress.getHostName();
-        String bookieID = networkAddress.toString();
         String realHostname;
-        String ip = null;
+        String ip;
         if (InetAddresses.isInetAddress(hostname)){
             ip = hostname;
             realHostname = networkAddress.getSocketAddress().getAddress().getCanonicalHostName();
@@ -59,14 +58,14 @@ public final class CommandHelpers {
            }
            realHostname = hostname;
         }
-        return formatBookieSocketAddress(bookieID, ip, networkAddress.getPort(), realHostname);
+        return formatBookieSocketAddress(bookidId, ip, networkAddress.getPort(), realHostname);
     }
 
     /**
      * Format {@link BookieSocketAddress}.
      **/
-    public static String formatBookieSocketAddress(String bookieId, String ip, int port, String hostName) {
-       return String.format("BookieID:%s, IP:%s, Port:%d, Hostname:%s", bookieId, ip, port, hostName);
+    private static String formatBookieSocketAddress(BookieId bookieId, String ip, int port, String hostName) {
+       return String.format("BookieID:%s, IP:%s, Port:%d, Hostname:%s", bookieId.toString(), ip, port, hostName);
     }
 
 }


### PR DESCRIPTION
### Motivation

BP-41 introduces the new bookieId concept, and tools have to be improvement in order to provide better user experience.

### Changes

- Fix NPE while shutting down the ZKRegistration client no function impact)
- Clean up logs in general
- Print "bookieId" instead of Bookie Address in "bin/bkctl bookies list" command
- Print bookieId at Bookie startup (using standard scripts)