### PR TITLE
Issue 2624: Update the NOTICE file to 2021 for copyright.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache BookKeeper
-Copyright 2011-2020 The Apache Software Foundation
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Very simple fix to update the year in the NOTICE file to 2021.

Fixes #2624 