### PR TITLE
Limit log output to prevent in case of the large group of the log segments

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadAheadEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadAheadEntryReader.java
@@ -33,6 +33,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.apache.bookkeeper.common.concurrent.FutureEventListener;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
@@ -411,8 +413,12 @@ class ReadAheadEntryReader implements
     }
 
     public void start(final List<LogSegmentMetadata> segmentList) {
-        logger.info("Starting the readahead entry reader for {} : segments = {}",
-                readHandler.getFullyQualifiedName(), segmentList);
+        // Managed to get 5mil character long log line from here.
+        // Will limit the output.
+        logger.info("Starting the readahead entry reader for {} : number of segments: {}, top 10 segments = {}",
+                readHandler.getFullyQualifiedName(), segmentList.size(),
+                segmentList.size() > 10
+                        ? segmentList.stream().limit(10).collect(Collectors.toList()) : segmentList);
         started.set(true);
         processLogSegments(segmentList);
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Limit logged data

### Motivation

Overly long log line at ReadAheadEntryReader
Found a log with single log line of over 5 mil characters long
"org.apache.distributedlog.ReadAheadEntryReader - Starting the readahead entry reader for ..." + the details of ~16000 segments.

### Changes

Output details of up to 10 segments plus count of segments.

Master Issue: #2561

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
