### PR TITLE
fix ledgerDirsMonitor's listener doesn't work well on dbLedgerStorage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Thread to monitor the disk space periodically.
  */
-class LedgerDirsMonitor {
+public class LedgerDirsMonitor {
     private static final Logger LOG = LoggerFactory.getLogger(LedgerDirsMonitor.class);
 
     private final int interval;


### PR DESCRIPTION
### Motivation
For `LedgerDirsMonitor`, it init and start in bookie startup according to `ledgersDirsManager`, and add listeners during Ledger Storage initialization. However, for dbLedgerStorage initialization, it create another LedgerDirsManager(ldm) to init `SingleDirectoryDbLedgerStorage` instance. During `SingleDirectoryDbLedgerStorage` initialization, 
```Java
for (File ledgerDir : ledgerDirsManager.getAllLedgerDirs()) {
            // Create a ledger dirs manager for the single directory
            File[] dirs = new File[1];
            // Remove the `/current` suffix which will be appended again by LedgersDirManager
            dirs[0] = ledgerDir.getParentFile();
            LedgerDirsManager ldm = new LedgerDirsManager(conf, dirs, ledgerDirsManager.getDiskChecker(), statsLogger);
            ledgerStorageList.add(newSingleDirectoryDbLedgerStorage(conf, ledgerManager, ldm, indexDirsManager,
                    stateManager, checkpointSource, checkpointer, statsLogger, gcExecutor, perDirectoryWriteCacheSize,
                    perDirectoryReadCacheSize));
            dirsManagers.add(ldm);
        }
```
During `SingleDirectoryDbLedgerStorage` initialization, it create `EntryLogManagerForSingleEntryLog` instance and register individual listener to ledgerDirsManager which create in `dbLedgerStorage` initialization.
```Java
EntryLogManagerForSingleEntryLog(ServerConfiguration conf, LedgerDirsManager ledgerDirsManager,
            EntryLoggerAllocator entryLoggerAllocator, List<EntryLogger.EntryLogListener> listeners,
            EntryLogger.RecentEntryLogsStatus recentlyCreatedEntryLogsStatus) {
        super(conf, ledgerDirsManager, entryLoggerAllocator, listeners);
        this.rotatedLogChannels = new LinkedList<BufferedLogChannel>();
        this.recentlyCreatedEntryLogsStatus = recentlyCreatedEntryLogsStatus;
        // Register listener for disk full notifications.
        ledgerDirsManager.addLedgerDirsListener(getLedgerDirsListener());
    }

    private LedgerDirsListener getLedgerDirsListener() {
        return new LedgerDirsListener() {
            @Override
            public void diskFull(File disk) {
                // If the current entry log disk is full, then create new
                // entry log.
                BufferedLogChannel currentActiveLogChannel = activeLogChannel;
                if (currentActiveLogChannel != null
                        && currentActiveLogChannel.getLogFile().getParentFile().equals(disk)) {
                    shouldCreateNewEntryLog.set(true);
                }
            }

            @Override
            public void diskAlmostFull(File disk) {
                // If the current entry log disk is almost full, then create new entry
                // log.
                BufferedLogChannel currentActiveLogChannel = activeLogChannel;
                if (currentActiveLogChannel != null
                        && currentActiveLogChannel.getLogFile().getParentFile().equals(disk)) {
                    shouldCreateNewEntryLog.set(true);
                }
            }
        };
    }
```

However, the ledgerDirsMonitor, which initiate and start in bookie, lost control for ledgerDirsManagers which created in dbLedgerStorage initialization and the listener registered in `EntryLogManagerForSingleEntryLog` will never be triggered.

### Changes
1. create individual ledgerDirsMonitor instance in dbLedgerStorage to control newly created ledgerDirsManagers (ldm).