### PR TITLE
ISSUE-2640: BP-43: Fix test cases that fail when running with gradle

### DIFF
--- a/bookkeeper-server/build.gradle
+++ b/bookkeeper-server/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     implementation depLibs.commonsConfiguration
     implementation depLibs.commonsIO
     implementation depLibs.commonsLang3
-    implementation depLibs.commonsLang3
     implementation depLibs.guava
     implementation depLibs.httpclient
     implementation depLibs.jacksonAnnotations
@@ -53,9 +52,12 @@ dependencies {
     implementation depLibs.nettyTransportNativeEpoll
     implementation depLibs.protobuf
     implementation depLibs.rocksDb
+    implementation depLibs.slf4j
+    implementation depLibs.slf4jLog4j
     implementation depLibs.zookeeper
 
     testImplementation project(':bookkeeper-stats-providers:prometheus-metrics-provider')
+    testImplementation project(':bookkeeper-http:vertx-http-server')
     testImplementation project(path: ':bookkeeper-common', configuration: 'testArtifacts')
 
     testCompileOnly depLibs.lombok
@@ -64,9 +66,11 @@ dependencies {
     testImplementation depLibs.junit
     testImplementation depLibs.junitFoundation
     testImplementation depLibs.kerbySimpleKdc
+    testImplementation depLibs.metricsCore
     testImplementation depLibs.mockito
     testImplementation depLibs.powermockJunit
     testImplementation depLibs.powermockMockito
+    testImplementation depLibs.snappy
     testImplementation depLibs.zookeeperTest
 
     annotationProcessor depLibs.lombok

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EnableZkSecurityBasicTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EnableZkSecurityBasicTest.java
@@ -53,7 +53,7 @@ public class EnableZkSecurityBasicTest extends BookKeeperClusterTestCase {
     @BeforeClass
     public static void setupJAAS() throws IOException {
         System.setProperty("zookeeper.authProvider.1", "org.apache.zookeeper.server.auth.SASLAuthenticationProvider");
-        File tmpJaasDir = new File("target").getAbsoluteFile();
+        File tmpJaasDir = Files.createTempDirectory("jassTmpDir").toFile();
         File tmpJaasFile = new File(tmpJaasDir, "jaas.conf");
         String jassFileContent = "Server {\n"
             + "       org.apache.zookeeper.server.auth.DigestLoginModule required\n"

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
@@ -138,8 +138,16 @@ public class ZooKeeperUtil implements ZooKeeperCluster {
                             final TimeUnit timeUnit,
                             final CountDownLatch l)
             throws InterruptedException, IOException {
-        Thread[] allthreads = new Thread[Thread.activeCount()];
-        Thread.enumerate(allthreads);
+
+        // Gradle handles thread groups differently to surefire, so we must
+        // enumerate from the parent thread group to find the zookeeper sync
+        // thread to sleep
+        ThreadGroup tg = Thread.currentThread().getThreadGroup();
+        while (tg.getParent() != null) {
+            tg = tg.getParent();
+        }
+        Thread[] allthreads = new Thread[tg.activeCount()];
+        tg.enumerate(allthreads);
         for (final Thread t : allthreads) {
             if (t.getName().contains("SyncThread:0")) {
                 Thread sleeper = new Thread() {

--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,24 @@ allprojects {
                 // Signing task is added by the release plugin
             }
         }
+        test {
+            testLogging {
+                events "skipped", "failed", "standardError"
+            }
+
+            String testGroup = System.properties['testGroup']
+            if (testGroup == 'client') {
+                include '**/client/*'
+            } else if (testGroup == 'bookie') {
+                include '**/bookie/*'
+            } else if (testGroup == 'other') {
+                exclude '**/client/*'
+                exclude '**/bookie/*'
+            }
+            if (project.hasProperty('excludeTests')) {
+                exclude project.property('excludeTests')
+            }
+        }
     }
 
     repositories {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -122,7 +122,9 @@ depLibs = [
     jna: "net.java.dev.jna:jna:${depVersions.jna}",
     jsr305: "com.google.code.findbugs:jsr305:${depVersions.jsr305}",
     junit: "junit:junit:${depVersions.junit}",
-    junitFoundation: "com.nordstrom.tools:junit-foundation:${depVersions.junitFoundation}",
+    junitFoundation: dependencies.create("com.nordstrom.tools:junit-foundation:${depVersions.junitFoundation}") {
+        exclude group: 'ch.qos.logback', module: 'logback-classic'
+    },
     kerbySimpleKdc: "org.apache.kerby:kerb-simplekdc:${depVersions.kerby}",
     log4j: "log4j:log4j:${depVersions.log4j}",
     lombok: "org.projectlombok:lombok:${depVersions.lombok}",
@@ -160,6 +162,17 @@ depLibs = [
     vertxCore: "io.vertx:vertx-core:${depVersions.vertx}",
     vertxWeb: "io.vertx:vertx-web:${depVersions.vertx}",
     yahooDatasketches: "com.yahoo.datasketches:sketches-core:${depVersions.yahooDatasketches}",
-    zookeeper: "org.apache.zookeeper:zookeeper:${depVersions.zookeeper}",
-    zookeeperTest: "org.apache.zookeeper:zookeeper:${depVersions.zookeeper}:tests"
+    zookeeper: dependencies.create("org.apache.zookeeper:zookeeper:${depVersions.zookeeper}"){
+        exclude group: "net.java.dev.javacc", module: "javacc"
+        exclude group: "org.slf4j", module: "slf4j-log4j12"
+        exclude group: "org.slf4j", module: "slf4j-api"
+        exclude group: "log4j", module: "log4j"
+        exclude group: "io.netty", module: "*"
+    },
+    zookeeperTest: dependencies.create("org.apache.zookeeper:zookeeper:${depVersions.zookeeper}:tests"){
+        exclude group: "org.slf4j", module: "slf4j-log4j12"
+        exclude group: "org.slf4j", module: "slf4j-api"
+        exclude group: "log4j", module: "log4j"
+        exclude group: "io.netty", module: "*"
+    }
 ]


### PR DESCRIPTION
### Motivation

Migrate bookkeeper build to gradle. Some test cases were failing while running test with gradle

### Changes

* Fix dependencies to exclude some transitive dependencies.
* jassTmpDir was created under target folder. This fails while running tests using gradle. Instead we should use createTempDirectory to create temp folder
