### PR TITLE
Release script does not work on MacOs Big Sur

### DIFF
--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -100,13 +100,15 @@ bash
 "
 
 pushd ${BOOKKEEPER_ROOT}
+echo $BOOKKEEPER_ROOT
 
 docker run -i -t \
   --rm=true \
   -w ${BOOKKEEPER_ROOT} \
   -u "${USER}" \
-  -v "$(realpath $BOOKKEEPER_ROOT):${BOOKKEEPER_ROOT}" \
-  -v "$(realpath ~):/home/${USER_NAME}" \
+  -v "$BOOKKEEPER_ROOT:${BOOKKEEPER_ROOT}" \
+  -v "$(realpath ~/):/home/${USER_NAME}" \
+  -e MAVEN_CONFIG=/home/${USER_NAME}/.m2 \
   -e VERSION=${VERSION} \
   -e MAJOR_VERSION=${MAJOR_VERSION} \
   -e NEXT_VERSION=${NEXT_VERSION} \


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fixed the script/docker run command to mount to `/home/$USER` instead of mac-style `/Users/$USER`. 

### Motivation

`dev/release/000-run-docker.sh` failed to mount source dir (got empty dir instead), printed permissions errors like
```
mkdir: cannot create directory '/root': Permission denied
Can not write to /root/.m2/copy_reference_file.log. Wrong volume permissions? Carrying on ...
```

### Changes

see above

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
