### PR TITLE
fix 2655 bookie will be down (out of memory), when there are a lots of ledgers under /ledgers/underreplication/ledgers to replication

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -212,6 +212,10 @@ class LedgerOpenOp {
                 public void readLastConfirmedComplete(int rc,
                         long lastConfirmed, Object ctx) {
                     if (rc != BKException.Code.OK) {
+                        if (lh != null && !doRecovery) {
+                            bk.getClientCtx().getLedgerManager()
+                                    .unregisterLedgerMetadataListener(ledgerId, lh);
+                        }
                         openComplete(bk.getReturnRc(BKException.Code.ReadException), null);
                     } else {
                         lh.lastAddConfirmed = lh.lastAddPushed = lastConfirmed;


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

In some exception branch, lh is not be unregister from listener,  so I make this change.

### Changes
`if (rc != BKException.Code.OK) {`
`                        if (lh != null && !doRecovery) {`
`                            bk.getClientCtx().getLedgerManager()`
`                                    .unregisterLedgerMetadataListener(ledgerId, lh);`
`                        }`
`                        openComplete(bk.getReturnRc(BKException.Code.ReadException), null);`
`                    }`