### PR TITLE
Activate GitHub Actions on all PRs and on push

### DIFF
--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -20,9 +20,11 @@
 name: Bookie Tests
 
 on:
+  push:
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -20,9 +20,11 @@
 name: Client Tests
 
 on:
+  push:
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -20,9 +20,11 @@
 name: Compatibility Check Java11
 
 on:
+  push:
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -20,9 +20,11 @@
 name: Compatibility Check Java8
 
 on:
+  push;
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -20,7 +20,7 @@
 name: Compatibility Check Java8
 
 on:
-  push;
+  push:
   pull_request:
     branches:
       - master

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,9 +20,11 @@
 name: Integration Tests
 
 on:
+  push:
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,9 +20,11 @@
 name: PR Validation
 
 on:
+  push:
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -20,9 +20,11 @@
 name: Remaining Tests
 
 on:
+  push:
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -20,9 +20,11 @@
 name: Replication Tests
 
 on:
+  push:
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -20,9 +20,11 @@
 name: TLS Tests
 
 on:
+  push:
   pull_request:
     branches:
       - master
+      - branch-*
     paths-ignore:
       - 'site/**'
 


### PR DESCRIPTION
### Motivation

Currently we are not running PR validation for Pull Requests against release branches (as branch-4.12).
Also we are not running tests on master branch and we do not have Jenkins anymore

### Changes
- Enable PR validation for pull requests against all release branches
- Enable GitHub actions on "push"
