### PR TITLE
[docs] Update dbStorage_writeCacheMaxSizeMb configuration description

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -659,8 +659,7 @@ ledgerDirectories=/tmp/bk-data
 
 # Size of Write Cache. Memory is allocated from JVM direct memory.
 # Write cache is used to buffer entries before flushing into the entry log
-# For good performance, it should be big enough to hold a substantial amount
-# of entries in the flush interval
+# For good performance, it should be big enough to hold a substantial amount of entries in the flush interval
 #  By default it will be allocated to 25% of the available direct memory
 
 # Size of Read cache. Memory is allocated from JVM direct memory.

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -659,8 +659,9 @@ ledgerDirectories=/tmp/bk-data
 
 # Size of Write Cache. Memory is allocated from JVM direct memory.
 # Write cache is used to buffer entries before flushing into the entry log
-# For good performance, it should be big enough to hold a sub
-# dbStorage_writeCacheMaxSizeMb=512
+# For good performance, it should be big enough to hold a substantial amount
+# of entries in the flush interval
+#  By default it will be allocated to 25% of the available direct memory
 
 # Size of Read cache. Memory is allocated from JVM direct memory.
 # This read cache is pre-filled doing read-ahead whenever a cache miss happens

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -450,8 +450,8 @@ groups:
 - name: DB Ledger Storage Settings
   params:
   - param: dbStorage_writeCacheMaxSizeMb
-    description: Size of write cache. Memory is allocated from JVM direct memory. Write cache is used for buffer entries before flushing into the entry log. For good performance, it should be big enough to hold a sub.
-    default: 512
+    description: Size of write cache. Memory is allocated from JVM direct memory. Write cache is used for buffer entries before flushing into the entry log. For good performance, it should be big enough to hold a substantial amount of entries in the flush interval.
+    default: 25% of the available direct memory
   - param: dbStorage_readAheadCacheMaxSizeMb
     description: Size of read cache. Memory is allocated from JVM direct memory. The read cache is pre-filled doing read-ahead whenever a cache miss happens.
     default: 256


### PR DESCRIPTION
Fixes #2500 

### Motivation

The dbStorage_writeCacheMaxSizeMb configuration is not described clearly.

### Changes

Refine the description in the broker.conf file.