### PR TITLE
ISSUE-2640: BP-43 Some clean up and making sure that all bookkeepr-se…

### DIFF
--- a/bookkeeper-server/build.gradle
+++ b/bookkeeper-server/build.gradle
@@ -32,8 +32,6 @@ dependencies {
 
     compileOnly depLibs.lombok
     compileOnly depLibs.spotbugsAnnotations
-    implementation depLibs.bcpkixJdk15on
-    implementation depLibs.bcproveExtJdk15on
     implementation depLibs.bcFips
     implementation depLibs.commonsCli
     implementation depLibs.commonsCodec
@@ -52,8 +50,6 @@ dependencies {
     implementation depLibs.nettyTransportNativeEpoll
     implementation depLibs.protobuf
     implementation depLibs.rocksDb
-    implementation depLibs.slf4j
-    implementation depLibs.slf4jLog4j
     implementation depLibs.zookeeper
 
     testImplementation project(':bookkeeper-stats-providers:prometheus-metrics-provider')
@@ -72,9 +68,9 @@ dependencies {
     testImplementation depLibs.powermockMockito
     testImplementation depLibs.snappy
     testImplementation depLibs.zookeeperTest
-
     annotationProcessor depLibs.lombok
     testAnnotationProcessor depLibs.lombok
+    testImplementation depLibs.slf4jLog4j
 }
 
 test {
@@ -85,6 +81,6 @@ test {
 test.doFirst {
     def junitFoundation = configurations.testCompileClasspath.resolvedConfiguration
         .resolvedArtifacts.find { it.name == 'junit-foundation' }
-    jvmArgs("-javaagent:${junitFoundation.file}", "-Djunit.timeout.test=600000", "-Djunit.max.retry=3",
+    jvmArgs("-Djunit.timeout.test=600000", "-Djunit.max.retry=3",
             "-Djava.net.preferIPv4Stack=true", "-Dio.netty.leakDetection.level=paranoid")
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
@@ -138,16 +138,8 @@ public class ZooKeeperUtil implements ZooKeeperCluster {
                             final TimeUnit timeUnit,
                             final CountDownLatch l)
             throws InterruptedException, IOException {
-
-        // Gradle handles thread groups differently to surefire, so we must
-        // enumerate from the parent thread group to find the zookeeper sync
-        // thread to sleep
-        ThreadGroup tg = Thread.currentThread().getThreadGroup();
-        while (tg.getParent() != null) {
-            tg = tg.getParent();
-        }
-        Thread[] allthreads = new Thread[tg.activeCount()];
-        tg.enumerate(allthreads);
+        Thread[] allthreads = new Thread[Thread.activeCount()];
+        Thread.enumerate(allthreads);
         for (final Thread t : allthreads) {
             if (t.getName().contains("SyncThread:0")) {
                 Thread sleeper = new Thread() {

--- a/build.gradle
+++ b/build.gradle
@@ -192,10 +192,6 @@ allprojects {
             }
         }
         test {
-            testLogging {
-                events "skipped", "failed", "standardError"
-            }
-
             String testGroup = System.properties['testGroup']
             if (testGroup == 'client') {
                 include '**/client/*'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,8 +24,8 @@ ext {
 depVersions = [
     arquillianCubeDocker: "1.18.2",
     arquillianJunit: "1.6.0.Final",
-    bcFips: "1.0.1",
-    bouncycastle: "1.60",
+    bcFips: "1.0.2",
+    bouncycastle: "1.56",
     commonsCli: "1.4",
     commonsCodec: "1.14",
     commonsCollections4: "4.1",
@@ -63,7 +63,7 @@ depVersions = [
     lz4: "1.3.0",
     mockito: "3.0.0",
     netty: "4.1.32.Final",
-    nettyTcnativeBoringSsl: "2.0.20.Final",
+    nettyTcnativeBoringSsl: "2.0.31.Final",
     powermock: "2.0.2",
     prometheus: "0.0.21",
     protobuf: "3.14.0",
@@ -122,9 +122,7 @@ depLibs = [
     jna: "net.java.dev.jna:jna:${depVersions.jna}",
     jsr305: "com.google.code.findbugs:jsr305:${depVersions.jsr305}",
     junit: "junit:junit:${depVersions.junit}",
-    junitFoundation: dependencies.create("com.nordstrom.tools:junit-foundation:${depVersions.junitFoundation}") {
-        exclude group: 'ch.qos.logback', module: 'logback-classic'
-    },
+    junitFoundation: "com.nordstrom.tools:junit-foundation:${depVersions.junitFoundation}",
     kerbySimpleKdc: "org.apache.kerby:kerb-simplekdc:${depVersions.kerby}",
     log4j: "log4j:log4j:${depVersions.log4j}",
     lombok: "org.projectlombok:lombok:${depVersions.lombok}",
@@ -162,17 +160,6 @@ depLibs = [
     vertxCore: "io.vertx:vertx-core:${depVersions.vertx}",
     vertxWeb: "io.vertx:vertx-web:${depVersions.vertx}",
     yahooDatasketches: "com.yahoo.datasketches:sketches-core:${depVersions.yahooDatasketches}",
-    zookeeper: dependencies.create("org.apache.zookeeper:zookeeper:${depVersions.zookeeper}"){
-        exclude group: "net.java.dev.javacc", module: "javacc"
-        exclude group: "org.slf4j", module: "slf4j-log4j12"
-        exclude group: "org.slf4j", module: "slf4j-api"
-        exclude group: "log4j", module: "log4j"
-        exclude group: "io.netty", module: "*"
-    },
-    zookeeperTest: dependencies.create("org.apache.zookeeper:zookeeper:${depVersions.zookeeper}:tests"){
-        exclude group: "org.slf4j", module: "slf4j-log4j12"
-        exclude group: "org.slf4j", module: "slf4j-api"
-        exclude group: "log4j", module: "log4j"
-        exclude group: "io.netty", module: "*"
-    }
+    zookeeper: "org.apache.zookeeper:zookeeper:${depVersions.zookeeper}",
+    zookeeperTest: "org.apache.zookeeper:zookeeper:${depVersions.zookeeper}:tests"
 ]


### PR DESCRIPTION
### Motivation
Consolidate and ensure that at last all bookkeeper server test pass with gradle. 
That essentially entails cleaning up direct dependencies.

### Changes

 % ./gradlew cleanTest bookkeeper-server:test

> Configure project :microbenchmarks
0
<============-> 99% EXECUTING [2m 54s]
<============-> 99% EXECUTING [9m 52s]
> :bookkeeper-server:test > 455 tests completed, 6 skipped
<============-> 99% EXECUTING [36m 52s]
> :bookkeeper-server:test > 487 tests completed, 7 skipped
<============-> 99% EXECUTING [54m 24s]
<============-> 99% EXECUTING [54m 25s]ompleted, 16 skipped
<============-> 99% EXECUTING [1h 3m 16s]
<============-> 99% EXECUTING [1h 6m 39s]
> :bookkeeper-server:test > 777 tests completed, 19 skippedeeper.replication.AuditorPeriodicCheckTest
> :bookkeeper-server:test > Executing test org.apache.bookkeeper.replication.AuditorBookieTest
<============-> 99% EXECUTING [1h 14m 37s]
<============-> 99% EXECUTING [1h 14m 38s]leted, 19 skipped
<============-> 99% EXECUTING [1h 20m 59s]
<============-> 99% EXECUTING [1h 21m 0s]
> :bookkeeper-server:test > Executing test org.apache.bookkeeper.client.BookKeeperAdminTest

I interrupted the tests after 777 tests after rebasing. But all the tests have passed before with same set of changes.

Master Issue: #2640
