### PR TITLE
Limit read-ahead bytes to the size of the read cache

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -134,6 +134,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
     private static final long DEFAULT_MAX_THROTTLE_TIME_MILLIS = TimeUnit.SECONDS.toMillis(10);
 
+    private final long maxReadAheadBytesSize;
+
     public SingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
             LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager, StateManager stateManager,
             CheckpointSource checkpointSource, Checkpointer checkpointer, StatsLogger statsLogger,
@@ -154,6 +156,9 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
         readCacheMaxSize = readCacheSize;
         readAheadCacheBatchSize = conf.getInt(READ_AHEAD_CACHE_BATCH_SIZE, DEFAULT_READ_AHEAD_CACHE_BATCH_SIZE);
+
+        // Do not attempt to perform read-ahead more than half the total size of the cache
+        maxReadAheadBytesSize = readCacheMaxSize / 2;
 
         long maxThrottleTimeMillis = conf.getLong(DbLedgerStorage.MAX_THROTTLE_TIME_MILLIS,
                 DEFAULT_MAX_THROTTLE_TIME_MILLIS);
@@ -469,7 +474,9 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             int count = 0;
             long size = 0;
 
-            while (count < readAheadCacheBatchSize && currentEntryLogId == firstEntryLogId) {
+            while (count < readAheadCacheBatchSize
+                    && size < readAheadCacheBatchSize
+                    && currentEntryLogId == firstEntryLogId) {
                 ByteBuf entry = entryLogger.internalReadEntry(orginalLedgerId, firstEntryId, currentEntryLocation,
                         false /* validateEntry */);
 


### PR DESCRIPTION
### Motivation

In DbLedgerStorage, the read ahead that feeds the read cache is being configured in terms of number of entries. If the entry size is big and the read cache is small, this could lead to trashing the read cache.

For example, a read-ahead of 1000 entries with 1MB avg size would pre-fetch a 1GB from volume. In the read-ahead there would never be a good read to pre-fetch an amount of data that exceeds the read cache size.