### PR TITLE
BookKeeper-Client config to write ledger metadata with configured version

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -108,7 +108,7 @@ class LedgerCreateOp {
             EnumSet<WriteFlag> writeFlags,
             BookKeeperClientStats clientStats) {
         this.bk = bk;
-        this.metadataFormatVersion = bk.conf.getLedgerMetadataFormatVersion();
+        this.metadataFormatVersion = bk.getConf().getLedgerMetadataFormatVersion();
         this.ensembleSize = ensembleSize;
         this.writeQuorumSize = writeQuorumSize;
         this.ackQuorumSize = ackQuorumSize;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -68,6 +68,7 @@ class LedgerCreateOp {
     final int writeQuorumSize;
     final int ackQuorumSize;
     final Map<String, byte[]> customMetadata;
+    final int metadataFormatVersion;
     final byte[] passwd;
     final BookKeeper bk;
     final DigestType digestType;
@@ -107,6 +108,7 @@ class LedgerCreateOp {
             EnumSet<WriteFlag> writeFlags,
             BookKeeperClientStats clientStats) {
         this.bk = bk;
+        this.metadataFormatVersion = bk.conf.getLedgerMetadataFormatVersion();
         this.ensembleSize = ensembleSize;
         this.writeQuorumSize = writeQuorumSize;
         this.ackQuorumSize = ackQuorumSize;
@@ -174,6 +176,7 @@ class LedgerCreateOp {
         if (customMetadata != null) {
             metadataBuilder.withCustomMetadata(customMetadata);
         }
+        metadataBuilder.withMetadataFormatVersion(metadataFormatVersion);
         if (bk.getConf().getStoreSystemtimeAsLedgerCreationTime()) {
             metadataBuilder.withCreationTime(System.currentTimeMillis()).storingCreationTime(true);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadataBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerMetadataBuilder.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.client;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.bookkeeper.meta.LedgerMetadataSerDe.CURRENT_METADATA_FORMAT_VERSION;
+import static org.apache.bookkeeper.meta.LedgerMetadataSerDe.METADATA_FORMAT_VERSION_1;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -108,6 +109,9 @@ public class LedgerMetadataBuilder {
     }
 
     public LedgerMetadataBuilder withMetadataFormatVersion(int version) {
+        if (version < METADATA_FORMAT_VERSION_1 || version > CURRENT_METADATA_FORMAT_VERSION) {
+            return this;
+        }
         this.metadataFormatVersion = version;
         return this;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -79,6 +79,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     // Ledger Manager
     protected static final String LEDGER_MANAGER_TYPE = "ledgerManagerType";
     protected static final String LEDGER_MANAGER_FACTORY_CLASS = "ledgerManagerFactoryClass";
+    protected static final String LEDGER_METADATA_FORMAT_VERSION = "ledgerMetadataVersion";
     protected static final String ALLOW_SHADED_LEDGER_MANAGER_FACTORY_CLASS = "allowShadedLedgerManagerFactoryClass";
     protected static final String SHADED_LEDGER_MANAGER_FACTORY_CLASS_PREFIX = "shadedLedgerManagerFactoryClassPrefix";
     protected static final String METADATA_SERVICE_URI = "metadataServiceUri";
@@ -438,6 +439,25 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      */
     public String getLedgerManagerFactoryClassName() {
         return getString(LEDGER_MANAGER_FACTORY_CLASS);
+    }
+
+    /**
+     * Set Ledger metadata format version.
+     *
+     * @param metadataFormatVersion
+     *          Ledger metadata format version. pass -1 to use default version
+     */
+    public void setLedgerMetadataFormatVersion(int metadataFormatVersion) {
+        setProperty(LEDGER_METADATA_FORMAT_VERSION, metadataFormatVersion);
+    }
+
+    /**
+     * Get Ledger metadata format version.
+     *
+     * @return ledger metadata format version.
+     */
+    public int getLedgerMetadataFormatVersion() {
+        return getInt(LEDGER_METADATA_FORMAT_VERSION, -1);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -61,9 +61,11 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.api.WriteAdvHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.meta.LedgerMetadataSerDe;
 import org.apache.bookkeeper.meta.LongHierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.test.TestStatsProvider;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Assert;
@@ -1426,6 +1428,16 @@ public class BookieWriteLedgerTest extends
         }
 
         bkc.deleteLedger(lh.ledgerId);
+    }
+
+    @Test
+    public void testLedgerMetadataTest() throws Exception {
+        baseClientConf.setLedgerMetadataFormatVersion(LedgerMetadataSerDe.METADATA_FORMAT_VERSION_2);
+        BookKeeperTestClient bkc = new BookKeeperTestClient(baseClientConf, new TestStatsProvider());
+        // Create a ledger
+        lh = bkc.createLedger(3, 3, 2, digestType, ledgerPassword);
+        assertEquals(lh.getLedgerMetadata().getMetadataFormatVersion(), LedgerMetadataSerDe.METADATA_FORMAT_VERSION_2);
+        lh.close();
     }
 
     private void readEntries(LedgerHandle lh, List<byte[]> entries) throws InterruptedException, BKException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -159,6 +160,7 @@ public abstract class MockBookKeeperTestCase {
         when(bookieWatcher.getBookieAddressResolver()).thenReturn(bookieAddressResolver);
 
         bk = mock(BookKeeper.class);
+        doReturn(new ClientConfiguration()).when(bk).getConf();
 
         failedBookies = new ArrayList<>();
         availableBookies = new HashSet<>();


### PR DESCRIPTION
### Motivation

We need a way to use old bookie which doesn't support metadata-version-3 and upgrade bookkeeper-client with latest version. Right now, bk-4.12 writes ledger metadata with version-3 which will not be supported by bookie and replicator and replicator fails with below error
```
2021-05-07.00:43:53.115 [main-EventThread] ERROR
                o.a.b.meta.AbstractZkLedgerManager   - Could not parse ledger metadata for ledger: 123456
java.io.IOException: Metadata version not compatible. Expected between 0 and 2, but got 3
        at org.apache.bookkeeper.client.LedgerMetadata.parseConfig(LedgerMetadata.java:465)
        at org.apache.bookkeeper.meta.AbstractZkLedgerManager$3.processResult(AbstractZkLedgerManager.java:414)
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient$19$1.processResult(ZooKeeperClient.java:994)
        at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:572)
        at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:508)

```
So, until one upgrades the bookie version, allow bk-client to use the appropriate metadata version.