### PR TITLE
java.lang.NullPointerException with metadataServiceUri = zk:///ledger…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -60,7 +60,7 @@ public class ZKMetadataDriverBase implements AutoCloseable {
 
     protected static final String SCHEME = "zk";
 
-    public static String getZKServersFromServiceUri(URI uri) throws IllegalArgumentException {
+    public static String getZKServersFromServiceUri(URI uri) {
         String authority = uri.getAuthority();
         if (authority == null) {
             throw new IllegalArgumentException("Invalid metadata service URI format: " + uri);
@@ -69,7 +69,7 @@ public class ZKMetadataDriverBase implements AutoCloseable {
     }
 
     @SuppressWarnings("deprecation")
-    public static String resolveZkServers(AbstractConfiguration<?> conf) throws IllegalArgumentException {
+    public static String resolveZkServers(AbstractConfiguration<?> conf) {
         String metadataServiceUriStr = conf.getMetadataServiceUriUnchecked();
         if (null == metadataServiceUriStr) {
             return conf.getZkServers();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -33,7 +33,6 @@ import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
-import org.apache.bookkeeper.conf.UncheckedConfigurationException;
 import org.apache.bookkeeper.meta.AbstractZkLedgerManagerFactory;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LayoutManager;
@@ -65,7 +64,7 @@ public class ZKMetadataDriverBase implements AutoCloseable {
         String authority = uri.getAuthority();
         if (authority == null) {
             throw new IllegalArgumentException("Invalid metadata service URI format: " + uri);
-        } 
+        }
         return authority.replace(";", ",");
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -33,6 +33,7 @@ import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.conf.UncheckedConfigurationException;
 import org.apache.bookkeeper.meta.AbstractZkLedgerManagerFactory;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LayoutManager;
@@ -60,8 +61,12 @@ public class ZKMetadataDriverBase implements AutoCloseable {
 
     protected static final String SCHEME = "zk";
 
-    public static String getZKServersFromServiceUri(URI uri) {
-        return uri.getAuthority().replace(";", ",");
+    public static String getZKServersFromServiceUri(URI uri) throws IllegalArgumentException {
+        String authority = uri.getAuthority();
+        if (authority == null) {
+            throw new IllegalArgumentException("Invalid metadata service URI format: " + uri);
+        } 
+        return authority.replace(";", ",");
     }
 
     @SuppressWarnings("deprecation")

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -69,7 +69,7 @@ public class ZKMetadataDriverBase implements AutoCloseable {
     }
 
     @SuppressWarnings("deprecation")
-    public static String resolveZkServers(AbstractConfiguration<?> conf) {
+    public static String resolveZkServers(AbstractConfiguration<?> conf) throws IllegalArgumentException {
         String metadataServiceUriStr = conf.getMetadataServiceUriUnchecked();
         if (null == metadataServiceUriStr) {
             return conf.getZkServers();
@@ -187,7 +187,13 @@ public class ZKMetadataDriverBase implements AutoCloseable {
             final String bookieReadonlyRegistrationPath = bookieRegistrationPath + "/" + READONLY;
 
             // construct the zookeeper
-            final String zkServers = getZKServersFromServiceUri(metadataServiceUri);
+            final String zkServers;
+            try {
+                zkServers = getZKServersFromServiceUri(metadataServiceUri);
+            } catch (IllegalArgumentException ex) {
+                throw new MetadataException(
+                        Code.INVALID_METADATA_SERVICE_URI, ex);
+            }
             log.info("Initialize zookeeper metadata driver at metadata service uri {} :"
                 + " zkServers = {}, ledgersRootPath = {}.", metadataServiceUriStr, zkServers, ledgersRootPath);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/WhoIsAuditorCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/WhoIsAuditorCommand.java
@@ -63,7 +63,7 @@ public class WhoIsAuditorCommand extends BookieCommand<CliFlags> {
         }
     }
 
-    public boolean getAuditor(ServerConfiguration conf)
+    private boolean getAuditor(ServerConfiguration conf)
         throws ConfigurationException, InterruptedException, IOException, KeeperException {
         ZooKeeper zk = null;
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/WhoIsAuditorCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/WhoIsAuditorCommand.java
@@ -64,7 +64,7 @@ public class WhoIsAuditorCommand extends BookieCommand<CliFlags> {
     }
 
     private boolean getAuditor(ServerConfiguration conf)
-        throws ConfigurationException, InterruptedException, IOException, KeeperException {
+        throws ConfigurationException, InterruptedException, IOException, KeeperException, IllegalArgumentException {
         ZooKeeper zk = null;
         try {
             String metadataServiceUri = conf.getMetadataServiceUri();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/WhoIsAuditorCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/WhoIsAuditorCommand.java
@@ -64,7 +64,7 @@ public class WhoIsAuditorCommand extends BookieCommand<CliFlags> {
     }
 
     private boolean getAuditor(ServerConfiguration conf)
-        throws ConfigurationException, InterruptedException, IOException, KeeperException, IllegalArgumentException {
+        throws ConfigurationException, InterruptedException, IOException, KeeperException {
         ZooKeeper zk = null;
         try {
             String metadataServiceUri = conf.getMetadataServiceUri();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -1604,7 +1604,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
             }
         }
     }
-    
+
     private void testInvalidServiceMetadataURICase(String uri) throws Exception {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setMetadataServiceUri(uri);
@@ -1614,5 +1614,5 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         } catch (MetadataStoreException e) {
             // ok
         }
-    } 
+    }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -1576,4 +1576,17 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
             LOG.info("As expected Bookie fails to come up without a cookie in metadata store.");
         }
     }
+
+    @Test
+    public void testInvalidServiceMetadataURI() throws Exception {
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setMetadataServiceUri("zk+flat:///ledgers"); // default value in docker image
+        try {
+            new BookieServer(conf);
+            Assert.fail("Bookie metadata initialization must fail with an invalid metadata service uri");
+        } catch (MetadataStoreException e) {
+            MetadataException cause = (MetadataException) e.getCause();
+            assertEquals(cause.getCode(), org.apache.bookkeeper.meta.exceptions.Code.INVALID_METADATA_SERVICE_URI);
+        }
+    }
 }


### PR DESCRIPTION
…s (Default on Docker image) #2463

Avoid NPE and throw IllegalArgumentException in case of invalid service metadata URI

Master Issue: #2463 