### PR TITLE
Fix Default Java Home in apachebookkeeper/bookkeeper-current image

### DIFF
--- a/tests/docker-images/current-version-image/Dockerfile
+++ b/tests/docker-images/current-version-image/Dockerfile
@@ -30,7 +30,7 @@ ENV BOOKIE_GRPC_PORT=4181
 EXPOSE ${BOOKIE_PORT} ${BOOKIE_HTTP_PORT} ${BOOKIE_GRPC_PORT}
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/jdk-11
+ENV JAVA_HOME=/usr/lib/jvm/java-11
 
 # prepare utils
 RUN set -x \


### PR DESCRIPTION
### Motivation

You can easily build locally a docker image regarding the "current" version, that is the code that you have currently on your git repository using these commands:

```
mvn clean install -DskipTests
mvn install -f tests/docker-images/current-version-image/pom.xml -DintegrationTests
```

```
 # start ZooKeeper server locally
docker run --network=host zookeeper:latest
```

```
# start one Bookie
docker run --network=host --env BK_zkServers=localhost:2181 --env BK_bookieId=bk1 --env BK_allowLoopback=true --env BK_bookiePort=3181 apachebookkeeper/bookkeeper-current
```

but in current master, after the first switch to JDK11 the Dockerfile of the "apachebookkeeper/bookkeeper-current" is broken and points to a broken path for the JAVA_HOME env entry.

### Changes
Change the default JAVA_HOME to the good path
