### PR TITLE
Fix javadoc for LedgerMetadata's method getAllEnsembles

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/LedgerMetadata.java
@@ -134,9 +134,9 @@ public interface LedgerMetadata {
     List<BookieId> getEnsembleAt(long entryId);
 
     /**
-     * Returns all the ensembles of this entry.
+     * Returns all the ensembles of this ledger.
      *
-     * @return all the ensembles of this entry.
+     * @return all the ensembles of this ledger.
      */
     NavigableMap<Long, ? extends List<BookieId>> getAllEnsembles();
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Minor change to the documentation of the `LedgerMetadata` interface.

### Motivation

Looking to improve the javadoc.

### Changes

The javadoc references an entry when it should (I believe) reference a ledger.