### PR TITLE
BP-40: Convert all System.*.print statements to LOG.* statements

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
@@ -144,14 +144,14 @@ public class ListUnderReplicatedCommand extends BookieCommand<ListUnderReplicate
             while (iter.hasNext()) {
                 UnderreplicatedLedger underreplicatedLedger = iter.next();
                 long urLedgerId = underreplicatedLedger.getLedgerId();
-                System.out.println(ledgerIdFormatter.formatLedgerId(urLedgerId));
+                LOG.info(ledgerIdFormatter.formatLedgerId(urLedgerId));
                 long ctime = underreplicatedLedger.getCtime();
                 if (ctime != UnderreplicatedLedger.UNASSIGNED_CTIME) {
-                    System.out.println("\tCtime : " + ctime);
+                    LOG.info("\tCtime : " + ctime);
                 }
                 if (printMissingReplica) {
                     underreplicatedLedger.getReplicaList().forEach((missingReplica) -> {
-                        System.out.println("\tMissingReplica : " + missingReplica);
+                        LOG.info("\tMissingReplica : " + missingReplica);
                     });
                 }
                 if (printReplicationWorkerId) {
@@ -159,7 +159,7 @@ public class ListUnderReplicatedCommand extends BookieCommand<ListUnderReplicate
                         String replicationWorkerId = underreplicationManager
                                                          .getReplicationWorkerIdRereplicatingLedger(urLedgerId);
                         if (replicationWorkerId != null) {
-                            System.out.println("\tReplicationWorkerId : " + replicationWorkerId);
+                            LOG.info("\tReplicationWorkerId : " + replicationWorkerId);
                         }
                     } catch (ReplicationException.UnavailableException e) {
                         LOG.error("Failed to get ReplicationWorkerId rereplicating ledger {} -- {}", urLedgerId,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
@@ -88,7 +88,7 @@ public class ToggleCommand extends BookieCommand<ToggleCommand.AutoRecoveryFlags
                 try (LedgerUnderreplicationManager underreplicationManager = mFactory
                          .newLedgerUnderreplicationManager()) {
                     if (flags.status) {
-                        System.out.println("Autorecovery is " + (underreplicationManager.isLedgerReplicationEnabled()
+                        LOG.info("Autorecovery is " + (underreplicationManager.isLedgerReplicationEnabled()
                                                                      ? "enabled." : "disabled."));
                         return null;
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/FormatUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/FormatUtil.java
@@ -23,11 +23,15 @@ import java.util.Formatter;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.util.EntryFormatter;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * .Provide to format message.
  */
 public class FormatUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FormatUtil.class);
 
     /**
      * Format the message into a readable format.
@@ -46,44 +50,44 @@ public class FormatUtil {
         long ledgerId = recBuff.readLong();
         long entryId = recBuff.readLong();
 
-        System.out.println(
+        LOG.info(
             "--------- Lid=" + ledgerIdFormatter.formatLedgerId(ledgerId) + ", Eid=" + entryId + ", ByteOffset=" + pos
                 + ", EntrySize=" + entrySize + " ---------");
         if (entryId == Bookie.METAENTRY_ID_LEDGER_KEY) {
             int masterKeyLen = recBuff.readInt();
             byte[] masterKey = new byte[masterKeyLen];
             recBuff.readBytes(masterKey);
-            System.out.println("Type:           META");
-            System.out.println("MasterKey:      " + bytes2Hex(masterKey));
-            System.out.println();
+            LOG.info("Type:           META");
+            LOG.info("MasterKey:      " + bytes2Hex(masterKey));
+            LOG.info("");
             return;
         }
         if (entryId == Bookie.METAENTRY_ID_FENCE_KEY) {
-            System.out.println("Type:           META");
-            System.out.println("Fenced");
-            System.out.println();
+            LOG.info("Type:           META");
+            LOG.info("Fenced");
+            LOG.info("");
             return;
         }
         // process a data entry
         long lastAddConfirmed = recBuff.readLong();
-        System.out.println("Type:           DATA");
-        System.out.println("LastConfirmed:  " + lastAddConfirmed);
+        LOG.info("Type:           DATA");
+        LOG.info("LastConfirmed:  " + lastAddConfirmed);
         if (!printMsg) {
-            System.out.println();
+            LOG.info("");
             return;
         }
         // skip digest checking
         recBuff.skipBytes(8);
-        System.out.println("Data:");
-        System.out.println();
+        LOG.info("Data:");
+        LOG.info("");
         try {
             byte[] ret = new byte[recBuff.readableBytes()];
             recBuff.readBytes(ret);
             entryFormatter.formatEntry(ret);
         } catch (Exception e) {
-            System.out.println("N/A. Corrupted.");
+            LOG.info("N/A. Corrupted.");
         }
-        System.out.println();
+        LOG.info("");
     }
 
     public static String bytes2Hex(byte[] data) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LastMarkCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LastMarkCommand.java
@@ -28,6 +28,8 @@ import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
 import org.apache.bookkeeper.util.DiskChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A bookie command to print the last log marker.
@@ -36,6 +38,7 @@ public class LastMarkCommand extends BookieCommand<CliFlags> {
 
     private static final String NAME = "lastmark";
     private static final String DESC = "Print last log marker";
+    private static final Logger LOG = LoggerFactory.getLogger(LastMarkCommand.class);
 
     public LastMarkCommand() {
         super(CliSpec.newBuilder()
@@ -55,7 +58,7 @@ public class LastMarkCommand extends BookieCommand<CliFlags> {
         for (int idx = 0; idx < journalDirs.length; idx++) {
             Journal journal = new Journal(idx, journalDirs[idx], conf, dirsManager);
             LogMark lastLogMark = journal.getLastLogMark().getCurMark();
-            System.out.println("LastLogMark : Journal Id - " + lastLogMark.getLogFileId() + "("
+            LOG.info("LastLogMark : Journal Id - " + lastLogMark.getLogFileId() + "("
                 + Long.toHexString(lastLogMark.getLogFileId()) + ".txn), Pos - "
                 + lastLogMark.getLogFileOffset());
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  *
  **/
 public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
-  static final Logger LOG = LoggerFactory.getLogger(ListActiveLedgersCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ListActiveLedgersCommand.class);
     private static final String NAME = "active ledger";
     private static final String DESC = "Retrieve bookie active ledger info.";
     private static final long  DEFAULT_TIME_OUT = 1000;
@@ -161,13 +161,13 @@ public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
 
     public void printActiveLedgerOnEntryLog(long logId, List<Long> activeLedgers){
       if (activeLedgers.size() == 0){
-        System.out.println("No active ledgers on log file " + logId);
+        LOG.info("No active ledgers on log file " + logId);
       } else {
-        System.out.println("Active ledgers on entry log " + logId + " as follow:");
+        LOG.info("Active ledgers on entry log " + logId + " as follow:");
       }
       Collections.sort(activeLedgers);
       for (long a:activeLedgers){
-        System.out.println(ledgerIdFormatter.formatLedgerId(a) + " ");
+        LOG.info(ledgerIdFormatter.formatLedgerId(a) + " ");
       }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommand.java
@@ -30,6 +30,8 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Command to list the files in JournalDirectory/LedgerDirectories/IndexDirectories.
@@ -38,6 +40,7 @@ public class ListFilesOnDiscCommand extends BookieCommand<ListFilesOnDiscCommand
 
     private static final String NAME = "listfilesondisc";
     private static final String DESC = "List the files in JournalDirectory/LedgerDirectories/IndexDirectories.";
+    private static final Logger LOG = LoggerFactory.getLogger(ListFilesOnDiscCommand.class);
 
     public ListFilesOnDiscCommand() {
         this(new LFODFlags());
@@ -76,27 +79,27 @@ public class ListFilesOnDiscCommand extends BookieCommand<ListFilesOnDiscCommand
         if (cmd.journal) {
             File[] journalDirs = conf.getJournalDirs();
             List<File> journalFiles = BookieShell.listFilesAndSort(journalDirs, "txn");
-            System.out.println("--------- Printing the list of Journal Files ---------");
+            LOG.info("--------- Printing the list of Journal Files ---------");
             for (File journalFile : journalFiles) {
-                System.out.println(journalFile.getCanonicalPath());
+                LOG.info(journalFile.getCanonicalPath());
             }
-            System.out.println();
+            LOG.info("");
         }
         if (cmd.entrylog) {
             File[] ledgerDirs = conf.getLedgerDirs();
             List<File> ledgerFiles = BookieShell.listFilesAndSort(ledgerDirs, "log");
-            System.out.println("--------- Printing the list of EntryLog/Ledger Files ---------");
+            LOG.info("--------- Printing the list of EntryLog/Ledger Files ---------");
             for (File ledgerFile : ledgerFiles) {
-                System.out.println(ledgerFile.getCanonicalPath());
+                LOG.info(ledgerFile.getCanonicalPath());
             }
-            System.out.println();
+            LOG.info("");
         }
         if (cmd.index) {
             File[] indexDirs = (conf.getIndexDirs() == null) ? conf.getLedgerDirs() : conf.getIndexDirs();
             List<File> indexFiles = BookieShell.listFilesAndSort(indexDirs, "idx");
-            System.out.println("--------- Printing the list of Index Files ---------");
+            LOG.info("--------- Printing the list of Index Files ---------");
             for (File indexFile : indexFiles) {
-                System.out.println(indexFile.getCanonicalPath());
+                LOG.info(indexFile.getCanonicalPath());
             }
         }
         return true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ListLedgersCommand extends BookieCommand<ListLedgersFlags> {
 
-    static final Logger LOG = LoggerFactory.getLogger(ListLedgersCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ListLedgersCommand.class);
 
     private static final String NAME = "listledgers";
     private static final String DESC = "List all ledgers on the cluster (this may take a long time).";
@@ -98,7 +98,7 @@ public class ListLedgersCommand extends BookieCommand<ListLedgersFlags> {
         try {
             handler(conf, cmdFlags);
         } catch (UnknownHostException e) {
-            System.err.println("Bookie id error");
+            LOG.error("Bookie id error");
             return false;
         } catch (MetadataException | ExecutionException e) {
             throw new UncheckedExecutionException(e.getMessage(), e);
@@ -187,9 +187,9 @@ public class ListLedgersCommand extends BookieCommand<ListLedgersFlags> {
     }
 
     private void printLedgerMetadata(long ledgerId, LedgerMetadata md, boolean printMeta) {
-        System.out.println("ledgerID: " + ledgerIdFormatter.formatLedgerId(ledgerId));
+        LOG.info("ledgerID: " + ledgerIdFormatter.formatLedgerId(ledgerId));
         if (printMeta) {
-            System.out.println(md.toString());
+            LOG.info(md.toString());
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadJournalCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadJournalCommand.java
@@ -38,6 +38,8 @@ import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.bookkeeper.util.DiskChecker;
 import org.apache.bookkeeper.util.EntryFormatter;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Command to scan a journal file and format the entries into readable format.
@@ -50,6 +52,7 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
     private static final String DEFAULT = "";
     private LedgerIdFormatter ledgerIdFormatter;
     private EntryFormatter entryFormatter;
+    private static final Logger LOG = LoggerFactory.getLogger(ReadJournalCommand.class);
 
     List<Journal> journals = null;
 
@@ -125,7 +128,7 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
         Journal journal = null;
         if (getJournals(conf).size() > 1) {
             if (cmd.dir.equals(DEFAULT)) {
-                System.err.println("ERROR: invalid or missing journal directory");
+                LOG.error("ERROR: invalid or missing journal directory");
                 usage();
                 return false;
             }
@@ -138,7 +141,7 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
             }
 
             if (journal == null) {
-                System.err.println("ERROR: journal directory not found");
+                LOG.error("ERROR: journal directory not found");
                 usage();
                 return false;
             }
@@ -151,7 +154,7 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
             File f = new File(cmd.fileName);
             String name = f.getName();
             if (!name.endsWith(".txn")) {
-                System.err.println("ERROR: invalid journal file name " + cmd.fileName);
+                LOG.error("ERROR: invalid journal file name " + cmd.fileName);
                 usage();
                 return false;
             }
@@ -164,7 +167,7 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
 
     private boolean checkArgs(ReadJournalFlags flags) {
         if ((flags.fileName.equals(DEFAULT) && flags.journalId == DEFAULT_JOURNALID)) {
-            System.out.println("ERROR: You should figure jounalId or journal filename");
+            LOG.info("ERROR: You should figure jounalId or journal filename");
             return false;
         }
 
@@ -191,14 +194,14 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
       * @param printMsg Whether printing the entry data.
       */
     private void scanJournal(Journal journal, long journalId, final boolean printMsg) throws IOException {
-        System.out.println("Scan journal " + journalId + " (" + Long.toHexString(journalId) + ".txn)");
+        LOG.info("Scan journal " + journalId + " (" + Long.toHexString(journalId) + ".txn)");
         scanJournal(journal, journalId, new Journal.JournalScanner() {
             boolean printJournalVersion = false;
 
             @Override
             public void process(int journalVersion, long offset, ByteBuffer entry) throws IOException {
                 if (!printJournalVersion) {
-                    System.out.println("Journal Version : " + journalVersion);
+                    LOG.info("Journal Version : " + journalVersion);
                     printJournalVersion = true;
                 }
                 FormatUtil

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ReadLedgerCommand extends BookieCommand<ReadLedgerCommand.ReadLedgerFlags> {
 
-    static final Logger LOG = LoggerFactory.getLogger(ReadLedgerCommand.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ReadLedgerCommand.class);
 
     private static final String NAME = "readledger";
     private static final String DESC = "Read a range of entries from a ledger.";
@@ -199,11 +199,11 @@ public class ReadLedgerCommand extends BookieCommand<ReadLedgerCommand.ReadLedge
                                                    return;
                                                }
 
-                                               System.out.println(
+                                               LOG.info(
                                                    "--------- Lid=" + ledgerIdFormatter.formatLedgerId(flags.ledgerId)
                                                    + ", Eid=" + entryId + " ---------");
                                                if (flags.msg) {
-                                                   System.out.println("Data: " + ByteBufUtil.prettyHexDump(buffer));
+                                                   LOG.info("Data: " + ByteBufUtil.prettyHexDump(buffer));
                                                }
 
                                                future.complete(null);
@@ -236,7 +236,7 @@ public class ReadLedgerCommand extends BookieCommand<ReadLedgerCommand.ReadLedge
         long ledgerId = entry.getLedgerId();
         long entryId = entry.getEntryId();
         long entrySize = entry.getLength();
-        System.out.println("--------- Lid=" + ledgerIdFormatter.formatLedgerId(ledgerId) + ", Eid=" + entryId
+        LOG.info("--------- Lid=" + ledgerIdFormatter.formatLedgerId(ledgerId) + ", Eid=" + entryId
                            + ", EntrySize=" + entrySize + " ---------");
         if (printMsg) {
             entryFormatter.formatEntry(entry.getEntry());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogCommand.java
@@ -34,6 +34,8 @@ import org.apache.bookkeeper.tools.framework.CliSpec;
 import org.apache.bookkeeper.util.EntryFormatter;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
 import org.apache.commons.lang.mutable.MutableBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Command to read entry log files.
@@ -42,6 +44,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
 
     private static final String NAME = "readlog";
     private static final String DESC = "Scan an entry file and format the entries into readable format.";
+    private static final Logger LOG = LoggerFactory.getLogger(ReadLogCommand.class);
 
     private EntryLogger entryLogger;
     private EntryFormatter entryFormatter;
@@ -111,7 +114,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
         }
 
         if (cmdFlags.entryLogId == -1 && cmdFlags.filename == null) {
-            System.err.println("Missing entry log id or entry log file name");
+            LOG.error("Missing entry log id or entry log file name");
             usage();
             return false;
         }
@@ -128,7 +131,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             File f = new File(flags.filename);
             String name = f.getName();
             if (!name.endsWith(".log")) {
-                System.err.println("Invalid entry log file name " + flags.filename);
+                LOG.error("Invalid entry log file name " + flags.filename);
                 usage();
                 return false;
             }
@@ -169,7 +172,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
     private void scanEntryLogForPositionRange(ServerConfiguration conf, long logId, final long rangeStartPos,
                                               final long rangeEndPos,
                                                 final boolean printMsg) throws Exception {
-        System.out.println("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)" + " for PositionRange: "
+        LOG.info("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)" + " for PositionRange: "
                            + rangeStartPos + " - " + rangeEndPos);
         final MutableBoolean entryFound = new MutableBoolean(false);
         scanEntryLog(conf, logId, new EntryLogger.EntryLogScanner() {
@@ -205,7 +208,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             }
         });
         if (!entryFound.booleanValue()) {
-            System.out.println(
+            LOG.info(
                 "Entry log " + logId + " (" + Long.toHexString(logId) + ".log) doesn't has any entry in the range "
                 + rangeStartPos + " - " + rangeEndPos
                 + ". Probably the position range, you have provided is lesser than the LOGFILE_HEADER_SIZE (1024) "
@@ -244,7 +247,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
     private void scanEntryLogForSpecificEntry(ServerConfiguration conf, long logId, final long ledgerId,
                                                 final long entryId,
                                                 final boolean printMsg) throws Exception {
-        System.out.println("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)" + " for LedgerId "
+        LOG.info("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)" + " for LedgerId "
                            + ledgerId + ((entryId == -1) ? "" : " for EntryId " + entryId));
         final MutableBoolean entryFound = new MutableBoolean(false);
         scanEntryLog(conf, logId, new EntryLogger.EntryLogScanner() {
@@ -265,7 +268,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             }
         });
         if (!entryFound.booleanValue()) {
-            System.out.println("LedgerId " + ledgerId + ((entryId == -1) ? "" : " EntryId " + entryId)
+            LOG.info("LedgerId " + ledgerId + ((entryId == -1) ? "" : " EntryId " + entryId)
                                + " is not available in the entry log " + logId + " (" + Long.toHexString(logId)
                                + ".log)");
         }
@@ -280,7 +283,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
      *          Whether printing the entry data.
      */
     private void scanEntryLog(ServerConfiguration conf, long logId, final boolean printMsg) throws Exception {
-        System.out.println("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)");
+        LOG.info("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)");
         scanEntryLog(conf, logId, new EntryLogger.EntryLogScanner() {
             @Override
             public boolean accept(long ledgerId) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
@@ -97,7 +97,7 @@ public class ReadLogMetadataCommand extends BookieCommand<ReadLogMetadataFlags> 
             this.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(conf);
         }
         if (cmdFlags.logId == DEFAULT_LOGID && cmdFlags.logFilename.equals(DEFAULT_FILENAME)) {
-            System.err.println("Missing entry log id or entry log file name");
+            LOG.error("Missing entry log id or entry log file name");
             return false;
         }
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/EndpointInfoCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/EndpointInfoCommand.java
@@ -87,28 +87,28 @@ public class EndpointInfoCommand extends BookieCommand<EndpointInfoCommand.Endpo
             BookieId address = BookieId.parse(bookieId);
             Collection<BookieId> allBookies = admin.getAllBookies();
             if (!allBookies.contains(address)) {
-                System.out.println("Bookie " + bookieId + " does not exist, only " + allBookies);
+                LOG.info("Bookie " + bookieId + " does not exist, only " + allBookies);
                 return false;
             }
             BookieServiceInfo bookieServiceInfo = admin.getBookieServiceInfo(bookieId);
 
-            System.out.println("BookiedId: " + bookieId);
+            LOG.info("BookiedId: " + bookieId);
             if (!bookieServiceInfo.getProperties().isEmpty()) {
-                System.out.println("Properties");
+                LOG.info("Properties");
                 bookieServiceInfo.getProperties().forEach((k, v) -> {
-                    System.out.println(k + ":" + v);
+                    LOG.info(k + ":" + v);
                 });
             }
             if (!bookieServiceInfo.getEndpoints().isEmpty()) {
                 bookieServiceInfo.getEndpoints().forEach(e -> {
-                    System.out.println("Endpoint: " + e.getId());
-                    System.out.println("Protocol: " + e.getProtocol());
-                    System.out.println("Address: " + e.getHost() + ":" + e.getPort());
-                    System.out.println("Auth: " + e.getAuth());
-                    System.out.println("Extensions: " + e.getExtensions());
+                    LOG.info("Endpoint: " + e.getId());
+                    LOG.info("Protocol: " + e.getProtocol());
+                    LOG.info("Address: " + e.getHost() + ":" + e.getPort());
+                    LOG.info("Auth: " + e.getAuth());
+                    LOG.info("Extensions: " + e.getExtensions());
                 });
             } else {
-                System.out.println("Bookie did not publish any endpoint info. Maybe it is down");
+                LOG.info("Bookie did not publish any endpoint info. Maybe it is down");
                 return false;
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/InfoCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/InfoCommand.java
@@ -34,6 +34,8 @@ import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
 import org.apache.bookkeeper.tools.cli.helpers.CommandHelpers;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -43,6 +45,7 @@ public class InfoCommand extends BookieCommand<CliFlags> {
 
     private static final String NAME = "info";
     private static final String DESC = "Retrieve bookie info such as free and total disk space.";
+    private static final Logger LOG = LoggerFactory.getLogger(InfoCommand.class);
 
     public InfoCommand() {
         super(CliSpec.newBuilder()
@@ -74,17 +77,17 @@ public class InfoCommand extends BookieCommand<CliFlags> {
         try (BookKeeper bk = new BookKeeper(clientConf)) {
             Map<BookieId, BookieInfo> map = bk.getBookieInfo();
             if (map.size() == 0) {
-                System.out.println("Failed to retrieve bookie information from any of the bookies");
+                LOG.info("Failed to retrieve bookie information from any of the bookies");
                 bk.close();
                 return true;
             }
 
-            System.out.println("Free disk space info:");
+            LOG.info("Free disk space info:");
             long totalFree = 0, total = 0;
             for (Map.Entry<BookieId, BookieInfo> e : map.entrySet()) {
                 BookieInfo bInfo = e.getValue();
                 BookieId bookieId = e.getKey();
-                System.out.println(CommandHelpers.getBookieSocketAddrStringRepresentation(bookieId,
+                LOG.info(CommandHelpers.getBookieSocketAddrStringRepresentation(bookieId,
                         bk.getBookieAddressResolver())
                     + ":\tFree: " + bInfo.getFreeDiskSpace() + getReadable(bInfo.getFreeDiskSpace())
                     + "\tTotal: " + bInfo.getTotalDiskSpace() + getReadable(bInfo.getTotalDiskSpace()));
@@ -103,8 +106,8 @@ public class InfoCommand extends BookieCommand<CliFlags> {
                 total += bookieInfo.getTotalDiskSpace();
             }
 
-            System.out.println("Total free disk space in the cluster:\t" + totalFree + getReadable(totalFree));
-            System.out.println("Total disk capacity in the cluster:\t" + total + getReadable(total));
+            LOG.info("Total free disk space in the cluster:\t" + totalFree + getReadable(totalFree));
+            LOG.info("Total disk capacity in the cluster:\t" + total + getReadable(total));
             bk.close();
 
             return true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/ListBookiesCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/ListBookiesCommand.java
@@ -34,6 +34,8 @@ import org.apache.bookkeeper.tools.cli.commands.bookies.ListBookiesCommand.Flags
 import org.apache.bookkeeper.tools.cli.helpers.DiscoveryCommand;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Command to list available bookies.
@@ -42,6 +44,7 @@ public class ListBookiesCommand extends DiscoveryCommand<Flags> {
 
     private static final String NAME = "list";
     private static final String DESC = "List the bookies, which are running as either readwrite or readonly mode.";
+    private static final Logger LOG = LoggerFactory.getLogger(ListBookiesCommand.class);
 
     public ListBookiesCommand() {
         this(new Flags());
@@ -86,7 +89,7 @@ public class ListBookiesCommand extends DiscoveryCommand<Flags> {
                 regClient.getWritableBookies()
             ).getValue();
             if (!bookies.isEmpty()) {
-                System.out.println("ReadWrite Bookies :");
+                LOG.info("ReadWrite Bookies :");
                 printBookies(bookies, new DefaultBookieAddressResolver(regClient));
                 hasBookies = true;
             }
@@ -96,7 +99,7 @@ public class ListBookiesCommand extends DiscoveryCommand<Flags> {
                 regClient.getReadOnlyBookies()
             ).getValue();
             if (!bookies.isEmpty()) {
-                System.out.println("Readonly Bookies :");
+                LOG.info("Readonly Bookies :");
                 printBookies(bookies, new DefaultBookieAddressResolver(regClient));
                 hasBookies = true;
             }
@@ -106,19 +109,19 @@ public class ListBookiesCommand extends DiscoveryCommand<Flags> {
                 regClient.getAllBookies()
             ).getValue();
             if (!bookies.isEmpty()) {
-                System.out.println("All Bookies :");
+                LOG.info("All Bookies :");
                 printBookies(bookies, new DefaultBookieAddressResolver(regClient));
                 hasBookies = true;
             }
         }
         if (!hasBookies) {
-            System.err.println("No bookie exists!");
+            LOG.error("No bookie exists!");
         }
     }
 
     private static void printBookies(Collection<BookieId> bookies, BookieAddressResolver bookieAddressResolver) {
         for (BookieId b : bookies) {
-            System.out.println(getBookieSocketAddrStringRepresentation(b, bookieAddressResolver));
+            LOG.info(getBookieSocketAddrStringRepresentation(b, bookieAddressResolver));
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/DeleteLedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/DeleteLedgerCommand.java
@@ -32,6 +32,8 @@ import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
 import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Command to delete a given ledger.
@@ -41,6 +43,7 @@ public class DeleteLedgerCommand extends BookieCommand<DeleteLedgerCommand.Delet
     private static final String NAME = "delete";
     private static final String DESC = "Delete a ledger.";
     private static final String DEFAULT = "";
+    private static final Logger LOG = LoggerFactory.getLogger(DeleteLedgerCommand.class);
 
     private LedgerIdFormatter ledgerIdFormatter;
 
@@ -101,7 +104,7 @@ public class DeleteLedgerCommand extends BookieCommand<DeleteLedgerCommand.Delet
         throws IOException, BKException, InterruptedException {
 
         if (flags.ledgerId < 0) {
-            System.err.println("Ledger id error.");
+            LOG.error("Ledger id error.");
             return false;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
@@ -38,6 +38,8 @@ import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
 import org.apache.bookkeeper.versioning.Versioned;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Print the metadata for a ledger.
@@ -48,6 +50,7 @@ public class LedgerMetaDataCommand extends BookieCommand<LedgerMetaDataCommand.L
     private static final String DESC = "Print the metadata for a ledger, or optionally dump to a file.";
     private static final String DEFAULT = "";
     private static final long DEFAULT_ID = -1L;
+    private static final Logger LOG = LoggerFactory.getLogger(LedgerMetaDataCommand.class);
 
     private LedgerMetadataSerDe serDe = new LedgerMetadataSerDe();
     private LedgerIdFormatter ledgerIdFormatter;
@@ -106,7 +109,7 @@ public class LedgerMetaDataCommand extends BookieCommand<LedgerMetaDataCommand.L
     private boolean handler(ServerConfiguration conf, LedgerMetadataFlag flag)
         throws MetadataException, ExecutionException {
         if (flag.ledgerId == DEFAULT_ID) {
-            System.err.println("Must specific a ledger id");
+            LOG.error("Must specific a ledger id");
             return false;
         }
         runFunctionWithLedgerManagerFactory(conf, mFactory -> {
@@ -132,9 +135,9 @@ public class LedgerMetaDataCommand extends BookieCommand<LedgerMetaDataCommand.L
     }
 
     private void printLedgerMetadata(long ledgerId, LedgerMetadata md, boolean printMeta) {
-        System.out.println("ledgerID: " + ledgerIdFormatter.formatLedgerId(ledgerId));
+        LOG.info("ledgerID: " + ledgerIdFormatter.formatLedgerId(ledgerId));
         if (printMeta) {
-            System.out.println(md.toString());
+            LOG.info(md.toString());
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
@@ -31,6 +31,8 @@ import org.apache.bookkeeper.tools.cli.commands.client.SimpleTestCommand.Flags;
 import org.apache.bookkeeper.tools.cli.helpers.ClientCommand;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A client command that simply tests if a cluster is healthy.
@@ -39,6 +41,7 @@ public class SimpleTestCommand extends ClientCommand<Flags> {
 
     private static final String NAME = "simpletest";
     private static final String DESC = "Simple test to create a ledger and write entries to it.";
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleTestCommand.class);
 
     /**
      * Flags for simple test command.
@@ -81,17 +84,17 @@ public class SimpleTestCommand extends ClientCommand<Flags> {
             .withPassword(new byte[0])
             .execute())) {
 
-            System.out.println("Ledger ID: " + wh.getId());
+            LOG.info("Ledger ID: " + wh.getId());
             long lastReport = System.nanoTime();
             for (int i = 0; i < flags.numEntries; i++) {
                 wh.append(data);
                 if (TimeUnit.SECONDS.convert(System.nanoTime() - lastReport,
                         TimeUnit.NANOSECONDS) > 1) {
-                    System.out.println(i + " entries written");
+                    LOG.info(i + " entries written");
                     lastReport = System.nanoTime();
                 }
             }
-            System.out.println(flags.numEntries + " entries written to ledger " + wh.getId());
+            LOG.info(flags.numEntries + " entries written to ledger " + wh.getId());
         }
     }
 }


### PR DESCRIPTION
### Motivation

In order to have an audit log of all user interactions, all print statements which come from such interactions need to be logged.
We have two user driven ways to mutate BookKeeper:
* BookieShell
* bkctl
Both internally use the same code from `tools/cli`

### Changes

The logging in the code was inconsistent. At times we used `System.out.println` and at times we used `LOG.info`.
As a part of this work item we change these in the following way:

* For every `cli` class, confirm if a Logger object is present, if not create one.
* Convert all `System.out.println()` -> `LOG.info()`
* Convert all `System.err.println()` -> `LOG.error()`

### Ramifications

BookieShell uses `log4j.shell.properties`
bkctl uses `log4j.cli.properties`

Both log4j property files have `CONSOLE appenders`, so the like previous `System.out.println()`, the new `LOG` statements will also be printed to console.
This is mentioned explicitly as certain upstream consumers / scripts utilize BookieShell / bkctl to assess the state of the BK cluster.

Master Issue: #2209 
