### PR TITLE
adjust default rocksDbBlockCache size to 10%/numberOfLedgers of direct memory

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -103,8 +103,9 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
             options.setCreateIfMissing(true);
 
             if (dbConfigType == DbConfigType.Huge) {
-                // Set default RocksDB block-cache size to 10% of direct mem, unless override
-                long defaultRocksDBBlockCacheSizeBytes = PlatformDependent.maxDirectMemory() / 10;
+                // Set default RocksDB block-cache size to 10% / numberOfLedgers of direct memory, unless override
+                int ledgerDirsSize = conf.getLedgerDirNames().length;
+                long defaultRocksDBBlockCacheSizeBytes = PlatformDependent.maxDirectMemory() / ledgerDirsSize / 10;
                 long blockCacheSize = DbLedgerStorage.getLongVariableOrDefault(conf, ROCKSDB_BLOCK_CACHE_SIZE,
                         defaultRocksDBBlockCacheSizeBytes);
 

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -684,8 +684,8 @@ ledgerDirectories=/tmp/bk-data
 # Size of RocksDB block-cache. For best performance, this cache
 # should be big enough to hold a significant portion of the index
 # database which can reach ~2GB in some cases
-# Default is 256 MBytes
-# dbStorage_rocksDB_blockCacheSize=268435456
+# Default is to use 10% / numberOfLedgers of the direct memory size
+# dbStorage_rocksDB_blockCacheSize=
 
 # Other RocksDB specific tunables
 # dbStorage_rocksDB_writeBufferSizeMB=64


### PR DESCRIPTION
### Motivation
For dbLedgerStorage, it will initiate an RocksDB instance for each ledger directory. However, for each RocksDB instance, it will set defaultRocksDBBlockCacheSizeBytes to  10% of direct memory. If we configured multi ledger directories and default dbStorage_rocksDB_blockCacheSize, the direct memory will be exhausted and cause Out Of Memory Error(OOM)

### Changes
1. Change default dbStorage_rocksDB_blockCacheSize to 10% / numberOfLedgers of direct memory.