### PR TITLE
Allow DBLedgerStorage to force GC by disk listener

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import java.util.concurrent.atomic.AtomicLong;
+
+import lombok.Getter;
 import org.apache.bookkeeper.bookie.GarbageCollector.GarbageCleaner;
 import org.apache.bookkeeper.bookie.stats.GarbageCollectorStats;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -75,6 +77,7 @@ public class GarbageCollectorThread extends SafeRunnable {
     final long majorCompactionInterval;
     long lastMajorCompactionTime;
 
+    @Getter
     final boolean isForceGCAllowWhenNoSpace;
 
     // Entry Logger Handle

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -129,6 +129,7 @@ public class DbLedgerStorage implements LedgerStorage {
             ledgerStorageList.add(newSingleDirectoryDbLedgerStorage(conf, ledgerManager, ldm, indexDirsManager,
                     stateManager, checkpointSource, checkpointer, statsLogger, gcExecutor, perDirectoryWriteCacheSize,
                     perDirectoryReadCacheSize));
+            ldm.getListeners().forEach(ledgerDirsManager::addLedgerDirsListener);
         }
 
         this.stats = new DbLedgerStorageStats(

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -39,6 +39,7 @@ import org.apache.bookkeeper.bookie.Bookie.NoEntryException;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.EntryLogger;
+import org.apache.bookkeeper.bookie.LedgerDirsManager;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.proto.BookieProtocol;
@@ -53,6 +54,7 @@ public class DbLedgerStorageTest {
 
     private DbLedgerStorage storage;
     private File tmpDir;
+    private LedgerDirsManager ledgerDirsManager;
 
     @Before
     public void setup() throws Exception {
@@ -69,6 +71,7 @@ public class DbLedgerStorageTest {
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
         Bookie bookie = new Bookie(conf);
 
+        ledgerDirsManager = bookie.getLedgerDirsManager();
         storage = (DbLedgerStorage) bookie.getLedgerStorage();
     }
 
@@ -432,5 +435,12 @@ public class DbLedgerStorageTest {
         assertEquals(entry1, storage.getEntry(1, 1));
 
         storage.flush();
+    }
+
+    @Test
+    public void testGetLedgerDirsListeners() throws IOException {
+        // we should have two listeners, one is the SingleLedgerDirectories listener,
+        // and another is EntryLogManagerForEntryLogPerLedger
+        assertEquals(2, ledgerDirsManager.getListeners().size());
     }
 }


### PR DESCRIPTION
---

Fixes #2596

*Motivation*

The isForceGCAllowWhenNoSpace does not work for the DBLedgerStorage.
Currently, the behavior of the isForceGCAllowWhenNoSpace is It is a
disk listener to decide whether to start the compaction task while
the disk of the Ledger almost full. 


*Modifications*

- Add dir listener for the SingleDirectoryDbledgerStorage

