### PR TITLE
ISSUE-2640: BP-43: Exclude smoke tests for now can be enabled when we move to gradle.

### DIFF
--- a/tests/integration/smoke/build.gradle
+++ b/tests/integration/smoke/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation project(path: ':bookkeeper-common', configuration: 'testArtifacts')
     testImplementation project(':bookkeeper-server')
     testImplementation project(':tests:integration-tests-utils')
+    testImplementation project(':tests:integration-tests-topologies')
     testCompileOnly depLibs.lombok
     testImplementation depLibs.arquillianJunitContainer
     testImplementation depLibs.arquillianJunitStandalone
@@ -32,6 +33,10 @@ dependencies {
     testImplementation depLibs.commonsConfiguration
     testImplementation depLibs.arquillianCubeDocker
     testAnnotationProcessor depLibs.lombok
+}
+
+test {
+    exclude '**/*'
 }
 
 publishing {


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

**Migrate bookkeeper to gradle.**
Current smoke tests in OSS do not run and do not do anything useful. 
They are quite old and need to move to testcontainer and away from Arquallian. 
That requires code change. Therefore punting running these tests with gradle too, 
until everything moved to gradle. 
### Changes

Exclude Smoke tests from run.

Master Issue: #2640

