### PR TITLE
[Security] Upgrade libthrift to 0.14.2 to address multiple CVEs

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -289,7 +289,7 @@ Apache Software License, Version 2.
 - lib/org.jctools-jctools-core-2.1.2.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.5.jar [39]
 - lib/org.apache.httpcomponents-httpcore-4.4.9.jar [40]
-- lib/org.apache.thrift-libthrift-0.12.0.jar [41]
+- lib/org.apache.thrift-libthrift-0.14.2.jar [41]
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
 - lib/com.google.http-client-google-http-client-1.34.0.jar [43]
 - lib/com.google.http-client-google-http-client-jackson2-1.34.0.jar [43]
@@ -342,7 +342,7 @@ Apache Software License, Version 2.
 [38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1
-[41] Source available at https://github.com/apache/thrift/tree/0.12.0
+[41] Source available at https://github.com/apache/thrift/tree/0.14.2
 [42] Source available at https://source.android.com/
 [43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.34.0
 [44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -270,7 +270,7 @@ Apache Software License, Version 2.
 - lib/org.jctools-jctools-core-2.1.2.jar [37]
 - lib/org.apache.httpcomponents-httpclient-4.5.5.jar [38]
 - lib/org.apache.httpcomponents-httpcore-4.4.9.jar [39]
-- lib/org.apache.thrift-libthrift-0.12.0.jar [40]
+- lib/org.apache.thrift-libthrift-0.14.2.jar [40]
 - lib/com.google.android-annotations-4.1.1.4.jar [41]
 - lib/com.google.auto.value-auto-value-annotations-1.7.jar [42]
 - lib/com.google.http-client-google-http-client-1.34.0.jar [43]
@@ -313,7 +313,7 @@ Apache Software License, Version 2.
 [37] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [38] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [39] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1
-[40] Source available at https://github.com/apache/thrift/tree/0.12.0
+[40] Source available at https://github.com/apache/thrift/tree/0.14.2
 [41] Source available at https://source.android.com/
 [42] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7
 [43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.34.0

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -289,7 +289,7 @@ Apache Software License, Version 2.
 - lib/org.jctools-jctools-core-2.1.2.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.5.jar [39]
 - lib/org.apache.httpcomponents-httpcore-4.4.9.jar [40]
-- lib/org.apache.thrift-libthrift-0.12.0.jar [41]
+- lib/org.apache.thrift-libthrift-0.14.2.jar [41]
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
 - lib/com.google.http-client-google-http-client-1.34.0.jar [43]
 - lib/com.google.http-client-google-http-client-jackson2-1.34.0.jar [43]
@@ -340,7 +340,7 @@ Apache Software License, Version 2.
 [38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1
-[41] Source available at https://github.com/apache/thrift/tree/0.12.0
+[41] Source available at https://github.com/apache/thrift/tree/0.14.2
 [42] Source available at https://source.android.com/
 [43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.34.0
 [44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -75,7 +75,7 @@ depVersions = [
     protocGenGrpcJava: "1.12.0",
     shrinkwrap:"3.1.4",
     snappy: "1.1.7.7",
-    thrift: "0.12.0",
+    thrift: "0.14.2",
     testcontainers: "1.15.1",
     vertx: "3.9.2",
     yahooDatasketches: "0.8.3",
@@ -155,7 +155,10 @@ depLibs = [
     snappy: "org.xerial.snappy:snappy-java:${depVersions.snappy}",
     snakeyaml: "org.yaml:snakeyaml:${depVersions.snakeyaml}",
     spotbugsAnnotations: "com.github.spotbugs:spotbugs-annotations:${depVersions.spotbugsAnnotations}",
-    thrift: "org.apache.thrift:libthrift:${depVersions.thrift}",
+    thrift: dependencies.create("org.apache.thrift:libthrift:${depVersions.thrift}") {
+        exclude group: 'org.apache.tomcat.embed', module: 'tomcat-embed-core'
+        exclude group: 'javax.annotation', module: 'javax.annotation-api'
+    },
     testcontainers: "org.testcontainers:testcontainers:${depVersions.testcontainers}",
     vertxCore: "io.vertx:vertx-core:${depVersions.vertx}",
     vertxWeb: "io.vertx:vertx-web:${depVersions.vertx}",

--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,7 @@
     <jmock.version>2.8.2</jmock.version>
     <jna.version>3.2.7</jna.version>
     <junit.version>4.12</junit.version>
-    <libthrift5.version>0.5.0-1</libthrift5.version>
-    <libthrift9.version>0.12.0</libthrift9.version>
+    <libthrift.version>0.14.2</libthrift.version>
     <lombok.version>1.18.20</lombok.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.0.0</mockito.version>
@@ -375,7 +374,17 @@
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>${libthrift9.version}</version>
+        <version>${libthrift.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- netty dependencies -->

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/acl/ZKAccessControl.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/acl/ZKAccessControl.java
@@ -22,7 +22,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.concurrent.CompletableFuture;
 import org.apache.distributedlog.ZooKeeperClient;
 import org.apache.distributedlog.thrift.AccessControlEntry;
@@ -208,16 +207,14 @@ public class ZKAccessControl {
     }
 
     static byte[] serialize(AccessControlEntry ace) throws IOException {
-        TMemoryBuffer transport = new TMemoryBuffer(BUFFER_SIZE);
-        TJSONProtocol protocol = new TJSONProtocol(transport);
         try {
+            TMemoryBuffer transport = new TMemoryBuffer(BUFFER_SIZE);
+            TJSONProtocol protocol = new TJSONProtocol(transport);
             ace.write(protocol);
             transport.flush();
-            return transport.toString(UTF_8.name()).getBytes(UTF_8);
+            return transport.toString(UTF_8).getBytes(UTF_8);
         } catch (TException e) {
             throw new IOException("Failed to serialize access control entry : ", e);
-        } catch (UnsupportedEncodingException uee) {
-            throw new IOException("Failed to serialize acesss control entry : ", uee);
         }
     }
 
@@ -227,9 +224,9 @@ public class ZKAccessControl {
         }
 
         AccessControlEntry ace = new AccessControlEntry();
-        TMemoryInputTransport transport = new TMemoryInputTransport(data);
-        TJSONProtocol protocol = new TJSONProtocol(transport);
         try {
+            TMemoryInputTransport transport = new TMemoryInputTransport(data);
+            TJSONProtocol protocol = new TJSONProtocol(transport);
             ace.read(protocol);
         } catch (TException e) {
             throw new CorruptedAccessControlException(zkPath, e);

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/BKDLConfig.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/BKDLConfig.java
@@ -22,7 +22,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -334,15 +333,13 @@ public class BKDLConfig implements DLConfig {
     }
 
     String serialize(BKDLConfigFormat configFormat) {
-        TMemoryBuffer transport = new TMemoryBuffer(BUFFER_SIZE);
-        TJSONProtocol protocol = new TJSONProtocol(transport);
         try {
+            TMemoryBuffer transport = new TMemoryBuffer(BUFFER_SIZE);
+            TJSONProtocol protocol = new TJSONProtocol(transport);
             configFormat.write(protocol);
             transport.flush();
-            return transport.toString("UTF-8");
+            return transport.toString(UTF_8);
         } catch (TException e) {
-            throw new RuntimeException("Failed to serialize BKDLConfig : ", e);
-        } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Failed to serialize BKDLConfig : ", e);
         }
     }
@@ -350,9 +347,9 @@ public class BKDLConfig implements DLConfig {
     @Override
     public void deserialize(byte[] data) throws IOException {
         BKDLConfigFormat configFormat = new BKDLConfigFormat();
-        TMemoryInputTransport transport = new TMemoryInputTransport(data);
-        TJSONProtocol protocol = new TJSONProtocol(transport);
         try {
+            TMemoryInputTransport transport = new TMemoryInputTransport(data);
+            TJSONProtocol protocol = new TJSONProtocol(transport);
             configFormat.read(protocol);
         } catch (TException e) {
             throw new IOException("Failed to deserialize data '"


### PR DESCRIPTION
Fixes #2512

### Motivation

See #2512 

The current libthrift version 0.12.0 has multiple vulnerabilities:
  - CVE-2019-0205 , CVE-2019-0210 , CVE-2020-13949

### Motivation

- Upgrade libthrift version to 0.14.1 and fix compilation errors
- exclude new transitive dependencies org.apache.tomcat.embed:tomcat-embed-core and javax.annotation:javax.annotation-api