### PR TITLE
Rocksdb tombstones

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -253,7 +253,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-server-9.4.33.v20201020.jar [22]
 - lib/org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar [22]
 - lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar [22]
-- lib/org.rocksdb-rocksdbjni-6.10.2.jar [23]
+- lib/org.rocksdb-rocksdbjni-6.16.4.jar [23]
 - lib/com.beust-jcommander-1.78.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
@@ -327,7 +327,7 @@ Apache Software License, Version 2.
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.6.2
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.33.v20201020
-[23] Source available at https://github.com/facebook/rocksdb/tree/v5.13.1
+[23] Source available at https://github.com/facebook/rocksdb/tree/v6.16.4
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
@@ -584,7 +584,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-6.10.2.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-6.16.4.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -253,7 +253,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-server-9.4.33.v20201020.jar [22]
 - lib/org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar [22]
 - lib/org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar [22]
-- lib/org.rocksdb-rocksdbjni-6.10.2.jar [23]
+- lib/org.rocksdb-rocksdbjni-6.16.4.jar [23]
 - lib/com.beust-jcommander-1.78.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
@@ -325,7 +325,7 @@ Apache Software License, Version 2.
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.6.2
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.33.v20201020
-[23] Source available at https://github.com/facebook/rocksdb/tree/v5.13.1
+[23] Source available at https://github.com/facebook/rocksdb/tree/v6.16.4
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
@@ -582,7 +582,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-6.10.2.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-6.16.4.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -196,6 +196,7 @@ public class EntryLocationIndex implements Closeable {
         long deletedEntriesInBatch = 0;
 
         Batch batch = locationsDb.newBatch();
+        final byte[] firstDeletedKey = new byte[keyToDelete.array.length];
 
         try {
             for (long ledgerId : ledgersToDelete) {
@@ -238,7 +239,9 @@ public class EntryLocationIndex implements Closeable {
                     }
                     batch.remove(keyToDelete.array);
                     ++deletedEntriesInBatch;
-                    ++deletedEntries;
+                    if (deletedEntries++ == 0) {
+                        System.arraycopy(keyToDelete.array, 0, firstDeletedKey, 0, firstDeletedKey.length);
+                    }
                 }
 
                 if (deletedEntriesInBatch > DELETE_ENTRIES_BATCH_SIZE) {
@@ -251,8 +254,10 @@ public class EntryLocationIndex implements Closeable {
             try {
                 batch.flush();
                 batch.clear();
+                if (deletedEntries != 0) {
+                    locationsDb.compact(firstDeletedKey, keyToDelete.array);
+                }
             } finally {
-
                 firstKeyWrapper.recycle();
                 lastKeyWrapper.recycle();
                 keyToDelete.recycle();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
@@ -97,6 +97,16 @@ public interface KeyValueStorage extends Closeable {
     void delete(byte[] key) throws IOException;
 
     /**
+     * Compact storage within a specified range.
+     *
+     * @param firstKey
+     *            the first key in the range (included)
+     * @param lastKey
+     *            the last key in the range (not included)
+     */
+    default void compact(byte[] firstKey, byte[] lastKey) throws IOException {}
+
+    /**
      * Get an iterator over to scan sequentially through all the keys in the
      * database.
      *

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -272,6 +272,15 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
     }
 
     @Override
+    public void compact(byte[] firstKey, byte[] lastKey) throws IOException {
+        try {
+            db.compactRange(firstKey, lastKey);
+        } catch (RocksDBException e) {
+            throw new IOException("Error in RocksDB compact", e);
+        }
+    }
+
+    @Override
     public void sync() throws IOException {
         try {
             db.write(optionSync, emptyBatch);

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <protoc3.version>3.14.0</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
-    <rocksdb.version>6.10.2</rocksdb.version>
+    <rocksdb.version>6.16.4</rocksdb.version>
     <shrinkwrap.version>3.0.1</shrinkwrap.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snakeyaml.version>1.19</snakeyaml.version>


### PR DESCRIPTION
### Motivation

After deleting many ledgers, seeking to the end of the RocksDB metadata can take a long time and trigger timeouts upstream. Address this by improving the seek logic as well as compacting out tombstones in situations where we've just deleted many entries.  This affects the entry location index and the ledger metadata index.
