### PR TITLE
Upgrade to Curator 5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <commons-lang3.version>3.6</commons-lang3.version>
     <commons-io.version>2.4</commons-io.version>
     <bouncycastle.version>1.60</bouncycastle.version>
-    <curator.version>5.0.0</curator.version>
+    <curator.version>5.1.0</curator.version>
     <dropwizard.version>3.1.0</dropwizard.version>
     <etcd.version>0.0.2</etcd.version>
     <freebuilder.version>1.14.9</freebuilder.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1135,16 +1135,4 @@
       </build>
     </profile>
   </profiles>
-
-   <repositories>
-
-        <repository>
-            <id>curator-50-rc0</id>
-            <name>Curator Vote repository</name>
-            <url>https://repository.apache.org/content/repositories/orgapachecurator-1049/</url>
-        </repository>
-
-    </repositories>
-
-  
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <commons-lang3.version>3.6</commons-lang3.version>
     <commons-io.version>2.4</commons-io.version>
     <bouncycastle.version>1.60</bouncycastle.version>
-    <curator.version>4.0.1</curator.version>
+    <curator.version>5.0.0</curator.version>
     <dropwizard.version>3.1.0</dropwizard.version>
     <etcd.version>0.0.2</etcd.version>
     <freebuilder.version>1.14.9</freebuilder.version>
@@ -1135,4 +1135,16 @@
       </build>
     </profile>
   </profiles>
+
+   <repositories>
+
+        <repository>
+            <id>curator-50-rc0</id>
+            <name>Curator Vote repository</name>
+            <url>https://repository.apache.org/content/repositories/orgapachecurator-1049/</url>
+        </repository>
+
+    </repositories>
+
+  
 </project>

--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterMetadataStore.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterMetadataStore.java
@@ -156,7 +156,7 @@ public class ZkClusterMetadataStore implements ClusterMetadataStore {
         synchronized (this) {
             if (assignmentDataCache == null) {
                 assignmentDataCache = new org.apache.curator.framework.recipes.cache.NodeCache(client,
-							zkClusterAssignmentPath);
+                                                                                               zkClusterAssignmentPath);
                 try {
                     assignmentDataCache.start();
                 } catch (Exception e) {

--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterMetadataStore.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterMetadataStore.java
@@ -38,7 +38,6 @@ import org.apache.bookkeeper.stream.proto.cluster.ClusterMetadata;
 import org.apache.bookkeeper.stream.storage.api.cluster.ClusterMetadataStore;
 import org.apache.bookkeeper.stream.storage.exceptions.StorageRuntimeException;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.cache.NodeCache;
 import org.apache.curator.framework.recipes.cache.NodeCacheListener;
 import org.apache.distributedlog.impl.metadata.BKDLConfig;
 import org.apache.distributedlog.metadata.DLMetadata;
@@ -48,6 +47,7 @@ import org.apache.zookeeper.KeeperException;
  * A zookeeper based implementation of cluster metadata store.
  */
 @Slf4j
+@SuppressWarnings("deprecation")
 public class ZkClusterMetadataStore implements ClusterMetadataStore {
 
     private final CuratorFramework client;
@@ -58,7 +58,7 @@ public class ZkClusterMetadataStore implements ClusterMetadataStore {
     private final String zkClusterAssignmentPath;
 
     private final Map<Consumer<Void>, NodeCacheListener> assignmentDataConsumers;
-    private NodeCache assignmentDataCache;
+    private org.apache.curator.framework.recipes.cache.NodeCache assignmentDataCache;
 
     private volatile boolean closed = false;
 
@@ -155,7 +155,7 @@ public class ZkClusterMetadataStore implements ClusterMetadataStore {
     public void watchClusterAssignmentData(Consumer<Void> watcher, Executor executor) {
         synchronized (this) {
             if (assignmentDataCache == null) {
-                assignmentDataCache = new NodeCache(client, zkClusterAssignmentPath);
+                assignmentDataCache = new org.apache.curator.framework.recipes.cache.NodeCache(client, zkClusterAssignmentPath);
                 try {
                     assignmentDataCache.start();
                 } catch (Exception e) {

--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterMetadataStore.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/cluster/ZkClusterMetadataStore.java
@@ -155,7 +155,8 @@ public class ZkClusterMetadataStore implements ClusterMetadataStore {
     public void watchClusterAssignmentData(Consumer<Void> watcher, Executor executor) {
         synchronized (this) {
             if (assignmentDataCache == null) {
-                assignmentDataCache = new org.apache.curator.framework.recipes.cache.NodeCache(client, zkClusterAssignmentPath);
+                assignmentDataCache = new org.apache.curator.framework.recipes.cache.NodeCache(client,
+							zkClusterAssignmentPath);
                 try {
                     assignmentDataCache.start();
                 } catch (Exception e) {


### PR DESCRIPTION
Descriptions of the changes in this PR:

Curator 5.x support ZooKeeper 3.6.x.
This change is needed to able the upgrade of Pulsar to ZooKeeper 3.6.2 

### Changes

Upgrade Curator
