### PR TITLE
fix openLedgerRereplicationGracePeriod default value doc

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -928,9 +928,9 @@ zkEnableSecurity=false
 # The number of entries that a replication will rereplicate in parallel.
 # rereplicationEntryBatchSize=10
 
-# The grace period, in seconds, that the replication worker waits before fencing and
+# The grace period, in milliseconds, that the replication worker waits before fencing and
 # replicating a ledger fragment that's still being written to upon bookie failure.
-# openLedgerRereplicationGracePeriod=30
+# openLedgerRereplicationGracePeriod=30000
 
 # The time to backoff when replication worker encounters exceptions on replicating a ledger, in milliseconds.
 # rwRereplicateBackoffMs=5000


### PR DESCRIPTION
### Motivation
`openLedgerRereplicationGracePeriod` default value doc doesn't consistent with the code

### Changes
1. update default value doc for bk_server.conf