### PR TITLE
ISSUE-2640: BP-43 Integrate checkstyle with gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
 plugins {
     id 'com.google.protobuf'
     id 'java'
+    id 'checkstyle'
 }
 
 subprojects {
@@ -35,7 +36,6 @@ apply from: "$rootDir/version.gradle"
 
 allprojects {
     apply from: "$rootDir/dependencies.gradle"
-
     if (it.path != ':circe-checksum:src:main:circe'
         && it.path != ':cpu-affinity:src:main:affinity'
         && it.name != 'src'
@@ -43,6 +43,18 @@ allprojects {
         apply plugin: 'java'
         apply plugin: 'maven-publish'
         apply plugin: 'signing'
+        apply plugin: "checkstyle"
+        checkstyle {
+            toolVersion "${checkStyleVersion}"
+            configFile file("$rootDir/buildtools/src/main/resources/bookkeeper/checkstyle.xml")
+            checkstyleMain {
+                source ='src/main/java'
+            }
+
+            checkstyleTest {
+                source ='src/test/java'
+            }
+        }
 
         task testJar(type: Jar, dependsOn: testClasses) {
             classifier = 'tests'

--- a/buildtools/src/main/resources/bookkeeper/checkstyle.xml
+++ b/buildtools/src/main/resources/bookkeeper/checkstyle.xml
@@ -60,7 +60,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
         <property name="checkFormat" value="$1"/>
     </module>
     <module name="SuppressionFilter">
-        <property name="file" value="${checkstyle.suppressions.file}" default="suppressions.xml" />
+        <property name="file" value="${checkstyle.suppressions.file}" default="./buildtools/src/main/resources/bookkeeper/suppressions.xml" />
     </module>
 
     <!-- Check that every module has a package-info.java -->

--- a/buildtools/src/main/resources/bookkeeper/suppressions.xml
+++ b/buildtools/src/main/resources/bookkeeper/suppressions.xml
@@ -29,4 +29,11 @@
 
     <!-- suppress all checks in the copied code -->
     <suppress checks=".*" files=".+[\\/]com[\\/]scurrilous[\\/]circe[\\/].+\.java" />
+    <suppress checks="AvoidStarImport" files=".*[\\/]distributedlog[\\/].*"/>
+    <suppress checks="StaticVariableName" files=".*[\\/]distributedlog[\\/].*"/>
+    <suppress checks="LocalVariableName" files=".*[\\/]distributedlog[\\/].*"/>
+    <suppress checks="LocalFinalVariableName" files=".*[\\/]distributedlog[\\/].*"/>
+    <suppress checks="MemberName" files=".*[\\/]distributedlog[\\/].*"/>
+    <!-- suppress all checks in the generated directories -->
+    <suppress checks=".*" files=".*[\\/]thrift[\\/].*"/>
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,4 @@
 #
 
 protobufPluginVersion=0.8.15
+checkStyleVersion=6.19


### PR DESCRIPTION
### Motivation

**Migrate bookkeeper to gradle.**
Checkstyle is gradle as well as maven plugin which checks for code formatting spacing etc. 
**How to run** 
 `./gradlew checkstyleMain  `

### Changes
Integrate gradle build with checkstyle plugin


Master Issue: #2640

