### PR TITLE
Impose a memory limit on the bookie journal

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/MemoryLimitController.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/MemoryLimitController.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.common.util;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class MemoryLimitController {
+
+    private final long memoryLimit;
+    private final AtomicLong currentUsage = new AtomicLong();
+    private final ReentrantLock mutex = new ReentrantLock(false);
+    private final Condition condition = mutex.newCondition();
+
+    public MemoryLimitController(long memoryLimitBytes) {
+        this.memoryLimit = memoryLimitBytes;
+    }
+
+    public boolean tryReserveMemory(long size) {
+        while (true) {
+            long current = currentUsage.get();
+            long newUsage = current + size;
+
+            // We allow one request to go over the limit, to make the notification
+            // path simpler and more efficient
+            if (current > memoryLimit && memoryLimit > 0) {
+                return false;
+            }
+
+            if (currentUsage.compareAndSet(current, newUsage)) {
+                return true;
+            }
+        }
+    }
+
+    public void reserveMemory(long size) throws InterruptedException {
+        if (!tryReserveMemory(size)) {
+            mutex.lock();
+
+            try {
+                while (!tryReserveMemory(size)) {
+                    condition.await();
+                }
+            } finally {
+                mutex.unlock();
+            }
+        }
+    }
+
+    public void releaseMemory(long size) {
+        long newUsage = currentUsage.addAndGet(-size);
+        if (newUsage + size > memoryLimit &&
+                newUsage <= memoryLimit) {
+            // We just crossed the limit. Now we have more space
+            mutex.lock();
+            try {
+                condition.signalAll();
+            } finally {
+                mutex.unlock();
+            }
+        }
+    }
+
+    public long currentUsage() {
+        return currentUsage.get();
+    }
+}

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/MemoryLimitControllerTest.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/MemoryLimitControllerTest.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.common.util;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class MemoryLimitControllerTest {
+
+    private ExecutorService executor;
+
+    @Before
+    public void setup() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @After
+    public void teardown() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testLimit() throws Exception {
+        MemoryLimitController mlc = new MemoryLimitController(100);
+
+        for (int i = 0; i < 101; i++) {
+            mlc.reserveMemory(1);
+        }
+
+        assertEquals(101, mlc.currentUsage());
+        assertFalse(mlc.tryReserveMemory(1));
+        mlc.releaseMemory(1);
+        assertEquals(100, mlc.currentUsage());
+
+        assertTrue(mlc.tryReserveMemory(1));
+        assertEquals(101, mlc.currentUsage());
+    }
+
+    @Test
+    public void testBlocking() throws Exception {
+        MemoryLimitController mlc = new MemoryLimitController(100);
+
+        for (int i = 0; i < 101; i++) {
+            mlc.reserveMemory(1);
+        }
+
+        CountDownLatch l1 = new CountDownLatch(1);
+        executor.submit(() -> {
+            try {
+                mlc.reserveMemory(1);
+                l1.countDown();
+            } catch (InterruptedException e) {
+            }
+        });
+
+        CountDownLatch l2 = new CountDownLatch(1);
+        executor.submit(() -> {
+            try {
+                mlc.reserveMemory(1);
+                l2.countDown();
+            } catch (InterruptedException e) {
+            }
+        });
+
+        CountDownLatch l3 = new CountDownLatch(1);
+        executor.submit(() -> {
+            try {
+                mlc.reserveMemory(1);
+                l3.countDown();
+            } catch (InterruptedException e) {
+            }
+        });
+
+        // The threads are blocked since the quota is full
+        assertFalse(l1.await(100, TimeUnit.MILLISECONDS));
+        assertFalse(l2.await(100, TimeUnit.MILLISECONDS));
+        assertFalse(l3.await(100, TimeUnit.MILLISECONDS));
+
+        assertEquals(101, mlc.currentUsage());
+        mlc.releaseMemory(3);
+
+        assertTrue(l1.await(1, TimeUnit.SECONDS));
+        assertTrue(l2.await(1, TimeUnit.SECONDS));
+        assertTrue(l3.await(1, TimeUnit.SECONDS));
+        assertEquals(101, mlc.currentUsage());
+    }
+
+    @Test
+    public void testStepRelease() throws Exception {
+        MemoryLimitController mlc = new MemoryLimitController(100);
+
+        for (int i = 0; i < 101; i++) {
+            mlc.reserveMemory(1);
+        }
+
+        CountDownLatch l1 = new CountDownLatch(1);
+        executor.submit(() -> {
+            try {
+                mlc.reserveMemory(1);
+                l1.countDown();
+            } catch (InterruptedException e) {
+            }
+        });
+
+        CountDownLatch l2 = new CountDownLatch(1);
+        executor.submit(() -> {
+            try {
+                mlc.reserveMemory(1);
+                l2.countDown();
+            } catch (InterruptedException e) {
+            }
+        });
+
+        CountDownLatch l3 = new CountDownLatch(1);
+        executor.submit(() -> {
+            try {
+                mlc.reserveMemory(1);
+                l3.countDown();
+            } catch (InterruptedException e) {
+            }
+        });
+
+        // The threads are blocked since the quota is full
+        assertFalse(l1.await(100, TimeUnit.MILLISECONDS));
+        assertFalse(l2.await(100, TimeUnit.MILLISECONDS));
+        assertFalse(l3.await(100, TimeUnit.MILLISECONDS));
+
+        assertEquals(101, mlc.currentUsage());
+
+        mlc.releaseMemory(1);
+        mlc.releaseMemory(1);
+        mlc.releaseMemory(1);
+
+        assertTrue(l1.await(1, TimeUnit.SECONDS));
+        assertTrue(l2.await(1, TimeUnit.SECONDS));
+        assertTrue(l3.await(1, TimeUnit.SECONDS));
+        assertEquals(101, mlc.currentUsage());
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -52,6 +52,7 @@ import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirExcepti
 import org.apache.bookkeeper.bookie.stats.JournalStats;
 import org.apache.bookkeeper.common.collections.BlockingMpscQueue;
 import org.apache.bookkeeper.common.collections.RecyclableArrayList;
+import org.apache.bookkeeper.common.util.MemoryLimitController;
 import org.apache.bookkeeper.common.util.affinity.CpuAffinity;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
@@ -295,7 +296,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
     /**
      * Journal Entry to Record.
      */
-    private static class QueueEntry implements Runnable {
+    static class QueueEntry implements Runnable {
         ByteBuf entry;
         long ledgerId;
         long entryId;
@@ -631,6 +632,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
     volatile boolean running = true;
     private final LedgerDirsManager ledgerDirsManager;
     private final ByteBufAllocator allocator;
+    private final MemoryLimitController memoryLimitController;
 
     // Expose Stats
     private final JournalStats journalStats;
@@ -655,6 +657,9 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
             forceWriteRequests = new ArrayBlockingQueue<>(conf.getJournalQueueSize());
         }
 
+        // Adjust the journal max memory in case there are multiple journals configured.
+        long journalMaxMemory = conf.getJournalMaxMemorySizeMb() / conf.getJournalDirNames().length * 1024 * 1024;
+        this.memoryLimitController = new MemoryLimitController(journalMaxMemory);
         this.ledgerDirsManager = ledgerDirsManager;
         this.conf = conf;
         this.journalDirectory = journalDirectory;
@@ -860,11 +865,14 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
     public void logAddEntry(long ledgerId, long entryId, ByteBuf entry,
                             boolean ackBeforeSync, WriteCallback cb, Object ctx)
             throws InterruptedException {
-        //Retain entry until it gets written to journal
+        // Retain entry until it gets written to journal
         entry.retain();
 
         journalStats.getJournalQueueSize().inc();
         journalStats.getJournalCbQueueSize().inc();
+
+        memoryLimitController.reserveMemory(entry.readableBytes());
+
         queue.put(QueueEntry.create(
                 entry, ackBeforeSync,  ledgerId, entryId, cb, ctx, MathUtils.nowInNano(),
                 journalStats.getJournalAddEntryStats(),
@@ -1110,6 +1118,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                      * shouldn't write this special entry
                      * (METAENTRY_ID_LEDGER_EXPLICITLAC) to Journal.
                      */
+                    memoryLimitController.releaseMemory(qe.entry.readableBytes());
                     qe.entry.release();
                 } else if (qe.entryId != Bookie.METAENTRY_ID_FORCE_LEDGER) {
                     int entrySize = qe.entry.readableBytes();
@@ -1125,6 +1134,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
                     bc.write(lenBuff);
                     bc.write(qe.entry);
+                    memoryLimitController.releaseMemory(qe.entry.readableBytes());
                     qe.entry.release();
                 }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -24,6 +24,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
+import io.netty.util.internal.PlatformDependent;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.bookie.SortedLedgerStorage;
@@ -140,6 +141,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String NUM_JOURNAL_CALLBACK_THREADS = "numJournalCallbackThreads";
     protected static final String JOURNAL_FORMAT_VERSION_TO_WRITE = "journalFormatVersionToWrite";
     protected static final String JOURNAL_QUEUE_SIZE = "journalQueueSize";
+    protected static final String JOURNAL_MAX_MEMORY_SIZE_MB = "journalMaxMemorySizeMb";
     protected static final String JOURNAL_PAGECACHE_FLUSH_INTERVAL_MSEC = "journalPageCacheFlushIntervalMSec";
     // backpressure control
     protected static final String MAX_ADDS_IN_PROGRESS_LIMIT = "maxAddsInProgressLimit";
@@ -817,6 +819,29 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public int getJournalQueueSize() {
         return this.getInt(JOURNAL_QUEUE_SIZE, 10_000);
+    }
+
+    /**
+     * Set the max amount of memory that can be used by the journal.
+     *
+     * @param journalMaxMemorySizeMb
+     *            the max amount of memory for the journal
+     * @return server configuration.
+     */
+    public ServerConfiguration setJournalMaxMemorySizeMb(long journalMaxMemorySizeMb) {
+        this.setProperty(JOURNAL_MAX_MEMORY_SIZE_MB, journalMaxMemorySizeMb);
+        return this;
+    }
+
+    /**
+     * Get the max amount of memory that can be used by the journal.
+     *
+     * @return the max amount of memory for the journal
+     */
+    public long getJournalMaxMemorySizeMb() {
+        // Default is taking 5% of max direct memory (and convert to MB).
+        long defaultValue = (long)(PlatformDependent.maxDirectMemory() * 0.05 / 1024 / 1024);
+        return this.getLong(JOURNAL_MAX_MEMORY_SIZE_MB, defaultValue);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalMaxMemoryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalMaxMemoryTest.java
@@ -1,0 +1,109 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.bookie.Journal.ForceWriteRequest;
+import org.apache.bookkeeper.bookie.Journal.LastLogMark;
+import org.apache.bookkeeper.common.util.MemoryLimitController;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import java.io.File;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+/**
+ * Test the bookie journal PageCache flush interval.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({JournalChannel.class, Journal.class})
+@Slf4j
+public class BookieJournalMaxMemoryTest {
+
+    private static final ByteBuf DATA = Unpooled.wrappedBuffer(new byte[1024 * 1024]);
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void testAckAfterSyncPageCacheFlush() throws Exception {
+        File journalDir = tempDir.newFolder();
+        Bookie.checkDirectoryStructure(Bookie.getCurrentDirectory(journalDir));
+
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+                .setJournalDirName(journalDir.getPath())
+                .setJournalMaxMemorySizeMb(1);
+
+        JournalChannel jc = spy(new JournalChannel(journalDir, 1));
+        whenNew(JournalChannel.class).withAnyArguments().thenReturn(jc);
+
+        LedgerDirsManager ledgerDirsManager = mock(LedgerDirsManager.class);
+        Journal journal = spy(new Journal(0, journalDir, conf, ledgerDirsManager));
+        Whitebox.setInternalState(journal, "memoryLimitController",
+                spy(new MemoryLimitController(1)));
+        MemoryLimitController mlc = Whitebox.getInternalState(journal, "memoryLimitController");
+
+        journal.start();
+
+        CountDownLatch latch = new CountDownLatch(10);
+
+        for (int i = 0; i < 10; i++) {
+            long ledgerId = 1;
+            long entryId = i;
+
+            journal.logAddEntry(ledgerId, entryId, DATA, false,
+                    (rc, ledgerId1, entryId1, addr, ctx) -> latch.countDown(),
+                    null);
+        }
+
+        latch.await();
+
+        verify(mlc, times(10)).reserveMemory(DATA.readableBytes());
+        verify(mlc, times(10)).releaseMemory(DATA.readableBytes());
+
+        journal.shutdown();
+    }
+}

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -358,6 +358,11 @@ journalDirectories=/tmp/bk-txn
 # Set the size of the journal queue.
 # journalQueueSize=10000
 
+# Set the max amount of memory that can be used by the journal.
+# If empty, this will be set to use 5% of available direct memory
+# Setting it to 0, it will disable the max memory control for the journal.
+# journalMaxMemorySizeMb=
+
 # Set PageCache flush interval (millisecond) when journalSyncData disabled
 # journalPageCacheFlushIntervalMSec = 1000
 


### PR DESCRIPTION
### Motivation

Currently, the journal has a configurable max queue size, with default to 10,000 entries. This can be used as a proxy measure to control the max amount of memory that has to be retained from the entries that are in the journal queue.

This is not very flexible and there are few potential problems that arise: 
 1. If using multiple journals, each one of them gets 10,000 entries
 2. entries can be of very different sizes, from few bytes to several MBs, so it can be difficult to estimate the memory usage
 3. if entries are big, it can cause the bookie to go OOM when the queue gets filled up

Instead (or additionally) of number of entries, we should use the total amount of memory as the metric for enabling the backpressure.

### Changes

Added `MemoryLimitController` class, already used in Pulsar (https://github.com/apache/pulsar/pull/8965) and use it to block the thread adding to the journal queue when memory is exhausted.

Defaulting to use 5% of max direct memory (eg: 100MB out of 2GB)

