### PR TITLE
Upgrade Guava to 30.0-jre

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultSpeculativeRequestExecutionPolicy.java
@@ -20,6 +20,7 @@
  */
 package org.apache.bookkeeper.client;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -102,7 +103,7 @@ public class DefaultSpeculativeRequestExecutionPolicy implements SpeculativeRequ
                             LOG.warn("Failed to issue speculative request for {}, speculativeReadTimeout = {} : ",
                                     requestExecutor, speculativeRequestTimeout, thrown);
                         }
-                    });
+                    }, directExecutor());
                 }
             }, speculativeRequestTimeout, TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException re) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperClusterUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperClusterUtil.java
@@ -20,8 +20,8 @@
  */
 package org.apache.bookkeeper.test;
 
-import com.google.common.io.Files;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
@@ -58,7 +58,7 @@ public class ZooKeeperClusterUtil implements ZooKeeperCluster {
         System.setProperty("zookeeper.4lw.commands.whitelist", "*");
         System.setProperty("zookeeper.admin.enableServer", "false");
         try {
-            System.setProperty("build.test.dir", Files.createTempDir().getCanonicalPath());
+            System.setProperty("build.test.dir", Files.createTempDirectory("zktests").toFile().getCanonicalPath());
         } catch (IOException e) {
             log.error("Failed to create temp dir, so setting build.test.dir system property to /tmp");
             System.setProperty("build.test.dir", "/tmp");

--- a/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleMetricsProvider.java
+++ b/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleMetricsProvider.java
@@ -78,7 +78,7 @@ public class CodahaleMetricsProvider implements StatsProvider {
             LOG.info("Configuring stats with graphite");
             HostAndPort addr = HostAndPort.fromString(graphiteHost);
             final Graphite graphite = new Graphite(
-                    new InetSocketAddress(addr.getHostText(), addr.getPort()));
+                    new InetSocketAddress(addr.getHost(), addr.getPort()));
             reporters.add(GraphiteReporter.forRegistry(getMetrics())
                           .prefixedWith(prefix)
                           .convertRatesTo(TimeUnit.SECONDS)

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.1.2</google.errorprone.version>
     <grpc.version>1.18.0</grpc.version>
-    <guava.version>23.0-jre</guava.version>
+    <guava.version>30.0-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>2.7.3</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.1.2</google.errorprone.version>
     <grpc.version>1.18.0</grpc.version>
-    <guava.version>21.0</guava.version>
+    <guava.version>23.0-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>2.7.3</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>

--- a/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/utils/RpcUtils.java
+++ b/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/utils/RpcUtils.java
@@ -14,6 +14,7 @@
 
 package org.apache.bookkeeper.clients.utils;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -83,7 +84,7 @@ public class RpcUtils {
                     GrpcUtils.processRpcException(throwable, result);
                 }
             }
-        );
+        , directExecutor());
     }
 
 }

--- a/stream/common/src/main/java/org/apache/bookkeeper/common/util/ListenableFutures.java
+++ b/stream/common/src/main/java/org/apache/bookkeeper/common/util/ListenableFutures.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.common.util;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static org.apache.bookkeeper.common.concurrent.FutureUtils.createFuture;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -71,7 +72,7 @@ public final class ListenableFutures {
             public void onFailure(Throwable t) {
                 completableFuture.completeExceptionally(t);
             }
-        });
+        }, directExecutor());
         return completableFuture;
     }
 
@@ -101,7 +102,7 @@ public final class ListenableFutures {
             public void onFailure(Throwable t) {
                 completableFuture.completeExceptionally(t);
             }
-        });
+        }, directExecutor());
         return completableFuture;
     }
 }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogSegmentWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogSegmentWriter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.distributedlog;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.distributedlog.DistributedLogConstants.INVALID_TXID;
 import static org.apache.distributedlog.LogRecord.MAX_LOGRECORDSET_SIZE;
@@ -1239,7 +1240,7 @@ class BKLogSegmentWriter implements LogSegmentWriter, AddCallback, Runnable, Siz
                         fullyQualifiedLogSegment, entryId,
                         transmitPacket.getRecordSet().getMaxTxId(), rc, cause);
                 }
-            });
+            }, directExecutor());
             // Race condition if we notify before the addComplete is enqueued.
             transmitPacket.notifyTransmitComplete(effectiveRC);
             outstandingTransmitsUpdater.getAndDecrement(this);

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVAsyncStore.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVAsyncStore.java
@@ -23,9 +23,9 @@ import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNull;
 
-import com.google.common.io.Files;
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.coder.ByteArrayCoder;
 import org.apache.bookkeeper.statelib.api.StateStoreSpec;
@@ -80,7 +80,7 @@ public class TestRocksdbKVAsyncStore extends TestDistributedLogBase {
         super.setup();
         ensureURICreated(uri);
 
-        tempDir = Files.createTempDir();
+        tempDir = Files.createTempDirectory("test").toFile();
 
         store = new RocksdbKVAsyncStore<>(
             () -> new RocksdbKVStore<>(),

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVStore.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVStore.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-import com.google.common.io.Files;
 import java.io.File;
 import org.apache.bookkeeper.common.coder.StringUtf8Coder;
 import org.apache.bookkeeper.common.kv.KV;
@@ -51,8 +50,8 @@ public class TestRocksdbKVStore {
     private RocksdbKVStore<String, String> store;
 
     @Before
-    public void setUp() {
-        tempDir = Files.createTempDir();
+    public void setUp() throws Exception {
+        tempDir = java.nio.file.Files.createTempDirectory("test").toFile();
         spec = StateStoreSpec.builder()
             .name(runtime.getMethodName())
             .keyCoder(StringUtf8Coder.of())

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/mvcc/TestMVCCStoreImpl.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/mvcc/TestMVCCStoreImpl.java
@@ -25,8 +25,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.io.Files;
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -68,8 +68,8 @@ public class TestMVCCStoreImpl {
     private MVCCStoreImpl<String, String> store;
 
     @Before
-    public void setUp() {
-        tempDir = Files.createTempDir();
+    public void setUp() throws IOException {
+        tempDir = java.nio.file.Files.createTempDirectory("test").toFile();
         spec = StateStoreSpec.builder()
             .name(runtime.getMethodName())
             .keyCoder(StringUtf8Coder.of())

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/Cli.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/Cli.java
@@ -152,7 +152,7 @@ public class Cli<CliFlagsT extends CliFlags> {
     }
 
     void usage() {
-        usage(null);
+        usage("");
     }
 
     void usage(String errorMsg) {


### PR DESCRIPTION
- Upgrade Guava to 30.0.jre (see https://github.com/google/guava/releases)
- adapt code, as Futures.addCallback(3-args) has been removed (see https://github.com/google/guava/commit/dfb00017144bf48c408bc4cfcebadc0a0498dc73)