### PR TITLE
Sync 4.12.0 autorecovery doc to lastest

### DIFF
--- a/site/docs/latest/admin/autorecovery.md
+++ b/site/docs/latest/admin/autorecovery.md
@@ -45,10 +45,11 @@ AutoRecovery is a process that:
 * automatically detects when a {% pop bookie %} in your BookKeeper cluster has become unavailable and then
 * rereplicates all the {% pop ledgers %} that were stored on that bookie.
 
-AutoRecovery can be run in two ways:
+AutoRecovery can be run in three ways:
 
 1. On dedicated nodes in your BookKeeper cluster
 1. On the same machines on which your bookies are running
+1. On a combination of autorecovery nodes and bookie nodes
 
 ## Running AutoRecovery
 
@@ -64,21 +65,24 @@ If you start up AutoRecovery on a machine that is already running a bookie, then
 
 You can also start up AutoRecovery on a fresh machine if you'd like to create a dedicated cluster of AutoRecovery nodes.
 
+Note that if you _only_ want the AutoRecovery process to run on your dedicated AutoRecovery nodes, you must set `autoRecoveryDaemonEnabled` to `false` in the `bookkeeper` configuration. Otherwise,
+bookkeeper nodes will also handle rereplication work.
+
 ## Configuration
 
 There are a handful of AutoRecovery-related configs in the [`bk_server.conf`](../../reference/config) configuration file. For a listing of those configs, see [AutoRecovery settings](../../reference/config#autorecovery-settings).
 
 ## Disable AutoRecovery
 
-You can disable AutoRecovery at any time, for example during maintenance. Disabling AutoRecovery ensures that bookies' data isn't unnecessarily rereplicated when the bookie is only taken down for a short period of time, for example when the bookie is being updated or the configuration if being changed.
+You can disable AutoRecovery for the whole cluster at any time, for example during maintenance. Disabling AutoRecovery ensures that bookies' data isn't unnecessarily rereplicated when the bookie is only taken down for a short period of time, for example when the bookie is being updated or the configuration if being changed.
 
-You can disable AutoRecover using the [`bookkeeper`](../../reference/cli#bookkeeper-shell-autorecovery) CLI tool:
+You can disable AutoRecover for the whole cluster using the [`bookkeeper`](../../reference/cli#bookkeeper-shell-autorecovery) CLI tool:
 
 ```bash
 $ bin/bookkeeper shell autorecovery -disable
 ```
 
-Once disabled, you can reenable AutoRecovery using the [`enable`](../../reference/cli#bookkeeper-shell-autorecovery) shell command:
+Once disabled, you can reenable AutoRecovery for the whole cluster using the [`enable`](../../reference/cli#bookkeeper-shell-autorecovery) shell command:
 
 ```bash
 $ bin/bookkeeper shell autorecovery -enable


### PR DESCRIPTION
Descriptions of the changes in this PR:

Copying documentation updates for auto recovery from the `4.12.0` directory to the `latest` directory based on @eolivelli's request in https://github.com/apache/bookkeeper/pull/2507.