### PR TITLE
Fix the broken links and links to archive pages from README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,29 +18,14 @@ It is suitable for being used in following scenarios:
 
 ## Get Started
 
-* *Concepts*: Start with the [basic concepts](https://bookkeeper.apache.org/docs/master/bookkeeperOverview.html) of Apache BookKeeper.
+* Checkout the project [website](https://bookkeeper.apache.org/).
+* *Concepts*: Start with the [basic concepts](https://bookkeeper.apache.org/docs/latest/getting-started/concepts/) of Apache BookKeeper.
   This will help you to fully understand the other parts of the documentation.
-* [Getting Started](https://bookkeeper.apache.org/docs/master/bookkeeperStarted.html) to setup BookKeeper to write logs.
+* Follow the [Install](https://bookkeeper.apache.org/docs/latest/getting-started/installation/) guide to setup BookKeeper.
 
 ## Documentation
 
-### Developers
-
-* [Programmer Guide](https://bookkeeper.apache.org/archives/docs/master/bookkeeperProgrammer.html)
-* [Tutorial](https://bookkeeper.apache.org/archives/docs/master/bookkeeperTutorial.html)
-* [Java API](https://bookkeeper.apache.org/archives/docs/master/apidocs/)
-
-You can also read [Turning Ledgers into Logs](https://bookkeeper.apache.org/docs/master/bookkeeperLedgers2Logs.html) to learn how to turn **ledgers** into continuous **log streams**.
-If you are looking for a high level **log stream** API, you can checkout [DistributedLog](http://distributedlog.io).
-
-### Administrators
-
-* [Admin Guide](https://bookkeeper.apache.org/docs/master/bookkeeperConfig.html)
-* [Configuration Parameters](https://bookkeeper.apache.org/docs/master/bookieConfigParams.html)
-
-### Contributors
-
-* [BookKeeper Internals](https://bookkeeper.apache.org/docs/master/bookkeeperInternals.html)
+Please visit the [Documentation](https://bookkeeper.apache.org/docs/latest/overview/overview/) from the project website for more information.
 
 ## Get In Touch
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -131,7 +131,7 @@ docker run -it\
 ```
 And so on for "bookie2" and "bookie3". We have now our fully functional ensemble, ready to accept clients.
 
-In order to play with our freshly created ensemble, you can use the simple application taken from [Bookkeeper Tutorial](http://bookkeeper.apache.org/docs/master/bookkeeperTutorial.html) and packaged in a [docker image](https://github.com/caiok/bookkeeper-tutorial) for convenience.
+In order to play with our freshly created ensemble, you can use the simple application taken from [Bookkeeper Tutorial](https://github.com/ivankelly/bookkeeper-tutorial) and packaged in a [docker image](https://github.com/caiok/bookkeeper-tutorial) for convenience.
 
 This application check if it can be leader, if yes start to roll a dice and book this rolls on Bookkeeper, otherwise it will start to follow the leader rolls. If leader stops, follower will try to become leader and so on.
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

There are some broken and obsolete archive links in the README. Update them to point to latest Documentation site.

### Motivation

(Explain: why you're making that change, what is the problem you're trying to solve)

Update the README to point to latest info of the project.

### Changes

(Describe: what changes you have made)

Update the links in the main and Docker README files to point to right information.

Master Issue:N/A