### PR TITLE
Allow force compact entry log when disabling entry log compaction

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -177,7 +177,7 @@ public class GarbageCollectorThread extends SafeRunnable {
         majorCompactionThreshold = conf.getMajorCompactionThreshold();
         majorCompactionInterval = conf.getMajorCompactionInterval() * SECOND;
         isForceGCAllowWhenNoSpace = conf.getIsForceGCAllowWhenNoSpace();
-        boolean isForceCompactionAllowWhenDisableCompaction= conf.isForceCompactionAllowWhenDisableCompaction();
+        boolean isForceCompactionAllowWhenDisableCompaction = conf.isForceCompactionAllowWhenDisableCompaction();
 
         AbstractLogCompactor.LogRemovalListener remover = new AbstractLogCompactor.LogRemovalListener() {
             @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -177,7 +177,7 @@ public class GarbageCollectorThread extends SafeRunnable {
         majorCompactionThreshold = conf.getMajorCompactionThreshold();
         majorCompactionInterval = conf.getMajorCompactionInterval() * SECOND;
         isForceGCAllowWhenNoSpace = conf.getIsForceGCAllowWhenNoSpace();
-        boolean isForceCompactionAllowWhenDisableCompaction = conf.isForceCompactionAllowWhenDisableCompaction();
+        boolean isForceAllowCompaction = conf.isForceAllowCompaction();
 
         AbstractLogCompactor.LogRemovalListener remover = new AbstractLogCompactor.LogRemovalListener() {
             @Override
@@ -203,7 +203,7 @@ public class GarbageCollectorThread extends SafeRunnable {
             enableMinorCompaction = true;
         }
 
-        if (isForceCompactionAllowWhenDisableCompaction) {
+        if (isForceAllowCompaction) {
             if (minorCompactionThreshold > 0 || minorCompactionThreshold < 1.0f) {
                 isForceMinorCompactionAllow = true;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -90,6 +90,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String ENTRY_LOG_FILE_PREALLOCATION_ENABLED = "entryLogFilePreallocationEnabled";
 
 
+    protected static final String IS_FORCE_COMPACTION_ALLOW_WHEN_DISABLE_COMPACTION =
+        "isForceCompactionAllowWhenDisableCompaction";
     protected static final String MINOR_COMPACTION_INTERVAL = "minorCompactionInterval";
     protected static final String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
     protected static final String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";
@@ -1448,6 +1450,27 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     public ServerConfiguration setStatisticsEnabled(boolean enabled) {
         setProperty(ENABLE_STATISTICS, Boolean.toString(enabled));
         return this;
+    }
+
+    /**
+     * Allow manually force compact the entry log or not.
+     *
+     * @param enable
+     *          whether allow manually force compact the entry log or not.
+     * @return service configuration.
+     */
+    public ServerConfiguration setIsForceCompactionAllowWhenDisableCompaction(boolean enable) {
+        setProperty(IS_FORCE_COMPACTION_ALLOW_WHEN_DISABLE_COMPACTION, enable);
+        return this;
+    }
+
+    /**
+     * The force compaction is allowed or not when disabling the entry log compaction.
+     *
+     * @return the force compaction is allowed or not when disabling the entry log compaction.
+     */
+    public boolean isForceCompactionAllowWhenDisableCompaction() {
+        return getBoolean(IS_FORCE_COMPACTION_ALLOW_WHEN_DISABLE_COMPACTION, false);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -90,8 +90,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String ENTRY_LOG_FILE_PREALLOCATION_ENABLED = "entryLogFilePreallocationEnabled";
 
 
-    protected static final String IS_FORCE_COMPACTION_ALLOW_WHEN_DISABLE_COMPACTION =
-        "isForceCompactionAllowWhenDisableCompaction";
+    protected static final String IS_FORCE_COMPACTION_ALLOW_WHEN_DISABLE_COMPACTION = "forceAllowCompaction";
     protected static final String MINOR_COMPACTION_INTERVAL = "minorCompactionInterval";
     protected static final String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
     protected static final String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -90,7 +90,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String ENTRY_LOG_FILE_PREALLOCATION_ENABLED = "entryLogFilePreallocationEnabled";
 
 
-    protected static final String IS_FORCE_COMPACTION_ALLOW_WHEN_DISABLE_COMPACTION = "forceAllowCompaction";
+    protected static final String FORCE_ALLOW_COMPACTION = "forceAllowCompaction";
     protected static final String MINOR_COMPACTION_INTERVAL = "minorCompactionInterval";
     protected static final String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
     protected static final String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";
@@ -1458,8 +1458,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      *          whether allow manually force compact the entry log or not.
      * @return service configuration.
      */
-    public ServerConfiguration setIsForceCompactionAllowWhenDisableCompaction(boolean enable) {
-        setProperty(IS_FORCE_COMPACTION_ALLOW_WHEN_DISABLE_COMPACTION, enable);
+    public ServerConfiguration setForceAllowCompaction(boolean enable) {
+        setProperty(FORCE_ALLOW_COMPACTION, enable);
         return this;
     }
 
@@ -1468,8 +1468,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      *
      * @return the force compaction is allowed or not when disabling the entry log compaction.
      */
-    public boolean isForceCompactionAllowWhenDisableCompaction() {
-        return getBoolean(IS_FORCE_COMPACTION_ALLOW_WHEN_DISABLE_COMPACTION, false);
+    public boolean isForceAllowCompaction() {
+        return getBoolean(FORCE_ALLOW_COMPACTION, false);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -233,7 +233,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         // prepare data
         LedgerHandle[] lhs = prepareData(3, false);
 
-        baseConf.setIsForceCompactionAllowWhenDisableCompaction(true);
+        baseConf.setForceAllowCompaction(true);
         baseConf.setMajorCompactionThreshold(0.5f);
         baseConf.setMinorCompactionThreshold(0.2f);
         baseConf.setMajorCompactionInterval(0);
@@ -261,7 +261,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         if (isForceCompactionAllowWhenDisableCompaction) {
             conf.setMinorCompactionInterval(0);
             conf.setMajorCompactionInterval(0);
-            conf.setIsForceCompactionAllowWhenDisableCompaction(true);
+            conf.setForceAllowCompaction(true);
             conf.setMajorCompactionThreshold(0.5f);
             conf.setMinorCompactionThreshold(0.2f);
         } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -229,11 +229,45 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
     }
 
     @Test
+    public void testForceGarbageCollectionWhenDisableCompactionConfigurationSettings() throws Exception {
+        // prepare data
+        LedgerHandle[] lhs = prepareData(3, false);
+
+        baseConf.setIsForceCompactionAllowWhenDisableCompaction(true);
+        baseConf.setMajorCompactionThreshold(0.5f);
+        baseConf.setMinorCompactionThreshold(0.2f);
+        baseConf.setMajorCompactionInterval(0);
+        baseConf.setMinorCompactionInterval(0);
+        restartBookies(baseConf);
+
+        assertFalse(getGCThread().enableMajorCompaction);
+        assertFalse(getGCThread().enableMinorCompaction);
+        assertTrue(getGCThread().isForceMajorCompactionAllow);
+        assertTrue(getGCThread().isForceMinorCompactionAllow);
+
+        assertEquals(0.5f, getGCThread().majorCompactionThreshold, 0f);
+        assertEquals(0.2f, getGCThread().minorCompactionThreshold, 0f);
+    }
+
+    @Test
     public void testForceGarbageCollection() throws Exception {
+        testForceGarbageCollection(true);
+        testForceGarbageCollection(false);
+    }
+
+    public void testForceGarbageCollection(boolean isForceCompactionAllowWhenDisableCompaction) throws Exception {
         ServerConfiguration conf = newServerConfiguration();
         conf.setGcWaitTime(60000);
-        conf.setMinorCompactionInterval(120000);
-        conf.setMajorCompactionInterval(240000);
+        if (isForceCompactionAllowWhenDisableCompaction) {
+            conf.setMinorCompactionInterval(0);
+            conf.setMajorCompactionInterval(0);
+            conf.setIsForceCompactionAllowWhenDisableCompaction(true);
+            conf.setMajorCompactionThreshold(0.5f);
+            conf.setMinorCompactionThreshold(0.2f);
+        } else {
+            conf.setMinorCompactionInterval(120000);
+            conf.setMajorCompactionInterval(240000);
+        }
         LedgerDirsManager dirManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
         CheckpointSource cp = new CheckpointSource() {

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -480,7 +480,7 @@ ledgerDirectories=/tmp/bk-data
 # It will enable you to manually force compact the entry log even if
 # the entry log compaction is disabled. The 'minorCompactionThreshold' or
 # 'majorCompactionThreshold' still needs to be specified.
-# isForceCompactionAllowWhenDisableCompaction=false
+# forceAllowCompaction=false
 
 # Set the rate at which compaction will read entries. The unit is adds per second.
 # compactionRate=1000

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -476,7 +476,13 @@ ledgerDirectories=/tmp/bk-data
 ## Entry log compaction settings
 #############################################################################
 
-# Set the rate at which compaction will readd entries. The unit is adds per second.
+# Allow force compaction when disabling the entry log compaction or not.
+# It will enable you to manually force compact the entry log even if
+# the entry log compaction is disabled. The 'minorCompactionThreshold' or
+# 'majorCompactionThreshold' still needs to be specified.
+# isForceCompactionAllowWhenDisableCompaction=false
+
+# Set the rate at which compaction will read entries. The unit is adds per second.
 # compactionRate=1000
 
 # Threshold of minor compaction


### PR DESCRIPTION
---

Master Issue: #2596

*Motivation*

Sometimes user will disable the entry log compaction to reduce the
I/O load. But we should allow forcing compact the entry even if
the entry log compaction is disabled.

*Modifications*

- Add a configuration to allow force compaction

