### PR TITLE
Opportunistic Striping

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -125,27 +125,49 @@ class LedgerCreateOp {
      * Initiates the operation.
      */
     public void initiate() {
+        int actualEnsembleSize = ensembleSize;
+        List<BookieId> ensemble = null;
+        // select bookies for first ensemble
+        if (bk.getConf().getOpportunisticStriping()) {
+            BKNotEnoughBookiesException lastError = null;
+            // we would like to select ensembleSize bookies, but
+            // we can settle to writeQuorumSize
+            while (actualEnsembleSize >= writeQuorumSize) {
+                try {
+                    ensemble = bk.getBookieWatcher()
+                        .newEnsemble(actualEnsembleSize, writeQuorumSize, ackQuorumSize, customMetadata);
+                    lastError = null;
+                    break;
+                } catch (BKNotEnoughBookiesException e) {
+                    LOG.error("Not enough bookies to create ledger with " + actualEnsembleSize + "/" + writeQuorumSize + "/" + ackQuorumSize);
+                    lastError = e;
+                    actualEnsembleSize--;
+                }
+            }
+            if (lastError != null) {
+                createComplete(lastError.getCode(), null);
+                return;
+            }
+        } else {
+            try {
+                ensemble = bk.getBookieWatcher()
+                        .newEnsemble(actualEnsembleSize, writeQuorumSize, ackQuorumSize, customMetadata);
+            } catch (BKNotEnoughBookiesException e) {
+                LOG.error("Not enough bookies to create ledger with " + actualEnsembleSize + "/" + writeQuorumSize + "/" + ackQuorumSize);
+                createComplete(e.getCode(), null);
+                return;
+            }
+        }
         LedgerMetadataBuilder metadataBuilder = LedgerMetadataBuilder.create()
-            .withEnsembleSize(ensembleSize).withWriteQuorumSize(writeQuorumSize).withAckQuorumSize(ackQuorumSize)
+            .withEnsembleSize(actualEnsembleSize).withWriteQuorumSize(writeQuorumSize).withAckQuorumSize(ackQuorumSize)
             .withDigestType(digestType.toApiDigestType()).withPassword(passwd);
+        metadataBuilder.newEnsembleEntry(0L, ensemble);
         if (customMetadata != null) {
             metadataBuilder.withCustomMetadata(customMetadata);
         }
         if (bk.getConf().getStoreSystemtimeAsLedgerCreationTime()) {
             metadataBuilder.withCreationTime(System.currentTimeMillis()).storingCreationTime(true);
         }
-
-        // select bookies for first ensemble
-        try {
-            List<BookieId> ensemble = bk.getBookieWatcher()
-                .newEnsemble(ensembleSize, writeQuorumSize, ackQuorumSize, customMetadata);
-            metadataBuilder.newEnsembleEntry(0L, ensemble);
-        } catch (BKNotEnoughBookiesException e) {
-            LOG.error("Not enough bookies to create ledger");
-            createComplete(e.getCode(), null);
-            return;
-        }
-
 
         if (this.generateLedgerId) {
             generateLedgerIdAndCreateLedger(metadataBuilder);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -139,7 +139,8 @@ class LedgerCreateOp {
                     lastError = null;
                     break;
                 } catch (BKNotEnoughBookiesException e) {
-                    LOG.error("Not enough bookies to create ledger with " + actualEnsembleSize + "/" + writeQuorumSize + "/" + ackQuorumSize);
+                    LOG.error("Not enough bookies to create ledger with {}/{}/{}",
+                            actualEnsembleSize, writeQuorumSize, ackQuorumSize);
                     lastError = e;
                     actualEnsembleSize--;
                 }
@@ -153,7 +154,8 @@ class LedgerCreateOp {
                 ensemble = bk.getBookieWatcher()
                         .newEnsemble(actualEnsembleSize, writeQuorumSize, ackQuorumSize, customMetadata);
             } catch (BKNotEnoughBookiesException e) {
-                LOG.error("Not enough bookies to create ledger with " + actualEnsembleSize + "/" + writeQuorumSize + "/" + ackQuorumSize);
+                LOG.error("Not enough bookies to create ledger with {}/{}/{}",
+                        actualEnsembleSize, writeQuorumSize, ackQuorumSize);
                 createComplete(e.getCode(), null);
                 return;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -141,7 +141,7 @@ class LedgerCreateOp {
                 } catch (BKNotEnoughBookiesException e) {
                     if (actualEnsembleSize >= writeQuorumSize + 1) {
                         LOG.info("Not enough bookies to create ledger with ensembleSize={},"
-                                + " writeQuorumSize={} and ackQuorumSize={}, opportusticStriping is enabled, try again",
+                                + " writeQuorumSize={} and ackQuorumSize={}, opportusticStriping enabled, try again",
                                     actualEnsembleSize, writeQuorumSize, ackQuorumSize);
                     }
                     lastError = e;
@@ -149,8 +149,9 @@ class LedgerCreateOp {
                 }
             }
             if (lastError != null) {
-                LOG.error("Not enough bookies to create ledger with ensembleSize={}, writeQuorumSize={} and ackQuorumSize={}",
-                            actualEnsembleSize, writeQuorumSize, ackQuorumSize);
+                LOG.error("Not enough bookies to create ledger with ensembleSize={},"
+                        + " writeQuorumSize={} and ackQuorumSize={}",
+                        actualEnsembleSize, writeQuorumSize, ackQuorumSize);
                 createComplete(lastError.getCode(), null);
                 return;
             }
@@ -159,7 +160,8 @@ class LedgerCreateOp {
                 ensemble = bk.getBookieWatcher()
                         .newEnsemble(actualEnsembleSize, writeQuorumSize, ackQuorumSize, customMetadata);
             } catch (BKNotEnoughBookiesException e) {
-                LOG.error("Not enough bookies to create ledger with ensembleSize={}, writeQuorumSize={} and ackQuorumSize={}",
+                LOG.error("Not enough bookies to create ledger with ensembleSize={},"
+                        + " writeQuorumSize={} and ackQuorumSize={}",
                             actualEnsembleSize, writeQuorumSize, ackQuorumSize);
                 createComplete(e.getCode(), null);
                 return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -139,13 +139,18 @@ class LedgerCreateOp {
                     lastError = null;
                     break;
                 } catch (BKNotEnoughBookiesException e) {
-                    LOG.error("Not enough bookies to create ledger with {}/{}/{}",
-                            actualEnsembleSize, writeQuorumSize, ackQuorumSize);
+                    if (actualEnsembleSize >= writeQuorumSize + 1) {
+                        LOG.info("Not enough bookies to create ledger with ensembleSize={},"
+                                + " writeQuorumSize={} and ackQuorumSize={}, opportusticStriping is enabled, try again",
+                                    actualEnsembleSize, writeQuorumSize, ackQuorumSize);
+                    }
                     lastError = e;
                     actualEnsembleSize--;
                 }
             }
             if (lastError != null) {
+                LOG.error("Not enough bookies to create ledger with ensembleSize={}, writeQuorumSize={} and ackQuorumSize={}",
+                            actualEnsembleSize, writeQuorumSize, ackQuorumSize);
                 createComplete(lastError.getCode(), null);
                 return;
             }
@@ -154,8 +159,8 @@ class LedgerCreateOp {
                 ensemble = bk.getBookieWatcher()
                         .newEnsemble(actualEnsembleSize, writeQuorumSize, ackQuorumSize, customMetadata);
             } catch (BKNotEnoughBookiesException e) {
-                LOG.error("Not enough bookies to create ledger with {}/{}/{}",
-                        actualEnsembleSize, writeQuorumSize, ackQuorumSize);
+                LOG.error("Not enough bookies to create ledger with ensembleSize={}, writeQuorumSize={} and ackQuorumSize={}",
+                            actualEnsembleSize, writeQuorumSize, ackQuorumSize);
                 createComplete(e.getCode(), null);
                 return;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -116,6 +116,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     protected static final String REORDER_READ_SEQUENCE_ENABLED = "reorderReadSequenceEnabled";
     protected static final String STICKY_READS_ENABLED = "stickyReadSEnabled";
     // Add Parameters
+    protected static final String OPPORTUNISTIC_STRIPING = "opportunisticStriping";
     protected static final String DELAY_ENSEMBLE_CHANGE = "delayEnsembleChange";
     protected static final String MAX_ALLOWED_ENSEMBLE_CHANGES = "maxNumEnsembleChanges";
     // Timeout Setting
@@ -1738,6 +1739,36 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
      */
     public ClientConfiguration setTLSCertificatePath(String arg) {
         setProperty(TLS_CERTIFICATE_PATH, arg);
+        return this;
+    }
+
+    /**
+     * Whether to allow opportunistic striping.
+     *
+     * @return true if opportunistic striping is enabled
+     */
+    public boolean getOpportunisticStriping() {
+        return getBoolean(OPPORTUNISTIC_STRIPING, false);
+    }
+
+    /**
+     * Enable/Disable opportunistic striping.
+     * <p>
+     * If set to true, when you are creating a ledger with a given
+     * ensemble size, the system will automatically handle the
+     * lack of enough bookies, reducing ensemble size up to
+     * the write quorum size. This way in little clusters
+     * you can try to use striping (ensemble size > write quorum size)
+     * in case that you have enough bookies up and running,
+     * and degrade automatically to the minimum requested replication count.
+     * </p>
+     *
+     * @param enabled
+     *          flag to enable/disable opportunistic striping.
+     * @return client configuration.
+     */
+    public ClientConfiguration setOpportunisticStriping(boolean enabled) {
+        setProperty(OPPORTUNISTIC_STRIPING, enabled);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -109,6 +109,7 @@ public abstract class MockBookKeeperTestCase {
     List<BookieId> failedBookies;
     Set<BookieId> availableBookies;
     private int lastIndexForBK;
+    protected int maxNumberOfAvailableBookies = Integer.MAX_VALUE;
 
     private Map<BookieId, Map<Long, MockEntry>> getMockLedgerContents(long ledgerId) {
         return mockLedgerData.computeIfAbsent(ledgerId, (id) -> new ConcurrentHashMap<>());
@@ -140,6 +141,7 @@ public abstract class MockBookKeeperTestCase {
 
     @Before
     public void setup() throws Exception {
+        maxNumberOfAvailableBookies = Integer.MAX_VALUE;
         deferredBookieForceLedgerResponses = new ConcurrentHashMap<>();
         suspendedBookiesForForceLedgerAcks = Collections.synchronizedSet(new HashSet<>());
         mockLedgerMetadataRegistry = new ConcurrentHashMap<>();
@@ -314,7 +316,11 @@ public abstract class MockBookKeeperTestCase {
         return new BookieSocketAddress("localhost", 1111 + index).toBookieId();
     }
 
-    protected ArrayList<BookieId> generateNewEnsemble(int ensembleSize) {
+    protected ArrayList<BookieId> generateNewEnsemble(int ensembleSize) throws BKException.BKNotEnoughBookiesException {
+        LOG.info("generateNewEnsemble {}", ensembleSize);
+        if (ensembleSize > maxNumberOfAvailableBookies) {
+            throw new BKException.BKNotEnoughBookiesException();
+        }
         ArrayList<BookieId> ensemble = new ArrayList<>(ensembleSize);
         for (int i = 0; i < ensembleSize; i++) {
             ensemble.add(generateBookieSocketAddress(i));


### PR DESCRIPTION
### Motivation
If you have a very small cluster, 3 bookies, you must use **2-2-2** as replication parameters in order to guarantee durability and tolerate the failure of at least one bookie.
With this situation you cannot leverage the striping feature of BookKeeper, when **ensembleSize > writeQuorumSize**.

With striping you can distribute your data among all of the bookies, and use better the available disk space.
You can also exploit the ability to write to/read from more disks (bookies) in parallel, achieving better overall performances.

With this change we introduce a new client option "opportunistic striping", that basically tells to the BK client to use as much bookies as configured in the ensembleSize parameter in the best case scenario, and to use less and less bookies, up to the configured writeQuorumSize.

### Changes
- New ClientConfiguration option "opportunisticStriping"
- in case of opportunisticStriping the client is allowed to use less bookies than the requested ensemble size, up to writeQuorumSize
- add test cases