### PR TITLE
Stream storage endpoint from hostname to return fully-qualified name in Java 11+

### DIFF
--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -117,7 +117,7 @@ public class StorageServer {
         String hostname;
         log.warn("Determining hostname for stream storage");
         if (useHostname) {
-            hostname = InetAddress.getLocalHost().getHostName();
+            hostname = InetAddress.getLocalHost().getCanonicalHostName()();
         } else {
             hostname = InetAddress.getLocalHost().getHostAddress();
         }

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -117,7 +117,7 @@ public class StorageServer {
         String hostname;
         log.warn("Determining hostname for stream storage");
         if (useHostname) {
-            hostname = InetAddress.getLocalHost().getCanonicalHostName()();
+            hostname = InetAddress.getLocalHost().getCanonicalHostName();
         } else {
             hostname = InetAddress.getLocalHost().getHostAddress();
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Update how hostname is retrieved when using hostname as identifier for stream storage to work consistenly between Java 8 and Java 11.

### Motivation

Between Java 8 and Java 11, the value returned by `InetAddress.getLocalHost().getHostName()` changed from being the fully qualified name to just the short hostname. When running in a Kubernetes environment, it is necessary for the endpoint to be identied by its fully qualified name so that clients can connect. 

This same change was made in Pulsar in https://github.com/apache/pulsar/pull/6235.

I have tested this change in Kubernetes environment using Java 11.

### Changes

This is a simple change from `getHostName` to `getCanonicalHostName()`.

Master Issue: #2559

