### PR TITLE
ISSUE-2640: BP-43 create shaded jar for bookkeeper-server and distrib…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,5 @@
 #
 
 protobufPluginVersion=0.8.15
+shadowPluginVersion=6.1.0
+licenseGradlePluginVersion=0.15.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,8 @@
 pluginManagement {
     plugins {
         id "com.google.protobuf" version "${protobufPluginVersion}"
+        id "com.github.johnrengelman.shadow" version "${shadowPluginVersion}"
+        id "com.github.hierynomus.license" version "${licenseGradlePluginVersion}"
     }
 }
 
@@ -41,6 +43,8 @@ include(':bookkeeper-benchmark',
         'bookkeeper-http:vertx-http-server',
         'bookkeeper-proto',
         'bookkeeper-server',
+        'shaded:bookkeeper-server-shaded',
+        'shaded:bookkeeper-server-tests-shaded',
         'bookkeeper-stats',
         'bookkeeper-stats-providers:prometheus-metrics-provider',
         'bookkeeper-stats-providers:codahale-metrics-provider',
@@ -50,6 +54,7 @@ include(':bookkeeper-benchmark',
         'cpu-affinity',
         'cpu-affinity:src:main:affinity',
         'microbenchmarks',
+        'shaded:distributedlog-core-shaded',
         'stats:utils',
         'stream:api',
         'stream:clients:java:all',

--- a/shaded/bookkeeper-server-shaded/build.gradle
+++ b/shaded/bookkeeper-server-shaded/build.gradle
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+plugins {
+    id 'java'
+    id 'com.github.johnrengelman.shadow'
+    id 'com.github.hierynomus.license'
+}
+
+description = 'Apache BookKeeper :: Shaded :: bookkeeper-server-shaded'
+
+dependencies {
+    implementation project(':bookkeeper-server')
+}
+
+shadowJar {
+    dependencies {
+    }
+    relocate 'com.google', 'org.apache.bookkeeper.shaded.com.google'
+    archiveBaseName.set("bookkeeper-server-shaded")
+    archiveClassifier.set("")
+}

--- a/shaded/distributedlog-core-shaded/build.gradle
+++ b/shaded/distributedlog-core-shaded/build.gradle
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'com.github.johnrengelman.shadow'
+    id 'com.github.hierynomus.license'
+}
+
+description = 'Apache BookKeeper :: Shaded :: distributedlog-core-shaded'
+
+dependencies {
+    implementation project(':stream:distributedlog:core')
+}
+
+shadowJar {
+    dependencies {
+    }
+    relocate 'com.google', 'org.apache.bookkeeper.shaded.com.google'
+    relocate 'org.apache.commons.cli', 'dlshade.org.apache.commons.cli'
+    relocate 'org.apache.commons.codec', 'dlshade.org.apache.commons.codec'
+    relocate 'org.apache.commons.collections4', 'dlshade.org.apache.commons.collections4'
+    relocate 'org.apache.commons.lang', 'dlshade.org.apache.commons.lang'
+    relocate 'org.apache.commons.lang3', 'dlshade.org.apache.commons.lang3'
+    relocate 'org.apache.commons.logging', 'dlshade.org.apache.commons.logging'
+    relocate 'org.apache.commons.io', 'dlshade.org.apache.commons.io'
+    relocate 'org.apache.httpcomponents', 'dlshade.org.apache.httpcomponents'
+    relocate 'org.apache.http', 'dlshade.org.apache.http'
+    relocate 'org.apache.thrift', 'dlshade.org.apache.thrift'
+    relocate 'org.apache.zookeeper', 'dlshade.org.apache.zookeeper'
+    relocate 'org.apache.jute', 'dlshade.org.apache.jute'
+    relocate 'com.fasterxml.jackson', 'dlshade.com.fasterxml.jackson'
+    relocate 'com.sun.jna', 'dlshade.com.sun.jna'
+    relocate 'com.google', 'dlshade.com.google'
+    relocate 'org.jboss.netty', 'dlshade.org.jboss.netty'
+    relocate 'net.jpountz', 'dlshade.net.jpountz'
+    relocate 'org.rocksdb', 'dlshade.org.rocksdb'
+    relocate 'com.scurrilous.circe', 'dlshade.com.scurrilous.circe'
+    relocate 'org.apache.bookkeeper', 'dlshade.org.apache.bookkeeper'
+    relocate 'org.apache.distributedlog', 'dhshade.org.apache.distributedlog'
+    archiveBaseName.set("distributedlog-core-shaded")
+    archiveClassifier.set("")
+}


### PR DESCRIPTION
…utedlog-core

Descriptions of the changes in this PR:


### Motivation
**Gradle migration** 
With maven shaded Jar was created for bookkeeper-sever as well as distributedlog-core.
Though shaded jar was not being used by anybody.
There has been some difference in layout of shaded jar produced by maven and gradles.

Maven produced shaded jar just shades bookkeeper classes and leaves transitive dependency unshaded and as part of dependency in POM file. This behavior is not supported in gradle shadow plugin. Therefore gradle produced shaded jar shades not only bookkeer-server but also its transitive and direct dependencies and leaving nothing in pom file as dependency. 

### Changes
Create gradle build for shading bookkeeper-sever and distributedlog-core

Master Issue: #2640 
