### PR TITLE
Fix javadoc for getAllBookies in RegistrationClient interface

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationClient.java
@@ -58,7 +58,7 @@ public interface RegistrationClient extends AutoCloseable {
     /**
      * Get the list of all bookies identifiers.
      *
-     * @return a future represents the list of writable bookies.
+     * @return a future represents the list of all bookies.
      */
     CompletableFuture<Versioned<Set<BookieId>>> getAllBookies();
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Basic javadoc update from what looks to be an accidental copy from another javadoc.

I opened https://github.com/apache/bookkeeper/issues/2588 to clarify what the meaning of "all" is. Either way, I'm sure we just need to update the javadoc as I did in this PR.

If https://github.com/apache/bookkeeper/issues/2588 reveals something interesting, it might be worth updating this javadoc to include that information.
