### PR TITLE
Reduce logs in case of down bookies: re-replicator and shell commands

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -59,13 +59,13 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
                 log.debug("Resolving dummy bookie Id {} using legacy bookie resolver", bookieId);
                 return BookieSocketAddress.resolveDummyBookieId(bookieId);
             }
-            log.info("Cannot resolve {}, bookie is unknown", bookieId, ex);
+            log.debug("Cannot resolve {}, bookie is unknown", bookieId, ex.toString());
             throw new BookieIdNotResolvedException(bookieId, ex);
         } catch (Exception ex) {
             if (ex instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            log.info("Cannot resolve {} ", bookieId, ex);
+            log.debug("Cannot resolve {} ", bookieId, ex);
             throw new BookieIdNotResolvedException(bookieId, ex);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/CommandHelpers.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/CommandHelpers.java
@@ -42,23 +42,27 @@ public final class CommandHelpers {
      */
     public static String getBookieSocketAddrStringRepresentation(BookieId bookieId,
                                                                  BookieAddressResolver bookieAddressResolver) {
-        BookieSocketAddress networkAddress = bookieAddressResolver.resolve(bookieId);
-        String hostname = networkAddress.getHostName();
-        String realHostname;
-        String ip;
-        if (InetAddresses.isInetAddress(hostname)){
-            ip = hostname;
-            realHostname = networkAddress.getSocketAddress().getAddress().getCanonicalHostName();
-        } else {
-           InetAddress ia = networkAddress.getSocketAddress().getAddress();
-           if (null != ia){
-              ip = ia.getHostAddress();
-           } else {
-              ip = UNKNOWN;
-           }
-           realHostname = hostname;
+        try {
+            BookieSocketAddress networkAddress = bookieAddressResolver.resolve(bookieId);
+            String hostname = networkAddress.getHostName();
+            String realHostname;
+            String ip;
+            if (InetAddresses.isInetAddress(hostname)){
+                ip = hostname;
+                realHostname = networkAddress.getSocketAddress().getAddress().getCanonicalHostName();
+            } else {
+               InetAddress ia = networkAddress.getSocketAddress().getAddress();
+               if (null != ia){
+                  ip = ia.getHostAddress();
+               } else {
+                  ip = UNKNOWN;
+               }
+               realHostname = hostname;
+            }
+            return formatBookieSocketAddress(bookieId, ip, networkAddress.getPort(), realHostname);
+        } catch (BookieAddressResolver.BookieIdNotResolvedException bookieNotAvailable) {
+            return formatBookieSocketAddress(bookieId, UNKNOWN, 0, UNKNOWN);
         }
-        return formatBookieSocketAddress(bookieId, ip, networkAddress.getPort(), realHostname);
     }
 
     /**


### PR DESCRIPTION
### Motivation

When a bookie is down you can see many error both on command line tools and during replicator work.

### Changes

Reduce the log level, and save printing useless stacktraces 
