### PR TITLE
Allow to configure Prometheus HTTP Server bind address

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -63,7 +63,7 @@ public class PrometheusMetricsProvider implements StatsProvider {
     public static final String PROMETHEUS_STATS_HTTP_ENABLE = "prometheusStatsHttpEnable";
     public static final boolean DEFAULT_PROMETHEUS_STATS_HTTP_ENABLE = true;
 
-    public static final String PROMETHEUS_STATS_HTTP_ADDR = "prometheusStatsHttpAddr";
+    public static final String PROMETHEUS_STATS_HTTP_ADDRESS = "prometheusStatsHttpAddress";
     public static final String DEFAULT_PROMETHEUS_STATS_HTTP_ADDR = "0.0.0.0";
 
     public static final String PROMETHEUS_STATS_HTTP_PORT = "prometheusStatsHttpPort";
@@ -127,7 +127,7 @@ public class PrometheusMetricsProvider implements StatsProvider {
         boolean bkHttpServerEnabled = conf.getBoolean("httpServerEnabled", false);
         // only start its own http server when prometheus http is enabled and bk http server is not enabled.
         if (httpEnabled && !bkHttpServerEnabled) {
-            String httpAddr = conf.getString(PROMETHEUS_STATS_HTTP_ADDR, DEFAULT_PROMETHEUS_STATS_HTTP_ADDR);
+            String httpAddr = conf.getString(PROMETHEUS_STATS_HTTP_ADDRESS, DEFAULT_PROMETHEUS_STATS_HTTP_ADDR);
             int httpPort = conf.getInt(PROMETHEUS_STATS_HTTP_PORT, DEFAULT_PROMETHEUS_STATS_HTTP_PORT);
             InetSocketAddress httpEndpoint = InetSocketAddress.createUnresolved(httpAddr, httpPort);
             this.server = new Server(httpEndpoint);

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -63,6 +63,9 @@ public class PrometheusMetricsProvider implements StatsProvider {
     public static final String PROMETHEUS_STATS_HTTP_ENABLE = "prometheusStatsHttpEnable";
     public static final boolean DEFAULT_PROMETHEUS_STATS_HTTP_ENABLE = true;
 
+    public static final String PROMETHEUS_STATS_HTTP_ADDR = "prometheusStatsHttpAddr";
+    public static final String DEFAULT_PROMETHEUS_STATS_HTTP_ADDR = "0.0.0.0";
+
     public static final String PROMETHEUS_STATS_HTTP_PORT = "prometheusStatsHttpPort";
     public static final int DEFAULT_PROMETHEUS_STATS_HTTP_PORT = 8000;
 
@@ -124,8 +127,9 @@ public class PrometheusMetricsProvider implements StatsProvider {
         boolean bkHttpServerEnabled = conf.getBoolean("httpServerEnabled", false);
         // only start its own http server when prometheus http is enabled and bk http server is not enabled.
         if (httpEnabled && !bkHttpServerEnabled) {
+            String httpAddr = conf.getString(PROMETHEUS_STATS_HTTP_ADDR, DEFAULT_PROMETHEUS_STATS_HTTP_ADDR);
             int httpPort = conf.getInt(PROMETHEUS_STATS_HTTP_PORT, DEFAULT_PROMETHEUS_STATS_HTTP_PORT);
-            InetSocketAddress httpEndpoint = InetSocketAddress.createUnresolved("0.0.0.0", httpPort);
+            InetSocketAddress httpEndpoint = InetSocketAddress.createUnresolved(httpAddr, httpPort);
             this.server = new Server(httpEndpoint);
             ServletContextHandler context = new ServletContextHandler();
             context.setContextPath("/");

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -94,7 +94,7 @@ public class TestPrometheusMetricsProvider {
         PropertiesConfiguration config = new PropertiesConfiguration();
         config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ENABLE, true);
         config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_PORT, 0); // ephemeral
-        config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ADDRESS, "127.0.0.1"); // ephemeral
+        config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ADDRESS, "127.0.0.1");
         PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
         try {
             provider.start(config);

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -90,6 +90,21 @@ public class TestPrometheusMetricsProvider {
     }
 
     @Test
+    public void testStartWithHttpSpecifyAddr() {
+        PropertiesConfiguration config = new PropertiesConfiguration();
+        config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ENABLE, true);
+        config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_PORT, 0); // ephemeral
+        config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ADDRESS, "127.0.0.1"); // ephemeral
+        PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
+        try {
+            provider.start(config);
+            assertNotNull(provider.server);
+        } finally {
+            provider.stop();
+        }
+    }
+
+    @Test
     public void testCounter() {
         LongAdderCounter counter = new LongAdderCounter();
         long value = counter.get();

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -787,7 +787,10 @@ zkEnableSecurity=false
 # These configs are used when using `PrometheusMetricsProvider`.
 # statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 
-# Default port for Prometheus metrics exporter
+# default bind address for Prometheus metrics exporter
+# prometheusStatsHttpAddr=0.0.0.0
+
+# default port for Prometheus metrics exporter
 # prometheusStatsHttpPort=8000
 
 # latency stats rollover interval, in seconds

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -788,7 +788,7 @@ zkEnableSecurity=false
 # statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 
 # default bind address for Prometheus metrics exporter
-# prometheusStatsHttpAddr=0.0.0.0
+# prometheusStatsHttpAddress=0.0.0.0
 
 # default port for Prometheus metrics exporter
 # prometheusStatsHttpPort=8000

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -554,7 +554,7 @@ groups:
 
 - name: Prometheus Metrics Provider Settings
   params:
-  - param: prometheusStatsHttpAddr
+  - param: prometheusStatsHttpAddress
     description: default bind address for Prometheus metrics exporter
     default: 0.0.0.0
   - param: prometheusStatsHttpPort

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -554,6 +554,9 @@ groups:
 
 - name: Prometheus Metrics Provider Settings
   params:
+  - param: prometheusStatsHttpAddr
+    description: default bind address for Prometheus metrics exporter
+    default: 0.0.0.0
   - param: prometheusStatsHttpPort
     description: default port for prometheus metrics exporter
     default: 8000


### PR DESCRIPTION
Descriptions of the changes in this PR:

make prometheus bind addr can cofigure

### Motivation

For security, make prometheus bind addr can config.
For compatibility, make default value is 0.0.0.0

### Changes

make prometheus bind addr can cofigure
