### PR TITLE
Add current ip address, long hostname and short hostname to /etc/hosts

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Tune Runner VM performance
+description: tunes the GitHub Runner VM operation system
+runs:
+  using: composite
+  steps:
+    - run: |
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # Ensure that reverse lookups for current hostname are handled properly
+            # Add the current IP address, long hostname and short hostname record to /etc/hosts file
+            echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+        fi
+      shell: bash

--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
### Motivation

Fixes reverse DNS lookup for current hostname. This is broken in GitHub Actions currently.
See https://github.com/apache/pulsar/issues/10232 and https://github.com/apache/pulsar/pull/10233 for more details.


### Changes

Add the current IP address, long hostname and short hostname record to /etc/hosts file at the beginning of each GitHub Actions workflow.