### PR TITLE
2531: Fix noisy stacktrace at boot

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -56,7 +56,7 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
             return res;
         } catch (BKException.BKBookieHandleNotAvailableException ex) {
             if (BookieSocketAddress.isDummyBookieIdForHostname(bookieId)) {
-                log.info("Resolving dummy bookie Id {} using legacy bookie resolver", bookieId, ex);
+                log.debug("Resolving dummy bookie Id {} using legacy bookie resolver", bookieId);
                 return BookieSocketAddress.resolveDummyBookieId(bookieId);
             }
             log.info("Cannot resolve {}, bookie is unknown", bookieId, ex);


### PR DESCRIPTION
### Motivation
The exception is managed with a fallback, printing the stacktrace would be misleading

### Changes
- Changed log level from info to debug for the log line
- Removed the exception from the log line

Master Issue: #2531

