### PR TITLE
[release 4.12.0] fix version 4.12 after release

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@
 FROM centos:7
 MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
 
-ARG BK_VERSION=4.11.0
+ARG BK_VERSION=4.12.0
 ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
 ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -8,8 +8,8 @@ destination: local-generated
 twitter_url: https://twitter.com/asfbookkeeper
 
 versions:
-- "4.12.0"
 # [next_version_placeholder]
+- "4.12.0"
 - "4.11.1"
 - "4.11.0"
 - "4.10.0"

--- a/site/releases.md
+++ b/site/releases.md
@@ -66,7 +66,9 @@ Client Guide | API docs
 
 ### [date] Release 4.12.0 available
 
-[INSERT SUMMARY]
+This is the 23th release of Apache BookKeeper !
+
+See [BookKeeper 4.12.0 Release Notes](../docs/4.12.0/overview/releaseNotes) for details.
 
 ### 20 October, 2020 Release 4.11.1 available
 


### PR DESCRIPTION
the link in site/releases.md is not updated, this is to fix the issue.
update the version in [docker/Dockerfile](https://github.com/apache/bookkeeper/blob/master/docker/Dockerfile).