### PR TITLE
Read entry error should print lastAddConfirmed in the log

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -685,8 +685,8 @@ public class LedgerHandle implements WriteHandle {
         }
 
         if (lastEntry > lastAddConfirmed) {
-            LOG.error("ReadException on ledgerId:{} firstEntry:{} lastEntry:{}",
-                    ledgerId, firstEntry, lastEntry);
+            LOG.error("ReadEntries exception on ledgerId:{} firstEntry:{} lastEntry:{} lastAddConfirmed:{}",
+                    ledgerId, firstEntry, lastEntry, lastAddConfirmed);
             cb.readComplete(BKException.Code.ReadException, this, null, ctx);
             return;
         }
@@ -751,8 +751,8 @@ public class LedgerHandle implements WriteHandle {
         }
 
         if (lastEntry > lastAddConfirmed) {
-            LOG.error("ReadException on ledgerId:{} firstEntry:{} lastEntry:{}",
-                    ledgerId, firstEntry, lastEntry);
+            LOG.error("ReadAsync exception on ledgerId:{} firstEntry:{} lastEntry:{} lastAddConfirmed:{}",
+                    ledgerId, firstEntry, lastEntry, lastAddConfirmed);
             return FutureUtils.exception(new BKReadException());
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MdcContextTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MdcContextTest.java
@@ -228,7 +228,7 @@ public class MdcContextTest extends BookKeeperClusterTestCase {
         } catch (BKException.BKReadException e) {
             // pass
         }
-        assertLogWithMdc("ledger_read_entry", "ReadException on ledgerId:0 firstEntry:100 lastEntry:100");
+        assertLogWithMdc("ledger_read_entry", "ReadEntries exception on ledgerId:0 firstEntry:100 lastEntry:100");
     }
 
     @Test
@@ -245,7 +245,7 @@ public class MdcContextTest extends BookKeeperClusterTestCase {
         } catch (BKException.BKReadException e) {
             // pass
         }
-        assertLogWithMdc("ledger_read_entry", "ReadException on ledgerId:0 firstEntry:100 lastEntry:100");
+        assertLogWithMdc("ledger_read_entry", "ReadEntries exception on ledgerId:0 firstEntry:100 lastEntry:100");
     }
 
 }


### PR DESCRIPTION
### Motivation

If we're trying to read an entry id that is bigger than the `lastAddConfirmed`, a read error is printed and looks like:

```
ReadException on ledgerId:1234 firstEntry:222 lastEntry:222
```

Adding the `lastAddConfirmed` would help to debug why the entries are out of the range.
