### PR TITLE
ISSUE #2451: Add sidebar to the documentation page

### DIFF
--- a/site2/docs/getting-started.md
+++ b/site2/docs/getting-started.md
@@ -1,7 +1,7 @@
 ---
 id: getting-started
 title: Latin-ish Lol
-sidebar_label: Example Page
+sidebar_label: Getting Started
 ---
 
 Check the [documentation](https://docusaurus.io) for how to use Docusaurus.

--- a/site2/website/pages/en/index.js
+++ b/site2/website/pages/en/index.js
@@ -45,7 +45,7 @@ class HomeSplash extends React.Component {
                 <div className="inner">
                     <ProjectTitle/>
                     <PromoSection>
-                        <Button href={docUrl('standalone', language)}>Read the docs</Button>
+                        <Button href={docUrl('getting-started', language)}>Read the docs</Button>
                         <Button href={githubUrl()}>GitHub</Button>
                     </PromoSection>
                 </div>

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -1,10 +1,19 @@
 {
   "docs": {
-    "Docusaurus": ["doc1"],
-    "First Category": ["doc2"],
-    "Second Category": ["doc3"]
-  },
-  "docs-other": {
-    "First Category": ["doc4", "doc5"]
+    "Getting Started": [
+      "getting-started"
+    ],
+    "Deployment": [
+    ],
+    "Administration": [
+    ],
+    "API":[
+    ],
+    "Security": [
+    ],
+    "Development": [
+    ],
+    "Reference":[
+    ]
   }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

This PR introduces changes for adding the sidebar to the new docusaurus based website.

### Motivation

The #2426 Pull Request introduced the changes for new docuasurus based website, However the new website still do not have sidebar similar to our current website. This PR introduces changes for adding the missing sidebar.

### Changes

Added link to the getting-started README in the _sidebars.json_.

Master Issue: #2451 

### Testing Details - 

I have build the changes locally and have verified that the sidebar is getting rendered properly. Here is the screenshot of the new sidebar - 

<img width="1680" alt="Screenshot 2020-11-28 at 12 23 28" src="https://user-images.githubusercontent.com/17764661/100495736-8d359b00-3174-11eb-853a-3d67f15dc5a4.png">
