### PR TITLE
Fixed unnecessary copy to heap, see https://github.com/apache/pulsar/pull/10330

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -19,6 +19,7 @@ package org.apache.bookkeeper.proto.checksum;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 
 import java.security.GeneralSecurityException;
@@ -110,7 +111,11 @@ public abstract class DigestManager {
         headersBuffer.writeLong(length);
 
         update(headersBuffer);
-        update(data);
+        if (data instanceof CompositeByteBuf) {
+            ((CompositeByteBuf) data).forEach(this::update);
+        } else {
+            update(data);
+        }
         populateValueAndReset(headersBuffer);
 
         return ByteBufList.get(headersBuffer, data);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -23,6 +23,7 @@ package org.apache.bookkeeper.util;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
@@ -136,7 +137,11 @@ public class ByteBufList extends AbstractReferenceCounted {
      * Append a {@link ByteBuf} at the end of this {@link ByteBufList}.
      */
     public void add(ByteBuf buf) {
-        buffers.add(buf);
+        if (buf instanceof CompositeByteBuf) {
+            ((CompositeByteBuf) buf).forEach(buffers::add);
+        } else {
+            buffers.add(buf);
+        }
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:

Handling CompositeByteBuf in a way that avoids unnecessary data copy.

### Motivation

https://github.com/apache/pulsar/pull/10330

https://github.com/apache/pulsar/pull/10330#issuecomment-825619753

### Changes

Handling CompositeByteBuf in a way that avoids unnecessary data copy.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
