### PR TITLE
Upgrade jetty to 9.4.33.v20201020

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -246,12 +246,12 @@ Apache Software License, Version 2.
 - lib/org.apache.commons-commons-lang3-3.6.jar [24]
 - lib/org.apache.zookeeper-zookeeper-3.5.7.jar [25]
 - lib/org.apache.zookeeper-zookeeper-jute-3.5.7.jar [25]
-- lib/org.eclipse.jetty-jetty-http-9.4.5.v20170502.jar [26]
-- lib/org.eclipse.jetty-jetty-io-9.4.5.v20170502.jar [26]
-- lib/org.eclipse.jetty-jetty-security-9.4.5.v20170502.jar [26]
-- lib/org.eclipse.jetty-jetty-server-9.4.5.v20170502.jar [26]
-- lib/org.eclipse.jetty-jetty-servlet-9.4.5.v20170502.jar [26]
-- lib/org.eclipse.jetty-jetty-util-9.4.5.v20170502.jar [26]
+- lib/org.eclipse.jetty-jetty-http-9.4.33.v20201020.jar [26]
+- lib/org.eclipse.jetty-jetty-io-9.4.33.v20201020.jar [26]
+- lib/org.eclipse.jetty-jetty-security-9.4.33.v20201020.jar [26]
+- lib/org.eclipse.jetty-jetty-server-9.4.33.v20201020.jar [26]
+- lib/org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar [26]
+- lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar [26]
 - lib/org.rocksdb-rocksdbjni-5.13.1.jar [27]
 - lib/com.beust-jcommander-1.48.jar [28]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [29]
@@ -309,7 +309,7 @@ Apache Software License, Version 2.
 [23] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [24] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=tag;h=3ad2e8
 [25] Source available at https://github.com/apache/zookeeper/tree/release-3.5.7
-[26] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.5.v20170502
+[26] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.33.v20201020
 [27] Source available at https://github.com/facebook/rocksdb/tree/v5.13.1
 [28] Source available at https://github.com/cbeust/jcommander/tree/jcommander-1.48
 [29] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -243,12 +243,12 @@ Apache Software License, Version 2.
 - lib/org.apache.commons-commons-lang3-3.6.jar [19]
 - lib/org.apache.zookeeper-zookeeper-3.5.7.jar [20]
 - lib/org.apache.zookeeper-zookeeper-jute-3.5.7.jar [20]
-- lib/org.eclipse.jetty-jetty-http-9.4.5.v20170502.jar [21]
-- lib/org.eclipse.jetty-jetty-io-9.4.5.v20170502.jar [21]
-- lib/org.eclipse.jetty-jetty-security-9.4.5.v20170502.jar [21]
-- lib/org.eclipse.jetty-jetty-server-9.4.5.v20170502.jar [21]
-- lib/org.eclipse.jetty-jetty-servlet-9.4.5.v20170502.jar [21]
-- lib/org.eclipse.jetty-jetty-util-9.4.5.v20170502.jar [21]
+- lib/org.eclipse.jetty-jetty-http-9.4.33.v20201020.jar [21]
+- lib/org.eclipse.jetty-jetty-io-9.4.33.v20201020.jar [21]
+- lib/org.eclipse.jetty-jetty-security-9.4.33.v20201020.jar [21]
+- lib/org.eclipse.jetty-jetty-server-9.4.33.v20201020.jar [21]
+- lib/org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar [21]
+- lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar [21]
 - lib/org.rocksdb-rocksdbjni-5.13.1.jar [22]
 - lib/com.beust-jcommander-1.48.jar [23]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [24]
@@ -304,7 +304,7 @@ Apache Software License, Version 2.
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [20] Source available at https://github.com/apache/zookeeper/tree/release-3.5.7
-[21] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.5.v20170502
+[21] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.33.v20201020
 [22] Source available at https://github.com/facebook/rocksdb/tree/v5.13.1
 [23] Source available at https://github.com/cbeust/jcommander/tree/jcommander-1.48
 [24] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -78,12 +78,12 @@ SoundCloud Ltd. (http://soundcloud.com/).
 This product includes software developed as part of the
 Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
 ------------------------------------------------------------------------------------
-- lib/org.eclipse.jetty-jetty-http-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-io-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-security-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-server-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-servlet-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-util-9.4.5.v20170502.jar
+- lib/org.eclipse.jetty-jetty-http-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-io-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-security-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-server-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar
 
 ==============================================================
  Jetty Web Container
@@ -105,7 +105,7 @@ Jetty is dual licensed under both
 
 Jetty may be distributed under either license.
 
-lib/org.eclipse.jetty-jetty-util-9.4.5.v20170502.jar bundles UnixCrypt
+lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar bundles UnixCrypt
 
 The UnixCrypt.java code implements the one way cryptography used by
 Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -61,12 +61,12 @@ SoundCloud Ltd. (http://soundcloud.com/).
 This product includes software developed as part of the
 Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
 ------------------------------------------------------------------------------------
-- lib/org.eclipse.jetty-jetty-http-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-io-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-security-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-server-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-servlet-9.4.5.v20170502.jar
-- lib/org.eclipse.jetty-jetty-util-9.4.5.v20170502.jar
+- lib/org.eclipse.jetty-jetty-http-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-io-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-security-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-server-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar
+- lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar
 
 ==============================================================
  Jetty Web Container
@@ -88,7 +88,7 @@ Jetty is dual licensed under both
 
 Jetty may be distributed under either license.
 
-lib/org.eclipse.jetty-jetty-util-9.4.5.v20170502.jar bundles UnixCrypt
+lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar bundles UnixCrypt
 
 The UnixCrypt.java code implements the one way cryptography used by
 Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <jackson.version>2.11.0</jackson.version>
     <jackson-mapper-asl.version>1.9.11</jackson-mapper-asl.version>
     <jcommander.version>1.48</jcommander.version>
-    <jetty.version>9.4.5.v20170502</jetty.version>
+    <jetty.version>9.4.33.v20201020</jetty.version>
     <jline.version>2.11</jline.version>
     <jmh.version>1.19</jmh.version>
     <jmock.version>2.8.2</jmock.version>


### PR DESCRIPTION
Jetty versions 9.4.32.v20200930 and earlier have a security vulnerability, so upgraded to the latest stable version.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27216