### PR TITLE
Start HTTP Server in Bookie Standlone Mode

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/HttpService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/HttpService.java
@@ -47,7 +47,8 @@ public class HttpService extends ServerLifecycleComponent {
 
         HttpServerLoader.loadHttpServer(conf.getServerConf());
         server = HttpServerLoader.get();
-        checkNotNull(server);
+        checkNotNull(server, "httpServerClass is not configured or it could not be started,"
+                + " please check your configuration and logs");
         server.initialize(provider);
     }
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -31,3 +31,16 @@
 
 # the cluster controller schedule interval, in milliseconds. default is 30 seconds.
 storage.cluster.controller.schedule.interval.ms=30000
+
+#################################################################
+# httpserver
+#################################################################
+
+# The flag enables/disables starting the admin http server. Default value is 'false'
+httpServerEnabled=true
+
+# The http server port to listen on. Default value is 8080.
+httpServerPort=8080
+
+# The http server class
+httpServerClass=org.apache.bookkeeper.http.vertx.VertxHttpServer

--- a/stream/server/pom.xml
+++ b/stream/server/pom.xml
@@ -40,6 +40,12 @@
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.bookkeeper.http</groupId>
+      <artifactId>vertx-http-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -246,7 +246,9 @@ public class StorageServer {
                         .setStatsProvider(statsProviderService.getStatsProvider())
                         .build();
                 HttpService httpService =
-                        new HttpService(provider, new org.apache.bookkeeper.server.conf.BookieConfiguration(bkServerConf), rootStatsLogger);
+                        new HttpService(provider,
+                                new org.apache.bookkeeper.server.conf.BookieConfiguration(bkServerConf),
+                                rootStatsLogger);
                 serverBuilder.addComponent(httpService);
                 log.info("Load lifecycle component : {}", HttpService.class.getName());
             }

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -238,7 +238,7 @@ public class StorageServer {
             serverBuilder.addComponent(bookieService);
             bkServerConf = bookieService.serverConf();
 
-            // 4. build http service
+            // Build http service
             if (bkServerConf.isHttpServerEnabled()) {
                 BKHttpServiceProvider provider = new BKHttpServiceProvider.Builder()
                         .setBookieServer(bookieService.getServer())

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -38,6 +38,8 @@ import org.apache.bookkeeper.common.component.LifecycleComponentStack;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.discover.BookieServiceInfo;
 import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
+import org.apache.bookkeeper.server.http.BKHttpServiceProvider;
+import org.apache.bookkeeper.server.service.HttpService;
 import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.dlog.DLCheckpointStore;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -213,8 +215,9 @@ public class StorageServer {
 
         // Create the stats provider
         StatsLogger rootStatsLogger;
+        StatsProviderService statsProviderService = null;
         if (startBookieAndStartProvider) {
-            StatsProviderService statsProviderService = new StatsProviderService(bkConf);
+            statsProviderService = new StatsProviderService(bkConf);
             rootStatsLogger = statsProviderService.getStatsProvider().getStatsLogger("");
             serverBuilder.addComponent(statsProviderService);
             log.info("Bookie configuration : {}", bkConf.asJson());
@@ -234,6 +237,20 @@ public class StorageServer {
             BookieService bookieService = new BookieService(bkConf, rootStatsLogger, bookieServiceInfoProvider);
             serverBuilder.addComponent(bookieService);
             bkServerConf = bookieService.serverConf();
+
+            // 4. build http service
+            if (bkServerConf.isHttpServerEnabled()) {
+                BKHttpServiceProvider provider = new BKHttpServiceProvider.Builder()
+                        .setBookieServer(bookieService.getServer())
+                        .setServerConfiguration(bkServerConf)
+                        .setStatsProvider(statsProviderService.getStatsProvider())
+                        .build();
+                HttpService httpService =
+                        new HttpService(provider, new org.apache.bookkeeper.server.conf.BookieConfiguration(bkServerConf), rootStatsLogger);
+                serverBuilder.addComponent(httpService);
+                log.info("Load lifecycle component : {}", HttpService.class.getName());
+            }
+
         } else {
             bkServerConf = new ServerConfiguration();
             bkServerConf.loadConf(bkConf.getUnderlyingConf());

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
@@ -82,6 +82,10 @@ public class BookieService extends AbstractLifecycleComponent<BookieConfiguratio
         // no-op
     }
 
+    public BookieServer getServer() {
+        return bs;
+    }
+
     @Override
     public void publishInfo(ComponentInfoPublisher componentInfoPublisher) {
         try {


### PR DESCRIPTION
### Motivation
- when you launch "bookkeeper standalone" service the system does not take into account the HTTP Server configuration
- the HTTP Server is important because it allows to use the HTTP API https://bookkeeper.apache.org/docs/latest/admin/http/
- the standalone service is very useful when you are working on client applications (like BKVM)

### Changes

- consider HTTP server configuration in 'bin/bookkeeper standalone' command
- add default example configuration
- add VertxHttpServer to dependencies of Standalone Module
- the change is basically a copy and paste of this part of Main.java, but applied to the Main class of the Standalone Starter, which is a separate code: https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java#L327


 ## Verify this change
After this change when you run "bookkeeper standalone" the HTTP API will be enabled
For instance you can check the Bookie API with
http://localhost:8080/api/v1/bookie/info