### PR TITLE
Fix logic in Bookkeeper forceAllowCompaction to run only when force i…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -356,8 +356,9 @@ public class GarbageCollectorThread extends SafeRunnable {
         }
 
         long curTime = System.currentTimeMillis();
-        if ((isForceMajorCompactionAllow || enableMajorCompaction) && (!suspendMajor)
-            && (force || curTime - lastMajorCompactionTime > majorCompactionInterval)) {
+        if (((isForceMajorCompactionAllow && force)
+                || (enableMajorCompaction && curTime - lastMajorCompactionTime > majorCompactionInterval))
+                && (!suspendMajor)) {
             // enter major compaction
             LOG.info("Enter major compaction, suspendMajor {}", suspendMajor);
             majorCompacting.set(true);
@@ -367,8 +368,9 @@ public class GarbageCollectorThread extends SafeRunnable {
             lastMinorCompactionTime = lastMajorCompactionTime;
             gcStats.getMajorCompactionCounter().inc();
             majorCompacting.set(false);
-        } else if ((isForceMinorCompactionAllow || enableMinorCompaction) && (!suspendMinor)
-            && (force || curTime - lastMinorCompactionTime > minorCompactionInterval)) {
+        } else if (((isForceMinorCompactionAllow && force)
+                || (enableMinorCompaction && curTime - lastMinorCompactionTime > minorCompactionInterval))
+                && (!suspendMinor)) {
             // enter minor compaction
             LOG.info("Enter minor compaction, suspendMinor {}", suspendMinor);
             minorCompacting.set(true);


### PR DESCRIPTION
Without the attached fix, when forceAllowCompaction and isForceGCAllowWhenNoSpace are set. The majorCompaction runs with every garbage collection. This results due to the fact that enableMajorCompaction which takes a negative interval into account to disable compaction always returns true since the difference in time will always be larger than -1. The time check must be "and" with the enableMajorCompaciton for the time check to be valid. And the force flag should also only be checked when the isForceGCAllowWhenNoSpace is activated. The attached PR makes the necessary adjustments. 