### PR TITLE
Remove the annoying logging stack

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -56,16 +56,16 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
             return res;
         } catch (BKException.BKBookieHandleNotAvailableException ex) {
             if (BookieSocketAddress.isDummyBookieIdForHostname(bookieId)) {
-                log.info("Resolving dummy bookie Id {} using legacy bookie resolver", bookieId, ex);
+                log.info("Resolving dummy bookie Id {} using legacy bookie resolver. {}", bookieId, ex.getMessage());
                 return BookieSocketAddress.resolveDummyBookieId(bookieId);
             }
-            log.info("Cannot resolve {}, bookie is unknown", bookieId, ex);
+            log.info("Cannot resolve {}, bookie is unknown. {}", bookieId, ex.getMessage());
             throw new BookieIdNotResolvedException(bookieId, ex);
         } catch (Exception ex) {
             if (ex instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            log.info("Cannot resolve {} ", bookieId, ex);
+            log.info("Cannot resolve {}. {} ", bookieId, ex.getMessage());
             throw new BookieIdNotResolvedException(bookieId, ex);
         }
     }


### PR DESCRIPTION
### Motivation

Remove the annoying logging stack. Keep it clear.

```
rg.apache.bookkeeper.client.DefaultBookieAddressResolver - Resolving dummy bookie Id  using legacy bookie resolver
org.apache.bookkeeper.client.BKException$BKBookieHandleNotAvailableException: Bookie handle is not available
	at org.apache.bookkeeper.discover.ZKRegistrationClient.getBookieServiceInfo(ZKRegistrationClient.java:248) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.DefaultBookieAddressResolver.resolve(DefaultBookieAddressResolver.java:43) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.TopologyAwareEnsemblePlacementPolicy.resolveNetworkLocation(TopologyAwareEnsemblePlacementPolicy.java:789) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.getRegion(RegionAwareEnsemblePlacementPolicy.java:90) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.getLocalRegion(RegionAwareEnsemblePlacementPolicy.java:110) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.initialize(RegionAwareEnsemblePlacementPolicy.java:173) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.initialize(RegionAwareEnsemblePlacementPolicy.java:53) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.BookKeeper.initializeEnsemblePlacementPolicy(BookKeeper.java:580) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.BookKeeper.<init>(BookKeeper.java:504) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
```