### PR TITLE
Issue 2615: Fix for invalid ensemble issue during ledger recovery

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -104,7 +104,24 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
                     public void readLastConfirmedDataComplete(int rc, RecoveryData data) {
                         if (rc == BKException.Code.OK) {
                             synchronized (lh) {
-                                lh.lastAddPushed = lh.lastAddConfirmed = data.getLastAddConfirmed();
+                                /**
+                                 The lowest an LAC can be for use in recovery is the first entry id
+                                 of the current ensemble - 1.
+                                 All ensembles prior to the current one, if any, are confirmed and
+                                 immutable (so are not part of the recovery process).
+                                 So we take the highest of:
+                                 - the LAC returned by the current bookie ensemble (could be -1)
+                                 - the first entry id of the current ensemble - 1.
+                                 */
+                                Long lastEnsembleEntryId = lh.getVersionedLedgerMetadata()
+                                        .getValue()
+                                        .getAllEnsembles()
+                                        .lastEntry()
+                                        .getKey();
+
+                                lh.lastAddPushed = lh.lastAddConfirmed = Math.max(data.getLastAddConfirmed(),
+                                        (lastEnsembleEntryId - 1));
+
                                 lh.length = data.getLength();
                                 lh.pendingAddsSequenceHead = lh.lastAddConfirmed;
                                 startEntryToRead = endEntryToRead = lh.lastAddConfirmed;


### PR DESCRIPTION
Ensures that only entries of the current ensemble are included in the ledger recovery process, thus avoiding a ledger recovery failure scenario where it tries to append an ensemble with a lower first entry id than the prior ensemble.

Descriptions of the changes in this PR:

This PR includes a small change in the LedgerRecoveryOp that avoids a scenario where ledger recovery tries to create an invalid ensemble thereby failing. This could cause data unavailability for as long as trigger conditions last.

During ledger recovery, only entries of the current ensemble can be included in the read and write back phase. Prior ensembles, if any, are immutable. But it is possible, in a multi-ensemble ledger, for the current ensemble to return an LAC of -1. This then causes the recovery to read entries from prior ensembles and write them back to the current ensemble. This does not cause any data loss, but it is wasteful of both space and time. The main issue is that if an ensemble change occurs when writing back entries, it will try and create a new ensemble with first entry id of 0. This causes an IllegalStateException as there is a check before the CAS metadata op to ensure that the ensemble does not have an entry id lower than an existing ensemble.

If a bookie of the current ensemble were to be down, then the ledger would be unrecoverable until it became available again. 

The solution is that the lowest safe LAC for recovery is: first entry id of current ensemble - 1.

### Changes

Change to LedgerRecoveryOp as described above.
New unit test in LedgerRecoveryTest2.

Master Issue: #2615
