### PR TITLE
[doc] fix the no striping occurs condition to Qw=E

### DIFF
--- a/site/docs/4.10.0/development/protocol.md
+++ b/site/docs/4.10.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.11.0/development/protocol.md
+++ b/site/docs/4.11.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.11.1/development/protocol.md
+++ b/site/docs/4.11.1/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.12.0/development/protocol.md
+++ b/site/docs/4.12.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.12.1/development/protocol.md
+++ b/site/docs/4.12.1/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.13.0/development/protocol.md
+++ b/site/docs/4.13.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.5.0/development/protocol.md
+++ b/site/docs/4.5.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.5.1/development/protocol.md
+++ b/site/docs/4.5.1/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.6.0/development/protocol.md
+++ b/site/docs/4.6.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.6.1/development/protocol.md
+++ b/site/docs/4.6.1/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.6.2/development/protocol.md
+++ b/site/docs/4.6.2/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.7.0/development/protocol.md
+++ b/site/docs/4.7.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.7.1/development/protocol.md
+++ b/site/docs/4.7.1/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.7.2/development/protocol.md
+++ b/site/docs/4.7.2/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.7.3/development/protocol.md
+++ b/site/docs/4.7.3/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.8.0/development/protocol.md
+++ b/site/docs/4.8.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.8.1/development/protocol.md
+++ b/site/docs/4.8.1/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.8.2/development/protocol.md
+++ b/site/docs/4.8.2/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.9.0/development/protocol.md
+++ b/site/docs/4.9.0/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.9.1/development/protocol.md
+++ b/site/docs/4.9.1/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/4.9.2/development/protocol.md
+++ b/site/docs/4.9.2/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 

--- a/site/docs/latest/development/protocol.md
+++ b/site/docs/latest/development/protocol.md
@@ -64,7 +64,7 @@ Entry | Write quorum
 4 | B1, B2, B3
 5 | B2, B3, B4
 
-There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **Q<sub>a</sub>**, then there is only one, as no striping occurs.
+There are only **E** distinct write quorums in any ensemble. If **Q<sub>w</sub>** = **E**, then there is only one, as no striping occurs.
 
 ### Ack quorums
 


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

the no striping occurs condition should Qw=E, not the Qw=Qa

### Changes

update the condition to Qw=E

