### PR TITLE
Make protoc-gen-grpc-java.version match grpc.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <httpclient.version>4.5.5</httpclient.version>
     <protobuf.version>3.5.1</protobuf.version>
     <protoc3.version>3.5.1-1</protoc3.version>
-    <protoc-gen-grpc-java.version>1.12.0</protoc-gen-grpc-java.version>
+    <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
     <rocksdb.version>6.10.2</rocksdb.version>
     <shrinkwrap.version>3.0.1</shrinkwrap.version>


### PR DESCRIPTION
### Motivation

protoc-gen-grpc-java is part of grpc libraries.
Usually it doesn't make sense to use a version other
than the current grpc version. Currently 2 different versions are used.

It seems that it has been forgotten to upgrade protoc-gen-grpc-java.version 
when grpc.version has been upgraded from 1.12.0 to 1.18.0

### Changes

Make protoc-gen-grpc-java.version match grpc.version by referencing it with ${grpc.version}