### PR TITLE
Allow stream storage to use hostname instead of IP address

### DIFF
--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -89,6 +89,9 @@ public class StorageServer {
         @Parameter(names = {"-p", "--port"}, description = "Port to listen on for gPRC server")
         private int port = 4181;
 
+        @Parameter(names = {"-u", "--useHostname"}, description = "Use hostname instead of IP for server ID")
+        private boolean useHostname = false;
+
         @Parameter(names = {"-h", "--help"}, description = "Show this help message")
         private boolean help = false;
 
@@ -112,11 +115,14 @@ public class StorageServer {
 
     public static Endpoint createLocalEndpoint(int port, boolean useHostname) throws UnknownHostException {
         String hostname;
+        log.warn("Determining hostname for stream storage");
         if (useHostname) {
             hostname = InetAddress.getLocalHost().getHostName();
         } else {
             hostname = InetAddress.getLocalHost().getHostAddress();
         }
+
+        log.warn("Decided to use hostname {}", hostname);
         return Endpoint.newBuilder()
             .setHostname(hostname)
             .setPort(port)
@@ -150,12 +156,14 @@ public class StorageServer {
         }
 
         int grpcPort = arguments.port;
+        boolean grpcUseHostname = arguments.useHostname;
 
         LifecycleComponent storageServer;
         try {
             storageServer = buildStorageServer(
                 conf,
-                grpcPort);
+                grpcPort,
+                grpcUseHostname);
         } catch (Exception e) {
             log.error("Invalid storage configuration", e);
             return ExitCode.INVALID_CONF.code();
@@ -178,14 +186,22 @@ public class StorageServer {
     public static LifecycleComponent buildStorageServer(CompositeConfiguration conf,
                                                         int grpcPort)
             throws Exception {
-        return buildStorageServer(conf, grpcPort, true, NullStatsLogger.INSTANCE);
+        return buildStorageServer(conf, grpcPort, false, true, NullStatsLogger.INSTANCE);
+    }
+
+    public static LifecycleComponent buildStorageServer(CompositeConfiguration conf,
+                                                        int grpcPort, boolean useHostname)
+            throws Exception {
+        return buildStorageServer(conf, grpcPort, false, useHostname, NullStatsLogger.INSTANCE);
     }
 
     public static LifecycleComponent buildStorageServer(CompositeConfiguration conf,
                                                         int grpcPort,
+                                                        boolean useHostname,
                                                         boolean startBookieAndStartProvider,
                                                         StatsLogger externalStatsLogger)
-        throws Exception {
+            throws Exception {
+
         final ComponentInfoPublisher componentInfoPublisher = new ComponentInfoPublisher();
 
         final Supplier<BookieServiceInfo> bookieServiceInfoProvider =
@@ -208,7 +224,7 @@ public class StorageServer {
         storageConf.validate();
 
         // Get my local endpoint
-        Endpoint myEndpoint = createLocalEndpoint(grpcPort, false);
+        Endpoint myEndpoint = createLocalEndpoint(grpcPort, useHostname);
 
         // Create shared resources
         StorageResources storageResources = StorageResources.create();

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StreamStorageLifecycleComponent.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StreamStorageLifecycleComponent.java
@@ -40,6 +40,7 @@ public class StreamStorageLifecycleComponent extends ServerLifecycleComponent {
         this.streamStorage = StorageServer.buildStorageServer(
             conf.getUnderlyingConf(),
             ssConf.getGrpcPort(),
+            ssConf.getGrpcUseHostname(),
             false,
             statsLogger.scope("stream"));
     }

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/conf/StorageServerConfiguration.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/conf/StorageServerConfiguration.java
@@ -25,6 +25,8 @@ public class StorageServerConfiguration extends ComponentConfiguration {
     private static final String COMPONENT_PREFIX = "storageserver" + DELIMITER;
 
     private static final String GRPC_PORT = "grpc.port";
+    private static final String GRPC_USE_HOSTNAME = "grpc.useHostname";
+
 
     public static StorageServerConfiguration of(CompositeConfiguration conf) {
         return new StorageServerConfiguration(conf);
@@ -41,5 +43,15 @@ public class StorageServerConfiguration extends ComponentConfiguration {
      */
     public int getGrpcPort() {
         return getInt(GRPC_PORT, 4181);
+    }
+
+    /**
+     * Returns the grpc flag that indicates to use hostname instead of IP address
+     * for the stream storage server.
+     *
+     * @return grpc useHostname flag
+     */
+    public boolean getGrpcUseHostname() {
+        return getBoolean(GRPC_USE_HOSTNAME, false);
     }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Allow stream storage to use hostname instead of IP address

### Motivation

issue #2559

### Changes

Allowed use of the host name for the endpoint.
Changes by @cdbartholomew

Master Issue: #2559

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
