### PR TITLE
Handling checkpoint corruption in case of bookie crash

### DIFF
--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/RocksCheckpointer.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/RocksCheckpointer.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -123,6 +124,8 @@ public class RocksCheckpointer implements AutoCloseable {
                     latestCheckpointId = checkpointId;
                     latestCheckpoint = ckpt;
                 }
+            } catch (FileNotFoundException fnfe) {
+                log.error("Metadata is corrupt for the checkpoint {}. Skipping it.", checkpointId);
             }
         }
         return Pair.of(latestCheckpointId, latestCheckpoint);


### PR DESCRIPTION
Descriptions of the changes in this PR:

Allowed fallback to previous checkpoint, assuming that corrupt checkpoint means that checkpointing did not complete and the journal is intact.

### Motivation

Reliability and resilience of teh table service.

### Changes

Allowed fallback to previous checkpoint, assuming that corrupt checkpoint means that checkpointing did not complete and the journal is intact.

Master Issue: #2565

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
