### PR TITLE
Issue 1533: DbLedgerStorage does not persist ExplicitLAC: Information (Header) of TransientLedgerInfo is not persisted

### DIFF
--- a/bookkeeper-proto/src/main/proto/DbLedgerStorageDataFormats.proto
+++ b/bookkeeper-proto/src/main/proto/DbLedgerStorageDataFormats.proto
@@ -27,4 +27,5 @@ message LedgerData {
     required bool exists = 1;
     required bool fenced = 2;
     required bytes masterKey = 3;
+    optional bytes explicitLac = 4;
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
@@ -87,7 +87,7 @@ public abstract class LedgerDescriptor {
 
     abstract void setExplicitLac(ByteBuf entry) throws IOException;
 
-    abstract  ByteBuf getExplicitLac();
+    abstract  ByteBuf getExplicitLac() throws IOException;
 
     abstract OfLong getListOfEntriesOfLedger(long ledgerId) throws IOException;
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -83,7 +83,7 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
     }
 
     @Override
-    ByteBuf getExplicitLac() {
+    ByteBuf getExplicitLac() throws IOException {
         return ledgerStorage.getExplicitLac(ledgerId);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -188,7 +188,7 @@ public interface LedgerStorage {
 
     void setExplicitLac(long ledgerId, ByteBuf lac) throws IOException;
 
-    ByteBuf getExplicitLac(long ledgerId);
+    ByteBuf getExplicitLac(long ledgerId) throws IOException;
 
     // for testability
     default LedgerStorage getUnderlyingLedgerStorage() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -247,7 +247,7 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     @Override
-    public ByteBuf getExplicitLac(long ledgerId) {
+    public ByteBuf getExplicitLac(long ledgerId) throws IOException {
         return getLedgerSorage(ledgerId).getExplicitLac(ledgerId);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
@@ -23,6 +23,8 @@ package org.apache.bookkeeper.bookie.storage.ldb;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -245,4 +247,25 @@ public class LedgerMetadataIndex implements Closeable {
     }
 
     private static final Logger log = LoggerFactory.getLogger(LedgerMetadataIndex.class);
+
+    void setExplicitLac(long ledgerId, ByteBuf lac) throws IOException {
+        LedgerData ledgerData = ledgers.get(ledgerId);
+        if (ledgerData != null) {
+            LedgerData newLedgerData = LedgerData.newBuilder(ledgerData)
+                    .setExplicitLac(ByteString.copyFrom(lac.nioBuffer())).build();
+
+            if (ledgers.put(ledgerId, newLedgerData) == null) {
+                // Ledger had been deleted
+                return;
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Set explicitLac on ledger {}", ledgerId);
+                }
+            }
+            pendingLedgersUpdates.add(new SimpleEntry<Long, LedgerData>(ledgerId, newLedgerData));
+        } else {
+            // unknown ledger here
+        }
+    }
+
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
@@ -24,7 +24,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/TransientLedgerInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/TransientLedgerInfo.java
@@ -124,7 +124,9 @@ class TransientLedgerInfo extends Watchable<LastAddConfirmedUpdateNotification> 
             if (explicitLac == null) {
                 explicitLac = ByteBuffer.allocate(lac.capacity());
             }
+            int readerIndex = lac.readerIndex();
             lac.readBytes(explicitLac);
+            lac.readerIndex(readerIndex);
             explicitLac.rewind();
 
             // skip the ledger id

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
@@ -35,7 +35,6 @@ import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.TestUtils;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -64,13 +63,13 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
     @Parameters
     public static Collection<Object[]> configs() {
         return Arrays.asList(new Object[][] {
-            { InterleavedLedgerStorage.class },
-            { SortedLedgerStorage.class },
+//            { InterleavedLedgerStorage.class },
+//            { SortedLedgerStorage.class },
             { DbLedgerStorage.class },
         });
-    }
+    } 
 
-    @Test
+//    @Test
     public void testReadHandleWithNoExplicitLAC() throws Exception {
         ClientConfiguration confWithNoExplicitLAC = new ClientConfiguration();
         confWithNoExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
@@ -135,19 +134,10 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testExplicitLACIsPersisted() throws Exception {
-        /*
-         * In DbLedgerStorage scenario, TransientLedgerInfo is not persisted -
-         * https://github.com/apache/bookkeeper/issues/1533.
-         *
-         * So for this testcase we are ignoring DbLedgerStorage. It can/should
-         * be enabled when Issue-1533 is fixed.
-         */
-        Assume.assumeTrue(!baseConf.getLedgerStorageClass().equals(DbLedgerStorage.class.getName()));
         ClientConfiguration confWithNoExplicitLAC = new ClientConfiguration();
         confWithNoExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         // enable explicitLacFlush by setting non-zero value for
         // explictLacInterval
-        long explictLacInterval = 100;
         confWithNoExplicitLAC.setExplictLacInterval(50);
 
         BookKeeper bkcWithExplicitLAC = new BookKeeper(confWithNoExplicitLAC);
@@ -193,7 +183,7 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
         bkcWithExplicitLAC.close();
     }
 
-    @Test
+//    @Test
     public void testReadHandleWithExplicitLAC() throws Exception {
         ClientConfiguration confWithExplicitLAC = new ClientConfiguration();
         confWithExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
@@ -260,7 +250,7 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
         bkcWithExplicitLAC.close();
     }
 
-    @Test
+//    @Test
     public void testReadHandleWithExplicitLACAndDeferredSync() throws Exception {
         ClientConfiguration confWithExplicitLAC = new ClientConfiguration();
         confWithExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
@@ -340,7 +330,7 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
         bkcWithExplicitLAC.close();
     }
 
-    @Test
+//    @Test
     public void fallbackV3() throws Exception {
         ClientConfiguration v2Conf = new ClientConfiguration();
         v2Conf.setUseV2WireProtocol(true);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
@@ -63,13 +63,13 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
     @Parameters
     public static Collection<Object[]> configs() {
         return Arrays.asList(new Object[][] {
-//            { InterleavedLedgerStorage.class },
-//            { SortedLedgerStorage.class },
+            { InterleavedLedgerStorage.class },
+            { SortedLedgerStorage.class },
             { DbLedgerStorage.class },
         });
-    } 
+    }
 
-//    @Test
+    @Test
     public void testReadHandleWithNoExplicitLAC() throws Exception {
         ClientConfiguration confWithNoExplicitLAC = new ClientConfiguration();
         confWithNoExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
@@ -183,7 +183,7 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
         bkcWithExplicitLAC.close();
     }
 
-//    @Test
+    @Test
     public void testReadHandleWithExplicitLAC() throws Exception {
         ClientConfiguration confWithExplicitLAC = new ClientConfiguration();
         confWithExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ExplicitLacTest.java
@@ -250,7 +250,7 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
         bkcWithExplicitLAC.close();
     }
 
-//    @Test
+    @Test
     public void testReadHandleWithExplicitLACAndDeferredSync() throws Exception {
         ClientConfiguration confWithExplicitLAC = new ClientConfiguration();
         confWithExplicitLAC.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
@@ -330,7 +330,7 @@ public class ExplicitLacTest extends BookKeeperClusterTestCase {
         bkcWithExplicitLAC.close();
     }
 
-//    @Test
+    @Test
     public void fallbackV3() throws Exception {
         ClientConfiguration v2Conf = new ClientConfiguration();
         v2Conf.setUseV2WireProtocol(true);


### PR DESCRIPTION
### Motivation
DbLedgerStorage does not persist "ExplicitLAC" on RocksDB, so when you restart a Bookie the information is lost.
This work can be considered a follow up of @reddycharan  work at #1527

### Changes

- persist ExplicitLAC on DBLedgerStorage
- save ExplicitLAC on RocksDB (it is an optional field, so this change is backward compatible)
- enable testExplicitLACIsPersisted test even for DBLedgerStorage
- on TransientLedgerInfo rewind the ByteBuf in order to be able to use it again while writing to RocksDB
- use computeIfAbsent in getOrAddLedgerInfo (code clean up, but code looked strange, probably subject to some possible race condition)

Master Issue: #1533 
