### PR TITLE
fix always select the same region set bug for RegionAwareEnsemblePlacementPolicy

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -78,7 +78,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
     protected boolean enableValidation = true;
     protected boolean enforceDurabilityInReplace = false;
     protected Feature disableDurabilityFeature;
-    private int regionIndex = new Random().nextInt(Integer.MAX_VALUE);
+    private int lastRegionIndex = 0;
 
     RegionAwareEnsemblePlacementPolicy() {
         super();
@@ -332,7 +332,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                         effectiveMinRegionsForDurability, minNumRacksPerWriteQuorum);
                 remainingEnsembleBeforeIteration = remainingEnsemble;
                 int regionsToAllocate = numRemainingRegions;
-                int startRegionIndex = regionIndex % numRegionsAvailable;
+                int startRegionIndex = lastRegionIndex % numRegionsAvailable;
                 for (int i = 0; i < numRegionsAvailable; ++i) {
                     String region = availableRegions.get(startRegionIndex % numRegionsAvailable);
                     startRegionIndex++;
@@ -368,7 +368,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                                 regionsWiseAllocation.put(region, Pair.of(newEnsembleSize, newWriteQuorumSize));
                                 success = true;
                                 regionsToAllocate--;
-                                regionIndex = startRegionIndex;
+                                lastRegionIndex = startRegionIndex;
                                 LOG.info("Region {} allocating bookies with ensemble size {} "
                                         + "and write quorum size {} : {}",
                                         region, newEnsembleSize, newWriteQuorumSize, allocated);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -333,7 +333,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
                 remainingEnsembleBeforeIteration = remainingEnsemble;
                 int regionsToAllocate = numRemainingRegions;
                 int startRegionIndex = regionIndex % numRegionsAvailable;
-                for (int i = 0; i< numRegionsAvailable; ++i) {
+                for (int i = 0; i < numRegionsAvailable; ++i) {
                     String region = availableRegions.get(startRegionIndex % numRegionsAvailable);
                     startRegionIndex++;
                     final Pair<Integer, Integer> currentAllocation = regionsWiseAllocation.get(region);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -1480,4 +1480,48 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         assertEquals(ensemble.get(reoderSet.get(7)), addr4.toBookieId());
     }
 
+    public void testNewEnsembleSetWithFiveRegions() throws Exception {
+        repp.uninitalize();
+        repp = new RegionAwareEnsemblePlacementPolicy();
+        repp.initialize(conf, Optional.empty(), timer, DISABLE_ALL,
+            NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
+        BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
+        BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
+        BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
+        BookieSocketAddress addr5 = new BookieSocketAddress("127.0.0.6", 3181);
+
+        // Update dns mapping
+        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region1/r1");
+        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region2/r2");
+        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region3/r3");
+        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region4/r4");
+        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region5/r5");
+
+        // Update cluster
+        Set<BookieId> addrs = new HashSet<>();
+        addrs.add(addr1.toBookieId());
+        addrs.add(addr2.toBookieId());
+        addrs.add(addr3.toBookieId());
+        addrs.add(addr4.toBookieId());
+        addrs.add(addr5.toBookieId());
+
+        repp.onClusterChanged(addrs, new HashSet<>());
+        try {
+            List<BookieId> ensemble1 = repp.newEnsemble(3,3,2,
+                null, new HashSet<>()).getResult();
+            assertEquals(ensemble1.size(), 3);
+            List<BookieId> ensemble2 = repp.newEnsemble(3, 3, 2,
+                null, new HashSet<>()).getResult();
+            ensemble1.retainAll(ensemble2);
+            assert(ensemble1.size() >= 1);
+
+            List<BookieId> ensemble3 = repp.newEnsemble(3, 3, 2,
+                null, new HashSet<>()).getResult();
+            ensemble2.removeAll(ensemble3);
+            assert(ensemble2.size() >= 1);
+        } catch (BKNotEnoughBookiesException bnebe) {
+            fail("Should not get not enough bookies exception even there is only one rack.");
+        }
+    }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -1508,7 +1508,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
         repp.onClusterChanged(addrs, new HashSet<>());
         try {
-            List<BookieId> ensemble1 = repp.newEnsemble(3,3,2,
+            List<BookieId> ensemble1 = repp.newEnsemble(3, 3, 2,
                 null, new HashSet<>()).getResult();
             assertEquals(ensemble1.size(), 3);
             List<BookieId> ensemble2 = repp.newEnsemble(3, 3, 2,


### PR DESCRIPTION
### Motivation
When use `RegionAwareEnsemblePlacementPolicy` to select ensemble set, it always select the same region set for all ledger creation.

The reason is that it traverse the availableRegions set in the same order for ensemble selection and select bookies in the same region set, which lead the load not balance between regions.
```java
for (String region: availableRegions) {
        regionsWiseAllocation.put(region, Pair.of(0, 0));
}
...

for (Map.Entry<String, Pair<Integer, Integer>> regionEntry: regionsWiseAllocation.entrySet()) {
    // do selection
}
```

### Changes
1. introduce `regionIndex` field to mark next select index for available region list, avoiding traverse from the same position for each ensemble selection.

I will add the test latter.