### PR TITLE
Issue 2622: Fix usage of JournalQueueSize and JournalCbQueueSize; JournalCbQueueSize should be bounded

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -864,11 +864,11 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         entry.retain();
 
         journalStats.getJournalQueueSize().inc();
-        journalStats.getJournalCBQueueSize().inc();
+        journalStats.getJournalCbQueueSize().inc();
         queue.put(QueueEntry.create(
                 entry, ackBeforeSync,  ledgerId, entryId, cb, ctx, MathUtils.nowInNano(),
                 journalStats.getJournalAddEntryStats(),
-                journalStats.getJournalCBQueueSize()));
+                journalStats.getJournalCbQueueSize()));
     }
 
     void forceLedger(long ledgerId, WriteCallback cb, Object ctx) {
@@ -876,10 +876,10 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                 null, false /* ackBeforeSync */, ledgerId,
                 Bookie.METAENTRY_ID_FORCE_LEDGER, cb, ctx, MathUtils.nowInNano(),
                 journalStats.getJournalForceLedgerStats(),
-                journalStats.getJournalCBQueueSize()));
-        // Add afterwards because the add operation could fail.
+                journalStats.getJournalCbQueueSize()));
+        // Increment afterwards because the add operation could fail.
         journalStats.getJournalQueueSize().inc();
-        journalStats.getJournalCBQueueSize().inc();
+        journalStats.getJournalCbQueueSize().inc();
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -390,7 +390,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     if (qe != null) {
                         cbThreadPool.execute(qe);
                     }
-                    journalStats.getJournalCbQueueSize().inc();
                 }
 
                 return forceWriteWaiters.size();
@@ -865,19 +864,22 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         entry.retain();
 
         journalStats.getJournalQueueSize().inc();
+        journalStats.getJournalCBQueueSize().inc();
         queue.put(QueueEntry.create(
                 entry, ackBeforeSync,  ledgerId, entryId, cb, ctx, MathUtils.nowInNano(),
                 journalStats.getJournalAddEntryStats(),
-                journalStats.getJournalQueueSize()));
+                journalStats.getJournalCBQueueSize()));
     }
 
     void forceLedger(long ledgerId, WriteCallback cb, Object ctx) {
-        journalStats.getJournalQueueSize().inc();
         queue.add(QueueEntry.create(
-                null, false /* ackBeforeSync */,  ledgerId,
+                null, false /* ackBeforeSync */, ledgerId,
                 Bookie.METAENTRY_ID_FORCE_LEDGER, cb, ctx, MathUtils.nowInNano(),
                 journalStats.getJournalForceLedgerStats(),
-                journalStats.getJournalQueueSize()));
+                journalStats.getJournalCBQueueSize()));
+        // Add afterwards because the add operation could fail.
+        journalStats.getJournalQueueSize().inc();
+        journalStats.getJournalCBQueueSize().inc();
     }
 
     /**
@@ -969,6 +971,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     if (numEntriesToFlush == 0) {
                         qe = queue.take();
                         dequeueStartTime = MathUtils.nowInNano();
+                        journalStats.getJournalQueueSize().dec();
                         journalStats.getJournalQueueStats()
                             .registerSuccessfulEvent(MathUtils.elapsedNanos(qe.enqueueTime), TimeUnit.NANOSECONDS);
                     } else {
@@ -981,6 +984,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                         dequeueStartTime = MathUtils.nowInNano();
 
                         if (qe != null) {
+                            journalStats.getJournalQueueSize().dec();
                             journalStats.getJournalQueueStats()
                                 .registerSuccessfulEvent(MathUtils.elapsedNanos(qe.enqueueTime), TimeUnit.NANOSECONDS);
                         }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fixes https://github.com/apache/bookkeeper/issues/2622.

This PR only affects metrics. Specifically, it improves the usage of `JournalQueueSize` and `JournalCbQueueSize` (including `bookie_journal_JOURNAL_QUEUE_SIZE` and `bookie_journal_JOURNAL_CB_QUEUE_SIZE`).

### Motivation

As mentioned in the issue, `bookie_journal_JOURNAL_CB_QUEUE_SIZE` grows unbounded. This PR looks to fix that, and in doing so, fixes `bookie_journal_JOURNAL_QUEUE_SIZE` as well.

### Changes

The `bookie_journal_JOURNAL_CB_QUEUE_SIZE ` grows unbounded because it is never decremented. Ideally, it would measure the number of call backs outstanding for the Journal. I've updated the `Counter` object that is passed into the `QueueEntry` class so that the `Counter` is the one for the call back queue size. In changing that code, I also needed to update the way the `JournalQueueSize` was handled. I updated the code so that it gets incremented when adding elements to the queue and decremented when elements are removed. The journal queue size should represent the size of the actual `queue` variable in the `Journal` class.

### Note
If my understanding of any of these metrics is off base, please question me. I'm new to this class, and while I read through it, I might have missed something. Thanks!