### PR TITLE
ISSUE-2640: BP-43: Run integration tests with current source code.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,7 +35,7 @@ depVersions = [
     commonsLang2: "2.6",
     commonsLang3: "3.6",
     commonsBeanutils: "1.9.3",
-    curator: "4.0.1",
+    curator: "5.1.0",
     dockerJava: "3.2.5",
     errorprone: "2.1.2",
     freebuilder: "1.14.9",
@@ -44,11 +44,12 @@ depVersions = [
     groovy: "2.5.8",
     guava: "30.1-jre",
     hamcrest: "1.3",
+    hdrhistogram: "2.1.4",
     httpclient: "4.5.13",
-    jackson: "2.9.7",
+    jackson: "2.11.1",
     jcommander: "1.78",
     jctools: "2.1.2",
-    jetty: "9.4.5.v20170502",
+    jetty: "9.4.31.v20200723",
     jmock: "2.8.2",
     jna: "3.2.7",
     jsr305: "3.0.2",
@@ -74,10 +75,10 @@ depVersions = [
     shrinkwrap:"3.1.4",
     snappy: "1.1.7.7",
     thrift: "0.12.0",
-    testcontainers: "1.14.3",
+    testcontainers: "1.15.1",
     vertx: "3.9.2",
     yahooDatasketches: "0.8.3",
-    zookeeper: "3.4.13",
+    zookeeper: "3.6.2",
 ]
 
 depLibs = [
@@ -105,6 +106,7 @@ depLibs = [
     grpc: "io.grpc:grpc-all:${depVersions.grpc}",
     groovy: "org.codehaus.groovy:groovy-all:${depVersions.groovy}",
     guava: "com.google.guava:guava:${depVersions.guava}",
+    hdrHistogram: "org.hdrhistogram:HdrHistogram:${depVersions.hdrhistogram}",
     hamcrest: "org.hamcrest:hamcrest-all:${depVersions.hamcrest}",
     httpclient: "org.apache.httpcomponents:httpclient:${depVersions.httpclient}",
     jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:${depVersions.jackson}",
@@ -153,5 +155,5 @@ depLibs = [
     vertxWeb: "io.vertx:vertx-web:${depVersions.vertx}",
     yahooDatasketches: "com.yahoo.datasketches:sketches-core:${depVersions.yahooDatasketches}",
     zookeeper: "org.apache.zookeeper:zookeeper:${depVersions.zookeeper}",
-    zookeeperTest: "org.apache.zookeeper:zookeeper:${depVersions.zookeeper}:tests",
+    zookeeperTest: "org.apache.zookeeper:zookeeper:${depVersions.zookeeper}:tests"
 ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,9 +24,14 @@ pluginManagement {
 
 rootProject.name = 'bookkeeper'
 
-include 'bookkeeper-benchmark',
+include(':bookkeeper-benchmark',
+        ':bookkeeper-tools-framework',
+        ':bookkeeper-tools-ledger',
+        ':bookkeeper-tools-perf',
+        ':bookkeeper-tools-stream',
         'bookkeeper-common',
         'bookkeeper-common-allocator',
+        'bookkeeper-dist:storage-bench',
         'bookkeeper-http:http-server',
         'bookkeeper-http:vertx-http-server',
         'bookkeeper-proto',
@@ -58,5 +63,12 @@ include 'bookkeeper-benchmark',
         'tests:integration:cluster',
         'tests:integration:smoke',
         'tests:integration:standalone',
-        'tools:framework'
+        'tools:framework')
+
+project(':bookkeeper-tools-framework').projectDir = file('tools/framework')
+project(':bookkeeper-tools-ledger').projectDir = file('tools/ledger')
+project(':bookkeeper-tools-stream').projectDir = file('tools/stream')
+project(':bookkeeper-tools-perf').projectDir = file('tools/perf')
+include 'stream:perf'
+findProject(':stream:perf')?.name = 'perf'
 

--- a/stream/api/build.gradle
+++ b/stream/api/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     annotationProcessor depLibs.lombok
 }
 
+jar {
+    archiveBaseName = 'stream-storage-api'
+}
+
 publishing {
     publications {
         maven(MavenPublication) {

--- a/stream/common/build.gradle
+++ b/stream/common/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     testAnnotationProcessor depLibs.lombok
 }
 
+jar {
+    archiveBaseName = 'stream-storage-common'
+}
 
 publishing {
     publications {

--- a/stream/server/build.gradle
+++ b/stream/server/build.gradle
@@ -16,7 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+    id 'application'
+    id 'distribution'
+}
+
 dependencies {
+    implementation project(':bookkeeper-common-allocator')
     implementation project(':bookkeeper-common')
     implementation project(':bookkeeper-server')
     implementation project(':bookkeeper-stats')
@@ -30,17 +36,36 @@ dependencies {
     implementation project(':stream:storage:api')
     implementation project(':stream:storage:impl')
 
+    implementation project(':bookkeeper-stats-providers:prometheus-metrics-provider')
+    runtimeOnly project(':bookkeeper-tools-ledger')
+    runtimeOnly project(':bookkeeper-tools-stream')
+    runtimeOnly project(':bookkeeper-http:vertx-http-server')
     implementation depLibs.commonsConfiguration
-    implementation depLibs.commonsLang2
+    implementation depLibs.commonsLang3
     implementation depLibs.curatorFramework
     implementation depLibs.grpc
     implementation depLibs.guava
     implementation depLibs.jcommander
     implementation depLibs.lombok
-    implementation depLibs.slf4j
+    implementation depLibs.zookeeper
+    runtimeOnly depLibs.metricsCore
+    runtimeOnly depLibs.snappy
+    runtimeOnly depLibs.slf4jLog4j
+    runtimeOnly depLibs.commonsBeanutils
+    runtimeOnly depLibs.vertxCore
+    runtimeOnly depLibs.vertxWeb
     testImplementation depLibs.mockito
 
     annotationProcessor depLibs.lombok
+}
+
+application {
+    mainClassName = "org.apache.bookkeeper.stream.cluster.StandaloneStarter"
+}
+
+task writeClasspath {
+    buildDir.mkdirs()
+    new File(buildDir, "classpath.txt").text = sourceSets.main.runtimeClasspath.collect { it.absolutePath }.join(':') + "\n"
 }
 
 publishing {

--- a/stream/storage/api/build.gradle
+++ b/stream/storage/api/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     implementation depLibs.grpc
 }
 
+jar {
+    archiveBaseName = 'stream-storage-service-api'
+}
+
 publishing {
     publications {
         maven(MavenPublication) {

--- a/tests/docker-images/statestore-image/Dockerfile
+++ b/tests/docker-images/statestore-image/Dockerfile
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM centos:7
+#ENV OPTS="$OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+ENV BOOKIE_PORT=3181
+ENV BOOKIE_HTTP_PORT=8080
+ENV BOOKIE_GRPC_PORT=4181
+EXPOSE ${BOOKIE_PORT} ${BOOKIE_HTTP_PORT} ${BOOKIE_GRPC_PORT}
+ENV BK_USER=bookkeeper
+ENV BK_HOME=/opt/bookkeeper
+ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+
+
+RUN set -x \
+    && adduser "${BK_USER}" \
+    && yum install -y java-1.8.0-openjdk-headless wget bash sudo \
+    && wget -q https://bootstrap.pypa.io/pip/2.7/get-pip.py \
+    && python get-pip.py \
+    && pip install zk-shell \
+    && rm -rf get-pip.py \
+    && mkdir -pv /opt \
+    && cd /opt \
+    && yum clean all
+
+WORKDIR /opt/bookkeeper
+RUN mkdir /opt/bookkeeper/lib
+RUN mkdir /opt/bookkeeper/bin
+RUN mkdir /opt/bookkeeper/conf
+RUN mkdir /opt/bookkeeper/scripts
+
+### -----Copy Jars------###
+ADD ./dist/server.tar /opt/
+RUN mv /opt/server/lib/*.jar /opt/bookkeeper/lib/
+### --------------------###
+
+### ----Copy scripts----------###
+COPY ./scripts/* /opt/bookkeeper/scripts/
+COPY ./temp_bin/* /opt/bookkeeper/bin/
+COPY ./bin/* /opt/bookkeeper/bin/
+### ----Copy scripts----------###
+
+### ----Copy conf-------------###
+COPY ./temp_conf/* /opt/bookkeeper/conf/
+COPY ./conf/* /opt/bookkeeper/conf/
+### ----Copy conf-------------###
+
+RUN chmod +x -R /opt/bookkeeper/scripts
+RUN chmod +x -R  /opt/bookkeeper/bin
+
+ENTRYPOINT [ "/bin/bash", "/opt/bookkeeper/scripts/entrypoint.sh" ]
+CMD ["bookie"]
+
+#HEALTHCHECK --interval=10s --timeout=50s CMD /bin/bash /opt/bookkeeper/scripts/healthcheck.sh

--- a/tests/docker-images/statestore-image/bin/bkctl
+++ b/tests/docker-images/statestore-image/bin/bkctl
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# BookKeeper CLI (experimental)
+
+BINDIR=`dirname "$0"`
+BK_HOME=`cd ${BINDIR}/..;pwd`
+
+source ${BK_HOME}/bin/common.sh
+source ${BK_HOME}/conf/bk_cli_env.sh
+
+# set up the classpath
+CLI_CLASSPATH=${BK_HOME}/lib/*
+
+DEFAULT_CONF=${BK_HOME}/conf/bk_server.conf
+if [ -z "${CLI_CONF}" ]; then
+  CLI_CONF=${DEFAULT_CONF}
+fi
+
+DEFAULT_LOG_CONF=${BK_HOME}/conf/log4j.cli.properties
+if [ -z "${CLI_LOG_CONF}" ]; then
+  CLI_LOG_CONF=${DEFAULT_LOG_CONF}
+fi
+CLI_LOG_DIR=${CLI_LOG_DIR:-"$BK_HOME/logs"}
+CLI_LOG_FILE=${CLI_LOG_FILE:-"bkctl.log"}
+CLI_ROOT_LOGGER=${CLI_ROOT_LOGGER:-"INFO,ROLLINGFILE"}
+
+# Configure the classpath
+CLI_CLASSPATH="$CLI_JAR:$CLI_CLASSPATH:$CLI_EXTRA_CLASSPATH"
+CLI_CLASSPATH="`dirname $CLI_LOG_CONF`:$CLI_CLASSPATH"
+
+# Build the OPTs
+BOOKIE_OPTS=$(build_bookie_opts)
+GC_OPTS=$(build_cli_jvm_opts ${CLI_LOG_DIR} "bkctl-gc.log")
+NETTY_OPTS=$(build_netty_opts)
+LOGGING_OPTS=$(build_cli_logging_opts ${CLI_LOG_CONF} ${CLI_LOG_DIR} ${CLI_LOG_FILE} ${CLI_ROOT_LOGGER})
+
+OPTS="${OPTS} -cp ${CLI_CLASSPATH} ${BOOKIE_OPTS} ${GC_OPTS} ${NETTY_OPTS} ${LOGGING_OPTS} ${CLI_EXTRA_OPTS}"
+
+#Change to BK_HOME to support relative paths
+cd "$BK_HOME"
+exec ${JAVA} ${OPTS} org.apache.bookkeeper.tools.cli.BKCtl --conf ${CLI_CONF} $@

--- a/tests/docker-images/statestore-image/bin/bkperf
+++ b/tests/docker-images/statestore-image/bin/bkperf
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# BookKeeper Perf Tool (experimental)
+
+BINDIR=`dirname "$0"`
+BK_HOME=`cd ${BINDIR}/..;pwd`
+
+source ${BK_HOME}/bin/common.sh
+source ${BK_HOME}/conf/bk_cli_env.sh
+
+CLI_CLASSPATH=${BK_HOME}/lib/*
+
+DEFAULT_CONF=${BK_HOME}/conf/bk_server.conf
+if [ -z "${CLI_CONF}" ]; then
+  CLI_CONF=${DEFAULT_CONF}
+fi
+
+DEFAULT_LOG_CONF=${BK_HOME}/conf/log4j.cli.properties
+if [ -z "${CLI_LOG_CONF}" ]; then
+  CLI_LOG_CONF=${DEFAULT_LOG_CONF}
+fi
+CLI_LOG_DIR=${CLI_LOG_DIR:-"$BK_HOME/logs"}
+CLI_LOG_FILE=${CLI_LOG_FILE:-"bkperf.log"}
+CLI_ROOT_LOGGER=${CLI_ROOT_LOGGER:-"INFO,CONSOLE"}
+
+# Configure the classpath
+CLI_CLASSPATH="$CLI_CLASSPATH:$CLI_EXTRA_CLASSPATH"
+CLI_CLASSPATH="`dirname $CLI_LOG_CONF`:$CLI_CLASSPATH"
+
+# Build the OPTs
+BOOKIE_OPTS=$(build_bookie_opts)
+GC_OPTS=$(build_cli_jvm_opts ${CLI_LOG_DIR} "bkperf-gc.log")
+NETTY_OPTS=$(build_netty_opts)
+LOGGING_OPTS=$(build_cli_logging_opts ${CLI_LOG_CONF} ${CLI_LOG_DIR} ${CLI_LOG_FILE} ${CLI_ROOT_LOGGER})
+
+OPTS="${OPTS} -cp ${CLI_CLASSPATH} ${BOOKIE_OPTS} ${GC_OPTS} ${NETTY_OPTS} ${LOGGING_OPTS} ${CLI_EXTRA_OPTS}"
+
+#Change to BK_HOME to support relative paths
+cd "$BK_HOME"
+exec ${JAVA} ${OPTS} org.apache.bookkeeper.tools.perf.BKPerf --conf ${CLI_CONF} $@

--- a/tests/docker-images/statestore-image/bin/bookkeeper
+++ b/tests/docker-images/statestore-image/bin/bookkeeper
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+set -e
+
+BINDIR=`dirname "$0"`
+BK_HOME=`cd ${BINDIR}/..;pwd`
+
+source ${BK_HOME}/bin/common.sh
+
+# default variables
+DEFAULT_CONF=${BK_HOME}/conf/bk_server.conf
+DEFAULT_ZK_CONF=${BK_HOME}/conf/zookeeper.conf
+
+if [ -z "$BOOKIE_CONF" ]; then
+  BOOKIE_CONF_TO_CHECK=${DEFAULT_CONF}
+else
+  BOOKIE_CONF_TO_CHECK=${BOOKIE_CONF}
+fi
+
+# set up the classpath
+BOOKIE_CLASSPATH=${BK_HOME}/lib/*
+
+
+# get arguments
+COMMAND=$1
+shift
+
+LOCALBOOKIES_CONFIG_DIR="${LOCALBOOKIES_CONFIG_DIR:-/tmp/localbookies-config}"
+if [ ${COMMAND} == "shell" ]; then
+  DEFAULT_LOG_CONF=${BK_HOME}/conf/log4j.shell.properties
+  if [[ $1 == "-localbookie"  ]]; then
+    if [[ $2 == *:* ]];
+    then
+      BOOKIE_CONF=${LOCALBOOKIES_CONFIG_DIR}/$2.conf
+      shift 2
+    else
+      BOOKIE_CONF=${LOCALBOOKIES_CONFIG_DIR}/baseconf.conf
+      shift
+    fi
+  fi
+fi
+
+if [ -z "$BOOKIE_ZK_CONF" ]; then
+    BOOKIE_ZK_CONF=$DEFAULT_ZK_CONF
+fi
+
+if [ -z "$BOOKIE_CONF" ]; then
+  BOOKIE_CONF=${DEFAULT_CONF}
+fi
+
+# Configure logging
+if [ -z "$BOOKIE_LOG_CONF" ]; then
+  BOOKIE_LOG_CONF=${DEFAULT_LOG_CONF}
+fi
+BOOKIE_LOG_DIR=${BOOKIE_LOG_DIR:-"$BK_HOME/logs"}
+BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"bookkeeper-server.log"}
+BOOKIE_ROOT_LOGGER=${BOOKIE_ROOT_LOGGER:-"INFO,CONSOLE"}
+
+# Configure the classpath
+BOOKIE_CLASSPATH="$BOOKIE_JAR:$BOOKIE_CLASSPATH:$BOOKIE_EXTRA_CLASSPATH"
+BOOKIE_CLASSPATH="`dirname $BOOKIE_LOG_CONF`:$BOOKIE_CLASSPATH"
+
+echo ${BOOKIE_LOG_CONF}
+
+# Build the OPTS
+BOOKIE_OPTS=$(build_bookie_opts)
+GC_OPTS=$(build_bookie_jvm_opts ${BOOKIE_LOG_DIR} "gc_%p.log")
+NETTY_OPTS=$(build_netty_opts)
+LOGGING_OPTS=$(build_logging_opts ${BOOKIE_LOG_CONF} ${BOOKIE_LOG_DIR} ${BOOKIE_LOG_FILE} ${BOOKIE_ROOT_LOGGER})
+
+OPTS="${OPTS} -cp ${BOOKIE_CLASSPATH} ${BOOKIE_OPTS} ${GC_OPTS} ${NETTY_OPTS} ${LOGGING_OPTS} ${BOOKIE_EXTRA_OPTS}"
+
+# Create log dir if it doesn't exist
+if [ ! -d ${BOOKIE_LOG_DIR} ]; then
+    mkdir ${BOOKIE_LOG_DIR}
+fi
+
+#Change to BK_HOME to support relative paths
+cd "$BK_HOME"
+if [ ${COMMAND} == "bookie" ]; then
+  exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.Main --conf ${BOOKIE_CONF} $@
+elif [ ${COMMAND} == "autorecovery" ]; then
+  exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.replication.AutoRecoveryMain --conf ${BOOKIE_CONF} $@
+elif [ ${COMMAND} == "localbookie" ]; then
+  NUMBER=$1
+  shift
+  exec ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.util.LocalBookKeeper ${NUMBER} ${BOOKIE_CONF} $@
+elif [ ${COMMAND} == "standalone" ]; then
+  exec ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.stream.cluster.StandaloneStarter --conf ${BK_HOME}/conf/standalone.conf $@
+elif [ ${COMMAND} == "upgrade" ]; then
+  exec ${JAVA} ${OPTS} org.apache.bookkeeper.bookie.FileSystemUpgrade --conf ${BOOKIE_CONF} $@
+elif [ $COMMAND == "zookeeper" ]; then
+    BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"zookeeper.log"}
+    exec $JAVA $OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE -Dzookeeper.4lw.commands.whitelist='*' org.apache.zookeeper.server.quorum.QuorumPeerMain $BOOKIE_ZK_CONF $@
+elif [ ${COMMAND} == "shell" ]; then
+  ENTRY_FORMATTER_ARG="-DentryFormatterClass=${ENTRY_FORMATTER_CLASS:-org.apache.bookkeeper.util.StringEntryFormatter}"
+  exec ${JAVA} ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
+else
+  exec ${JAVA} ${OPTS} ${COMMAND} $@
+fi
+

--- a/tests/docker-images/statestore-image/conf/log4j.cli.properties
+++ b/tests/docker-images/statestore-image/conf/log4j.cli.properties
@@ -1,0 +1,41 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+
+log4j.rootLogger=DEBUG,CONSOLE
+
+#
+# Log INFO level and above messages to the console
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=DEBUG
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ABSOLUTE} %-5p %m%n
+
+# verbose console logging
+log4j.appender.VERBOSECONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.VERBOSECONSOLE.Threshold=INFO
+log4j.appender.VERBOSECONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.VERBOSECONSOLE.layout.ConversionPattern=%m%n
+
+log4j.logger.verbose=INFO,VERBOSECONSOLE
+log4j.logger.org.apache.zookeeper=INFO
+log4j.logger.org.apache.bookkeeper=INFO

--- a/tests/docker-images/statestore-image/conf/log4j.properties
+++ b/tests/docker-images/statestore-image/conf/log4j.properties
@@ -1,0 +1,40 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+log4j.rootLogger=DEBUG,CONSOLE
+
+#
+# Log INFO level and above messages to the console
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=DEBUG
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ABSOLUTE} %-5p %m%n
+
+# verbose console logging
+log4j.appender.VERBOSECONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.VERBOSECONSOLE.Threshold=INFO
+log4j.appender.VERBOSECONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.VERBOSECONSOLE.layout.ConversionPattern=%m%n
+
+log4j.logger.verbose=INFO,VERBOSECONSOLE
+log4j.logger.org.apache.zookeeper=INFO
+log4j.logger.org.apache.bookkeeper=INFO

--- a/tests/docker-images/statestore-image/conf/log4j.shell.properties
+++ b/tests/docker-images/statestore-image/conf/log4j.shell.properties
@@ -1,0 +1,41 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+
+log4j.rootLogger=DEBUG,CONSOLE
+
+#
+# Log INFO level and above messages to the console
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=DEBUG
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ABSOLUTE} %-5p %m%n
+
+# verbose console logging
+log4j.appender.VERBOSECONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.VERBOSECONSOLE.Threshold=INFO
+log4j.appender.VERBOSECONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.VERBOSECONSOLE.layout.ConversionPattern=%m%n
+
+log4j.logger.verbose=INFO,VERBOSECONSOLE
+log4j.logger.org.apache.zookeeper=INFO
+log4j.logger.org.apache.bookkeeper=INFO

--- a/tests/docker-images/statestore-image/image_builder.sh
+++ b/tests/docker-images/statestore-image/image_builder.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+SCRIPT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+## BASE_DIR will be ./bookkeeper/
+BASE_DIR=${SCRIPT_DIR}/../../../
+mkdir "${BASE_DIR}"/tests/docker-images/statestore-image/dist
+mkdir "${BASE_DIR}"/tests/docker-images/statestore-image/scripts
+mkdir "${BASE_DIR}"/tests/docker-images/statestore-image/temp_conf
+mkdir "${BASE_DIR}"/tests/docker-images/statestore-image/temp_bin
+
+cp "${BASE_DIR}"/stream/server/build/distributions/server.tar "${BASE_DIR}"/tests/docker-images/statestore-image/dist
+cp "${BASE_DIR}"/docker/scripts/* "${BASE_DIR}"/tests/docker-images/statestore-image/scripts
+cp "${BASE_DIR}"/conf/* "${BASE_DIR}"/tests/docker-images/statestore-image/temp_conf
+cp "${BASE_DIR}"/bin/* "${BASE_DIR}"/tests/docker-images/statestore-image/temp_bin
+docker build -t apachebookkeeper/bookkeeper-current:latest "${BASE_DIR}"/tests/docker-images/statestore-image
+
+rm -rf "${BASE_DIR}"/tests/docker-images/statestore-image/dist
+rm -rf "${BASE_DIR}"/tests/docker-images/statestore-image/scripts
+rm -rf "${BASE_DIR}"/tests/docker-images/statestore-image/temp_conf
+rm -rf "${BASE_DIR}"/tests/docker-images/statestore-image/temp_bin

--- a/tests/integration/cluster/build.gradle
+++ b/tests/integration/cluster/build.gradle
@@ -16,6 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+    id 'java'
+    id 'com.adarshr.test-logger' version '2.0.0'
+}
+
 dependencies {
     implementation depLibs.grpc
     testImplementation project(path: ':bookkeeper-common', configuration: 'testArtifacts')
@@ -29,12 +34,26 @@ dependencies {
     testImplementation project(':bookkeeper-server')
     testImplementation project(':bookkeeper-stats')
     testImplementation project(':tests:integration-tests-topologies')
+    testImplementation project(':stream:clients:java:kv')
 
     testCompileOnly depLibs.lombok
     testImplementation depLibs.slf4jLog4j
     testImplementation depLibs.testcontainers
     testImplementation depLibs.commonsConfiguration
     testAnnotationProcessor depLibs.lombok
+}
+
+task buildImage(type:Exec) {
+    workingDir '../../..'
+    commandLine './tests/docker-images/statestore-image/image_builder.sh'
+}
+
+test {
+    dependsOn buildImage
+    jvmArgs("-Djunit.timeout.test=600000",
+            "-Djunit.max.retry=3",
+            "-Djava.net.preferIPv4Stack=true",
+            "-Dio.netty.leakDetection.level=paranoid")
 }
 
 publishing {

--- a/tests/integration/smoke/build.gradle
+++ b/tests/integration/smoke/build.gradle
@@ -16,6 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+    id 'java'
+    id 'com.adarshr.test-logger' version '2.0.0'
+}
+
 dependencies {
     testImplementation project(path: ':bookkeeper-common', configuration: 'testArtifacts')
     testImplementation project(':bookkeeper-server')

--- a/tests/integration/standalone/build.gradle
+++ b/tests/integration/standalone/build.gradle
@@ -16,6 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+    id 'java'
+    id 'com.adarshr.test-logger' version '2.0.0'
+}
+
 dependencies {
     testImplementation project(path: ':bookkeeper-common', configuration: 'testArtifacts')
     testImplementation project(':bookkeeper-server')
@@ -27,6 +32,15 @@ dependencies {
     testImplementation depLibs.commonsConfiguration
     testImplementation depLibs.arquillianCubeDocker
     testAnnotationProcessor depLibs.lombok
+}
+
+task buildImage(type:Exec) {
+    workingDir '../../..'
+    commandLine './tests/docker-images/statestore-image/image_builder.sh'
+}
+
+test {
+    dependsOn buildImage
 }
 
 publishing {

--- a/tools/framework/build.gradle
+++ b/tools/framework/build.gradle
@@ -32,3 +32,7 @@ dependencies {
 
     annotationProcessor depLibs.lombok
 }
+
+jar {
+    archiveBaseName = 'bookkeeper-tools-framework'
+}

--- a/tools/ledger/build.gradle
+++ b/tools/ledger/build.gradle
@@ -16,34 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+    id 'java'
+}
+
 dependencies {
-    implementation project(':bookkeeper-common')
-    implementation project(':stream:api')
-    implementation project(':stream:common')
-    implementation project(':stream:clients:java:base')
-    implementation project(':stream:clients:java:kv')
-    implementation project(':stream:proto')
+    implementation project(":bookkeeper-common")
+    implementation project(':bookkeeper-tools-framework')
+    implementation project(':bookkeeper-server')
 
-    implementation depLibs.grpc
-    implementation depLibs.lombok
+    compileOnly depLibs.lombok
+    compileOnly depLibs.spotbugsAnnotations
+
+    implementation depLibs.commonsConfiguration
+    implementation depLibs.guava
+    implementation depLibs.jcommander
     implementation depLibs.slf4j
+    implementation depLibs.zookeeper
 
-    testImplementation project(path: ':stream:clients:java:base', configuration: 'testArtifacts')
+    testImplementation project(":bookkeeper-stats")
+    testCompileOnly depLibs.lombok
+    testImplementation depLibs.junit
+    testImplementation depLibs.commonsConfiguration
     testImplementation depLibs.mockito
     testImplementation depLibs.powermockJunit
     testImplementation depLibs.powermockMockito
+    testImplementation depLibs.zookeeperTest
 
     annotationProcessor depLibs.lombok
+    testAnnotationProcessor depLibs.lombok
 }
 
 jar {
-    archiveBaseName = 'stream-storage-java-client'
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'stream-storage-java-client'
-        }
-    }
+    archiveBaseName = 'bookkeeper-tools-ledger'
 }

--- a/tools/ledger/src/main/resources/META-INF/services/org.apache.bookkeeper.tools.framework.CommandGroup
+++ b/tools/ledger/src/main/resources/META-INF/services/org.apache.bookkeeper.tools.framework.CommandGroup
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.bookkeeper.tools.cli.commands.BookieCommandGroup
+org.apache.bookkeeper.tools.cli.commands.BookieIdCommandGroup
+org.apache.bookkeeper.tools.cli.commands.BookiesCommandGroup
+org.apache.bookkeeper.tools.cli.commands.CookieCommandGroup
+org.apache.bookkeeper.tools.cli.commands.LedgerCommandGroup
+org.apache.bookkeeper.tools.cli.commands.AutoRecoveryCommandGroup

--- a/tools/perf/build.gradle
+++ b/tools/perf/build.gradle
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+plugins {
+    id 'java'
+}
+
+dependencies {
+
+    implementation project(":bookkeeper-common")
+    implementation project(':bookkeeper-tools-framework')
+    implementation project(':bookkeeper-server')
+    implementation project(':bookkeeper-stats')
+    implementation project(':bookkeeper-stats-providers:prometheus-metrics-provider')
+    implementation project(':bookkeeper-common-allocator')
+    implementation project(':stream:api')
+    implementation project(':stream:common')
+    implementation project(':stream:clients:java:base')
+    implementation project(':stream:clients:java:all')
+    implementation project(':stream:storage:api')
+    implementation project(':stream:storage:impl')
+    implementation project(':stream:distributedlog:common')
+    implementation project(':stream:distributedlog:core')
+    implementation project(':stream:distributedlog:protocol')
+    implementation project(':stream:proto')
+
+    compileOnly depLibs.lombok
+    implementation depLibs.commonsConfiguration
+    implementation depLibs.guava
+    implementation depLibs.jcommander
+    implementation depLibs.slf4jLog4j
+    implementation depLibs.zookeeper
+    implementation depLibs.curatorFramework
+    implementation depLibs.protobuf
+    implementation depLibs.jacksonDatabind
+    implementation depLibs.hdrHistogram
+    implementation depLibs.nettyBuffer
+    implementation depLibs.commonsLang3
+    compileOnly depLibs.spotbugsAnnotations
+
+    testImplementation project(path: ':bookkeeper-common', configuration: 'testArtifacts')
+    testImplementation project(':bookkeeper-http:vertx-http-server')
+    testImplementation depLibs.junit
+    testImplementation depLibs.commonsConfiguration
+    testImplementation depLibs.mockito
+    testImplementation depLibs.powermockJunit
+    testImplementation depLibs.powermockMockito
+    testImplementation depLibs.zookeeperTest
+    annotationProcessor depLibs.lombok
+    testAnnotationProcessor depLibs.lombok
+}
+
+jar {
+    archiveBaseName = 'bookkeeper-tools-perf'
+}

--- a/tools/stream/build.gradle
+++ b/tools/stream/build.gradle
@@ -16,34 +16,40 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+    id 'java'
+}
+
 dependencies {
-    implementation project(':bookkeeper-common')
+    implementation project(":bookkeeper-common")
+    implementation project(':bookkeeper-tools-framework')
+    implementation project(':bookkeeper-server')
     implementation project(':stream:api')
     implementation project(':stream:common')
     implementation project(':stream:clients:java:base')
     implementation project(':stream:clients:java:kv')
+    implementation project(':stream:clients:java:all')
+    implementation project(':stream:storage:api')
+    implementation project(':stream:storage:impl')
+    implementation project(':stream:distributedlog:core')
+    implementation project(':stream:distributedlog:protocol')
+    implementation project(':stream:distributedlog:core')
     implementation project(':stream:proto')
 
-    implementation depLibs.grpc
-    implementation depLibs.lombok
-    implementation depLibs.slf4j
-
-    testImplementation project(path: ':stream:clients:java:base', configuration: 'testArtifacts')
-    testImplementation depLibs.mockito
-    testImplementation depLibs.powermockJunit
-    testImplementation depLibs.powermockMockito
-
+    compileOnly depLibs.lombok
+    compileOnly depLibs.spotbugsAnnotations
+    implementation depLibs.commonsConfiguration
+    implementation depLibs.guava
+    implementation depLibs.jcommander
+    implementation depLibs.slf4jLog4j
+    implementation depLibs.zookeeper
+    implementation depLibs.curatorFramework
+    implementation depLibs.protobuf
+    implementation depLibs.commonsLang3
+    implementation depLibs.nettyBuffer
     annotationProcessor depLibs.lombok
 }
 
 jar {
-    archiveBaseName = 'stream-storage-java-client'
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'stream-storage-java-client'
-        }
-    }
+    archiveBaseName = 'bookkeeper-tools-stream'
 }

--- a/tools/stream/src/main/resources/META-INF/services/org.apache.bookkeeper.tools.framework.CommandGroup
+++ b/tools/stream/src/main/resources/META-INF/services/org.apache.bookkeeper.tools.framework.CommandGroup
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.bookkeeper.stream.cli.ClusterCommandGroup
+org.apache.bookkeeper.stream.cli.NamespaceCommandGroup
+org.apache.bookkeeper.stream.cli.TableAdminCommandGroup
+org.apache.bookkeeper.stream.cli.TableCommandGroup


### PR DESCRIPTION
### Motivation
Migrate bookkeeper to gradle. 

- Build BKCTL and generate artifacts 
- Build docker image from the jar created from existing source and run integration tests.

### Changes

- A Dockerfile which will build docker image from existing source.
- A Shell file which will generate all the artifacts for building Docker image
- All build.gradle files to build and run integration tests.

Master Issue: #2640 

### How to build

./gradlew :tests:integration:cluster:test

` Task :tests:integration:cluster:buildImage
#1 [internal] load build definition from Dockerfile
#1 sha256:13c696b34811c50ef1582dd1c27e59e8cf726660222ada83feb0b294a4197b14
#1 transferring dockerfile: 37B 0.0s done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 sha256:028ece09d81436333eece58b183b9dc0a52cbc28bf2d07cfad5f3080e03d38b7
#2 transferring context: 2B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/centos:7
#3 sha256:30875b35a89c8e8a29cd7cf120689bb68cdab8d769419707e07138dfe977d237
#3 DONE 9.7s

#4 [ 1/16] FROM docker.io/library/centos:7@sha256:0f4ec88e21daf75124b8a9e5ca03c37a5e937e0e108a255d890492430789b60e
#4 sha256:a82657dc9009ab4ecab0a966d899b2972800cfe1ee9d42fc736a0cac1581ac52
#4 DONE 0.0s

#11 [internal] load build context
#11 sha256:2ba06714f2ca9169cd544ca120d73724654078b8159628baf9e4af328b2d617a
#11 transferring context: 23B
#11 transferring context: 122.54MB 4.5s done
#11 DONE 4.5s

#13 [ 9/16] RUN mv /opt/server/lib/*.jar /opt/bookkeeper/lib/
#13 sha256:0edb1ad87b6c9035382a0500b77b4577388841c8eef32516507007f857f058a8
#13 CACHED

#18 [14/16] COPY ./conf/* /opt/bookkeeper/conf/
#18 sha256:53a4f93597253dff0934c46de43bac4f857ced79886d97523b3f5c190624aeb6
#18 CACHED

#19 [15/16] RUN chmod +x -R /opt/bookkeeper/scripts
#19 sha256:6be237cc3422cc33cb527d6ac9dac6132f82d474e1f0a28a4f50784454319dee
#19 CACHED

#7 [ 4/16] RUN mkdir /opt/bookkeeper/lib
#7 sha256:3fe6bccdc94f36263533c94142448099fa427415412b40e6c2d7003f0f9172f9
#7 CACHED

#17 [13/16] COPY ./temp_conf/* /opt/bookkeeper/conf/
#17 sha256:da439db0c1a32b3a7a60d1ffabc8fe4c4d23f1c4a7bd6095fc5d4a4530691f9d
#17 CACHED

#6 [ 3/16] WORKDIR /opt/bookkeeper
#6 sha256:75cb16fec34eda0a19b049218df4fd332274fb1af59e20dea96ce8bda3cac37f
#6 CACHED

#16 [12/16] COPY ./bin/* /opt/bookkeeper/bin/
#16 sha256:fe3bceec3581b5e8183cf2804a8e8c0ef06c5eb11b498260bd6fa5a3df7ec139
#16 CACHED

#8 [ 5/16] RUN mkdir /opt/bookkeeper/bin
#8 sha256:1efcf781a6c50daf837d1ed53d859145b6d07b9050cfa5ed2cab6a370d64c0fb
#8 CACHED

#15 [11/16] COPY ./temp_bin/* /opt/bookkeeper/bin/
#15 sha256:7e7fb09841111dd8b7444c6007be8c945bf0b84d698d81cf2e7cfda7df01bff0
#15 CACHED

#5 [ 2/16] RUN set -x     && adduser "bookkeeper"     && yum install -y java-1.8.0-openjdk-headless wget bash sudo     && wget -q https://bootstrap.pypa.io/pip/2.7/get-pip.py     && python get-pip.py     && pip install zk-shell     && rm -rf get-pip.py     && mkdir -pv /opt     && cd /opt     && yum clean all
#5 sha256:055562ef0c2a679a10597b7a9c15d731dc1235a63e74c44e0ec246d059b2cdbd
#5 CACHED

#10 [ 7/16] RUN mkdir /opt/bookkeeper/scripts
#10 sha256:8ed4308f6f3b2710fc497036cc4d75df7e0c8d335b9f4ca3962f2fbac5ba55f5
#10 CACHED

#14 [10/16] COPY ./scripts/* /opt/bookkeeper/scripts/
#14 sha256:f78d90c1c59a8d4bf347fc9109ea28ad5a811ab605fc688a1e60336daf6e1564
#14 CACHED

#12 [ 8/16] ADD ./dist/server.tar /opt/
#12 sha256:1f8a62db7f0bcabf8bbc7b9293c362a4c5b91a90801fab595e264a106529ac45
#12 CACHED

#9 [ 6/16] RUN mkdir /opt/bookkeeper/conf
#9 sha256:271a4ee43b22ab37ab9ba5e511fc9a477950119c63da39d5d399bf72f4c7ab08
#9 CACHED

#20 [16/16] RUN chmod +x -R  /opt/bookkeeper/bin
#20 sha256:65e54de91545e3a96a707a741727068de55978138d7ead28000b789a7dc4818f
#20 CACHED

#21 exporting to image
#21 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
#21 exporting layers done
#21 writing image sha256:3c816ab89d94c687e47c91df2ccd85a20f481679bb76540848d137e60adbcbb0 done
#21 naming to docker.io/apachebookkeeper/bookkeeper-current:latest done
#21 DONE 0.0s

> Task :tests:integration:cluster:test

org.apache.bookkeeper.tests.integration.cluster.SimpleClusterTest

  Test test000_ClusterIsEmpty PASSED
  Test test001_StartBookie PASSED (5.9s)
  Test test002_StopBookie PASSED (10.5s)

org.apache.bookkeeper.tests.integration.stream.LocationClientTest

  Test testLocateStorageContainers PASSED

org.apache.bookkeeper.tests.integration.stream.BkCtlTest

  Test simpleTest PASSED (2.9s)
  Test putGetKey PASSED (7.9s)
  Test createTable PASSED (2.5s)
  Test createNamespace PASSED (2.4s)
  Test listBookies PASSED (1.3s)
  Test incGetKey PASSED (6.9s)
  Test showLastMark PASSED (1s)

org.apache.bookkeeper.tests.integration.stream.StorageAdminClientTest

  Test testStreamAPIClientSideRouting PASSED
  Test testNamespaceAPIClientSideRouting PASSED
  Test testStreamAPIServerSideRouting PASSED
  Test testNamespaceAPIServerSideRouting PASSED

org.apache.bookkeeper.tests.integration.stream.TableClientTest

  Test testTableAPIClientSideRouting PASSED (3.9s)
  Test testTableAPIServerSideRouting PASSED (4s)

SUCCESS: Executed 17 tests in 2m 47s


Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3m 6s
`