### PR TITLE
Issue 2522: Update jcommander from 1.48 to 1.78

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -253,7 +253,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar [26]
 - lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar [26]
 - lib/org.rocksdb-rocksdbjni-5.13.1.jar [27]
-- lib/com.beust-jcommander-1.48.jar [28]
+- lib/com.beust-jcommander-1.78.jar [28]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [29]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [29]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [30]
@@ -311,7 +311,7 @@ Apache Software License, Version 2.
 [25] Source available at https://github.com/apache/zookeeper/tree/release-3.5.7
 [26] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.33.v20201020
 [27] Source available at https://github.com/facebook/rocksdb/tree/v5.13.1
-[28] Source available at https://github.com/cbeust/jcommander/tree/jcommander-1.48
+[28] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [29] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [30] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [31] Source available at https://github.com/codehaus/jackson/tree/d1c26ec538a8701cff7548009254fd6183b71873

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -234,7 +234,7 @@ Apache Software License, Version 2.
 - lib/org.apache.commons-commons-lang3-3.6.jar [19]
 - lib/org.apache.zookeeper-zookeeper-3.5.7.jar [20]
 - lib/org.apache.zookeeper-zookeeper-jute-3.5.7.jar [20]
-- lib/com.beust-jcommander-1.48.jar [23]
+- lib/com.beust-jcommander-1.78.jar [23]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
 - lib/com.google.api.grpc-proto-google-common-protos-1.12.0.jar [27]
 - lib/com.google.code.gson-gson-2.7.jar [28]
@@ -280,7 +280,7 @@ Apache Software License, Version 2.
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [20] Source available at https://github.com/apache/zookeeper/tree/release-3.5.7
-[23] Source available at https://github.com/cbeust/jcommander/tree/jcommander-1.48
+[23] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [27] Source available at https://github.com/googleapis/googleapis
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.7

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -250,7 +250,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar [21]
 - lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar [21]
 - lib/org.rocksdb-rocksdbjni-5.13.1.jar [22]
-- lib/com.beust-jcommander-1.48.jar [23]
+- lib/com.beust-jcommander-1.78.jar [23]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [24]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [24]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
@@ -306,7 +306,7 @@ Apache Software License, Version 2.
 [20] Source available at https://github.com/apache/zookeeper/tree/release-3.5.7
 [21] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.33.v20201020
 [22] Source available at https://github.com/facebook/rocksdb/tree/v5.13.1
-[23] Source available at https://github.com/cbeust/jcommander/tree/jcommander-1.48
+[23] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [24] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [26] Source available at https://github.com/codehaus/jackson/tree/d1c26ec538a8701cff7548009254fd6183b71873

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -114,7 +114,7 @@ Permission to use, copy, modify and distribute UnixCrypt
 for non-commercial or commercial purposes and without fee is
 granted provided that the copyright notice appears in all copies.
 ------------------------------------------------------------------------------------
-- lib/com.beust-jcommander-1.48.jar
+- lib/com.beust-jcommander-1.78.jar
 
 Copyright 2010 Cedric Beust cedric@beust.com
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -42,7 +42,7 @@ License for the specific language governing permissions and limitations
 under the License.
 
 ------------------------------------------------------------------------------------
-- lib/com.beust-jcommander-1.48.jar
+- lib/com.beust-jcommander-1.78.jar
 
 Copyright 2010 Cedric Beust cedric@beust.com
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -97,7 +97,7 @@ Permission to use, copy, modify and distribute UnixCrypt
 for non-commercial or commercial purposes and without fee is
 granted provided that the copyright notice appears in all copies.
 ------------------------------------------------------------------------------------
-- lib/com.beust-jcommander-1.48.jar
+- lib/com.beust-jcommander-1.78.jar
 
 Copyright 2010 Cedric Beust cedric@beust.com
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
     <jackson.version>2.11.0</jackson.version>
     <jackson-mapper-asl.version>1.9.11</jackson-mapper-asl.version>
-    <jcommander.version>1.48</jcommander.version>
+    <jcommander.version>1.78</jcommander.version>
     <jetty.version>9.4.33.v20201020</jetty.version>
     <jline.version>2.11</jline.version>
     <jmh.version>1.19</jmh.version>

--- a/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/Cli.java
+++ b/tools/framework/src/main/java/org/apache/bookkeeper/tools/framework/Cli.java
@@ -139,7 +139,7 @@ public class Cli<CliFlagsT extends CliFlags> {
         }
         // trigger command to generate help information
         StringBuilder usageBuilder = new StringBuilder();
-        commander.usage(usageBuilder);
+        commander.getUsageFormatter().usage(usageBuilder);
         return commander;
     }
 

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/CreateCookieCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/CreateCookieCommandTest.java
@@ -92,7 +92,7 @@ public class CreateCookieCommandTest extends CookieCommandTestBase {
     public void testMissingCookieFileOption() {
         assertFalse(runCommand(new String[] { BOOKIE_ID }));
         String consoleOutput = getConsoleOutput();
-        assertOptionMissing(consoleOutput, "-cf, --cookie-file");
+        assertOptionMissing(consoleOutput, "[-cf | --cookie-file]");
         assertPrintUsage(consoleOutput);
     }
 

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/GenerateCookieCommandTest.java
@@ -102,7 +102,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
     public void testMissingJournalDir() {
         assertFalse(runCommand(new String[] { "-l", "/path/to/ledgers", "-o", "/path/to/cookie-file", BOOKIE_ID }));
         String consoleOutput = getConsoleOutput();
-        assertOptionMissing(consoleOutput, "-j, --journal-dirs");
+        assertOptionMissing(consoleOutput, "[-j | --journal-dirs]");
     }
 
     /**
@@ -112,7 +112,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
     public void testMissingLedgerDirs() {
         assertFalse(runCommand(new String[] { "-j", "/path/to/journal", "-o", "/path/to/cookie-file", BOOKIE_ID }));
         String consoleOutput = getConsoleOutput();
-        assertOptionMissing(consoleOutput, "-l, --ledger-dirs");
+        assertOptionMissing(consoleOutput, "[-l | --ledger-dirs]");
     }
 
     /**
@@ -122,7 +122,7 @@ public class GenerateCookieCommandTest extends CookieCommandTestBase {
     public void testMissingOutputFile() {
         assertFalse(runCommand(new String[] { "-j", "/path/to/journal", "-l", "/path/to/ledgers", BOOKIE_ID }));
         String consoleOutput = getConsoleOutput();
-        assertOptionMissing(consoleOutput, "-o, --output-file");
+        assertOptionMissing(consoleOutput, "[-o | --output-file]");
     }
 
     /**

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/UpdateCookieCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/cookie/UpdateCookieCommandTest.java
@@ -92,7 +92,7 @@ public class UpdateCookieCommandTest extends CookieCommandTestBase {
     public void testMissingCookieFileOption() {
         assertFalse(runCommand(new String[] { BOOKIE_ID }));
         String consoleOutput = getConsoleOutput();
-        assertOptionMissing(consoleOutput, "-cf, --cookie-file");
+        assertOptionMissing(consoleOutput, "[-cf | --cookie-file]");
         assertPrintUsage(consoleOutput);
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation
Certain bookkeeper shell commands when bookkeeper is bundled with pulsar because of conflicting jcommander versions

### Changes
Updates jcommander to 1.78, same as pulsar.

Master Issue: #2522 