### PR TITLE
Issue 2593: Run license check as part of CI

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -49,3 +49,5 @@ jobs:
           java-version: 1.8
       - name: Validate pull request style
         run: mvn clean -B -nsu apache-rat:check checkstyle:check package -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+      - name: Check license files
+        run: dev/check-all-licenses

--- a/dev/check-all-licenses
+++ b/dev/check-all-licenses
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Script to check licenses on a binary tarball.
+# It extracts the list of bundled jars, the NOTICE, and the LICENSE
+# files. It checked that every non-bk jar bundled is mentioned in the
+# LICENSE file. It checked that all jar files mentioned in NOTICE and
+# LICENSE are actually bundled.
+
+# all error fatal
+set -e -x
+
+HERE=$(dirname $0)
+BOOKKEEPER_DIST=$HERE/../bookkeeper-dist
+$HERE/check-binary-license $BOOKKEEPER_DIST/server/target/bookkeeper-server-*-bin.tar.gz
+$HERE/check-binary-license $BOOKKEEPER_DIST/server/all/bookkeeper-all-*-bin.tar.gz
+$HERE/check-binary-license $BOOKKEEPER_DIST/server/bkctl/bkctl-*-bin.tar.gz
+

--- a/dev/check-binary-license
+++ b/dev/check-binary-license
@@ -115,7 +115,7 @@ done
 
 if [ $EXIT != 0 ]; then
     echo
-    echo It looks like there are issues with the LICENSE/NOTICE.
+    echo It looks like there are issues with the LICENSE/NOTICE in $TARBALL.
     echo See http://bookkeeper.apache.org/community/licensing for details on how to fix.
 fi
 


### PR DESCRIPTION
Run license check against all binary artifacts that we are going to release.

Fixes #2593