### PR TITLE
fix default value in bk_server.conf, sync with code default value

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -661,13 +661,15 @@ ledgerDirectories=/tmp/bk-data
 # Write cache is used to buffer entries before flushing into the entry log
 # For good performance, it should be big enough to hold a substantial amount of entries in the flush interval
 #  By default it will be allocated to 25% of the available direct memory
+# dbStorage_writeCacheMaxSizeMb=
 
 # Size of Read cache. Memory is allocated from JVM direct memory.
 # This read cache is pre-filled doing read-ahead whenever a cache miss happens
-# dbStorage_readAheadCacheMaxSizeMb=256
+# By default it will be allocated to 25% of the available direct memory
+# dbStorage_readAheadCacheMaxSizeMb=
 
 # How many entries to pre-fill in cache after a read cache miss
-# dbStorage_readAheadCacheBatchSize=1000
+# dbStorage_readAheadCacheBatchSize=100
 
 ## RocksDB specific configurations
 ## DbLedgerStorage uses RocksDB to store the indexes from

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -454,10 +454,10 @@ groups:
     default: 25% of the available direct memory
   - param: dbStorage_readAheadCacheMaxSizeMb
     description: Size of read cache. Memory is allocated from JVM direct memory. The read cache is pre-filled doing read-ahead whenever a cache miss happens.
-    default: 256
+    default: 25% of the available direct memroy
   - param: dbStorage_readAheadCacheBatchSize
     description: How many entries to pre-fill in cache after a read cache miss
-    default: 1000
+    default: 100
   - param: dbStorage_rocksDB_blockSize
     description: |
       Size of RocksDB block-cache. RocksDB is used for storing ledger indexes.


### PR DESCRIPTION
### Motivation
Fix the default value in `bk_server.conf`, sync with the default value in code.

For `readAheadCacheBatchSize` in code default value.
``` Java
private static final int DEFAULT_READ_AHEAD_CACHE_BATCH_SIZE = 100;
readAheadCacheBatchSize = conf.getInt(READ_AHEAD_CACHE_BATCH_SIZE, DEFAULT_READ_AHEAD_CACHE_BATCH_SIZE);
```
So, it should be 100 in `bk_server.conf` default configuration.

For `dbStorage_readAheadCacheMaxSizeMb` in code default value.
```Java
public static final String READ_AHEAD_CACHE_MAX_SIZE_MB = "dbStorage_readAheadCacheMaxSizeMb";
private static final long DEFAULT_READ_CACHE_MAX_SIZE_MB = (long) (0.25 * PlatformDependent.maxDirectMemory())
            / MB;
long readCacheMaxSize = getLongVariableOrDefault(conf, READ_AHEAD_CACHE_MAX_SIZE_MB,
                DEFAULT_READ_CACHE_MAX_SIZE_MB) * MB;
```
So, it should be 25% of direct memory in `bk_server.conf` default configuration.