### PR TITLE
Fix a typo in bookkeeper script

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -146,7 +146,7 @@ GC_OPTS=$(build_bookie_jvm_opts ${BOOKIE_LOG_DIR} "gc_%p.log")
 NETTY_OPTS=$(build_netty_opts)
 LOGGING_OPTS=$(build_logging_opts ${BOOKIE_LOG_CONF} ${BOOKIE_LOG_DIR} ${BOOKIE_LOG_FILE} ${BOOKIE_ROOT_LOGGER})
 
-BOOKIE_EXTRA_OPTS=$(BOOKIE_EXTRA_OPTS) "-Dorg.bouncycastle.fips.approved_only=true"
+BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS} -Dorg.bouncycastle.fips.approved_only=true"
 OPTS="${OPTS} -cp ${BOOKIE_CLASSPATH} ${BOOKIE_OPTS} ${GC_OPTS} ${NETTY_OPTS} ${LOGGING_OPTS} ${BOOKIE_EXTRA_OPTS}"
 
 # Create log dir if it doesn't exist


### PR DESCRIPTION
### Motivation

Bookkeeper script is failing to start. The variable is not being interpreted as a string. Instead we trying to run this as command and failing.

```
$ ./bin/bookkeeper localbookie 3
JAVA_HOME not set, using java from PATH. (/usr/bin/java)
./bin/bookkeeper: line 149: BOOKIE_EXTRA_OPTS: command not found
./bin/bookkeeper: line 149: -Dorg.bouncycastle.fips.approved_only=true: command not found
```

### Changes

Add quotes around the variable definition.

