### PR TITLE
Auto-throttle read operations

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -203,7 +203,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String MAX_PENDING_ADD_REQUESTS_PER_THREAD = "maxPendingAddRequestsPerThread";
     protected static final String NUM_LONG_POLL_WORKER_THREADS = "numLongPollWorkerThreads";
     protected static final String NUM_HIGH_PRIORITY_WORKER_THREADS = "numHighPriorityWorkerThreads";
-    protected static final String READ_WORKER_THREADS_THROTTLE = "readWorkerThreadsThrottle";
+    protected static final String READ_WORKER_THREADS_THROTTLING_ENABLED = "readWorkerThreadsThrottlingEnabled";
 
     // Long poll parameters
     protected static final String REQUEST_TIMER_TICK_DURATION_MILLISEC = "requestTimerTickDurationMs";
@@ -1765,8 +1765,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      *          whether to throttle the read workers threads
      * @return server configuration
      */
-    public ServerConfiguration setReadWorkerThreadsThrottle(boolean throttle) {
-        setProperty(READ_WORKER_THREADS_THROTTLE, throttle);
+    public ServerConfiguration setReadWorkerThreadsThrottlingEnabled(boolean throttle) {
+        setProperty(READ_WORKER_THREADS_THROTTLING_ENABLED, throttle);
         return this;
     }
 
@@ -1774,8 +1774,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * Get the auto-throttling status of the read-worker threads.
      * @return
      */
-    public boolean isReadWorkerThreadsThrottle() {
-        return getBoolean(READ_WORKER_THREADS_THROTTLE, true);
+    public boolean isReadWorkerThreadsThrottlingEnabled() {
+        return getBoolean(READ_WORKER_THREADS_THROTTLING_ENABLED, true);
     }
 
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -1771,7 +1771,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get the auto-throttling status of the read-worker threads
+     * Get the auto-throttling status of the read-worker threads.
      * @return
      */
     public boolean isReadWorkerThreadsThrottle() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -203,6 +203,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String MAX_PENDING_ADD_REQUESTS_PER_THREAD = "maxPendingAddRequestsPerThread";
     protected static final String NUM_LONG_POLL_WORKER_THREADS = "numLongPollWorkerThreads";
     protected static final String NUM_HIGH_PRIORITY_WORKER_THREADS = "numHighPriorityWorkerThreads";
+    protected static final String READ_WORKER_THREADS_THROTTLE = "readWorkerThreadsThrottle";
 
     // Long poll parameters
     protected static final String REQUEST_TIMER_TICK_DURATION_MILLISEC = "requestTimerTickDurationMs";
@@ -1754,6 +1755,29 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     public int getNumHighPriorityWorkerThreads() {
         return getInt(NUM_HIGH_PRIORITY_WORKER_THREADS, 8);
     }
+
+    /**
+     * Use auto-throttling of the read-worker threads. This is done
+     * to ensure the bookie is not using unlimited amount of memory
+     * to respond to read-requests.
+     *
+     * @param throttle
+     *          whether to throttle the read workers threads
+     * @return server configuration
+     */
+    public ServerConfiguration setReadWorkerThreadsThrottle(boolean throttle) {
+        setProperty(READ_WORKER_THREADS_THROTTLE, throttle);
+        return this;
+    }
+
+    /**
+     * Get the auto-throttling status of the read-worker threads
+     * @return
+     */
+    public boolean isReadWorkerThreadsThrottle() {
+        return getBoolean(READ_WORKER_THREADS_THROTTLE, true);
+    }
+
 
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -137,7 +137,7 @@ public class BookieRequestProcessor implements RequestProcessor {
         this.waitTimeoutOnBackpressureMillis = serverCfg.getWaitTimeoutOnResponseBackpressureMillis();
         this.preserveMdcForTaskExecution = serverCfg.getPreserveMdcForTaskExecution();
         this.bookie = bookie;
-        this.throttleReadResponses = serverCfg.isReadWorkerThreadsThrottle();
+        this.throttleReadResponses = serverCfg.isReadWorkerThreadsThrottlingEnabled();
         this.readThreadPool = createExecutor(
                 this.serverCfg.getNumReadWorkerThreads(),
                 "BookieReadThreadPool",

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -128,6 +128,8 @@ public class BookieRequestProcessor implements RequestProcessor {
 
     private final ByteBufAllocator allocator;
 
+    private final boolean throttleReadResponses;
+
     public BookieRequestProcessor(ServerConfiguration serverCfg, Bookie bookie, StatsLogger statsLogger,
             SecurityHandlerFactory shFactory, ByteBufAllocator allocator) throws SecurityException {
         this.serverCfg = serverCfg;
@@ -135,6 +137,7 @@ public class BookieRequestProcessor implements RequestProcessor {
         this.waitTimeoutOnBackpressureMillis = serverCfg.getWaitTimeoutOnResponseBackpressureMillis();
         this.preserveMdcForTaskExecution = serverCfg.getPreserveMdcForTaskExecution();
         this.bookie = bookie;
+        this.throttleReadResponses = serverCfg.isReadWorkerThreadsThrottle();
         this.readThreadPool = createExecutor(
                 this.serverCfg.getNumReadWorkerThreads(),
                 "BookieReadThreadPool",
@@ -643,7 +646,7 @@ public class BookieRequestProcessor implements RequestProcessor {
     private void processReadRequest(final BookieProtocol.ReadRequest r, final Channel c) {
         ExecutorService fenceThreadPool =
                 null == highPriorityThreadPool ? null : highPriorityThreadPool.chooseThread(c);
-        ReadEntryProcessor read = ReadEntryProcessor.create(r, c, this, fenceThreadPool);
+        ReadEntryProcessor read = ReadEntryProcessor.create(r, c, this, fenceThreadPool, throttleReadResponses);
 
         // If it's a high priority read (fencing or as part of recovery process), we want to make sure it
         // gets executed as fast as possible, so bypass the normal readThreadPool

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -76,8 +76,8 @@ abstract class PacketProcessorBase<T extends Request> extends SafeRunnable {
 
     /**
      * Write on the channel and wait until the write is completed.
-     * <p>
-     * That will make the thread to get blocked until we're able to
+     *
+     * <p>That will make the thread to get blocked until we're able to
      * write everything on the TCP stack, providing auto-throttling
      * and avoiding using too much memory when handling read-requests.
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -19,7 +19,6 @@ package org.apache.bookkeeper.proto;
 
 import io.netty.channel.Channel;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.proto.BookieProtocol.Request;
@@ -77,7 +76,7 @@ abstract class PacketProcessorBase<T extends Request> extends SafeRunnable {
 
     /**
      * Write on the channel and wait until the write is completed.
-     *
+     * <p>
      * That will make the thread to get blocked until we're able to
      * write everything on the TCP stack, providing auto-throttling
      * and avoiding using too much memory when handling read-requests.

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -137,6 +137,11 @@ extraServerComponents=
 # avoid the executor queue to grow indefinitely
 # maxPendingAddRequestsPerThread=10000
 
+# Use auto-throttling of the read-worker threads. This is done
+# to ensure the bookie is not using unlimited amount of memory
+# to respond to read-requests.
+# readWorkerThreadsThrottle=true
+
 # Option to enable busy-wait settings. Default is false.
 # WARNING: This option will enable spin-waiting on executors and IO threads in order to reduce latency during
 # context switches. The spinning will consume 100% CPU even when bookie is not doing any work. It is recommended to

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -140,7 +140,7 @@ extraServerComponents=
 # Use auto-throttling of the read-worker threads. This is done
 # to ensure the bookie is not using unlimited amount of memory
 # to respond to read-requests.
-# readWorkerThreadsThrottle=true
+# readWorkerThreadsThrottlingEnabled=true
 
 # Option to enable busy-wait settings. Default is false.
 # WARNING: This option will enable spin-waiting on executors and IO threads in order to reduce latency during


### PR DESCRIPTION
### Motivation

When bookie is doing reads, it may use a considerable amount of memory if there are many simultaneous readers and especially when the network becomes the bottleneck.

The problem is that the read thread is scheduling the async operation to write on the socket and then it moves on for the next read operation. If the TCP window is full, these write requests on the socket are just piling up in memory, resulting in a spike of direct memory usage, which may exceed the max configured in the JVM.

Instead, if the socket write operation is blocking, we should block the BK read thread in order to auto-throttle and limit the amount of memory. 

This change does not introduce any performance penalty on the read-path. The old behavior will still be available as a config option.