### PR TITLE
Add checksum validation for SST files

### DIFF
--- a/stream/proto/src/main/proto/kv_store.proto
+++ b/stream/proto/src/main/proto/kv_store.proto
@@ -59,11 +59,17 @@ message Command {
 // Checkpoint related
 //
 
+message FileInfo {
+    string name = 1;
+    string checksum = 2;
+}
+
 message CheckpointMetadata {
 
     repeated string files = 1;
     bytes txid = 2;
     uint64 created_at = 3;
 
+    repeated FileInfo fileInfos = 4;
 }
 

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -336,7 +336,7 @@ public class StorageServer {
                     () -> new DLCheckpointStore(dlNamespaceProvider.get()),
                     storageConf.getRangeStoreDirs(),
                     storageResources,
-                    storageConf.getServeReadOnlyTables()))
+                    storageConf.getServeReadOnlyTables(), storageConf))
             // with client manager for proxying grpc requests
             .withStorageServerClientManager(() -> new StorageServerClientManagerImpl(
                 proxyClientSettings,

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/api/StateStoreSpec.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/api/StateStoreSpec.java
@@ -51,4 +51,8 @@ public class StateStoreSpec {
     @Singular
     private Map<String, Object> configs;
 
+    @Default
+    private boolean checkpointChecksumEnable = true;
+    @Default
+    private boolean checkpointChecksumCompatible = true;
 }

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVStore.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVStore.java
@@ -176,7 +176,7 @@ public class RocksdbKVStore<K, V> implements KVStore<K, V> {
                 break;
             } catch (StateStoreException e) {
                 // Got an exception. Log and try the next checkpoint
-                log.error("Failed to restore checkpoint: {}", cpi);
+                log.error("Failed to restore checkpoint: {}", cpi, e);
             }
         }
     }
@@ -280,7 +280,9 @@ public class RocksdbKVStore<K, V> implements KVStore<K, V> {
                 db,
                 checkpointStore,
                 true,
-                true);
+                true,
+                spec.isCheckpointChecksumEnable(),
+                spec.isCheckpointChecksumCompatible());
             checkpointScheduler = spec.getCheckpointIOScheduler();
         }
 

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/RocksUtils.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/RocksUtils.java
@@ -60,6 +60,10 @@ public final class RocksUtils {
         return String.format("%s/ssts/%s", dbPrefix, file.getName());
     }
 
+    public static String getDestSstPath(String dbPrefix, String cksum, File file) {
+        return String.format("%s/ssts/%s-%s", dbPrefix, file.getName(), cksum);
+    }
+
     public static String getDestSstPath(String dbPrefix, String fileName) {
         return String.format("%s/ssts/%s", dbPrefix, fileName);
     }
