### PR TITLE
Upgrade Lombok to 1.18.20

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -59,7 +59,7 @@ depVersions = [
     junitFoundation: "11.0.0",
     kerby: "1.1.1",
     log4j: "1.2.17",
-    lombok: "1.18.10",
+    lombok: "1.18.20",
     lz4: "1.3.0",
     mockito: "3.0.0",
     netty: "4.1.32.Final",

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <junit.version>4.12</junit.version>
     <libthrift5.version>0.5.0-1</libthrift5.version>
     <libthrift9.version>0.12.0</libthrift9.version>
-    <lombok.version>1.18.18</lombok.version>
+    <lombok.version>1.18.20</lombok.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.0.0</mockito.version>
     <netty.version>4.1.50.Final</netty.version>
@@ -235,7 +235,7 @@
         <artifactId>freebuilder</artifactId>
         <version>${freebuilder.version}</version>
       </dependency>
-      
+
       <!-- logging dependencies -->
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### Motivation

- required for compilation on JDK 16
- see https://projectlombok.org/changelog

### Changes

Upgrade Lombok version to `1.18.20` in `pom.xml` and `dependencies.gradle`.