### PR TITLE
Defect-Fix Compaction status report into correct buckets.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -454,9 +454,7 @@ public class GarbageCollectorThread extends SafeRunnable {
         int[] entryLogUsageBuckets = new int[numBuckets];
 
         for (EntryLogMetadata meta : logsToCompact) {
-            int bucketIndex = Math.min(
-                    numBuckets - 1,
-                    (int) Math.ceil(meta.getUsage() * numBuckets));
+            int bucketIndex = calculateUsageIndex(numBuckets, meta.getUsage());
             entryLogUsageBuckets[bucketIndex]++;
 
             if (meta.getUsage() >= threshold) {
@@ -477,6 +475,19 @@ public class GarbageCollectorThread extends SafeRunnable {
         LOG.info(
                 "Compaction: entry log usage buckets[10% 20% 30% 40% 50% 60% 70% 80% 90% 100%] = {}",
                 entryLogUsageBuckets);
+    }
+
+    /**
+     * Calculate the index for the batch based on the usage between 0 and 1.
+     *
+     * @param numBuckets Number of reporting buckets.
+     * @param usage 0.0 - 1.0 value representing the usage of the entry log.
+     * @return index based on the number of buckets The last bucket will have the 1.0 if added.
+     */
+    int calculateUsageIndex(int numBuckets, double usage) {
+        return Math.min(
+                numBuckets - 1,
+                (int) Math.floor(usage * numBuckets));
     }
 
     /**


### PR DESCRIPTION
The compaction status report is off by 1. 

When compaction is enabled, the 10% log is always empty. Setting the compaction threshold to .2 we were seeing the number of compacted entrylogs that were removed, match the sum of the 20% and 30% buckets. While the 10% bucket remained empty. Increasing the threshold to .3 we would see the sum of the first 4 buckets compacted (10%-40%). Also with the 10% bucket empty. 

Upon inspection of the code, the code is using the .ceil function to calculate the bucket index to be updated. This means that 10% bucket will never be used. However, there could be a rare 100% case in which the code runs into a index out of bounds exception when the entrylog is actually 100% used.  The index calculation should be using floor and not the ceil call using the next index lower. So usage of .00 to .9 ends up in the 0 index instead of the current calculation which puts the .0 - .9  in the 1 index. 

This will leave the 100% index empty most of the time, as rarely will the entry logs be 100% used. 

