### PR TITLE
Issue 2557: Bookkeeper docker image build fails because of deprecated Python version for pip

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN set -x \
     && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
     && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
     # install zookeeper shell
-    && wget -q https://bootstrap.pypa.io/get-pip.py \
+    && wget -q https://bootstrap.pypa.io/2.7/get-pip.py \
     && python get-pip.py \
     && pip install zk-shell \
     && rm -rf get-pip.py \

--- a/tests/docker-images/current-version-image/Dockerfile
+++ b/tests/docker-images/current-version-image/Dockerfile
@@ -40,7 +40,7 @@ RUN set -x \
     && mkdir -pv /opt \
     && cd /opt \
     # install zookeeper shell
-    && wget -q https://bootstrap.pypa.io/get-pip.py \
+    && wget -q https://bootstrap.pypa.io/2.7/get-pip.py \
     && python get-pip.py \
     && pip install zk-shell \
     && rm -rf get-pip.py \


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Fix Docker image build for Bookkeeper.

### Changes

This PR just makes sure that the `pip` version used in the Dockerfile is compatible with Python 2.7. We may need to consider cherry-picking this PR to branches of Bookkeeper that are not end-of-life. 

Master Issue: #2557

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>