### PR TITLE
fix: BKAsyncLogWriter swallows rootcause of the WriteException

### DIFF
--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/exceptions/WriteException.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/exceptions/WriteException.java
@@ -28,4 +28,9 @@ public class WriteException extends DLException {
         super(StatusCode.WRITE_EXCEPTION,
             "Write rejected because stream " + stream + " has encountered an error : " + transmitError);
     }
+
+    public WriteException(String stream, String transmitError, Throwable cause) {
+        super(StatusCode.WRITE_EXCEPTION,
+                "Write rejected because stream " + stream + " has encountered an error : " + transmitError, cause);
+    }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Added first exception as a rootcause for the WriteException

### Motivation

simplify troubleshooting

### Changes

Added first exception as a rootcause for the WriteException

Master Issue: #2574

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
