### PR TITLE
Fix failing test in /stream

### DIFF
--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: Integration Tests
+name: StreamStorage Tests
 
 on:
   push:

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Integration Tests
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'site/**'
+    workflow_dispatch:
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -B -nsu clean install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+      - name: Run StreamStorage tests
+        run: mvn -B -nsu -f stream/pom.xml verify -DstreamTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -23,7 +23,6 @@ import static org.apache.bookkeeper.util.BookKeeperConstants.COOKIE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -194,8 +193,6 @@ public class ZKRegistrationClient implements RegistrationClient {
                                 String ledgersRootPath,
                                 ScheduledExecutorService scheduler,
                                 boolean bookieAddressTracking) {
-        Preconditions.checkNotNull(zk, "need zk client");
-        Preconditions.checkNotNull(scheduler, "need scheduler");
         this.zk = zk;
         this.scheduler = scheduler;
         // Following Bookie Network Address Changes is an expensive operation

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -23,6 +23,7 @@ import static org.apache.bookkeeper.util.BookKeeperConstants.COOKIE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -193,6 +194,8 @@ public class ZKRegistrationClient implements RegistrationClient {
                                 String ledgersRootPath,
                                 ScheduledExecutorService scheduler,
                                 boolean bookieAddressTracking) {
+        Preconditions.checkNotNull(zk, "need zk client");
+        Preconditions.checkNotNull(scheduler, "need scheduler");
         this.zk = zk;
         this.scheduler = scheduler;
         // Following Bookie Network Address Changes is an expensive operation

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -18,12 +18,12 @@
 
 package org.apache.bookkeeper.discover;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.COOKIE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -194,8 +194,8 @@ public class ZKRegistrationClient implements RegistrationClient {
                                 String ledgersRootPath,
                                 ScheduledExecutorService scheduler,
                                 boolean bookieAddressTracking) {
-        checkNotNull(zk, "need zk client");
-        checkNotNull(scheduler, "need scheduler");
+        Preconditions.checkNotNull(zk, "need zk client");
+        Preconditions.checkNotNull(scheduler, "need scheduler");
         this.zk = zk;
         this.scheduler = scheduler;
         // Following Bookie Network Address Changes is an expensive operation

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -18,12 +18,12 @@
 
 package org.apache.bookkeeper.discover;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.COOKIE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -194,8 +194,8 @@ public class ZKRegistrationClient implements RegistrationClient {
                                 String ledgersRootPath,
                                 ScheduledExecutorService scheduler,
                                 boolean bookieAddressTracking) {
-        Preconditions.checkNotNull(zk, "need zk client");
-        Preconditions.checkNotNull(scheduler, "need scheduler");
+        checkNotNull(zk, "need zk client");
+        checkNotNull(scheduler, "need scheduler");
         this.zk = zk;
         this.scheduler = scheduler;
         // Following Bookie Network Address Changes is an expensive operation

--- a/stream/bk-grpc-name-resolver/src/main/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolver.java
+++ b/stream/bk-grpc-name-resolver/src/main/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolver.java
@@ -59,7 +59,6 @@ class BKRegistrationNameResolver extends NameResolver {
                                URI serviceURI) {
         this.clientDriver = clientDriver;
         this.serviceURI = serviceURI;
-        this.bookieAddressResolver = new DefaultBookieAddressResolver(clientDriver.getRegistrationClient());
         this.executor = Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder().setNameFormat("registration-name-resolver").build());
     }
@@ -82,6 +81,7 @@ class BKRegistrationNameResolver extends NameResolver {
         } catch (MetadataException e) {
             throw new RuntimeException("Failed to initialize registration client driver at " + serviceURI, e);
         }
+        this.bookieAddressResolver = new DefaultBookieAddressResolver(clientDriver.getRegistrationClient());
 
         resolve();
     }

--- a/stream/common/pom.xml
+++ b/stream/common/pom.xml
@@ -39,6 +39,12 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-all</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty-shaded</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
@@ -60,6 +60,8 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +71,9 @@ import org.slf4j.LoggerFactory;
  */
 public class TestDistributedLogBase {
     static final Logger LOG = LoggerFactory.getLogger(TestDistributedLogBase.class);
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(120);
 
     static {
         // org.apache.zookeeper.test.ClientBase uses FourLetterWordMain, from 3.5.3 four letter words

--- a/stream/tests-common/pom.xml
+++ b/stream/tests-common/pom.xml
@@ -31,6 +31,12 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-all</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty-shaded</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Descriptions of the changes in this PR:

GrpcChannelsTest and BKRegistrationNameResolverTest fail in /stream


### Motivation

fix tests

### Changes

BKRegistrationNameResolverTest failed because the bookieAddressResolver tried to use clientDriver before clientDriver's initialization. Fixed initialization order.

GrpcChannelsTest failed because of the grpc.netty-shaded conflict with unshaded grpc.netty

Picked up @eolivelli 's changes to run stream tests on CI

Master Issue: #2594

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
