### PR TITLE
Fix tests TestStorageServerClientManagerImpl and more

### DIFF
--- a/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/impl/internal/LocationClientImpl.java
+++ b/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/impl/internal/LocationClientImpl.java
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.clients.config.StorageClientSettings;
 import org.apache.bookkeeper.clients.impl.internal.api.LocationClient;
 import org.apache.bookkeeper.clients.utils.ClientConstants;
@@ -49,6 +51,7 @@ import org.apache.bookkeeper.stream.proto.storage.StorageContainerServiceGrpc.St
 /**
  * Default Implementation of {@link LocationClient}.
  */
+@Slf4j
 public class LocationClientImpl implements LocationClient {
 
     private final StorageClientSettings settings;
@@ -81,6 +84,7 @@ public class LocationClientImpl implements LocationClient {
         cause -> shouldRetryOnException(cause);
 
     private static boolean shouldRetryOnException(Throwable cause) {
+        log.error("Not able to locate storage container {}", cause);
         if (cause instanceof StatusRuntimeException || cause instanceof StatusException) {
             Status status;
             if (cause instanceof StatusException) {

--- a/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/impl/internal/RootRangeClientImplWithRetries.java
+++ b/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/impl/internal/RootRangeClientImplWithRetries.java
@@ -46,6 +46,7 @@ class RootRangeClientImplWithRetries implements RootRangeClient {
         cause -> shouldRetryOnException(cause);
 
     private static boolean shouldRetryOnException(Throwable cause) {
+        log.error("Reason for the failure {}", cause);
         if (cause instanceof StatusRuntimeException || cause instanceof StatusException) {
             Status status;
             if (cause instanceof StatusException) {

--- a/stream/clients/java/base/src/test/java/org/apache/bookkeeper/clients/grpc/GrpcClientTestBase.java
+++ b/stream/clients/java/base/src/test/java/org/apache/bookkeeper/clients/grpc/GrpcClientTestBase.java
@@ -63,7 +63,7 @@ public abstract class GrpcClientTestBase {
     public void setUp() throws Exception {
         serverName = "fake-server";
         fakeServer = InProcessServerBuilder
-            .forName(serverName)
+            .forName(serverName + ":4181")
             .fallbackHandlerRegistry(serviceRegistry)
             .directExecutor()
             .build()


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Fixing hanging tests TestStorageServerClientManagerImpl and other tests in the directory 

Some tests were not running because they were hanging waiting on future while storage container was being fetched.
But inproc grpc server was running on endpoint `fake-server` while client was connecting on `fake-server:4181`

### Changes

Make GRPC inproc server run on `fake-server:4181` and client connect on `fake-server:4181`