### PR TITLE
Allow DNSToSwitchMapping to access BookieAddressResolver

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -499,7 +499,9 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
         BookieAddressResolver bookieAddressResolver =
                 new DefaultBookieAddressResolver(metadataDriver.getRegistrationClient());
-
+        if (dnsResolver != null) {
+            dnsResolver.setBookieAddressResolver(bookieAddressResolver);
+        }
         // initialize the ensemble placement
         this.placementPolicy = initializeEnsemblePlacementPolicy(conf,
                 dnsResolver, this.requestTimer, this.featureProvider, this.statsLogger, bookieAddressResolver);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -282,6 +282,9 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                 }
             }
         }
+        if (dnsResolver != null) {
+            dnsResolver.setBookieAddressResolver(bookieAddressResolver);
+        }
         slowBookies = CacheBuilder.newBuilder()
             .expireAfterWrite(conf.getBookieFailureHistoryExpirationMSec(), TimeUnit.MILLISECONDS)
             .build(new CacheLoader<BookieId, Long>() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -546,6 +546,11 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements
         }
 
         @Override
+        public void setBookieAddressResolver(BookieAddressResolver bookieAddressResolver) {
+            this.resolver.setBookieAddressResolver(bookieAddressResolver);
+        }
+
+        @Override
         public List<String> resolve(List<String> names) {
             if (names == null) {
                 return Collections.emptyList();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ZoneawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ZoneawareEnsemblePlacementPolicyImpl.java
@@ -237,7 +237,7 @@ public class ZoneawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                 ((Configurable) actualDNSResolver).setConf(conf);
             }
         }
-        
+
         this.dnsResolver = new DNSResolverDecorator(actualDNSResolver, () -> this.getDefaultFaultDomain(),
                 failedToResolveNetworkLocationCounter);
         dnsResolver.setBookieAddressResolver(bookieAddressResolver);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ZoneawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ZoneawareEnsemblePlacementPolicyImpl.java
@@ -237,9 +237,10 @@ public class ZoneawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                 ((Configurable) actualDNSResolver).setConf(conf);
             }
         }
-
+        
         this.dnsResolver = new DNSResolverDecorator(actualDNSResolver, () -> this.getDefaultFaultDomain(),
                 failedToResolveNetworkLocationCounter);
+        dnsResolver.setBookieAddressResolver(bookieAddressResolver);
         this.stabilizePeriodSeconds = conf.getNetworkTopologyStabilizePeriodSeconds();
         // create the network topology
         if (stabilizePeriodSeconds > 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
@@ -18,7 +18,6 @@
 package org.apache.bookkeeper.net;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/AbstractDNSToSwitchMapping.java
@@ -18,10 +18,12 @@
 package org.apache.bookkeeper.net;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.bookkeeper.conf.Configurable;
+import org.apache.bookkeeper.proto.BookieAddressResolver;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.StringUtils;
 
@@ -42,6 +44,7 @@ import org.apache.commons.lang.StringUtils;
 public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, Configurable {
 
     private Configuration conf;
+    private BookieAddressResolver bookieAddressResolver;
 
     /**
      * Create an unconfigured instance.
@@ -57,6 +60,15 @@ public abstract class AbstractDNSToSwitchMapping implements DNSToSwitchMapping, 
      */
     protected AbstractDNSToSwitchMapping(Configuration conf) {
         this.conf = conf;
+    }
+
+    public BookieAddressResolver getBookieAddressResolver() {
+        return bookieAddressResolver;
+    }
+
+    @Override
+    public void setBookieAddressResolver(BookieAddressResolver bookieAddressResolver) {
+        this.bookieAddressResolver = bookieAddressResolver;
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.net;
 import com.google.common.annotations.Beta;
 
 import java.util.List;
+import org.apache.bookkeeper.proto.BookieAddressResolver;
 
 /**
  * An interface that must be implemented to allow pluggable
@@ -66,5 +67,12 @@ public interface DNSToSwitchMapping {
       */
     default boolean useHostName() {
         return true;
+    }
+    
+    /**
+     * Receives the current BookieAddressResolver
+     * @param bookieAddressResolver
+     */
+    default void setBookieAddressResolver(BookieAddressResolver bookieAddressResolver) {
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNSToSwitchMapping.java
@@ -68,9 +68,9 @@ public interface DNSToSwitchMapping {
     default boolean useHostName() {
         return true;
     }
-    
+
     /**
-     * Receives the current BookieAddressResolver
+     * Receives the current BookieAddressResolver.
      * @param bookieAddressResolver
      */
     default void setBookieAddressResolver(BookieAddressResolver bookieAddressResolver) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -53,7 +53,6 @@ import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.client.api.WriteHandle;
 import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.net.AbstractDNSToSwitchMapping;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -52,12 +53,14 @@ import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.client.api.WriteHandle;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.net.AbstractDNSToSwitchMapping;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.test.TestStatsProvider;
+import org.apache.bookkeeper.util.StaticDNSResolver;
 import org.apache.bookkeeper.zookeeper.BoundExponentialBackoffRetryPolicy;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase;
@@ -85,7 +88,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     private final DigestType digestType;
 
     public BookKeeperTest() {
-        super(4);
+        super(3);
         this.digestType = DigestType.CRC32;
     }
 
@@ -1112,4 +1115,20 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
                          1);
         }
     }
+
+    @Test
+    public void testBookieAddressResolverPassedToDNSToSwitchMapping() throws Exception {
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+
+        StaticDNSResolver tested = new StaticDNSResolver();
+        try (BookKeeper bkc = BookKeeper
+                        .forConfig(conf)
+                        .dnsResolver(tested)
+                        .build()) {
+            bkc.createLedger(digestType, "testPasswd".getBytes()).close();
+            assertSame(bkc.getBookieAddressResolver(), tested.getBookieAddressResolver());
+        }
+    }
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/StaticDNSResolver.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/StaticDNSResolver.java
@@ -73,6 +73,10 @@ public class StaticDNSResolver extends AbstractDNSToSwitchMapping implements Rac
 
     @Override
     public List<String> resolve(List<String> names) {
+        if (getBookieAddressResolver() == null) {
+            // test that this istance has been properly initialized
+            throw new IllegalStateException("bookieAddressResolver was not set");
+        }
         List<String> racks = new ArrayList<String>();
         for (String n : names) {
             String rack = name2Racks.get(n);


### PR DESCRIPTION
In order to allow Pulsar to leverage BookieId with custom Bookie-To-Rack Mapping (ZkBookieRackAffinityMapping) we need to inject the BookieAddressResolver into it.

There is not way to do it currently because it is created by the BookKeeper client, and we have to inject the same BookieAddressResolver used by the client itself.

*Changes*
- add new setBookieAddressResolver method (use 'default' methods in order to preserve backward compatibility
- call the new method in every point in which we instantiate a DNSToSwitchMapping and when we receive an instance at construction time

*Compatibility*
- this change is 100% compatible with previous versions