### PR TITLE
Limit maven http connection pool TTL in Github flows

### DIFF
--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -27,6 +27,9 @@ on:
       - 'site/**'
 
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   test:
 

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -27,6 +27,9 @@ on:
       - 'site/**'
 
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   test:
 

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -26,6 +26,9 @@ on:
     paths-ignore:
       - 'site/**'
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   check:
 

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -26,6 +26,9 @@ on:
     paths-ignore:
       - 'site/**'
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   check:
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,6 +27,9 @@ on:
       - 'site/**'
 
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   test:
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -27,6 +27,9 @@ on:
       - 'site/**'
 
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   check:
 

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -26,6 +26,9 @@ on:
     paths-ignore:
       - 'site/**'
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   test:
 

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -27,6 +27,9 @@ on:
       - 'site/**'
 
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   test:
 

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -27,6 +27,9 @@ on:
       - 'site/**'
 
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:
   test:
 


### PR DESCRIPTION
### Motivation

Fixes "Transfer failed for https://repo.maven.apache.org/...
.jar: Connection reset" type of failures in Github Flows environment such as
```
Error:  Failed to execute goal on project bookkeeper-common: Could not resolve dependencies for project org.apache.bookkeeper:bookkeeper-common:jar:4.12.0-SNAPSHOT: Could not transfer artifact org.jctools:jctools-core:jar:2.1.2 from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/org/jctools/jctools-core/2.1.2/jctools-core-2.1.2.jar: Connection reset -> [Help 1]
```

### Changes

Set `maven.wagon.httpconnectionManager.ttlSeconds` to 25 seconds.
Besides this, set `maven.wagon.http.retryHandler.count` to 3 retries.

https://issues.apache.org/jira/browse/WAGON-545
contains a recommendation "Azure users shall set the TTL to 240 seconds or less."

The reason for the 25 second TTL is to ensure that it's shorter than any common
firewall or NAT timeout. Some NATs have a 30 second idle timeout although
that is very rare. There shouldn't be harm in using the 25 second TTL since
the connection pool will be able to pool connections well with a 25 second TTL.

The documentation for `maven.wagon.httpconnectionManager.ttlSeconds` is
available in the source code:
https://github.com/apache/maven-wagon/blob/wagon-3.4.1/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java#L297-L305

Documentation for `maven.wagon.http.retryHandler.count` is in
https://maven.apache.org/wagon/wagon-providers/wagon-http/
"Any retry handler can only react to exceptions when executing the request and
receiving the response head. It will not salvage in-flight failures of ongoing
response body streams." Therefore the retry count setting is a bit
different than expected. WAGON-545 explains that ConnectionExceptions
aren't part of the retried exceptions by default. If such issues become
problems, it's possible to configure the retry handler in a more fine
grained way.

This is similar to the change made in Pulsar: https://github.com/apache/pulsar/pull/8386