### PR TITLE
Upgrading dropwizard to 3.2.5

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -215,9 +215,9 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.4.jar [11]
 - lib/commons-lang-commons-lang-2.6.jar [12]
 - lib/commons-logging-commons-logging-1.1.1.jar [13]
-- lib/io.dropwizard.metrics-metrics-core-3.1.0.jar [14]
-- lib/io.dropwizard.metrics-metrics-graphite-3.1.0.jar [14]
-- lib/io.dropwizard.metrics-metrics-jvm-3.1.0.jar [14]
+- lib/io.dropwizard.metrics-metrics-core-3.2.5.jar [14]
+- lib/io.dropwizard.metrics-metrics-graphite-3.2.5.jar [14]
+- lib/io.dropwizard.metrics-metrics-jvm-3.2.5.jar [14]
 - lib/io.netty-netty-buffer-4.1.32.Final.jar [16]
 - lib/io.netty-netty-codec-4.1.32.Final.jar [16]
 - lib/io.netty-netty-codec-dns-4.1.32.Final.jar [16]
@@ -298,7 +298,7 @@ Apache Software License, Version 2.
 [11] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-io.git;a=tag;h=603579
 [12] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [13] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
-[14] Source available at https://github.com/dropwizard/metrics/tree/v3.1.0
+[14] Source available at https://github.com/dropwizard/metrics/tree/v3.2.5
 [16] Source available at https://github.com/netty/netty/tree/netty-4.1.32.Final
 [17] Source available at https://github.com/prometheus/client_java/tree/parent-0.0.21
 [18] Source available at https://github.com/vert-x3/vertx-auth/tree/3.5.3

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -263,6 +263,7 @@ Apache Software License, Version 2.
 - lib/org.apache.httpcomponents-httpclient-4.5.5.jar [38]
 - lib/org.apache.httpcomponents-httpcore-4.4.9.jar [39]
 - lib/org.apache.thrift-libthrift-0.9.3.jar [40]
+- lib/io.dropwizard.metrics-metrics-core-3.2.5.jar [41]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.8.9
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.8.9
@@ -296,6 +297,7 @@ Apache Software License, Version 2.
 [38] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [39] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1
 [30] Source available at https://github.com/apache/thrift/tree/0.9.3
+[41] Source available at https://github.com/dropwizard/metrics/tree/v3.2.5
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.32.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -291,6 +291,7 @@ Apache Software License, Version 2.
 - lib/org.apache.httpcomponents-httpclient-4.5.5.jar [38]
 - lib/org.apache.httpcomponents-httpcore-4.4.9.jar [39]
 - lib/org.apache.thrift-libthrift-0.9.3.jar [40]
+- lib/io.dropwizard.metrics-metrics-core-3.2.5.jar [41]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.8.9
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.8.9
@@ -332,6 +333,7 @@ Apache Software License, Version 2.
 [38] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [39] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1
 [30] Source available at https://github.com/apache/thrift/tree/0.9.3
+[41] Source available at https://github.com/dropwizard/metrics/tree/v3.2.5
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.50.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -5,9 +5,9 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.dropwizard.metrics-metrics-core-3.1.0.jar
-- lib/io.dropwizard.metrics-metrics-graphite-3.1.0.jar
-- lib/io.dropwizard.metrics-metrics-jvm-3.1.0.jar
+- lib/io.dropwizard.metrics-metrics-core-3.2.5.jar
+- lib/io.dropwizard.metrics-metrics-graphite-3.2.5.jar
+- lib/io.dropwizard.metrics-metrics-jvm-3.2.5.jar
 
 Metrics
 Copyright 2010-2013 Coda Hale and Yammer, Inc.

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <commons-io.version>2.4</commons-io.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <curator.version>5.1.0</curator.version>
-    <dropwizard.version>3.1.0</dropwizard.version>
+    <dropwizard.version>3.2.5</dropwizard.version>
     <etcd.version>0.5.4</etcd.version>
     <freebuilder.version>1.14.9</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:

Upgraded Dropwizard Metrics to 3.2.5, that is the same version used by ZooKeeper 3.6.2

### Motivation

Upgraded Dropwizard Metrics to the same version used by ZooKeeper 3.6.2 (and Pulsar 2.8)

### Changes

pom + license files

Master Issue: #2599

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
