### PR TITLE
Issue 2638: Compaction Limits

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -71,12 +71,14 @@ public class GarbageCollectorThread extends SafeRunnable {
     boolean enableMinorCompaction = false;
     final double minorCompactionThreshold;
     final long minorCompactionInterval;
+    final long minorCompactionLimit;
     long lastMinorCompactionTime;
 
     boolean isForceMajorCompactionAllow = false;
     boolean enableMajorCompaction = false;
     final double majorCompactionThreshold;
     final long majorCompactionInterval;
+    long majorCompactionLimit;
     long lastMajorCompactionTime;
 
     @Getter
@@ -180,6 +182,9 @@ public class GarbageCollectorThread extends SafeRunnable {
         majorCompactionThreshold = conf.getMajorCompactionThreshold();
         majorCompactionInterval = conf.getMajorCompactionInterval() * SECOND;
         isForceGCAllowWhenNoSpace = conf.getIsForceGCAllowWhenNoSpace();
+        majorCompactionLimit = conf.getMajorCompactionLimitMs();
+        minorCompactionLimit = conf.getMinorCompactionLimitMs();
+
         boolean isForceAllowCompaction = conf.isForceAllowCompaction();
 
         AbstractLogCompactor.LogRemovalListener remover = new AbstractLogCompactor.LogRemovalListener() {
@@ -361,7 +366,7 @@ public class GarbageCollectorThread extends SafeRunnable {
             // enter major compaction
             LOG.info("Enter major compaction, suspendMajor {}", suspendMajor);
             majorCompacting.set(true);
-            doCompactEntryLogs(majorCompactionThreshold);
+            doCompactEntryLogs(majorCompactionThreshold, majorCompactionLimit);
             lastMajorCompactionTime = System.currentTimeMillis();
             // and also move minor compaction time
             lastMinorCompactionTime = lastMajorCompactionTime;
@@ -372,7 +377,7 @@ public class GarbageCollectorThread extends SafeRunnable {
             // enter minor compaction
             LOG.info("Enter minor compaction, suspendMinor {}", suspendMinor);
             minorCompacting.set(true);
-            doCompactEntryLogs(minorCompactionThreshold);
+            doCompactEntryLogs(minorCompactionThreshold, minorCompactionLimit);
             lastMinorCompactionTime = System.currentTimeMillis();
             gcStats.getMinorCompactionCounter().inc();
             minorCompacting.set(false);
@@ -442,7 +447,7 @@ public class GarbageCollectorThread extends SafeRunnable {
      * </p>
      */
     @VisibleForTesting
-    void doCompactEntryLogs(double threshold) {
+    void doCompactEntryLogs(double threshold, long limit) {
         LOG.info("Do compaction to compact those files lower than {}", threshold);
 
         // sort the ledger meta by usage in ascending order.
@@ -452,29 +457,46 @@ public class GarbageCollectorThread extends SafeRunnable {
 
         final int numBuckets = 10;
         int[] entryLogUsageBuckets = new int[numBuckets];
+        int[] compactedBuckets = new int[numBuckets];
+
+        long start = System.currentTimeMillis();
+        long end = start;
+        long timeDiff = 0;
 
         for (EntryLogMetadata meta : logsToCompact) {
             int bucketIndex = calculateUsageIndex(numBuckets, meta.getUsage());
             entryLogUsageBuckets[bucketIndex]++;
 
-            if (meta.getUsage() >= threshold) {
+            if (timeDiff < limit) {
+                end = System.currentTimeMillis();
+                timeDiff = end - start;
+            }
+            if (meta.getUsage() >= threshold || (limit > 0 && timeDiff > limit) || !running) {
+                // We allow the usage limit calculation to continue so that we get a accurate
+                // report of where the usage was prior to running compaction.
                 continue;
             }
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Compacting entry log {} below threshold {}", meta.getEntryLogId(), threshold);
+                LOG.debug("Compacting entry log {} with usage {} below threshold {}",
+                        meta.getEntryLogId(), meta.getUsage(), threshold);
             }
 
             long priorRemainingSize = meta.getRemainingSize();
             compactEntryLog(meta);
             gcStats.getReclaimedSpaceViaCompaction().add(meta.getTotalSize() - priorRemainingSize);
-
-            if (!running) { // if gc thread is not running, stop compaction
-                return;
+            compactedBuckets[bucketIndex]++;
+        }
+        if (LOG.isDebugEnabled()) {
+            if (!running) {
+                LOG.debug("Compaction exited due to gc not running");
+            }
+            if (timeDiff > limit) {
+                LOG.debug("Compaction ran for {} but was limited by {}", timeDiff, limit);
             }
         }
         LOG.info(
-                "Compaction: entry log usage buckets[10% 20% 30% 40% 50% 60% 70% 80% 90% 100%] = {}",
-                entryLogUsageBuckets);
+                "Compaction: entry log usage buckets[10% 20% 30% 40% 50% 60% 70% 80% 90% 100%] = {}, compacted {}",
+                entryLogUsageBuckets, compactedBuckets);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -71,14 +71,14 @@ public class GarbageCollectorThread extends SafeRunnable {
     boolean enableMinorCompaction = false;
     final double minorCompactionThreshold;
     final long minorCompactionInterval;
-    final long minorCompactionLimit;
+    final long minorCompactionLimitMs;
     long lastMinorCompactionTime;
 
     boolean isForceMajorCompactionAllow = false;
     boolean enableMajorCompaction = false;
     final double majorCompactionThreshold;
     final long majorCompactionInterval;
-    long majorCompactionLimit;
+    long majorCompactionLimitMs;
     long lastMajorCompactionTime;
 
     @Getter
@@ -182,8 +182,8 @@ public class GarbageCollectorThread extends SafeRunnable {
         majorCompactionThreshold = conf.getMajorCompactionThreshold();
         majorCompactionInterval = conf.getMajorCompactionInterval() * SECOND;
         isForceGCAllowWhenNoSpace = conf.getIsForceGCAllowWhenNoSpace();
-        majorCompactionLimit = conf.getMajorCompactionLimitMs();
-        minorCompactionLimit = conf.getMinorCompactionLimitMs();
+        majorCompactionLimitMs = conf.getMajorCompactionLimitMs();
+        minorCompactionLimitMs = conf.getMinorCompactionLimitMs();
 
         boolean isForceAllowCompaction = conf.isForceAllowCompaction();
 
@@ -366,7 +366,7 @@ public class GarbageCollectorThread extends SafeRunnable {
             // enter major compaction
             LOG.info("Enter major compaction, suspendMajor {}", suspendMajor);
             majorCompacting.set(true);
-            doCompactEntryLogs(majorCompactionThreshold, majorCompactionLimit);
+            doCompactEntryLogs(majorCompactionThreshold, majorCompactionLimitMs);
             lastMajorCompactionTime = System.currentTimeMillis();
             // and also move minor compaction time
             lastMinorCompactionTime = lastMajorCompactionTime;
@@ -377,7 +377,7 @@ public class GarbageCollectorThread extends SafeRunnable {
             // enter minor compaction
             LOG.info("Enter minor compaction, suspendMinor {}", suspendMinor);
             minorCompacting.set(true);
-            doCompactEntryLogs(minorCompactionThreshold, minorCompactionLimit);
+            doCompactEntryLogs(minorCompactionThreshold, minorCompactionLimitMs);
             lastMinorCompactionTime = System.currentTimeMillis();
             gcStats.getMinorCompactionCounter().inc();
             minorCompacting.set(false);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -93,10 +93,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String FORCE_ALLOW_COMPACTION = "forceAllowCompaction";
     protected static final String MINOR_COMPACTION_INTERVAL = "minorCompactionInterval";
     protected static final String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
-    protected static final String MINOR_COMPACTION_LIMIT_MS = "minorCompactionLimit";
+    protected static final String MINOR_COMPACTION_LIMIT_MS = "minorCompactionLimitMs";
     protected static final String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";
     protected static final String MAJOR_COMPACTION_THRESHOLD = "majorCompactionThreshold";
-    protected static final String MAJOR_COMPACTION_LIMIT_MS = "majorCompactionLimit";
+    protected static final String MAJOR_COMPACTION_LIMIT_MS = "majorCompactionLimitMs";
     protected static final String IS_THROTTLE_BY_BYTES = "isThrottleByBytes";
     protected static final String COMPACTION_MAX_OUTSTANDING_REQUESTS = "compactionMaxOutstandingRequests";
     protected static final String COMPACTION_RATE = "compactionRate";
@@ -1532,8 +1532,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get the limit on the number of seconds to run. If <= 0 the
-     * thread will run till all compaction is completed.
+     * Get the limit on the number of milliseconds to run. If <= 0 the
+     * thread will run until all compaction is completed.
      *
      * @return limit
      *           The number of milliseconds to run compaction.
@@ -1543,8 +1543,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Set the limit on the number of seconds to run. If <= 0 the
-     * thread will run till all compaction is completed.
+     * Set the limit on the number of milliseconds to run. If <= 0 the
+     * thread will run until all compaction is completed.
      *
      * @see #getMajorCompactionLimitMs()
      *
@@ -1609,8 +1609,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get the limit on the number of seconds to run. If <= 0 the
-     * thread will run till all compaction is completed.
+     * Get the limit on the number of milliseconds to run. If <= 0 the
+     * thread will run until all compaction is completed.
      *
      * @return limit
      *           The number of milliseconds to run compaction.
@@ -1620,8 +1620,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Set the limit on the number of seconds to run. If <= 0 the
-     * thread will run till all compaction is completed.
+     * Set the limit on the number of milliseconds to run. If <= 0 the
+     * thread will run until all compaction is completed.
      *
      * @see #getMinorCompactionLimitMs()
      *

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -93,8 +93,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String FORCE_ALLOW_COMPACTION = "forceAllowCompaction";
     protected static final String MINOR_COMPACTION_INTERVAL = "minorCompactionInterval";
     protected static final String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
+    protected static final String MINOR_COMPACTION_LIMIT_MS = "minorCompactionLimit";
     protected static final String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";
     protected static final String MAJOR_COMPACTION_THRESHOLD = "majorCompactionThreshold";
+    protected static final String MAJOR_COMPACTION_LIMIT_MS = "majorCompactionLimit";
     protected static final String IS_THROTTLE_BY_BYTES = "isThrottleByBytes";
     protected static final String COMPACTION_MAX_OUTSTANDING_REQUESTS = "compactionMaxOutstandingRequests";
     protected static final String COMPACTION_RATE = "compactionRate";
@@ -1063,7 +1065,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * Configure the bookie to advertise a specific address.
      *
      * <p>By default, a bookie will advertise either its own IP or hostname,
-     * depending on the {@link getUseHostNameAsBookieID()} setting.
+     * depending on the {@link #getUseHostNameAsBookieID()} setting.
      *
      * <p>When the advertised is set to a non-empty string, the bookie will
      * register and advertise using this address.
@@ -1332,7 +1334,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * This is the number of threads used by Netty to handle TCP connections.
      * </p>
      *
-     * @see #getNumIOThreads()
+     * @see #getServerNumIOThreads()
      * @param numThreads number of IO threads used for bookkeeper
      * @return client configuration
      */
@@ -1530,6 +1532,33 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
+     * Get the limit on the number of seconds to run. If <= 0 the
+     * thread will run till all compaction is completed.
+     *
+     * @return limit
+     *           The number of milliseconds to run compaction.
+     */
+    public long getMajorCompactionLimitMs() {
+        return getLong(MAJOR_COMPACTION_LIMIT_MS, -1);
+    }
+
+    /**
+     * Set the limit on the number of seconds to run. If <= 0 the
+     * thread will run till all compaction is completed.
+     *
+     * @see #getMajorCompactionLimitMs()
+     *
+     * @param majorCompactionLimitMs
+     *           The number of milliseconds to run compaction.
+     *
+     * @return  server configuration
+     */
+    public ServerConfiguration setMajorCompactionLimitMs(long majorCompactionLimitMs) {
+        setProperty(MAJOR_COMPACTION_LIMIT_MS, majorCompactionLimitMs);
+        return this;
+    }
+
+    /**
      * Get interval to run minor compaction, in seconds.
      *
      * <p>If it is set to less than zero, the minor compaction is disabled.
@@ -1576,6 +1605,33 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setMajorCompactionInterval(long interval) {
         setProperty(MAJOR_COMPACTION_INTERVAL, interval);
+        return this;
+    }
+
+    /**
+     * Get the limit on the number of seconds to run. If <= 0 the
+     * thread will run till all compaction is completed.
+     *
+     * @return limit
+     *           The number of milliseconds to run compaction.
+     */
+    public long getMinorCompactionLimitMs() {
+        return getLong(MINOR_COMPACTION_LIMIT_MS, -1);
+    }
+
+    /**
+     * Set the limit on the number of seconds to run. If <= 0 the
+     * thread will run till all compaction is completed.
+     *
+     * @see #getMinorCompactionLimitMs()
+     *
+     * @param minorCompactionLimitMs
+     *           The number of milliseconds to run compaction.
+     *
+     * @return  server configuration
+     */
+    public ServerConfiguration setMinorCompactionLimitMs(long minorCompactionLimitMs) {
+        setProperty(MINOR_COMPACTION_LIMIT_MS, minorCompactionLimitMs);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -93,10 +93,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String FORCE_ALLOW_COMPACTION = "forceAllowCompaction";
     protected static final String MINOR_COMPACTION_INTERVAL = "minorCompactionInterval";
     protected static final String MINOR_COMPACTION_THRESHOLD = "minorCompactionThreshold";
-    protected static final String MINOR_COMPACTION_LIMIT_MS = "minorCompactionLimitMs";
+    protected static final String MINOR_COMPACTION_MAX_TIME_MILLIS = "minorCompactionMaxTimeMillis";
     protected static final String MAJOR_COMPACTION_INTERVAL = "majorCompactionInterval";
     protected static final String MAJOR_COMPACTION_THRESHOLD = "majorCompactionThreshold";
-    protected static final String MAJOR_COMPACTION_LIMIT_MS = "majorCompactionLimitMs";
+    protected static final String MAJOR_COMPACTION_MAX_TIME_MILLIS = "majorCompactionMaxTimeMillis";
     protected static final String IS_THROTTLE_BY_BYTES = "isThrottleByBytes";
     protected static final String COMPACTION_MAX_OUTSTANDING_REQUESTS = "compactionMaxOutstandingRequests";
     protected static final String COMPACTION_RATE = "compactionRate";
@@ -1532,29 +1532,29 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get the limit on the number of milliseconds to run. If <= 0 the
+     * Get the maximum milliseconds to run major compaction. If <= 0 the
      * thread will run until all compaction is completed.
      *
      * @return limit
      *           The number of milliseconds to run compaction.
      */
-    public long getMajorCompactionLimitMs() {
-        return getLong(MAJOR_COMPACTION_LIMIT_MS, -1);
+    public long getMajorCompactionMaxTimeMillis() {
+        return getLong(MAJOR_COMPACTION_MAX_TIME_MILLIS, -1);
     }
 
     /**
-     * Set the limit on the number of milliseconds to run. If <= 0 the
+     * Set the maximum milliseconds to run major compaction. If <= 0 the
      * thread will run until all compaction is completed.
      *
-     * @see #getMajorCompactionLimitMs()
+     * @see #getMajorCompactionMaxTimeMillis()
      *
-     * @param majorCompactionLimitMs
+     * @param majorCompactionMaxTimeMillis
      *           The number of milliseconds to run compaction.
      *
      * @return  server configuration
      */
-    public ServerConfiguration setMajorCompactionLimitMs(long majorCompactionLimitMs) {
-        setProperty(MAJOR_COMPACTION_LIMIT_MS, majorCompactionLimitMs);
+    public ServerConfiguration setMajorCompactionMaxTimeMillis(long majorCompactionMaxTimeMillis) {
+        setProperty(MAJOR_COMPACTION_MAX_TIME_MILLIS, majorCompactionMaxTimeMillis);
         return this;
     }
 
@@ -1609,29 +1609,29 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get the limit on the number of milliseconds to run. If <= 0 the
+     * Get the maximum milliseconds to run minor compaction. If <= 0 the
      * thread will run until all compaction is completed.
      *
      * @return limit
      *           The number of milliseconds to run compaction.
      */
-    public long getMinorCompactionLimitMs() {
-        return getLong(MINOR_COMPACTION_LIMIT_MS, -1);
+    public long getMinorCompactionMaxTimeMillis() {
+        return getLong(MINOR_COMPACTION_MAX_TIME_MILLIS, -1);
     }
 
     /**
-     * Set the limit on the number of milliseconds to run. If <= 0 the
+     * Set the maximum milliseconds to run minor compaction. If <= 0 the
      * thread will run until all compaction is completed.
      *
-     * @see #getMinorCompactionLimitMs()
+     * @see #getMinorCompactionMaxTimeMillis()
      *
-     * @param minorCompactionLimitMs
+     * @param minorCompactionMaxTimeMillis
      *           The number of milliseconds to run compaction.
      *
      * @return  server configuration
      */
-    public ServerConfiguration setMinorCompactionLimitMs(long minorCompactionLimitMs) {
-        setProperty(MINOR_COMPACTION_LIMIT_MS, minorCompactionLimitMs);
+    public ServerConfiguration setMinorCompactionMaxTimeMillis(long minorCompactionMaxTimeMillis) {
+        setProperty(MINOR_COMPACTION_MAX_TIME_MILLIS, minorCompactionMaxTimeMillis);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -371,6 +371,80 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         // entry logs ([0,1,2].log) should be compacted.
         for (File ledgerDirectory : tmpDirs) {
             assertFalse("Found entry log file ([0,1,2].log that should have not been compacted in ledgerDirectory: "
+                    + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1, 2));
+        }
+
+        // even though entry log files are removed, we still can access entries for ledger1
+        // since those entries have been compacted to a new entry log
+        verifyLedger(lhs[0].getId(), 0, lhs[0].getLastAddConfirmed());
+
+        assertTrue(
+                "RECLAIMED_COMPACTION_SPACE_BYTES should have been updated",
+                getStatsProvider(0)
+                        .getCounter("bookie.gc." + RECLAIMED_COMPACTION_SPACE_BYTES)
+                        .get().intValue() > 0);
+        assertTrue(
+                "RECLAIMED_DELETION_SPACE_BYTES should have been updated",
+                getStatsProvider(0)
+                        .getCounter("bookie.gc." + RECLAIMED_DELETION_SPACE_BYTES)
+                        .get().intValue() > 0);
+    }
+
+    @Test
+    public void testMinorCompactionWithLimits() throws Exception {
+        // prepare data
+        LedgerHandle[] lhs = prepareData(6, false);
+
+        for (LedgerHandle lh : lhs) {
+            lh.close();
+        }
+
+        // disable major compaction
+        baseConf.setMajorCompactionThreshold(0.0f);
+        baseConf.setGcWaitTime(60000);
+        baseConf.setMinorCompactionInterval(120000);
+        baseConf.setMajorCompactionInterval(240000);
+
+        // Setup limit on compaction duration.
+        baseConf.setMinorCompactionLimitMs(15);
+        baseConf.setMajorCompactionLimitMs(15);
+
+        // restart bookies
+        restartBookies(baseConf);
+
+        getGCThread().enableForceGC();
+        getGCThread().triggerGC().get();
+        assertTrue(
+                "ACTIVE_ENTRY_LOG_COUNT should have been updated",
+                getStatsProvider(0)
+                        .getGauge("bookie.gc." + ACTIVE_ENTRY_LOG_COUNT)
+                        .getSample().intValue() > 0);
+        assertTrue(
+                "ACTIVE_ENTRY_LOG_SPACE_BYTES should have been updated",
+                getStatsProvider(0)
+                        .getGauge("bookie.gc." + ACTIVE_ENTRY_LOG_SPACE_BYTES)
+                        .getSample().intValue() > 0);
+
+        long lastMinorCompactionTime = getGCThread().lastMinorCompactionTime;
+        long lastMajorCompactionTime = getGCThread().lastMajorCompactionTime;
+        assertFalse(getGCThread().enableMajorCompaction);
+        assertTrue(getGCThread().enableMinorCompaction);
+
+        // remove ledger2 and ledger3
+        bkc.deleteLedger(lhs[1].getId());
+        bkc.deleteLedger(lhs[2].getId());
+
+        LOG.info("Finished deleting the ledgers contains most entries.");
+        getGCThread().enableForceGC();
+        getGCThread().triggerGC().get();
+
+        // after garbage collection, major compaction should not be executed
+        assertEquals(lastMajorCompactionTime, getGCThread().lastMajorCompactionTime);
+        assertTrue(getGCThread().lastMinorCompactionTime > lastMinorCompactionTime);
+
+        // entry logs ([0,1,2].log) should be compacted.
+        for (File ledgerDirectory : tmpDirs) {
+            assertFalse("Found entry log file ([0,1,2].log that should have not been compacted in ledgerDirectory: "
                             + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1, 2));
         }
 
@@ -389,6 +463,9 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
                         .getCounter("bookie.gc." + RECLAIMED_DELETION_SPACE_BYTES)
                         .get().intValue() > 0);
     }
+
+
+
 
     @Test
     public void testMinorCompactionWithNoWritableLedgerDirs() throws Exception {
@@ -1065,8 +1142,10 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             UnpooledByteBufAllocator.DEFAULT);
 
         double threshold = 0.1;
+        long limit = 0;
+
         // shouldn't throw exception
-        storage.gcThread.doCompactEntryLogs(threshold);
+        storage.gcThread.doCompactEntryLogs(threshold, limit);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -391,7 +391,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
     }
 
     @Test
-    public void testMinorCompactionWithLimits() throws Exception {
+    public void testMinorCompactionWithMaxTimeMillis() throws Exception {
         // prepare data
         LedgerHandle[] lhs = prepareData(6, false);
 
@@ -406,8 +406,8 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         baseConf.setMajorCompactionInterval(240000);
 
         // Setup limit on compaction duration.
-        baseConf.setMinorCompactionLimitMs(15);
-        baseConf.setMajorCompactionLimitMs(15);
+        baseConf.setMinorCompactionMaxTimeMillis(15);
+        baseConf.setMajorCompactionMaxTimeMillis(15);
 
         // restart bookies
         restartBookies(baseConf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.commons.configuration.ConfigurationException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -151,5 +152,72 @@ public class TestServerConfiguration {
         conf.setEntryLogSizeLimit(1073741824);
         conf.validate();
         assertEquals(1073741824, conf.getEntryLogSizeLimit());
+    }
+
+    @Test
+    public void testCompactionSettings() {
+        ServerConfiguration conf = new ServerConfiguration();
+        long major, minor;
+
+        // Default Values
+        major = conf.getMajorCompactionLimitMs();
+        minor = conf.getMinorCompactionLimitMs();
+        Assert.assertEquals(-1, major);
+        Assert.assertEquals(-1, minor);
+
+        // Set values major then minor
+        conf.setMajorCompactionLimitMs(500).setMinorCompactionLimitMs(250);
+        major = conf.getMajorCompactionLimitMs();
+        minor = conf.getMinorCompactionLimitMs();
+        Assert.assertEquals(500, major);
+        Assert.assertEquals(250, minor);
+
+        // Set values minor then major
+        conf.setMinorCompactionLimitMs(150).setMajorCompactionLimitMs(1500);
+        major = conf.getMajorCompactionLimitMs();
+        minor = conf.getMinorCompactionLimitMs();
+        Assert.assertEquals(1500, major);
+        Assert.assertEquals(150, minor);
+
+        // Default Values
+        major = conf.getMajorCompactionInterval();
+        minor = conf.getMinorCompactionInterval();
+        Assert.assertEquals(3600, minor);
+        Assert.assertEquals(86400, major);
+
+        // Set values major then minor
+        conf.setMajorCompactionInterval(43200).setMinorCompactionInterval(1800);
+        major = conf.getMajorCompactionInterval();
+        minor = conf.getMinorCompactionInterval();
+        Assert.assertEquals(1800, minor);
+        Assert.assertEquals(43200, major);
+
+        // Set values minor then major
+        conf.setMinorCompactionInterval(900).setMajorCompactionInterval(21700);
+        major = conf.getMajorCompactionInterval();
+        minor = conf.getMinorCompactionInterval();
+        Assert.assertEquals(900, minor);
+        Assert.assertEquals(21700, major);
+
+        // Default Values
+        double majorThreshold, minorThreshold;
+        majorThreshold = conf.getMajorCompactionThreshold();
+        minorThreshold = conf.getMinorCompactionThreshold();
+        Assert.assertEquals(0.8, majorThreshold, 0.00001);
+        Assert.assertEquals(0.2, minorThreshold, 0.00001);
+
+        // Set values major then minor
+        conf.setMajorCompactionThreshold(0.7).setMinorCompactionThreshold(0.1);
+        majorThreshold = conf.getMajorCompactionThreshold();
+        minorThreshold = conf.getMinorCompactionThreshold();
+        Assert.assertEquals(0.7, majorThreshold, 0.00001);
+        Assert.assertEquals(0.1, minorThreshold, 0.00001);
+
+        // Set values minor then major
+        conf.setMinorCompactionThreshold(0.3).setMajorCompactionThreshold(0.6);
+        majorThreshold = conf.getMajorCompactionThreshold();
+        minorThreshold = conf.getMinorCompactionThreshold();
+        Assert.assertEquals(0.6, majorThreshold, 0.00001);
+        Assert.assertEquals(0.3, minorThreshold, 0.00001);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestServerConfiguration.java
@@ -160,22 +160,22 @@ public class TestServerConfiguration {
         long major, minor;
 
         // Default Values
-        major = conf.getMajorCompactionLimitMs();
-        minor = conf.getMinorCompactionLimitMs();
+        major = conf.getMajorCompactionMaxTimeMillis();
+        minor = conf.getMinorCompactionMaxTimeMillis();
         Assert.assertEquals(-1, major);
         Assert.assertEquals(-1, minor);
 
         // Set values major then minor
-        conf.setMajorCompactionLimitMs(500).setMinorCompactionLimitMs(250);
-        major = conf.getMajorCompactionLimitMs();
-        minor = conf.getMinorCompactionLimitMs();
+        conf.setMajorCompactionMaxTimeMillis(500).setMinorCompactionMaxTimeMillis(250);
+        major = conf.getMajorCompactionMaxTimeMillis();
+        minor = conf.getMinorCompactionMaxTimeMillis();
         Assert.assertEquals(500, major);
         Assert.assertEquals(250, minor);
 
         // Set values minor then major
-        conf.setMinorCompactionLimitMs(150).setMajorCompactionLimitMs(1500);
-        major = conf.getMajorCompactionLimitMs();
-        minor = conf.getMinorCompactionLimitMs();
+        conf.setMinorCompactionMaxTimeMillis(150).setMajorCompactionMaxTimeMillis(1500);
+        major = conf.getMajorCompactionMaxTimeMillis();
+        minor = conf.getMinorCompactionMaxTimeMillis();
         Assert.assertEquals(1500, major);
         Assert.assertEquals(150, minor);
 

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -500,8 +500,8 @@ ledgerDirectories=/tmp/bk-data
 # If it is set to less than zero, the minor compaction is disabled.
 # minorCompactionInterval=3600
 
-# Limit in milliseconds to run minor Compaction. Defaults to -1 run indefinitely.
-# minorCompactionLimitMs=-1
+# Maximum milliseconds to run minor Compaction. Defaults to -1 run indefinitely.
+# minorCompactionMaxTimeMillis=-1
 
 # Set the maximum number of entries which can be compacted without flushing.
 # When compacting, the entries are written to the entrylog and the new offsets
@@ -525,8 +525,8 @@ ledgerDirectories=/tmp/bk-data
 # If it is set to less than zero, the major compaction is disabled.
 # majorCompactionInterval=86400
 
-# Limit in milliseconds to run major Compaction. Defaults to -1 run indefinitely.
-# majorCompactionLimitMs=-1
+# Maximum milliseconds to run major Compaction. Defaults to -1 run indefinitely.
+# majorCompactionMaxTimeMillis=-1
 
 # Throttle compaction by bytes or by entries.
 # isThrottleByBytes=false

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -500,6 +500,9 @@ ledgerDirectories=/tmp/bk-data
 # If it is set to less than zero, the minor compaction is disabled.
 # minorCompactionInterval=3600
 
+# Limit in milliseconds to run minor Compaction. Defaults to -1 run indefinitely.
+# minorCompactionLimitMs=-1
+
 # Set the maximum number of entries which can be compacted without flushing.
 # When compacting, the entries are written to the entrylog and the new offsets
 # are cached in memory. Once the entrylog is flushed the index is updated with
@@ -521,6 +524,9 @@ ledgerDirectories=/tmp/bk-data
 # Interval to run major compaction, in seconds
 # If it is set to less than zero, the major compaction is disabled.
 # majorCompactionInterval=86400
+
+# Limit in milliseconds to run major Compaction. Defaults to -1 run indefinitely.
+# majorCompactionLimitMs=-1
 
 # Throttle compaction by bytes or by entries.
 # isThrottleByBytes=false


### PR DESCRIPTION
This resolves issue 2638, by allowing a customer to set a limit on the duration of the major and minor compaction runs. This allows the customer to balance the needs for compaction against the need for normal garbage collection. Unbounded execution of compaction can starve the garbage collection process, and may lead to extended periods of high disk IO. By setting a upper bound on the execution duration for the garbage collection, we can ensure a balance is maintained between both GC and Compaction processes. 

Logging has been improved to allow a user to see the complete usage of the buckets, vs. those that were compacted, so that they can decide on any further tuning that may be required. 

Test cases have been added to ensure limits are enforced properly and that defaulting of the values is correctly implemented.

