### PR TITLE
Fixed get-pip URL in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN set -x \
     && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
     && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
     # install zookeeper shell
-    && wget -q https://bootstrap.pypa.io/2.7/get-pip.py \
+    && wget -q https://bootstrap.pypa.io/pip/2.7/get-pip.py \
     && python --version \
     && python get-pip.py \
     && pip install zk-shell \

--- a/tests/docker-images/current-version-image/Dockerfile
+++ b/tests/docker-images/current-version-image/Dockerfile
@@ -40,7 +40,7 @@ RUN set -x \
     && mkdir -pv /opt \
     && cd /opt \
     # install zookeeper shell
-    && wget -q https://bootstrap.pypa.io/2.7/get-pip.py \
+    && wget -q https://bootstrap.pypa.io/pip/2.7/get-pip.py \
     && python get-pip.py \
     && pip install zk-shell \
     && rm -rf get-pip.py \


### PR DESCRIPTION
### Motivation

Integration tests are failing because the URL for get-pip.py has changed: 

```
[INFO] + wget -q https://bootstrap.pypa.io/2.7/get-pip.py
[INFO] 
[INFO] + python get-pip.py
[INFO] 
[INFO] 
[INFO] Hi there!
[INFO] 
[INFO] The URL you are using to fetch this script has changed, and this one will no
[INFO] longer work. Please use get-pip.py from the following URL instead:
[INFO] 
[INFO]     https://bootstrap.pypa.io/pip/2.7/get-pip.py
[INFO] 
[INFO] Sorry if this change causes any inconvenience for you!
[INFO] 
[INFO] We don't have a good mechanism to make more gradual changes here, and this
[INFO] renaming is a part of an effort to make it easier to us to update these
[INFO] scripts, when there's a pip release. It's also essential for improving how we
[INFO] handle the `get-pip.py` scripts, when pip drops support for a Python minor
[INFO] version.
[INFO] 
[INFO] There are no more renames/URL changes planned, and we don't expect that a need
[INFO] would arise to do this again in the near future.
[INFO] 
[INFO] Thanks for understanding!
[INFO] 
[INFO] - Pradyun, on behalf of the volunteers who maintain pip.
[INFO] 
[INFO] 
Error:  The command '/bin/sh -c set -x     && adduser "${BK_USER}"     && yum install -y epel-release     && yum install -y java-11-openjdk-devel wget bash python-pip python-devel sudo netcat gcc gcc-c++     && mkdir -pv /opt     && cd /opt     && wget -q https://bootstrap.pypa.io/2.7/get-pip.py     && python get-pip.py     && pip install zk-shell     && rm -rf get-pip.py     && yum clean all' returned a non-zero code: 1
```