### PR TITLE
Fix the current site to allow click links in doc

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -6,8 +6,6 @@ Welcome to the code for the Apache BookKeeper website! Instructions on building 
 
 The site is built using Jekyll and Sass.
 
-> I'll provide more specific info here later.
-
 ## Prerequisities
 
 In order to run the site locally, you need to have the following installed:

--- a/site/css/style.sass
+++ b/site/css/style.sass
@@ -159,6 +159,8 @@ h2.bk-subtitle
   .container
     top: $navbar-height
     position: sticky
+    flex: 1 1 auto
+    max-width: 240px
 
 .bk-community-container
   width: 60%


### PR DESCRIPTION
Since there will be some time before we get site2 up and running, sending
this fix to allow links in doc content ot be clickable.

Currently, if user go to https://bookkeeper.apache.org/docs/latest/ the links
in the doc can not be click since the div overlay of navigator on left is
covering the content body.

The simple proposed fix is to set width of navigator container class to
certain width to not cover the body content.

To verify behavior and proposed fix difference:

1. Go to https://bookkeeper.apache.org/docs/latest/ and try to click the `WAL` link. You will not see the cursor change to hand icon to click the link
2. Now, visit the proposed fix at https://hsaputra.github.io/bookkeeper-staging-site/docs/latest/, then when  you hover on top of `WAL` link you should see the cursor change to hand point and allow you to click the link and navigate to the URL.
