### PR TITLE
[Doc] Correct the argument of the recover command of bookie shell

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -489,7 +489,7 @@ public class BookieShell implements Tool {
 
         @Override
         String getUsage() {
-            return "recover [-deleteCookie] <bookieSrc[:bookieSrc]>";
+            return "recover [-deleteCookie] <bookieSrc[,bookieSrc,...]>";
         }
 
         @Override

--- a/site/_data/cli/shell.yaml
+++ b/site/_data/cli/shell.yaml
@@ -145,7 +145,7 @@ commands:
     description: End Position
 - name: recover
   description: Recover the ledger data for failed bookie.
-  argument: <bookieSrc> [<bookieDest>]
+  argument: <bookieSrc[,bookieSrc,...]>
   options:
   - flag: -deleteCookie
     description: Delete cookie node for the bookie.


### PR DESCRIPTION
The arguments in the bookie shell documentation and help are incorrect.

In the past, the `recover` command required two arguments, `bookieSrc` and `bookieDest`, but now there is only one, `bookieSrc`.
https://github.com/apache/bookkeeper/commit/dad7e2ce0d1cf8f04c7e2f128900ea69792c948d#diff-981f006571d24dbcd1538399a5974163e7550e20bf7b49622b5a624d93fb40ceL305

In addition, we can specify multiple `bookieSrc`, but the delimiter is "," instead of ":".
https://github.com/apache/bookkeeper/blob/b1e602afc93cfd6299c43f99d26c9a6b7bcd27a7/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/RecoverCommand.java#L125