### PR TITLE
Issue 2567: Save last revision in rocksdb

### DIFF
--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVStore.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVStore.java
@@ -227,7 +227,8 @@ public class RocksdbKVStore<K, V> implements KVStore<K, V> {
                 setLastRevision(revision);
                 batch.put(metaCfHandle, LAST_REVISION, lastRevisionBytes);
             } catch (RocksDBException e) {
-                throw new StateStoreRuntimeException("Error while updating last revision " + revision + " from store " + name, e);
+                throw new StateStoreRuntimeException(
+                        "Error while updating last revision " + revision + " from store " + name, e);
             }
         }
     }

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVStore.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVStore.java
@@ -217,6 +217,21 @@ public class RocksdbKVStore<K, V> implements KVStore<K, V> {
         }
     }
 
+    protected void updateLastRevision(WriteBatch batch, long revision) {
+        if (revision >= 0) { // k/v comes from log stream
+            if (getLastRevision() >= revision) { // these k/v pairs are duplicates
+                return;
+            }
+            try {
+                // update revision
+                setLastRevision(revision);
+                batch.put(metaCfHandle, LAST_REVISION, lastRevisionBytes);
+            } catch (RocksDBException e) {
+                throw new StateStoreRuntimeException("Error while updating last revision " + revision + " from store " + name, e);
+            }
+        }
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public synchronized void init(StateStoreSpec spec) throws StateStoreException {

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCStoreImpl.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCStoreImpl.java
@@ -365,6 +365,7 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
         IncrementResult<K, V> result = null;
         try {
             result = increment(revision, batch, op);
+            updateLastRevision(batch, revision);
             executeBatch(batch);
             return result;
         } catch (StateStoreRuntimeException e) {
@@ -463,6 +464,7 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
         PutResult<K, V> result = null;
         try {
             result = put(revision, batch, op);
+            updateLastRevision(batch, revision);
             executeBatch(batch);
             return result;
         } catch (StateStoreRuntimeException e) {
@@ -576,6 +578,7 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
         DeleteResult<K, V> result = null;
         try {
             result = delete(revision, batch, op, true);
+            updateLastRevision(batch, revision);
             executeBatch(batch);
             return result;
         } catch (StateStoreRuntimeException e) {
@@ -740,6 +743,7 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
             for (Op<K, V> o : operations) {
                 results.add(executeOp(revision, batch, o));
             }
+            updateLastRevision(batch, revision);
             executeBatch(batch);
 
             // 4. repare the result


### PR DESCRIPTION

Descriptions of the changes in this PR:

Save latest revision in rocksdb.

### Motivation
Currently while restoring the complete transaction log is replayed. 
As the transaction log builds up over time, it takes longer and longer to restore the storage containers on a new pod.

### Changes

Instead we will save the revision in the rocksdb. We will use the revision retrieved after
restoring the last checkpoint to skip ahead in the journal logs and only replay the entries
that are not included in the checkpoint

Master Issue: #2567 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
