### PR TITLE
add flag to control whether basic metrics expose to prometheus or not

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusTextFormatUtil.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusTextFormatUtil.java
@@ -147,4 +147,33 @@ public class PrometheusTextFormatUtil {
             }
         }
     }
+
+
+    static void writeMetricsCollectedByPrometheusClient(Writer w, CollectorRegistry registry, String metricPrefix)
+        throws IOException {
+        Enumeration<MetricFamilySamples> metricFamilySamples = registry.metricFamilySamples();
+        while (metricFamilySamples.hasMoreElements()) {
+            MetricFamilySamples metricFamily = metricFamilySamples.nextElement();
+
+            for (int i = 0; i < metricFamily.samples.size(); i++) {
+                Sample sample = metricFamily.samples.get(i);
+                w.write(metricPrefix);
+                w.write(sample.name);
+                w.write('{');
+                for (int j = 0; j < sample.labelNames.size(); j++) {
+                    if (j != 0) {
+                        w.write(", ");
+                    }
+                    w.write(sample.labelNames.get(j));
+                    w.write("=\"");
+                    w.write(sample.labelValues.get(j));
+                    w.write('"');
+                }
+
+                w.write("} ");
+                w.write(Collector.doubleToGoString(sample.value));
+                w.write('\n');
+            }
+        }
+    }
 }

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -17,6 +17,7 @@
 package org.apache.bookkeeper.stats.prometheus;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -105,7 +106,7 @@ public class TestPrometheusMetricsProvider {
             assertNotNull(provider.server);
             StringWriter writer = new StringWriter();
             provider.writeAllMetrics(writer);
-            assertTrue(!writer.toString().contains("process_cpu_seconds_total"));
+            assertFalse(writer.toString().contains("process_cpu_seconds_total"));
         } catch (IOException e) {
             fail();
         } finally {

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -798,6 +798,9 @@ zkEnableSecurity=false
 # latency stats rollover interval, in seconds
 # prometheusStatsLatencyRolloverSeconds=60
 
+# whether export basic metrics, such as cpu, jvm etc. default is true
+# prometheusBasicStatsEnable=true
+
 #############################################################################
 ## Codahale Metrics Provider
 #############################################################################


### PR DESCRIPTION
### Motivation
When using prometheus-metrics-provider lib provided by BookKeeper, it will expose basic metrics such as cpu, jvm, memory metrics etc. However, other systems, eg. Apache Pulsar, may also expose those metrics, which will lead to those metrics register twice, and prometheus metrics provider thread will start failed.

### Changes
1. Add a flag to control whether basic metrics expose to prometheus or not.