### PR TITLE
Upgrade protobuf to 3.14.0 (latest)

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Cookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Cookie.java
@@ -165,7 +165,7 @@ public class Cookie {
         }
         StringBuilder b = new StringBuilder();
         b.append(CURRENT_COOKIE_LAYOUT_VERSION).append("\n");
-        b.append(TextFormat.printToString(builder.build()));
+        b.append(builder.build().toString());
         return b.toString();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerMetadataSerDe.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerMetadataSerDe.java
@@ -278,7 +278,7 @@ public class LedgerMetadataSerDe {
                     builder.addSegment(segmentBuilder.build());
                 }
 
-                TextFormat.print(builder.build(), writer);
+                TextFormat.printer().print(builder.build(), writer);
                 writer.flush();
             }
             return os.toByteArray();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
@@ -164,7 +164,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             // if we cant get the address, ignore. it's optional
             // in the data structure in any case
         }
-        return TextFormat.printToString(lockDataBuilder.build()).getBytes(UTF_8);
+        return lockDataBuilder.build().toString().getBytes(UTF_8);
     }
 
     private void checkLayout()
@@ -182,7 +182,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
                 LedgerRereplicationLayoutFormat.Builder builder = LedgerRereplicationLayoutFormat.newBuilder();
                 builder.setType(LAYOUT).setVersion(LAYOUT_VERSION);
                 try {
-                    zkc.create(layoutZNode, TextFormat.printToString(builder.build()).getBytes(UTF_8),
+                    zkc.create(layoutZNode, builder.build().toString().getBytes(UTF_8),
                                zkAcls, CreateMode.PERSISTENT);
                 } catch (KeeperException.NodeExistsException nne) {
                     // someone else managed to create it
@@ -310,7 +310,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             builder.setCtime(System.currentTimeMillis());
         }
         missingReplicas.forEach(builder::addReplica);
-        final byte[] urLedgerData = TextFormat.printToString(builder.build()).getBytes(UTF_8);
+        final byte[] urLedgerData = builder.build().toString().getBytes(UTF_8);
         ZkUtils.asyncCreateFullPathOptimistic(
             zkc, znode, urLedgerData, zkAcls, CreateMode.PERSISTENT,
             (rc, path, ctx, name) -> {
@@ -361,7 +361,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
                 if (conf.getStoreSystemTimeAsLedgerUnderreplicatedMarkTime()) {
                     builder.setCtime(System.currentTimeMillis());
                 }
-                final byte[] newUrLedgerData = TextFormat.printToString(builder.build()).getBytes(UTF_8);
+                final byte[] newUrLedgerData = builder.build().toString().getBytes(UTF_8);
                 zkc.setData(znode, newUrLedgerData, getStat.getVersion(), (setRc, setPath, setCtx, setStat) -> {
                     if (Code.OK.intValue() == setRc) {
                         FutureUtils.complete(finalFuture, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
@@ -184,7 +184,7 @@ public class AuditorElector {
             AuditorVoteFormat.Builder builder = AuditorVoteFormat.newBuilder()
                 .setBookieId(bookieId);
             myVote = zkc.create(getVotePath(PATH_SEPARATOR + VOTE_PREFIX),
-                    TextFormat.printToString(builder.build()).getBytes(UTF_8), zkAcls,
+                    builder.build().toString().getBytes(UTF_8), zkAcls,
                     CreateMode.EPHEMERAL_SEQUENTIAL);
         }
     }
@@ -310,7 +310,7 @@ public class AuditorElector {
                                 .setBookieId(bookieId);
 
                             zkc.setData(getVotePath(""),
-                                        TextFormat.printToString(builder.build()).getBytes(UTF_8), -1);
+                                        builder.build().toString().getBytes(UTF_8), -1);
                             auditor = new Auditor(bookieId, conf, bkc, false, statsLogger);
                             auditor.start();
                         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -157,8 +157,8 @@
     <prometheus.version>0.8.1</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.5</httpclient.version>
-    <protobuf.version>3.5.1</protobuf.version>
-    <protoc3.version>3.5.1-1</protoc3.version>
+    <protobuf.version>3.14.0</protobuf.version>
+    <protoc3.version>3.14.0</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
     <rocksdb.version>6.10.2</rocksdb.version>
@@ -195,7 +195,7 @@
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <nar-maven-plugin.version>3.5.2</nar-maven-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
-    <protobuf-maven-plugin.version>0.5.0</protobuf-maven-plugin.version>
+    <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
     <forkCount.variable>1</forkCount.variable>


### PR DESCRIPTION
Descriptions of the changes in this PR:

Upgraded protobuf dependency

### Motivation

unit tests log "WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil" on Java11
This has been fixed in protobuf since version 3.7

### Changes

Upgraded protobuf; 
updated code to remove use of deprecated methods

Master Issue: #2579

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
