### PR TITLE
Add CI job for StreamStorage tests

### DIFF
--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: Integration Tests
+name: StreamStorage Tests
 
 on:
   push:

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Integration Tests
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'site/**'
+    workflow_dispatch:
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -B -nsu clean install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+      - name: Run StreamStorage tests
+        run: mvn -B -nsu -f stream/pom.xml verify -DstreamTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO


### PR DESCRIPTION
### Motivation

Stream Storage tests now are back in good shape again, we must enable verification on CI

### Changes

Add StreamStorage tests on master branch.
Tests do not pass on olde branches and there is no way to pick all of the fixes without breaking changes (like important dependencies upgrades).