### PR TITLE
Remove reference to thirdparty untrusted github actions

### DIFF
--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -27,6 +27,7 @@ on:
       - branch-*
     paths-ignore:
       - 'site/**'
+    workflow_dispatch:
 
 
 env:
@@ -38,11 +39,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -27,6 +27,7 @@ on:
       - branch-*
     paths-ignore:
       - 'site/**'
+    workflow_dispatch:
 
 
 env:
@@ -38,11 +39,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -27,6 +27,7 @@ on:
       - branch-*
     paths-ignore:
       - 'site/**'
+    workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
@@ -37,11 +38,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -27,6 +27,7 @@ on:
       - branch-*
     paths-ignore:
       - 'site/**'
+    workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
@@ -37,11 +38,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ on:
       - branch-*
     paths-ignore:
       - 'site/**'
-
+    workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
@@ -38,11 +38,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -27,7 +27,7 @@ on:
       - branch-*
     paths-ignore:
       - 'site/**'
-
+    workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
@@ -38,11 +38,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -27,6 +27,7 @@ on:
       - branch-*
     paths-ignore:
       - 'site/**'
+    workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
@@ -37,11 +38,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -38,11 +38,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -27,7 +27,7 @@ on:
       - branch-*
     paths-ignore:
       - 'site/**'
-
+    workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
@@ -38,11 +38,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
- remove reference to untrusted styfle/cancel-workflow-action
- add workflow_dispach event in order to be able to trigger the execution manually from release branches