@@ -72,6 +76,12 @@ public final class RocksUtils {
                                      String checkpointId,
                                      File file) {
         return String.format("%s/checkpoints/%s/%s", dbPrefix, checkpointId, file.getName());
+    }
+
+    public static String getDestPath(String dbPrefix,
+                                     String checkpointId,
+                                     String fileName) {
+        return String.format("%s/checkpoints/%s/%s", dbPrefix, checkpointId, fileName);
     }
 
 }

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/CheckpointFile.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/CheckpointFile.java
@@ -1,0 +1,226 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint;
+
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.statelib.api.checkpoint.CheckpointStore;
+import org.apache.bookkeeper.statelib.impl.rocksdb.RocksUtils;
+import org.apache.bookkeeper.stream.proto.kv.store.CheckpointMetadata;
+import org.apache.bookkeeper.stream.proto.kv.store.FileInfo;
+
+/**
+ * CheckpointFile encapsulates the attributes and operations for a file in checkpoint.
+ */
+@Slf4j
+@lombok.Builder
+@lombok.EqualsAndHashCode
+public class CheckpointFile {
+    private final File file;
+    private final String checksum;
+    private final boolean isSstFile;
+
+    private CheckpointFile(File file, String checksum, boolean isSstFile) {
+        this.file = file;
+        this.checksum = checksum;
+        this.isSstFile = isSstFile;
+    }
+
+    /**
+     * CheckpointFileBuilder for building instances of CheckpointFile objects.
+     */
+    public static class CheckpointFileBuilder {
+        CheckpointFileBuilder file(File file) {
+            this.file = file;
+            this.isSstFile = RocksUtils.isSstFile(this.file);
+            return this;
+        }
+        CheckpointFileBuilder file(File checkpointDir, String filename) {
+            file(new File(checkpointDir, filename));
+            return this;
+        }
+
+        CheckpointFileBuilder computeChecksum() {
+            return checksum(computeChecksum(this.file));
+        }
+
+        private static String computeChecksum(File file) {
+            String ckSum = "invalid-" + System.currentTimeMillis();
+            try {
+                ckSum = Files.asByteSource(file).hash(Hashing.sha256()).toString();
+                return ckSum;
+            } catch (IOException e) {
+                log.error("Failed to get checksum for file {} {}", file.getName(), e.getMessage(), e);
+            }
+            return ckSum;
+        }
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public String toString() {
+        return String.format("CheckpointFile: %s", file.getName());
+    }
+
+    public boolean isSstFile() {
+        return isSstFile;
+    }
+
+    public String getName() {
+        return file.getName();
+    }
+
+    public String getNameWithChecksum() {
+        if (checksum != null) {
+            return file.getName() + "_" + checksum;
+        }
+        return getName();
+    }
+
+    public String getRemoteSstPath(String dbPrefix, boolean enableChecksum) {
+        if (enableChecksum) {
+            return RocksUtils.getDestSstPath(dbPrefix, getNameWithChecksum());
+        } else {
+            return RocksUtils.getDestSstPath(dbPrefix, getName());
+        }
+    }
+
+    public String getRemotePath(String dbPrefix, String checkpointId, boolean enableChecksum) {
+        if (isSstFile) {
+            return getRemoteSstPath(dbPrefix, enableChecksum);
+        }
+        return RocksUtils.getDestPath(dbPrefix, checkpointId, file);
+    }
+
+    public static List<CheckpointFile> list(File checkpointedDir) {
+        // List for files from checkpoint folder
+        return Arrays.stream(checkpointedDir.listFiles())
+            .map(f -> CheckpointFile.builder()
+                .file(f)
+                .computeChecksum()
+                .build())
+            .collect(Collectors.toList());
+    }
+
+    public static List<CheckpointFile> list(File checkpointDir, CheckpointMetadata metadata) {
+        // List for files from checkpoint metadata
+        if (metadata.getFileInfosCount() != 0) {
+            return metadata.getFileInfosList().stream()
+                .map(f -> CheckpointFile.builder()
+                    .file(checkpointDir, f.getName())
+                    .checksum(f.getChecksum())
+                    .build())
+                .collect(Collectors.toList());
+        } else {
+            // Old checkpoint without checksums
+            return metadata.getFilesList().stream()
+                .map(f -> CheckpointFile.builder()
+                    .file(checkpointDir, f)
+                    .build())
+                .collect(Collectors.toList());
+        }
+    }
+
+    public boolean needCopy(CheckpointStore checkpointStore, String dbPrefix, boolean enableChecksum) {
+        if (!isSstFile) {
+            // Always copy the non SST files
+            return true;
+        }
+        // sst files
+        String destSstPath = getRemoteSstPath(dbPrefix, enableChecksum);
+        try {
+            if (checkpointStore.fileExists(destSstPath)) {
+                return false;
+            }
+        } catch (IOException e) {
+            log.error("Failed fileExists {} {}", file.getName(), e.getMessage(), e);
+        }
+        return true;
+    }
+
+    public void copyToRemote(CheckpointStore checkpointStore, String dbPrefix, String checkpointId) throws IOException {
+        String destPath = RocksUtils.getDestPath(dbPrefix, checkpointId, getName());
+        try (OutputStream os = checkpointStore.openOutputStream(destPath)) {
+            Files.copy(file, os);
+        }
+    }
+
+    public void finalize(CheckpointStore checkpointStore,
+                         String dbPrefix,
+                         String checkpointId,
+                         boolean enableChecksum,
+                         boolean enableNonChecksumCompatibility) throws IOException {
+        if (!RocksUtils.isSstFile(file)) {
+            return;
+        }
+        // Move the SST file to common area where it can be shared among other checkpoints
+        String destSstTempPath = RocksUtils.getDestPath(dbPrefix, checkpointId, getName());
+        String destSstPath = getRemoteSstPath(dbPrefix, enableChecksum);
+        checkpointStore.rename(destSstTempPath, destSstPath);
+
+        if (enableChecksum && enableNonChecksumCompatibility) {
+            copyToRemoteWithoutChecksum(checkpointStore, dbPrefix, checkpointId);
+        }
+    }
+
+    public void copyToRemoteWithoutChecksum(CheckpointStore checkpointStore,
+                                            String dbPrefix,
+                                            String checkpointId) throws IOException {
+        String destPath = getRemoteSstPath(dbPrefix, false);
+
+        try (OutputStream os = checkpointStore.openOutputStream(destPath)) {
+            Files.copy(file, os);
+        }
+    }
+
+    public void copyFromRemote(CheckpointStore checkpointStore,
+                               String dbPrefix,
+                               String checkpointId) throws IOException {
+        String remoteFilePath = getRemotePath(dbPrefix, checkpointId, true);
+
+        try (InputStream is = checkpointStore.openInputStream(remoteFilePath)) {
+            java.nio.file.Files.copy(
+                is,
+                Paths.get(file.getAbsolutePath()),
+                StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+
+    public FileInfo getFileInfo() {
+        return FileInfo.newBuilder()
+            .setName(file.getName())
+            .setChecksum(checksum)
+            .build();
+    }
+}

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/RocksCheckpointer.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/rocksdb/checkpoint/RocksCheckpointer.java
@@ -125,19 +125,25 @@ public class RocksCheckpointer implements AutoCloseable {
     private final CheckpointStore checkpointStore;
     private final boolean removeLocalCheckpointAfterSuccessfulCheckpoint;
     private final boolean removeRemoteCheckpointsAfterSuccessfulCheckpoint;
+    private final boolean checkpointChecksumEnable;
+    private final boolean checkpointChecksumCompatible;
 
     public RocksCheckpointer(String dbName,
                              File dbPath,
                              RocksDB rocksDB,
                              CheckpointStore checkpointStore,
                              boolean removeLocalCheckpointAfterSuccessfulCheckpoint,
-                             boolean removeRemoteCheckpointsAfterSuccessfulCheckpoint) {
+                             boolean removeRemoteCheckpointsAfterSuccessfulCheckpoint,
+                             boolean checkpointChecksumEnable,
+                             boolean checkpointChecksumCompatible) {
         this.dbName = dbName;
         this.dbPath = dbPath;
         this.checkpoint = Checkpoint.create(rocksDB);
         this.checkpointStore = checkpointStore;
         this.removeLocalCheckpointAfterSuccessfulCheckpoint = removeLocalCheckpointAfterSuccessfulCheckpoint;
         this.removeRemoteCheckpointsAfterSuccessfulCheckpoint = removeRemoteCheckpointsAfterSuccessfulCheckpoint;
+        this.checkpointChecksumEnable = checkpointChecksumEnable;
+        this.checkpointChecksumCompatible = checkpointChecksumCompatible;
     }
 
     public String checkpointAtTxid(byte[] txid) throws StateStoreException {
@@ -147,7 +153,10 @@ public class RocksCheckpointer implements AutoCloseable {
             new File(dbPath, "checkpoints"),
             checkpointStore,
             removeLocalCheckpointAfterSuccessfulCheckpoint,
-            removeRemoteCheckpointsAfterSuccessfulCheckpoint);
+            removeRemoteCheckpointsAfterSuccessfulCheckpoint,
+            checkpointChecksumEnable,
+            checkpointChecksumCompatible
+        );
         return task.checkpoint(txid);
     }
 

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVAsyncStoreWithCheckpoints.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVAsyncStoreWithCheckpoints.java
@@ -146,6 +146,8 @@ public class TestRocksdbKVAsyncStoreWithCheckpoints extends TestDistributedLogBa
             .checkpointStore(checkpointStore)
             .checkpointIOScheduler(checkpointExecutor)
             .checkpointDuration(Duration.ofMinutes(1))
+            .checkpointChecksumEnable(true)
+            .checkpointChecksumCompatible(false)
             .build();
     }
 

--- a/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/conf/StorageConfiguration.java
+++ b/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/conf/StorageConfiguration.java
@@ -31,6 +31,10 @@ public class StorageConfiguration extends ComponentConfiguration {
 
     private static final String CONTROLLER_SCHEDULE_INTERVAL_MS = "cluster.controller.schedule.interval.ms";
 
+    private static final String CHECKPOINT_CHECKSUM_ENABLE = "checkpoint.checksum.enable";
+
+    private static final String CHECKPOINT_CHECKSUM_COMPATIBLE = "checkpoint.checksum.compatible";
+
     public StorageConfiguration(CompositeConfiguration conf) {
         super(conf, COMPONENT_PREFIX);
     }
@@ -87,6 +91,14 @@ public class StorageConfiguration extends ComponentConfiguration {
     public StorageConfiguration setClusterControllerScheduleInterval(long time, TimeUnit timeUnit) {
         setProperty(CONTROLLER_SCHEDULE_INTERVAL_MS, timeUnit.toMillis(time));
         return this;
+    }
+
+    public boolean getCheckpointChecksumEnable() {
+        return getBoolean(CHECKPOINT_CHECKSUM_ENABLE, true);
+    }
+
+    public boolean getCheckpointChecksumCompatible() {
+        return getBoolean(CHECKPOINT_CHECKSUM_COMPATIBLE, true);
     }
 
 }

--- a/stream/storage/impl/src/test/java/org/apache/bookkeeper/stream/storage/impl/store/MVCCStoreFactoryImplTest.java
+++ b/stream/storage/impl/src/test/java/org/apache/bookkeeper/stream/storage/impl/store/MVCCStoreFactoryImplTest.java
@@ -39,6 +39,8 @@ import org.apache.bookkeeper.statelib.api.mvcc.MVCCAsyncStore;
 import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.fs.FSCheckpointManager;
 import org.apache.bookkeeper.stream.storage.StorageResources;
 import org.apache.bookkeeper.stream.storage.StorageResourcesSpec;
+import org.apache.bookkeeper.stream.storage.conf.StorageConfiguration;
+import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.distributedlog.DLSN;
 import org.apache.distributedlog.LogRecord;
 import org.apache.distributedlog.LogRecordWithDLSN;
@@ -64,6 +66,11 @@ public class MVCCStoreFactoryImplTest {
     private File[] storeDirs;
     private StorageResources resources;
     private MVCCStoreFactoryImpl factory;
+
+    private final CompositeConfiguration compConf =
+        new CompositeConfiguration();
+    private final StorageConfiguration storageConf =
+        new StorageConfiguration(compConf);
 
     @Before
     public void setup() throws IOException {
@@ -103,7 +110,7 @@ public class MVCCStoreFactoryImplTest {
             () -> new FSCheckpointManager(new File(storeDirs[0], "checkpoints")),
             storeDirs,
             resources,
-            false);
+            false, storageConf);
     }
 
     @Test


### PR DESCRIPTION

### Motivation

Normally the SST file are immutable. A SST file from previous checkpoint can
be reused in subsequent checkpoints. This fact is used to avoid unnecessary
upload of SST files.

However there are scenarios in which just the name comparison doesn't work.
It is possible that the checkpoint process doesn't complete (due to
crash/restart). In such cases the stale SST files are left behind. When the
storage container is restarted, it will be correctly restored from previous
checkpoint. When we do a checkpoint on this new state, a new SST files
are created. Since we only compare the SST file names, we assume that files is
already available in the checkpoint store.

At best the size of the new files will mismatch, and restore will fail. But if
the size of the files match, restore will succeed and we will have invalid
data in the state store.

### Changes

With this change we are adding the checksum for the SST files. The checksum
will be appended to the name when the SST file is uploaded. This will ensure
that the correct files are always uploaded
