### PR TITLE
Fix BookKeeper shell "list bookies" in case of downbookie and reduce noisy log during re-replication in case of down bookie

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -59,13 +59,13 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
                 log.debug("Resolving dummy bookie Id {} using legacy bookie resolver", bookieId);
                 return BookieSocketAddress.resolveDummyBookieId(bookieId);
             }
-            log.info("Cannot resolve {}, bookie is unknown", bookieId, ex);
+            log.debug("Cannot resolve {}, bookie is unknown", bookieId, ex.toString());
             throw new BookieIdNotResolvedException(bookieId, ex);
         } catch (Exception ex) {
             if (ex instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            log.info("Cannot resolve {} ", bookieId, ex);
+            log.debug("Cannot resolve {} ", bookieId, ex);
             throw new BookieIdNotResolvedException(bookieId, ex);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -59,7 +59,7 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
                 log.debug("Resolving dummy bookie Id {} using legacy bookie resolver", bookieId);
                 return BookieSocketAddress.resolveDummyBookieId(bookieId);
             }
-            log.debug("Cannot resolve {}, bookie is unknown", bookieId, ex.toString());
+            log.info("Cannot resolve {}, bookie is unknown", bookieId, ex.toString());
             throw new BookieIdNotResolvedException(bookieId, ex);
         } catch (Exception ex) {
             if (ex instanceof InterruptedException) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -65,7 +65,6 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
             if (ex instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            log.debug("Cannot resolve {} ", bookieId, ex);
             throw new BookieIdNotResolvedException(bookieId, ex);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -542,7 +542,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         try {
             addr = bookieAddressResolver.resolve(bookieId);
         } catch (BookieAddressResolver.BookieIdNotResolvedException err) {
-            LOG.error("Cannot connect to {} as endpopint resolution failed", bookieId, err);
+            LOG.error("Cannot connect to {} as endpopint resolution failed (probably bookie is down)", bookieId, err.toString());
             return processBookieNotResolvedError(startTime, err);
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -542,7 +542,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         try {
             addr = bookieAddressResolver.resolve(bookieId);
         } catch (BookieAddressResolver.BookieIdNotResolvedException err) {
-            LOG.error("Cannot connect to {} as endpopint resolution failed (probably bookie is down)", bookieId, err.toString());
+            LOG.error("Cannot connect to {} as endpoint resolution failed (probably bookie is down)",
+                    bookieId, err.toString());
             return processBookieNotResolvedError(startTime, err);
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/CommandHelpers.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/CommandHelpers.java
@@ -42,23 +42,27 @@ public final class CommandHelpers {
      */
     public static String getBookieSocketAddrStringRepresentation(BookieId bookieId,
                                                                  BookieAddressResolver bookieAddressResolver) {
-        BookieSocketAddress networkAddress = bookieAddressResolver.resolve(bookieId);
-        String hostname = networkAddress.getHostName();
-        String realHostname;
-        String ip;
-        if (InetAddresses.isInetAddress(hostname)){
-            ip = hostname;
-            realHostname = networkAddress.getSocketAddress().getAddress().getCanonicalHostName();
-        } else {
-           InetAddress ia = networkAddress.getSocketAddress().getAddress();
-           if (null != ia){
-              ip = ia.getHostAddress();
-           } else {
-              ip = UNKNOWN;
-           }
-           realHostname = hostname;
+        try {
+            BookieSocketAddress networkAddress = bookieAddressResolver.resolve(bookieId);
+            String hostname = networkAddress.getHostName();
+            String realHostname;
+            String ip;
+            if (InetAddresses.isInetAddress(hostname)){
+                ip = hostname;
+                realHostname = networkAddress.getSocketAddress().getAddress().getCanonicalHostName();
+            } else {
+               InetAddress ia = networkAddress.getSocketAddress().getAddress();
+               if (null != ia){
+                  ip = ia.getHostAddress();
+               } else {
+                  ip = UNKNOWN;
+               }
+               realHostname = hostname;
+            }
+            return formatBookieSocketAddress(bookieId, ip, networkAddress.getPort(), realHostname);
+        } catch (BookieAddressResolver.BookieIdNotResolvedException bookieNotAvailable) {
+            return formatBookieSocketAddress(bookieId, UNKNOWN, 0, UNKNOWN);
         }
-        return formatBookieSocketAddress(bookieId, ip, networkAddress.getPort(), realHostname);
     }
 
     /**


### PR DESCRIPTION
### Motivation

When a bookie is down you can see many error both on command line tools and during replicator work.

Also the CLI is not working at all

```

This is the error on "bookkeeper shell listbookies" when a bookie is downb
org.apache.bookkeeper.client.BKException$BKBookieHandleNotAvailableException: Bookie handle is not available
	at org.apache.bookkeeper.discover.ZKRegistrationClient.getBookieServiceInfo(ZKRegistrationClient.java:248) ~[org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.client.DefaultBookieAddressResolver.resolve(DefaultBookieAddressResolver.java:43) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.tools.cli.helpers.CommandHelpers.getBookieSocketAddrStringRepresentation(CommandHelpers.java:45) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.tools.cli.commands.bookies.ListBookiesCommand.printBookies(ListBookiesCommand.java:124) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.tools.cli.commands.bookies.ListBookiesCommand.run(ListBookiesCommand.java:113) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.tools.cli.commands.bookies.ListBookiesCommand.run(ListBookiesCommand.java:43) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.tools.cli.helpers.DiscoveryCommand.apply(DiscoveryCommand.java:57) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.tools.cli.helpers.ClientCommand.apply(ClientCommand.java:60) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.bookie.BookieShell$ListBookiesCmd.runCmd(BookieShell.java:1202) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.bookie.BookieShell$MyCommand.runCmd(BookieShell.java:236) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.bookie.BookieShell.run(BookieShell.java:2235) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.bookie.BookieShell.main(BookieShell.java:2326) [org.apache.bookkeeper-bookkeeper-server-4.12.0.jar:4.12.0]

```

### Changes

Reduce the log level, and save printing useless stacktraces:
- CommandsHelpers -> prevent error on the CLI in case of down bookie (this is a blocker for the usage of the CLI)
- PerChannelBookieClient -> any time you try to connect to a down bookie
- DefaultBookieAddressResolver -> duplicate log line, the error already bubbles up on the caller