### PR TITLE
[Security] Remove jackson-mapper-asl dependency to resolve multiple CVEs

### DIFF
--- a/bookkeeper-dist/all/pom.xml
+++ b/bookkeeper-dist/all/pom.xml
@@ -103,12 +103,6 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
 
-    <!-- jackson mapper for running zookeeper -->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-
     <dependency>
        <!-- needed by ZooKeeper server -->
        <groupId>org.xerial.snappy</groupId>

--- a/bookkeeper-dist/server/pom.xml
+++ b/bookkeeper-dist/server/pom.xml
@@ -89,11 +89,6 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
 
-    <!-- jackson mapper for running zookeeper -->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
     <dependency>
        <!-- needed by ZooKeeper server -->
        <groupId>org.xerial.snappy</groupId>

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -258,8 +258,6 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/org.codehaus.jackson-jackson-core-asl-1.9.11.jar [27]
-- lib/org.codehaus.jackson-jackson-mapper-asl-1.9.11.jar [27]
 - lib/com.google.api.grpc-proto-google-common-protos-1.17.0.jar [28]
 - lib/com.google.code.gson-gson-2.8.6.jar [29]
 - lib/io.opencensus-opencensus-api-0.24.0.jar [30]
@@ -331,7 +329,6 @@ Apache Software License, Version 2.
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[27] Source available at https://github.com/codehaus/jackson/tree/d1c26ec538a8701cff7548009254fd6183b71873
 [28] Source available at https://github.com/googleapis/googleapis
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
@@ -629,7 +626,7 @@ Bundled as
 Source available at https://github.com/google/protobuf/tree/v3.14.0
 For details, see deps/protobuf-3.14.0/LICENSE.
 
-Bundled as 
+Bundled as
   - lib/com.google.protobuf-protobuf-java-util-3.12.0.jar
 Source available at https://github.com/protocolbuffers/protobuf/tree/v3.12.0
 For details, see deps/protobuf-3.12.0/LICENSE.
@@ -656,7 +653,7 @@ Bundled as
   - lib/com.google.auth-google-auth-library-oauth2-http-0.20.0.jar
 Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v0.20.0
 ------------------------------------------------------------------------------------
-This product bundles the bouncycastle Library. 
+This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2/LICENSE.html
 
 Bundled as

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -279,8 +279,6 @@ Apache Software License, Version 2.
 - lib/com.google.re2j-re2j-1.2.jar [45]
 - lib/io.dropwizard.metrics-metrics-core-3.2.5.jar [46]
 - lib/io.perfmark-perfmark-api-0.19.0.jar [47]
-- lib/org.codehaus.jackson-jackson-core-asl-1.9.11.jar [48]
-- lib/org.codehaus.jackson-jackson-mapper-asl-1.9.11.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.jar [50]
 
@@ -323,7 +321,6 @@ Apache Software License, Version 2.
 [45] Source available at https://github.com/google/re2j/releases/tag/re2j-1.2
 [46] Source available at https://github.com/dropwizard/metrics/releases/tag/v3.1.0
 [47] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.19.0
-[48] Source available at https://github.com/codehaus/jackson/tree/d1c26ec538a8701cff7548009254fd6183b71873
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
 [50] Source available at https://github.com/google/snappy/releases/tag/1.1.7
 
@@ -563,7 +560,7 @@ Bundled as
 Source available at https://github.com/google/protobuf/tree/v3.14.0
 For details, see deps/protobuf-3.14.0/LICENSE.
 
-Bundled as 
+Bundled as
   - lib/com.google.protobuf-protobuf-java-util-3.12.0.jar
 Source available at https://github.com/protocolbuffers/protobuf/tree/v3.12.0
 For details, see deps/protobuf-3.12.0/LICENSE.
@@ -584,7 +581,7 @@ Bundled as
   - lib/com.google.auth-google-auth-library-oauth2-http-0.20.0.jar
 Source available at https://github.com/google/google-auth-library-java/tree/0.20.0
 ------------------------------------------------------------------------------------
-This product bundles the bouncycastle Library. 
+This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2/LICENSE.html
 
 Bundled as

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -258,8 +258,6 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/org.codehaus.jackson-jackson-core-asl-1.9.11.jar [27]
-- lib/org.codehaus.jackson-jackson-mapper-asl-1.9.11.jar [27]
 - lib/com.google.api.grpc-proto-google-common-protos-1.17.0.jar [28]
 - lib/com.google.code.gson-gson-2.8.6.jar [29]
 - lib/io.opencensus-opencensus-api-0.24.0.jar [30]
@@ -329,7 +327,6 @@ Apache Software License, Version 2.
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[27] Source available at https://github.com/codehaus/jackson/tree/d1c26ec538a8701cff7548009254fd6183b71873
 [28] Source available at https://github.com/googleapis/googleapis
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
@@ -621,7 +618,7 @@ Bundled as
 Source available at https://github.com/google/protobuf/tree/v3.14.0
 For details, see deps/protobuf-3.14.0/LICENSE.
 
-Bundled as 
+Bundled as
   - lib/com.google.protobuf-protobuf-java-util-3.12.0.jar
 Source available at https://github.com/protocolbuffers/protobuf/tree/v3.12.0
 For details, see deps/protobuf-3.12.0/LICENSE.
@@ -648,7 +645,7 @@ Bundled as
   - lib/com.google.auth-google-auth-library-oauth2-http-0.20.0.jar
 Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v0.20.0
 ------------------------------------------------------------------------------------
-This product bundles the bouncycastle Library. 
+This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2/LICENSE.html
 
 Bundled as

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
     <jackson.version>2.11.0</jackson.version>
-    <jackson-mapper-asl.version>1.9.11</jackson-mapper-asl.version>
     <jcommander.version>1.78</jcommander.version>
     <jetty.version>9.4.33.v20201020</jetty.version>
     <jmh.version>1.19</jmh.version>
@@ -235,7 +234,7 @@
         <artifactId>freebuilder</artifactId>
         <version>${freebuilder.version}</version>
       </dependency>
-      
+
       <!-- logging dependencies -->
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -363,12 +362,6 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.11</artifactId>
         <version>${jackson.version}</version>
-      </dependency>
-      <!-- dependency needed for zookeeper jetty admin server -->
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>${jackson-mapper-asl.version}</version>
       </dependency>
 
       <!-- protobuf dependencies -->

--- a/stream/statelib/pom.xml
+++ b/stream/statelib/pom.xml
@@ -125,13 +125,6 @@
       </exclusions>
     </dependency>
 
-    <!-- dependency needed for zookeeper jetty admin server -->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>${jackson-mapper-asl.version}</version>
-    </dependency>
-
     <dependency>
       <!-- needed by ZooKeeper server -->
       <groupId>org.xerial.snappy</groupId>

--- a/stream/storage/impl/pom.xml
+++ b/stream/storage/impl/pom.xml
@@ -126,13 +126,6 @@
         </exclusions>
       </dependency>
 
-      <!-- dependency needed for zookeeper jetty admin server -->
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>${jackson-mapper-asl.version}</version>
-      </dependency>
-
       <dependency>
          <!-- needed by ZooKeeper server -->
          <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
### Motivation

- jackson-mapper-asl is not required since Zookeeper 3.6.x+ no more depends on jackson-mapper-asl library (ZOOKEEPER-3051)

### Modifications

Remove jackson-mapper-asl dependency