### PR TITLE
BookKeeper Standalone does not work after ZK upgrade - missing third party deps

### DIFF
--- a/stream/server/pom.xml
+++ b/stream/server/pom.xml
@@ -46,6 +46,18 @@
       <version>${project.parent.version}</version>
       <scope>runtime</scope>
     </dependency>
+  <dependency>
+       <!-- needed by ZooKeeper server -->
+       <groupId>org.xerial.snappy</groupId>
+       <artifactId>snappy-java</artifactId>
+       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+        <!-- needed by ZooKeeper server -->
+       <groupId>io.dropwizard.metrics</groupId>
+       <artifactId>metrics-core</artifactId>
+       <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
With the upgrade to ZooKeeper 3.6.2 the two dependencies "snappy java" and "metrics-core" are to be explicitly added at runtime in order to make the ZooKeeper server work.

This fix is for "bin/bookkeeper standalone", that is not working anymore

Related commit that broke "standalone" mode:
https://github.com/apache/bookkeeper/commit/79cbf19a449a2dc96745fc563a489375b0846a09

How to verify this change:
- on current master "bin/bookkeeper standalone" does not work
- on this branch it works