### PR TITLE
Handle corrupted checkpoints

### DIFF
--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/CheckpointInfo.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/CheckpointInfo.java
@@ -1,0 +1,150 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint;
+
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.statelib.api.checkpoint.CheckpointStore;
+import org.apache.bookkeeper.statelib.api.exceptions.StateStoreException;
+import org.apache.bookkeeper.stream.proto.kv.store.CheckpointMetadata;
+
+
+/**
+ * CheckpointInfo encapsulated information and operatation for a checkpoint.
+ */
+@Slf4j
+public class CheckpointInfo implements Comparable<CheckpointInfo> {
+
+    final String id;
+    CheckpointMetadata metadata;
+
+    public CheckpointInfo(String id, InputStream is) throws IOException {
+        this.id = id;
+        this.metadata = CheckpointMetadata.parseFrom(is);
+    }
+
+    public CheckpointInfo(String id) {
+        this.id = id;
+    }
+    public String getId() {
+        return id;
+    }
+
+    public CheckpointMetadata getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public String toString() {
+        return "Checkpoint{ID='" + id + "', createdAt: " + getCreatedAt() + " " + metadata + "}";
+    }
+
+    // default fallback checkpoint. This essentially creates a blank store.
+    public static CheckpointInfo nullCheckpoint() {
+        return new CheckpointInfo(UUID.randomUUID().toString()) {
+            public CheckpointMetadata restore(String dbName,
+                                              File dbPath,
+                                              CheckpointStore store) throws StateStoreException {
+                try {
+                    Files.createDirectories(getCheckpointPath(dbPath));
+                } catch (IOException ioe) {
+                    throw new StateStoreException("Failed to create dir " + dbName, ioe);
+                }
+                return null;
+            }
+            // for proper sorting
+            public Long getCreatedAt() {
+                return Long.valueOf(0);
+            }
+        };
+    }
+
+    public void remove(File dbPath) {
+        try {
+            Path checkpointPath = getCheckpointPath(dbPath);
+            if (checkpointPath.toFile().exists()) {
+                MoreFiles.deleteRecursively(checkpointPath, RecursiveDeleteOption.ALLOW_INSECURE);
+            }
+        } catch (IOException ioe) {
+            log.warn("Failed to remove unused checkpoint {} from {}",
+                id, getCheckpointBaseDir(dbPath), ioe);
+        }
+    }
+
+    public Long getCreatedAt() {
+        return this.metadata.getCreatedAt();
+    }
+
+    public File getCheckpointBaseDir(File dbPath) {
+        return new File(dbPath, "checkpoints");
+    }
+
+    public Path getCheckpointPath(File dbPath) {
+        return Paths.get(getCheckpointBaseDir(dbPath).getAbsolutePath(), id);
+    }
+
+    public File getCurrentDir(File dbPath) {
+        return new File(dbPath, "current");
+    }
+    public Path getCurrentPath(File dbPath) {
+        return Paths.get(getCurrentDir(dbPath).getAbsolutePath());
+    }
+
+    public void updateCurrent(File dbPath) throws IOException {
+        Path currentPath = getCurrentPath(dbPath);
+        Files.deleteIfExists(currentPath);
+        Files.createSymbolicLink(currentPath, getCheckpointPath(dbPath));
+    }
+
+    @Override
+    public int compareTo(CheckpointInfo o) {
+        return this.getCreatedAt().compareTo(o.getCreatedAt());
+    }
+
+    public CheckpointMetadata restore(RocksdbRestoreTask task) throws StateStoreException {
+        task.restore(id, metadata);
+        return metadata;
+    }
+
+    public CheckpointMetadata restore(String dbName, File dbPath, CheckpointStore store) throws StateStoreException {
+        try {
+            File checkpointsDir = new File(dbPath, "checkpoints");
+            RocksdbRestoreTask task = new RocksdbRestoreTask(dbName, checkpointsDir, store);
+
+            task.restore(id, metadata);
+            updateCurrent(dbPath);
+
+            log.info("Successfully restore checkpoint {} to {}", id, getCheckpointPath(dbPath));
+            return metadata;
+        } catch (IOException ioe) {
+            log.error("Failed to restore rocksdb {}", dbName, ioe);
+            throw new StateStoreException("Failed to restore rocksdb " + dbName, ioe);
+        }
+    }
+}

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVStoreCheckpoint.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVStoreCheckpoint.java
@@ -1,0 +1,97 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.statelib.impl.kv;
+
+import static org.junit.Assert.assertEquals;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.CheckpointInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+
+
+
+/**
+ * Test cases for Rocksdb KV Store with checkpoints.
+ */
+@Slf4j
+public class TestRocksdbKVStoreCheckpoint {
+
+    @Rule
+    public final TestName runtime = new TestName();
+    @Rule
+    public final TemporaryFolder testDir = new TemporaryFolder();
+
+    private TestStateStore store;
+
+    @Before
+    public void setUp() throws Exception {
+        store = new TestStateStore(runtime, testDir);
+        store.enableCheckpoints(true);
+        store.init();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (null != store) {
+            store.close();
+        }
+    }
+
+    @Test
+    public void testRestoreCorruptCheckpoint() throws Exception {
+        int numKvs = 100;
+
+        store.addNumKVs("transaction-1", numKvs, 0);
+        String checkpoint1 = store.checkpoint("checkpoint-1");
+        assertEquals("transaction-1", store.get("transaction-id"));
+
+        store.addNumKVs("transaction-2", numKvs, 100);
+        assertEquals("transaction-2", store.get("transaction-id"));
+        String checkpoint2 = store.checkpoint("checkpoint-2");
+
+        store.addNumKVs("transaction-3", numKvs, 200);
+        assertEquals("transaction-3", store.get("transaction-id"));
+
+        store.destroyLocal();
+        store.restore();
+        assertEquals("transaction-2", store.get("transaction-id"));
+
+        // Ensure we can write to new store
+        store.addNumKVs("transaction-4", numKvs, 300);
+        assertEquals("transaction-4", store.get("transaction-id"));
+
+        // corrupt the checkpoint-2 so restore fails
+
+        CheckpointInfo cpi = store.getLatestCheckpoint();
+        store.corruptCheckpoint(cpi);
+        store.destroyLocal();
+
+        // latest checkpoint is checkpoint-2, which has been corrupted.
+        store.restore();
+        // We should fallback to checkpoint-1
+        assertEquals("transaction-1", store.get("transaction-id"));
+    }
+}

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestStateStore.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestStateStore.java
@@ -1,0 +1,232 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.statelib.impl.kv;
+
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.coder.StringUtf8Coder;
+import org.apache.bookkeeper.statelib.api.StateStoreSpec;
+import org.apache.bookkeeper.statelib.api.checkpoint.CheckpointStore;
+import org.apache.bookkeeper.statelib.api.exceptions.StateStoreException;
+import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.CheckpointInfo;
+import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.RocksCheckpointer;
+import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.RocksdbCheckpointTask;
+import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.RocksdbRestoreTask;
+import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.fs.FSCheckpointManager;
+import org.apache.bookkeeper.stream.proto.kv.store.CheckpointMetadata;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+import org.rocksdb.Checkpoint;
+
+
+/**
+ * TestStateStore is a helper class for testing various statestore operations.
+ */
+@Slf4j
+public class TestStateStore {
+
+    private final String dbName;
+    private final boolean removeLocal;
+    private final boolean removeRemote;
+
+    private File localDir;
+    private File localCheckpointsDir;
+    private File remoteDir;
+    private Path remoteCheckpointsPath;
+    private StateStoreSpec spec;
+    private RocksdbKVStore<String, String> store;
+    private CheckpointStore checkpointStore;
+    private RocksdbCheckpointTask checkpointer;
+    private RocksdbRestoreTask restorer;
+    private ScheduledExecutorService checkpointExecutor;
+
+    public TestStateStore(String dbName,
+                          File localDir,
+                          File remoteDir,
+                          boolean removeLocal,
+                          boolean removeRemote) throws IOException {
+        this.dbName = dbName;
+        this.localDir = localDir;
+        this.remoteDir = remoteDir;
+        this.removeLocal = removeLocal;
+        this.removeRemote = removeRemote;
+        localCheckpointsDir = new File(localDir, "checkpoints");
+        remoteCheckpointsPath = Paths.get(remoteDir.getAbsolutePath(), dbName);
+    }
+    public TestStateStore(TestName runtime, TemporaryFolder testDir) throws IOException {
+        this(
+            runtime.getMethodName(),
+            testDir.newFolder("local"),
+            testDir.newFolder("remote"),
+            false,
+            false
+        );
+    }
+
+    public File getLocalDir() {
+        return localDir;
+    }
+
+    public File getRemoteDir() {
+        return remoteDir;
+    }
+
+    public void enableCheckpoints(boolean enable) {
+        if (enable) {
+            checkpointExecutor = Executors.newSingleThreadScheduledExecutor();
+        } else {
+            checkpointExecutor.shutdown();
+            checkpointExecutor = null;
+        }
+    }
+
+    public void init() throws StateStoreException {
+        checkpointStore = new FSCheckpointManager(remoteDir);
+        StateStoreSpec.StateStoreSpecBuilder builder = StateStoreSpec.builder()
+            .name(dbName)
+            .keyCoder(StringUtf8Coder.of())
+            .valCoder(StringUtf8Coder.of())
+            .localStateStoreDir(localDir)
+            .stream(dbName);
+        if (checkpointExecutor != null) {
+            builder = builder.checkpointStore(checkpointStore)
+                .checkpointIOScheduler(checkpointExecutor);
+        }
+        spec = builder.build();
+        store = new RocksdbKVStore<>();
+        store.init(spec);
+
+        this.checkpointer = new RocksdbCheckpointTask(
+            dbName, Checkpoint.create(store.getDb()), localCheckpointsDir, checkpointStore,
+            removeLocal, removeRemote);
+        this.restorer = new RocksdbRestoreTask(dbName, localCheckpointsDir, checkpointStore);
+    }
+
+    public void close() {
+        store.close();
+    }
+
+    public void destroyLocal() {
+        store.close();
+
+        try {
+            // delete the checkpoints
+            for (File f: localCheckpointsDir.listFiles()) {
+                Path p = f.toPath();
+                MoreFiles.deleteRecursively(f.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+            }
+            // remove `current` symlink
+            new File(localDir, "current").delete();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    public String checkpoint(String checkpointID) throws StateStoreException {
+        byte[] txid = checkpointID.getBytes();
+        return checkpointer.checkpoint(txid);
+    }
+
+    List<CheckpointInfo> getCheckpoints() {
+        return RocksCheckpointer.getCheckpoints(store.name(), checkpointStore);
+    }
+    public CheckpointInfo getLatestCheckpoint() {
+        List<CheckpointInfo> checkpoints = RocksCheckpointer.getCheckpoints(store.name(), checkpointStore);
+        return checkpoints.get(0);
+    }
+
+    public void restore() throws Exception {
+        store.close();
+        if (checkpointExecutor != null) {
+            checkpointExecutor.submit(() -> {}).get();
+        }
+        this.init();
+    }
+
+    CheckpointMetadata restore(CheckpointInfo checkpoint) throws StateStoreException {
+        try {
+            MoreFiles.deleteRecursively(
+                checkpoint.getCheckpointPath(localDir),
+                RecursiveDeleteOption.ALLOW_INSECURE);
+        } catch (Exception e) {
+            // ignore
+        }
+
+        CheckpointMetadata md = checkpoint.restore(store.name(), localDir, checkpointStore);
+        store.close();
+        store = new RocksdbKVStore<>();
+        store.init(spec);
+        this.init();
+        return md;
+    }
+
+
+    private static String getKey(int i) {
+        return String.format("key-%06d", i);
+    }
+
+    private static String getValue(int i) {
+        return String.format("val-%06d", i);
+    }
+
+    public void addNumKVs(String txId, int numKvs, int startIdx) throws StateStoreException {
+        for (int i = 0; i < numKvs; i++) {
+            String key = getKey(startIdx + i);
+            String val = getValue(startIdx + i);
+
+            store.put(key, val);
+        }
+        store.put("transaction-id", txId);
+        store.flush();
+    }
+
+    public void addNumKVs(int numKvs, int startIdx) throws StateStoreException {
+        for (int i = 0; i < numKvs; i++) {
+            String key = getKey(startIdx + i);
+            String val = getValue(startIdx + i);
+
+            store.put(key, val);
+        }
+        store.flush();
+    }
+
+    public String get(String key) {
+        return store.get(key);
+    }
+
+    public void corruptCheckpoint(CheckpointInfo cpi) throws IOException {
+        File checkpointDir = cpi.getCheckpointPath(remoteCheckpointsPath.toFile()).toFile();
+
+        File current = new File(checkpointDir, "CURRENT");
+        FileWriter w = new FileWriter(current);
+        w.write("MANIFEST-xxxx\n");
+        w.close();
+    }
+}

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/RocksCheckpointerTest.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/RocksCheckpointerTest.java
@@ -331,6 +331,23 @@ public class RocksCheckpointerTest {
 
         verifyNumKvs(300);
     }
+    @Test
+    public void testCheckpointOrder() throws Exception {
+        List<String> checkpointIds = createMultipleCheckpoints(3, false, false);
+
+        List<CheckpointInfo> checkpoints = RocksCheckpointer.getCheckpoints(store.name(), checkpointStore);
+        int totalCheckpoints = checkpoints.size();
+        // there is an additional null checkpoint
+        assertTrue(checkpoints.size() == checkpointIds.size() + 1);
+
+        // Last checkpoint should be null checkpoint
+        assertTrue(checkpoints.get(totalCheckpoints - 1).getMetadata() == null);
+
+        // checkpoints are in reverse order
+        for (int i = 0; i < checkpointIds.size(); i++) {
+            assertEquals(checkpointIds.get(i), checkpoints.get(totalCheckpoints - 2 - i).getId());
+        }
+    }
 
     @Test
     public void testRestoreCheckpointMissingLocally() throws Exception {


### PR DESCRIPTION
### Motivation

If a checkpoint is corrupted, checkpoint restoration will fail. Currently we will keep
retrying to restore the same checkpoint. The system will never recover from this.
The only way out is to manually remove the checkpoint from the zookeeper

### Changes

When a checkpoint is corrupted, we need to try and restore from previous checkpoint.
This  is done recursively till we hit a checkpoint that works. If none of the checkpoints
work, we will fallback to a `nullcheckpoint` which will initialize rocksdb from scratch
and replay all state from journal.

Instead of just dealing with the latest checkpoint, we now return a list of checkpoints
ordered by age. We then simply walk this list and stop as soon as a checkpoint is
successfully restored. We currently only keep a single checkpoint,  but with this change
we can potentially keep `N` checkpoints to provide more robustness. 

