### PR TITLE
Update bc tests to include versions up to 4.14.0

### DIFF
--- a/tests/backward-compat/current-server-old-clients/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatOldClients.groovy
+++ b/tests/backward-compat/current-server-old-clients/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatOldClients.groovy
@@ -40,7 +40,8 @@ class TestCompatOldClients {
     private static byte[] PASSWD = "foobar".getBytes()
 
     // 4.1.0 doesn't work because metadata format changed
-    private def oldClientVersions = ["4.4.0", "4.5.1", "4.6.2", "4.7.2", "4.8.2", "4.9.2" ]
+    private def oldClientVersions = ["4.4.0", "4.5.1", "4.6.2", "4.7.2", "4.8.2", "4.9.2",
+                                     "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.0" ]
 
     @ArquillianResource
     DockerClient docker

--- a/tests/backward-compat/hostname-bookieid/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeWithHostnameBookieId.groovy
+++ b/tests/backward-compat/hostname-bookieid/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeWithHostnameBookieId.groovy
@@ -37,7 +37,8 @@ class TestCompatUpgradeWithHostnameBookieId {
     private static final Logger LOG = LoggerFactory.getLogger(TestCompatUpgradeWithHostnameBookieId.class)
     private static byte[] PASSWD = "foobar".getBytes()
 
-    private def oldClientVersions = ["4.4.0", "4.5.1", "4.6.2", "4.7.2", "4.8.2", "4.9.2"]
+    private def oldClientVersions = ["4.4.0", "4.5.1", "4.6.2", "4.7.2", "4.8.2", "4.9.2",
+                                     "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.0" ]
 
     @ArquillianResource
     DockerClient docker

--- a/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
+++ b/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
@@ -202,7 +202,70 @@ class TestCompatUpgrade {
     }
 
     @Test
-    public void test472toCurrentMaster() throws Exception {
-        testUpgrade("4.7.2", System.getProperty("currentVersion"))
+    public void test472to480() throws Exception {
+        testUpgrade("4.7.2", "4.8.0")
+    }
+
+    @Test
+    public void test480to481() throws Exception {
+        testUpgrade("4.8.0", "4.8.1")
+    }
+
+
+    @Test
+    public void test481to482() throws Exception {
+        testUpgrade("4.8.1", "4.8.2")
+    }
+
+    @Test
+    public void test490to491() throws Exception {
+        testUpgrade("4.9.0", "4.9.1")
+    }
+
+
+    @Test
+    public void test491to492() throws Exception {
+        testUpgrade("4.9.1", "4.9.2")
+    }
+
+    @Test
+    public void test492to4100() throws Exception {
+        testUpgrade("4.9.2", "4.10.0")
+    }
+
+    @Test
+    public void test4100to4110() throws Exception {
+        testUpgrade("4.10.0", "4.11.0")
+    }
+
+    @Test
+    public void test4110to4111() throws Exception {
+        testUpgrade("4.11.0", "4.11.1")
+    }
+
+    @Test
+    public void test4111to4120() throws Exception {
+        testUpgrade("4.11.1", "4.12.0")
+    }
+
+
+    @Test
+    public void test4120to4121() throws Exception {
+        testUpgrade("4.12.0", "4.12.1")
+    }
+
+    @Test
+    public void test4121to4130() throws Exception {
+        testUpgrade("4.12.1", "4.13.0")
+    }
+
+    @Test
+    public void test4130to4140() throws Exception {
+        testUpgrade("4.13.0", "4.14.0")
+    }
+
+    @Test
+    public void test414toCurrentMaster() throws Exception {
+        testUpgrade("4.14.0", System.getProperty("currentVersion"))
     }
 }

--- a/tests/docker-images/all-released-versions-image/Dockerfile
+++ b/tests/docker-images/all-released-versions-image/Dockerfile
@@ -52,6 +52,14 @@ RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.7.1/bookkee
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.7.2/bookkeeper-server-4.7.2-bin.tar.gz{,.sha512,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.8.2/bookkeeper-server-4.8.2-bin.tar.gz{,.sha512,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.9.2/bookkeeper-server-4.9.2-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.10.0/bookkeeper-server-4.10.0-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.11.0/bookkeeper-server-4.11.0-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.11.1/bookkeeper-server-4.11.1-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.12.0/bookkeeper-server-4.12.0-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.12.1/bookkeeper-server-4.12.1-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.13.0/bookkeeper-server-4.13.0-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.14.0/bookkeeper-server-4.14.0-bin.tar.gz{,.sha512,.asc}
+
 RUN wget -nv https://archive.apache.org/dist/incubator/pulsar/pulsar-1.21.0-incubating/apache-pulsar-1.21.0-incubating-bin.tar.gz{,.asc}
 RUN wget -nv https://dist.apache.org/repos/dist/release/bookkeeper/KEYS
 RUN wget -nv http://svn.apache.org/repos/asf/zookeeper/bookkeeper/dist/KEYS?p=1620552 -O KEYS.old


### PR DESCRIPTION
### Motivation

4.14.0 release 

### Changes

followed https://bookkeeper.apache.org/community/release_guide/#verify-docker-image and used https://github.com/apache/bookkeeper/pull/2171 as example

