### PR TITLE
[Build] Run PR builds for merge commit

### DIFF
--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -41,9 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -41,9 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -40,9 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -40,9 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,9 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -40,9 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -40,9 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -40,9 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -40,9 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm


### PR DESCRIPTION
### Motivation

In GitHub Actions, the default way to handle PR builds is to checkout GitHub provided merge_commit_sha . 

GitHub's merge_commit_sha is explained in [this documentation](https://docs.github.com/en/rest/reference/pulls#get-a-pull-request)
> Before merging a pull request, the merge_commit_sha attribute holds the SHA of the test merge commit.

Behind the scenes, GitHub automatically creates a "test merge commit" that merges the PR branch and the target branch (master). A pull request build won't be started at all if this test merge commit cannot be created without conflicts.

In current BK GitHub Actions workflows, the PR builds happen for the HEAD commit on the pull request branch, without a merge to the master branch. The downside of the approach used in the existing BK CI is that the PR build won't pick up changes made in the master branch. It is required to explicitly rebase or merge the master branch to the pull request branch to get the changes. Another disadvantage is that there's a higher chance that the PR breaks the master branch after the PR is merged.
The isolated behavior might be seen as a benefit. The PR branch build will be only impacted by the changes made in the PR branch. 

This PR is about changing the BK CI PR builds to use the GitHub Actions default for checking out the merge_commit_sha for PR builds.

A similar change was made in apache/pulsar in PR https://github.com/apache/pulsar/pull/9963


### Modifications

- instead of running the build for PR branch HEAD commit,
  run the commit for the GitHub provided merge_commit_sha