### PR TITLE
Introduce new retry policy for metadata operations

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ExponentialBackOffWithDeadlinePolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ExponentialBackOffWithDeadlinePolicy.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ExponentialBackOffWithDeadlinePolicy implements RetryPolicy {
 
-    public static final int [] RETRY_BACKOFF = {0, 1, 2, 3, 5, 5, 5, 10, 10, 10, 20, 40, 100};
+    static final int [] RETRY_BACKOFF = {0, 1, 2, 3, 5, 5, 5, 10, 10, 10, 20, 40, 100};
     public static final int JITTER_PERCENT = 10;
     private final Random random;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ExponentialBackOffWithDeadlinePolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/zookeeper/ExponentialBackOffWithDeadlinePolicy.java
@@ -1,0 +1,73 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.zookeeper;
+
+import java.util.Arrays;
+import java.util.Random;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Backoff time determined based as a multiple of baseBackoffTime.
+ * The multiple value depends on retryCount.
+ * If the retry schedule exceeds the deadline, we schedule a final attempt exactly at the deadline.
+ */
+@Slf4j
+public class ExponentialBackOffWithDeadlinePolicy implements RetryPolicy {
+
+    public static final int [] RETRY_BACKOFF = {0, 1, 2, 3, 5, 5, 5, 10, 10, 10, 20, 40, 100};
+    public static final int JITTER_PERCENT = 10;
+    private final Random random;
+
+    private final long baseBackoffTime;
+    private final long deadline;
+    private final int maxRetries;
+
+    public ExponentialBackOffWithDeadlinePolicy(long baseBackoffTime, long deadline, int maxRetries) {
+        this.baseBackoffTime = baseBackoffTime;
+        this.deadline = deadline;
+        this.maxRetries = maxRetries;
+        this.random = new Random(System.currentTimeMillis());
+    }
+
+    @Override
+    public boolean allowRetry(int retryCount, long elapsedRetryTime) {
+        return retryCount <= maxRetries && elapsedRetryTime < deadline;
+    }
+
+    @Override
+    public long nextRetryWaitTime(int retryCount, long elapsedRetryTime) {
+        int idx = retryCount;
+        if (idx >= RETRY_BACKOFF.length) {
+            idx = RETRY_BACKOFF.length - 1;
+        }
+
+        long waitTime = (baseBackoffTime * RETRY_BACKOFF[idx]);
+        long jitter = (random.nextInt(JITTER_PERCENT) * waitTime / 100);
+
+        if (elapsedRetryTime + waitTime + jitter > deadline) {
+            log.warn("Final retry attempt: {}, timeleft: {}, stacktrace: {}",
+                    retryCount, (deadline - elapsedRetryTime), Arrays.toString(Thread.currentThread().getStackTrace()));
+            return deadline - elapsedRetryTime;
+        }
+
+        return waitTime + jitter;
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestRetryPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestRetryPolicy.java
@@ -20,6 +20,8 @@
  */
 package org.apache.bookkeeper.zookeeper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -54,5 +56,33 @@ public class TestRetryPolicy {
         assertTimeRange(policy.nextRetryWaitTime(127, 2000), 1000L, 1000L);
         assertTimeRange(policy.nextRetryWaitTime(128, 2000), 1000L, 2000L);
         assertTimeRange(policy.nextRetryWaitTime(129, 2000), 1000L, 2000L);
+    }
+
+    @Test
+    public void testExponentialBackoffWithDeadlineRetryPolicy() throws Exception {
+        RetryPolicy policy = new ExponentialBackOffWithDeadlinePolicy(100, 55 * 1000, 20);
+
+        // Retries are allowed as long as we don't exceed the limits of retry count and deadline
+        assertTrue(policy.allowRetry(1, 5 * 1000));
+        assertTrue(policy.allowRetry(4, 20 * 1000));
+        assertTrue(policy.allowRetry(10, 50 * 1000));
+
+        assertFalse(policy.allowRetry(0, 60 * 1000));
+        assertFalse(policy.allowRetry(22, 20 * 1000));
+        assertFalse(policy.allowRetry(22, 60 * 1000));
+
+        // Verify that the wait times are in the range and with the excepted jitter, until deadline is exceeded
+        assertTimeRange(policy.nextRetryWaitTime(0, 0), 0, 0);
+        assertTimeRange(policy.nextRetryWaitTime(1, 0), 100, 110);
+        assertTimeRange(policy.nextRetryWaitTime(1, 53 * 1000), 100, 110);
+        assertTimeRange(policy.nextRetryWaitTime(2, 0), 200, 220);
+        assertTimeRange(policy.nextRetryWaitTime(3, 0), 300, 330);
+        assertTimeRange(policy.nextRetryWaitTime(3, 53 * 1000), 300, 330);
+        assertTimeRange(policy.nextRetryWaitTime(4, 0), 500, 550);
+        assertTimeRange(policy.nextRetryWaitTime(5, 0), 500, 550);
+
+        // Verify that the final attempt is triggered at deadline.
+        assertEquals(2000, policy.nextRetryWaitTime(10, 53 * 1000));
+        assertEquals(4000, policy.nextRetryWaitTime(15, 51 * 1000));
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestZKClientBoundExpBackoffRP.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestZKClientBoundExpBackoffRP.java
@@ -1,0 +1,51 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.zookeeper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.bookkeeper.test.ZooKeeperCluster;
+import org.apache.bookkeeper.test.ZooKeeperClusterUtil;
+import org.apache.bookkeeper.test.ZooKeeperUtil;
+import org.apache.zookeeper.KeeperException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Test zk client resiliency with BoundExponentialBackoffRetryPolicy.
+ */
+@RunWith(Parameterized.class)
+public class TestZKClientBoundExpBackoffRP extends TestZooKeeperClient {
+
+    public TestZKClientBoundExpBackoffRP(Class<? extends ZooKeeperCluster> zooKeeperUtilClass,
+                                         Class<? extends RetryPolicy> retryPolicyClass)
+            throws IOException, KeeperException, InterruptedException {
+        super(zooKeeperUtilClass, retryPolicyClass);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> zooKeeperUtilClass() {
+        return Arrays.asList(new Object[][] { { ZooKeeperUtil.class, BoundExponentialBackoffRetryPolicy.class },
+                { ZooKeeperClusterUtil.class, BoundExponentialBackoffRetryPolicy.class } });
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestZKClientExpBackoffWithDeadlineRP.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestZKClientExpBackoffWithDeadlineRP.java
@@ -1,0 +1,51 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.zookeeper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.bookkeeper.test.ZooKeeperCluster;
+import org.apache.bookkeeper.test.ZooKeeperClusterUtil;
+import org.apache.bookkeeper.test.ZooKeeperUtil;
+import org.apache.zookeeper.KeeperException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Test zk client resiliency with ExponentialBackOffWithDeadlinePolicy.
+ */
+@RunWith(Parameterized.class)
+public class TestZKClientExpBackoffWithDeadlineRP extends TestZooKeeperClient {
+
+    public TestZKClientExpBackoffWithDeadlineRP(Class<? extends ZooKeeperCluster> zooKeeperUtilClass,
+                                                Class<? extends RetryPolicy> retryPolicyClass)
+            throws IOException, KeeperException, InterruptedException {
+        super(zooKeeperUtilClass, retryPolicyClass);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> zooKeeperUtilClass() {
+        return Arrays.asList(new Object[][] { { ZooKeeperUtil.class, ExponentialBackOffWithDeadlinePolicy.class },
+                { ZooKeeperClusterUtil.class, ExponentialBackOffWithDeadlinePolicy.class } });
+    }
+
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation
Current retry backoff policy is truly exponential, hence retries are spaced out at large intervals. There is maxBackOff time that limits it, but it doesn't have a concept of deadline. Hence, applications with shorter SLA's have issues dealing with ZK failures and recovering from it.

### Changes

The new policy introduces an aggressive retry mechanism with the backoff constants as less exponential. The deadline ensures that we retry at least once at the deadline. The stack trace would indicate the operation at risk.

This doesn't update the product code, which is still in testing. I am splitting PR's for for sake of reviews.
