### PR TITLE
Exception in BK GC with corrupted data files

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1009,6 +1009,9 @@ public class EntryLogger {
                     continue;
                 }
                 // read the entry
+                if (entrySize == 0) {
+                    continue;
+                }
 
                 data.clear();
                 if (entrySize < 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1009,12 +1009,8 @@ public class EntryLogger {
                     continue;
                 }
                 // read the entry
-                if (entrySize == 0) {
-                    continue;
-                }
-
                 data.clear();
-                if (entrySize < 0) {
+                if (entrySize <= 0) {
                     LOG.warn("bad read for ledger entry from entryLog {}@{} (entry size {})",
                             entryLogId, pos, entrySize);
                     return;


### PR DESCRIPTION
### Motivation

In case of corrupted entry log, this exception can show up during the compaction phase: 

```
18:53:37.224 [GarbageCollectorThread-7-1] ERROR org.apache.bookkeeper.bookie.GarbageCollectorThread - Failed to compact entry log 16 due to unexpected error
java.lang.IndexOutOfBoundsException: index: 8, length: 8 (expected: range(0, 0))
	at io.netty.buffer.AbstractByteBuf.checkRangeBounds(AbstractByteBuf.java:1425) ~[netty-buffer-4.1.51.Final.jar:4.1.51.Final]
	at io.netty.buffer.AbstractByteBuf.checkIndex0(AbstractByteBuf.java:1432) ~[netty-buffer-4.1.51.Final.jar:4.1.51.Final]
	at io.netty.buffer.AbstractByteBuf.checkIndex(AbstractByteBuf.java:1419) ~[netty-buffer-4.1.51.Final.jar:4.1.51.Final]
	at io.netty.buffer.UnpooledUnsafeDirectByteBuf.getLong(UnpooledUnsafeDirectByteBuf.java:144) ~[netty-buffer-4.1.51.Final.jar:4.1.51.Final]
	at org.apache.bookkeeper.bookie.EntryLogCompactor$CompactionScannerFactory$1.process(EntryLogCompactor.java:103) ~[bookkeeper-server-4.11.0.SPLK.8715995.jar:?]
	at org.apache.bookkeeper.bookie.EntryLogger.scanEntryLog(EntryLogger.java:1011) ~[bookkeeper-server-4.11.0.SPLK.8715995.jar:?]
	at org.apache.bookkeeper.bookie.EntryLogCompactor.compact(EntryLogCompactor.java:64) ~[bookkeeper-server-4.11.0.SPLK.8715995.jar:?]
	at org.apache.bookkeeper.bookie.GarbageCollectorThread.compactEntryLog(GarbageCollectorThread.java:528) [bookkeeper-server-4.11.0.SPLK.8715995.jar:?]
	at org.apache.bookkeeper.bookie.GarbageCollectorThread.doCompactEntryLogs(GarbageCollectorThread.java:462) [bookkeeper-server-4.11.0.SPLK.8715995.jar:?]
	at org.apache.bookkeeper.bookie.GarbageCollectorThread.runWithFlags(GarbageCollectorThread.java:367) [bookkeeper-server-4.11.0.SPLK.8715995.jar:?]
	at org.apache.bookkeeper.bookie.GarbageCollectorThread.safeRun(GarbageCollectorThread.java:316) [bookkeeper-server-4.11.0.SPLK.8715995.jar:?]
	at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [bookkeeper-common-4.11.0.SPLK.8715995.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_232]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_232]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_232]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_232]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_232]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_232]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.51.Final.jar:4.1.51.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_232]
```