### PR TITLE
Upgrade Lombok version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <junit.version>4.12</junit.version>
     <libthrift5.version>0.5.0-1</libthrift5.version>
     <libthrift9.version>0.12.0</libthrift9.version>
-    <lombok.version>1.18.10</lombok.version>
+    <lombok.version>1.18.18</lombok.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.0.0</mockito.version>
     <netty.version>4.1.50.Final</netty.version>


### PR DESCRIPTION
### Motivation

- 1.18.18 includes fixes for IDE compatibility (IntelliJ, Eclipse, Netbeans).
  This is relevant while developing Bookkeeper.
  - see https://projectlombok.org/changelog for more details

### Modifications

Upgrade Lombok version from 1.18.10 to 1.18.18