### PR TITLE
ISSUE-2640: BP-43: gradle build: sign published packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ allprojects {
         && it.name != 'main') {
         apply plugin: 'java'
         apply plugin: 'maven-publish'
+        apply plugin: 'signing'
 
         task testJar(type: Jar, dependsOn: testClasses) {
             classifier = 'tests'
@@ -74,6 +75,31 @@ allprojects {
                     from components.java
                     artifact testJar
                 }
+            }
+        }
+        signing {
+            def skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
+            def shouldSign = !skipSigning
+
+            if (shouldSign) {
+                if (project.hasProperty("singingKey")) {
+                    // The following allow the secretKey and password to be specified using env var
+                    // This is mainly for the CI system.
+                    //   * ORG_GRADLE_PROJECT_signingKey
+                    //   * ORG_GRADLE_PROJECT_signingPassword
+                    //   * ORG_GRADLE_PROJECT_signingKeyId
+                    // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+                    // for details
+                    def signingKey = findProperty("signingKey")
+                    def signingKeyId = findProperty("signingKeyId")
+                    def signingPassword = findProperty("signingPassword")
+                    if (signingKeyId && signingKey && signingPassword) {
+                        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+                    } else if (signingKey && signingPassword) {
+                        useInMemoryPgpKeys(signingKey, signingPassword)
+                    }
+                }
+                sign publishing.publications.maven
             }
         }
     }


### PR DESCRIPTION

### Motivation

Migrate bookkeeper build to gradle. The published artifacts need to be signed.

### Changes

Add signing plugin to sign published artifacts. For details see
https://docs.gradle.org/current/userguide/signing_plugin.html

This was testing by publishing to local maven repository:
```
$ gradlew bookkeeper-server:publishMavenPublicationToMavenLocal

$ ls -ln ~/.m2/repository/org/apache/bookkeeper/bookkeeper-server/4.14.0-SNAPSHOT/
total 10568
-rw-r--r--  1 501  20  1596624 Mar 31 13:07 bookkeeper-server-4.14.0-SNAPSHOT-tests.jar
-rw-r--r--  1 501  20      650 Mar 31 13:07 bookkeeper-server-4.14.0-SNAPSHOT-tests.jar.asc
-rw-r--r--  1 501  20  2254279 Mar 31 13:07 bookkeeper-server-4.14.0-SNAPSHOT.jar
-rw-r--r--  1 501  20      650 Mar 31 13:07 bookkeeper-server-4.14.0-SNAPSHOT.jar.asc
-rw-r--r--  1 501  20     6983 Mar 31 13:07 bookkeeper-server-4.14.0-SNAPSHOT.module
-rw-r--r--  1 501  20      650 Mar 31 13:07 bookkeeper-server-4.14.0-SNAPSHOT.module.asc
-rw-r--r--  1 501  20     6251 Mar 31 13:07 bookkeeper-server-4.14.0-SNAPSHOT.pom
-rw-r--r--  1 501  20      650 Mar 31 13:07 bookkeeper-server-4.14.0-SNAPSHOT.pom.asc
-rw-r--r--  1 501  20     1817 Mar 31 13:07 maven-metadata-local.xml

```

signing can be disable using following using `ORG_GRADLE_PROJECT_skipSigning`:

```
ORG_GRADLE_PROJECT_skipSigning=1 gradlew :bookkeeper-server:publishMavenPublicationToMavenLoca
```

Master Issue: #2640