### PR TITLE
Refactor book keeper cluster test case

### DIFF
--- a/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
+++ b/bookkeeper-benchmark/src/test/java/org/apache/bookkeeper/benchmark/TestBenchmark.java
@@ -68,7 +68,8 @@ public class TestBenchmark extends BookKeeperClusterTestCase {
 
     @Test
     public void testBookie() throws Exception {
-        BookieSocketAddress bookie = getBookieAddress(0);
+        BookieSocketAddress bookie = serverByIndex(0).getLocalAddress();
+
         BenchBookie.main(new String[] {
                 "--host", bookie.getSocketAddress().getHostName(),
                 "--port", String.valueOf(bookie.getPort()),

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -225,10 +225,10 @@ public class BookKeeperAdmin implements AutoCloseable {
     }
 
     @SneakyThrows
-    public BookieServiceInfo getBookieServiceInfo(String bookiedId)
+    public BookieServiceInfo getBookieServiceInfo(BookieId bookiedId)
             throws BKException {
         return FutureUtils.result(bkc.getMetadataClientDriver()
-                .getRegistrationClient().getBookieServiceInfo(BookieId.parse(bookiedId))).getValue();
+                .getRegistrationClient().getBookieServiceInfo(bookiedId)).getValue();
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -504,12 +504,6 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         };
     }
 
-    public static String buildStatsLoggerScopeName(BookieId addr) {
-        StringBuilder nameBuilder = new StringBuilder();
-        nameBuilder.append(addr.toString().replace('.', '_').replace('-', '_').replace(":", "_"));
-        return nameBuilder.toString();
-    }
-
     private void completeOperation(GenericCallback<PerChannelBookieClient> op, int rc) {
         closeLock.readLock().lock();
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -504,6 +504,12 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         };
     }
 
+    public static String buildStatsLoggerScopeName(BookieId addr) {
+        StringBuilder nameBuilder = new StringBuilder();
+        nameBuilder.append(addr.toString().replace('.', '_').replace('-', '_').replace(":", "_"));
+        return nameBuilder.toString();
+    }
+
     private void completeOperation(GenericCallback<PerChannelBookieClient> op, int rc) {
         closeLock.readLock().lock();
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/EndpointInfoCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/EndpointInfoCommand.java
@@ -80,13 +80,13 @@ public class EndpointInfoCommand extends BookieCommand<EndpointInfoCommand.Endpo
         ClientConfiguration adminConf = new ClientConfiguration(conf);
         BookKeeperAdmin admin = new BookKeeperAdmin(adminConf);
         try {
-            final String bookieId = flags.bookie;
-            if (bookieId == null || bookieId.isEmpty()) {
+            final String bookieIdStr = flags.bookie;
+            if (bookieIdStr == null || bookieIdStr.isEmpty()) {
                 throw new IllegalArgumentException("BookieId is required");
             }
-            BookieId address = BookieId.parse(bookieId);
+            BookieId bookieId = BookieId.parse(bookieIdStr);
             Collection<BookieId> allBookies = admin.getAllBookies();
-            if (!allBookies.contains(address)) {
+            if (!allBookies.contains(bookieId)) {
                 LOG.info("Bookie " + bookieId + " does not exist, only " + allBookies);
                 return false;
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/AdvertisedAddressTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/AdvertisedAddressTest.java
@@ -22,11 +22,9 @@
 package org.apache.bookkeeper.bookie;
 
 import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-
 import java.util.UUID;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -34,7 +32,6 @@ import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.PortManager;
 import org.junit.Test;
 
@@ -49,11 +46,10 @@ public class AdvertisedAddressTest extends BookKeeperClusterTestCase {
     }
 
     private String newDirectory(boolean createCurDir) throws IOException {
-        File d = IOUtils.createTempDir("cookie", "tmpdir");
+        File d = createTempDir("cookie", "tmpdir");
         if (createCurDir) {
             new File(d, "current").mkdirs();
         }
-        tmpDirs.add(d);
         return d.getPath();
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -317,7 +317,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         bkServer.start();
         bkServer.join();
         assertEquals("Failed to return ExitCode.ZK_REG_FAIL",
-                ExitCode.ZK_REG_FAIL, bkServer.getExitCode());
+                     ExitCode.ZK_REG_FAIL, bkServer.getExitCode());
     }
 
     @Test
@@ -433,7 +433,6 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
 
         final BookieId bookieId = BookieId.parse(InetAddress.getLocalHost().getCanonicalHostName().split("\\.", 2)[0]
             + ":" + conf.getBookiePort());
-
         driver.initialize(conf, () -> {}, NullStatsLogger.INSTANCE);
         try (StateManager manager = new BookieStateManager(conf, driver)) {
             manager.registerBookie(true).get();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalBypassTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalBypassTest.java
@@ -27,7 +27,6 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.api.WriteHandle;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Test;
 
@@ -44,7 +43,7 @@ public class BookieJournalBypassTest extends BookKeeperClusterTestCase {
     }
 
     @Override
-    protected BookieServer startBookie(ServerConfiguration conf) throws Exception {
+    protected ServerTester startBookie(ServerConfiguration conf) throws Exception {
         if (bookieIdx++ == 0) {
             // First bookie will have the journal disabled
             conf.setJournalWriteData(false);
@@ -56,13 +55,13 @@ public class BookieJournalBypassTest extends BookKeeperClusterTestCase {
     public void testJournalBypass() throws Exception {
         ClientConfiguration conf = new ClientConfiguration(baseClientConf);
 
-        BookieImpl bookieImpl = (BookieImpl) bs.get(0).getBookie();
+        BookieImpl bookieImpl = (BookieImpl) serverByIndex(0).getBookie();
         Journal journal0 = bookieImpl.journals.get(0);
-        LedgerStorage ls0 = bs.get(0).getBookie().getLedgerStorage();
+        LedgerStorage ls0 = serverByIndex(0).getBookie().getLedgerStorage();
 
-        bookieImpl = (BookieImpl) bs.get(1).getBookie();
+        bookieImpl = (BookieImpl) serverByIndex(1).getBookie();
         Journal journal1 = bookieImpl.journals.get(0);
-        LedgerStorage ls1 = bs.get(1).getBookie().getLedgerStorage();
+        LedgerStorage ls1 = serverByIndex(1).getBookie().getLedgerStorage();
 
         ls0.flush();
         ls1.flush();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShutdownTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShutdownTest.java
@@ -84,9 +84,7 @@ public class BookieShutdownTest extends BookKeeperClusterTestCase {
                         + " and now going to fail bookie.");
                 // Shutdown one Bookie server and restarting new one to continue
                 // writing
-                bsConfs.remove(0);
-                bs.get(0).shutdown();
-                bs.remove(0);
+                killBookie(0);
                 startNewBookie();
                 LOG.info("Shutdown one bookie server and started new bookie server...");
             } catch (BKException e) {
@@ -118,7 +116,7 @@ public class BookieShutdownTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testBookieShutdownFromBookieThread() throws Exception {
-        ServerConfiguration conf = bsConfs.get(0);
+        ServerConfiguration conf = confByIndex(0);
         killBookie(0);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch shutdownComplete = new CountDownLatch(1);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStickyReadsTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStickyReadsTest.java
@@ -153,7 +153,7 @@ public class BookieStickyReadsTest extends BookKeeperClusterTestCase {
 
         // Suspend the sticky bookie. Reads should now go to a different sticky
         // bookie
-        bs.get(bookieWithRequests).suspendProcessing();
+        serverByIndex(bookieWithRequests).suspendProcessing();
 
         for (int i = 0; i < n; i++) {
             @Cleanup

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
@@ -154,9 +154,8 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
         };
         conf.setLedgerDirNames(ledgerDirNames);
         conf.setJournalDirName(journalDir.getPath());
-        BookieServer server = startBookie(conf);
-        bs.add(server);
-        bsConfs.add(conf);
+
+        BookieServer server = startAndAddBookie(conf).getServer();
         BookieImpl bookie = (BookieImpl) server.getBookie();
         // since we are going to set dependency injected dirsMonitor, so we need to shutdown
         // the dirsMonitor which was created as part of the initialization of Bookie

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
@@ -29,7 +29,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.File;
@@ -80,7 +79,9 @@ public class BookieWriteToJournalTest {
     /**
      * test that Bookie calls correctly Journal.logAddEntry about "ackBeforeSync" parameter.
      */
+
     @Test
+//    @Ignore("PLSR-1850 test is failing due to Bookie interface change")
     public void testJournalLogAddEntryCalledCorrectly() throws Exception {
 
         File journalDir = tempDir.newFolder();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
@@ -81,7 +81,6 @@ public class BookieWriteToJournalTest {
      */
 
     @Test
-//    @Ignore("PLSR-1850 test is failing due to Bookie interface change")
     public void testJournalLogAddEntryCalledCorrectly() throws Exception {
 
         File journalDir = tempDir.newFolder();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CookieTest.java
@@ -21,14 +21,13 @@
 
 package org.apache.bookkeeper.bookie;
 
-import static org.apache.bookkeeper.bookie.UpgradeTest.newV1JournalDirectory;
-import static org.apache.bookkeeper.bookie.UpgradeTest.newV1LedgerDirectory;
-import static org.apache.bookkeeper.bookie.UpgradeTest.newV2JournalDirectory;
-import static org.apache.bookkeeper.bookie.UpgradeTest.newV2LedgerDirectory;
+import static org.apache.bookkeeper.bookie.UpgradeTest.initV1JournalDirectory;
+import static org.apache.bookkeeper.bookie.UpgradeTest.initV1LedgerDirectory;
+import static org.apache.bookkeeper.bookie.UpgradeTest.initV2JournalDirectory;
+import static org.apache.bookkeeper.bookie.UpgradeTest.initV2LedgerDirectory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +45,6 @@ import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.BookKeeperConstants;
-import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.PortManager;
 import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Version;
@@ -69,11 +67,10 @@ public class CookieTest extends BookKeeperClusterTestCase {
     }
 
     private String newDirectory(boolean createCurDir) throws IOException {
-        File d = IOUtils.createTempDir("cookie", "tmpdir");
+        File d = createTempDir("cookie", "tmpdir");
         if (createCurDir) {
             new File(d, "current").mkdirs();
         }
-        tmpDirs.add(d);
         return d.getPath();
     }
 
@@ -547,10 +544,8 @@ public class CookieTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testV2data() throws Exception {
-        File journalDir = newV2JournalDirectory();
-        tmpDirs.add(journalDir);
-        File ledgerDir = newV2LedgerDirectory();
-        tmpDirs.add(ledgerDir);
+        File journalDir = initV2JournalDirectory(createTempDir("bookie", "journal"));
+        File ledgerDir = initV2LedgerDirectory(createTempDir("bookie", "ledger"));
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
@@ -572,10 +567,8 @@ public class CookieTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testV1data() throws Exception {
-        File journalDir = newV1JournalDirectory();
-        tmpDirs.add(journalDir);
-        File ledgerDir = newV1LedgerDirectory();
-        tmpDirs.add(ledgerDir);
+        File journalDir = initV1JournalDirectory(createTempDir("bookie", "journal"));
+        File ledgerDir = initV1LedgerDirectory(createTempDir("bookie", "ledger"));
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())
@@ -678,10 +671,8 @@ public class CookieTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testV2dataWithHostNameAsBookieID() throws Exception {
-        File journalDir = newV2JournalDirectory();
-        tmpDirs.add(journalDir);
-        File ledgerDir = newV2LedgerDirectory();
-        tmpDirs.add(ledgerDir);
+        File journalDir = initV2JournalDirectory(createTempDir("bookie", "journal"));
+        File ledgerDir = initV2LedgerDirectory(createTempDir("bookie", "ledger"));
 
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setJournalDirName(journalDir.getPath())

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/ForceAuditorChecksCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/ForceAuditorChecksCmdTest.java
@@ -51,7 +51,7 @@ public class ForceAuditorChecksCmdTest extends BookKeeperClusterTestCase {
         String[] argv = new String[] { "forceauditchecks", "-calc", "-ppc", "-rc" };
         long curTime = System.currentTimeMillis();
 
-        final ServerConfiguration conf = bsConfs.get(0);
+        final ServerConfiguration conf = confByIndex(0);
         BookieShell bkShell = new BookieShell();
         bkShell.setConf(conf);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GcOverreplicatedLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GcOverreplicatedLedgerTest.java
@@ -22,9 +22,7 @@
 package org.apache.bookkeeper.bookie;
 
 import com.google.common.collect.Lists;
-
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -41,7 +39,6 @@ import org.apache.bookkeeper.meta.LedgerManagerTestCase;
 import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
 import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieId;
-import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.SnapshotMap;
 import org.apache.zookeeper.ZooDefs;
@@ -182,11 +179,9 @@ public class GcOverreplicatedLedgerTest extends LedgerManagerTestCase {
         Assert.assertTrue(activeLedgers.containsKey(lh.getId()));
     }
 
-    private BookieId getBookieNotInEnsemble(LedgerMetadata ledgerMetadata) throws UnknownHostException {
+    private BookieId getBookieNotInEnsemble(LedgerMetadata ledgerMetadata) throws Exception {
         List<BookieId> allAddresses = Lists.newArrayList();
-        for (BookieServer bk : bs) {
-            allAddresses.add(bk.getBookieId());
-        }
+        allAddresses.addAll(bookieAddresses());
         SortedMap<Long, ? extends List<BookieId>> ensembles = ledgerMetadata.getAllEnsembles();
         for (List<BookieId> fragmentEnsembles : ensembles.values()) {
             allAddresses.removeAll(fragmentEnsembles);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/IndexCorruptionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/IndexCorruptionTest.java
@@ -55,7 +55,7 @@ public class IndexCorruptionTest extends BookKeeperClusterTestCase {
     public void testNoSuchLedger() throws Exception {
         LOG.debug("Testing NoSuchLedger");
 
-        SyncThread syncThread = ((BookieImpl) bs.get(0).getBookie()).syncThread;
+        SyncThread syncThread = ((BookieImpl) serverByIndex(0).getBookie()).syncThread;
         syncThread.suspendSync();
         // Create a ledger
         LedgerHandle lh = bkc.createLedger(1, 1, digestType, "".getBytes());
@@ -96,7 +96,7 @@ public class IndexCorruptionTest extends BookKeeperClusterTestCase {
     public void testEmptyIndexPage() throws Exception {
         LOG.debug("Testing EmptyIndexPage");
 
-        SyncThread syncThread = ((BookieImpl) bs.get(0).getBookie()).syncThread;
+        SyncThread syncThread = ((BookieImpl) serverByIndex(0).getBookie()).syncThread;
         assertNotNull("Not found SyncThread.", syncThread);
 
         syncThread.suspendSync();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpdateCookieCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpdateCookieCmdTest.java
@@ -102,8 +102,8 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
         updateCookie("-b", "ip", false);
 
         // start bookie to ensure everything works fine
-        ServerConfiguration conf = bsConfs.get(0);
-        BookieServer restartBookie = startBookie(conf);
+        ServerConfiguration conf = confByIndex(0);
+        BookieServer restartBookie = startAndAddBookie(conf).getServer();
         restartBookie.shutdown();
     }
 
@@ -113,7 +113,7 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
     @Test
     public void testUpdateCookieWithInvalidOption() throws Exception {
         String[] argv = new String[] { "updatecookie", "-b", "invalidBookieID" };
-        final ServerConfiguration conf = bsConfs.get(0);
+        final ServerConfiguration conf = confByIndex(0);
         updateCookie(argv, -1, conf);
 
         argv = new String[] { "updatecookie", "-b" };
@@ -143,7 +143,7 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
         updateCookie("-b", "hostname", true);
 
         // creates cookie with ipaddress
-        ServerConfiguration conf = bsConfs.get(0);
+        ServerConfiguration conf = confByIndex(0);
         conf.setUseHostNameAsBookieID(true); // sets to hostname
         Cookie cookie = Cookie.readFromRegistrationManager(rm, conf).getValue();
         Cookie.Builder cookieBuilder = Cookie.newBuilder(cookie);
@@ -175,15 +175,15 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
     @Test
     public void testDuplicateUpdateCookieIpAddress() throws Exception {
         String[] argv = new String[] { "updatecookie", "-b", "ip" };
-        final ServerConfiguration conf = bsConfs.get(0);
+        final ServerConfiguration conf = confByIndex(0);
         conf.setUseHostNameAsBookieID(true);
         updateCookie(argv, -1, conf);
     }
 
     @Test
     public void testWhenNoCookieExists() throws Exception {
-        ServerConfiguration conf = bsConfs.get(0);
-        BookieServer bks = bs.get(0);
+        ServerConfiguration conf = confByIndex(0);
+        BookieServer bks = serverByIndex(0);
         bks.shutdown();
 
         String zkCookiePath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf)
@@ -213,8 +213,8 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
 
     private void updateCookie(String option, String optionVal, boolean useHostNameAsBookieID, boolean useShortHostName)
             throws Exception {
-        ServerConfiguration conf = new ServerConfiguration(bsConfs.get(0));
-        BookieServer bks = bs.get(0);
+        ServerConfiguration conf = new ServerConfiguration(confByIndex(0));
+        BookieServer bks = serverByIndex(0);
         bks.shutdown();
 
         conf.setUseHostNameAsBookieID(!useHostNameAsBookieID);
@@ -252,7 +252,7 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
 
     private void updateCookie(String[] argv, int exitCode, ServerConfiguration conf) throws KeeperException,
             InterruptedException, IOException, UnknownHostException, Exception {
-        BookieServer bks = bs.get(0);
+        BookieServer bks = serverByIndex(0);
         bks.shutdown();
 
         LOG.info("Perform updatecookie command");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
@@ -110,14 +110,12 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
         return jc;
     }
 
-    static File newV1JournalDirectory() throws Exception {
-        File d = IOUtils.createTempDir("bookie", "tmpdir");
+    static File initV1JournalDirectory(File d) throws Exception {
         writeJournal(d, 100, "foobar".getBytes()).close();
         return d;
     }
 
-    static File newV1LedgerDirectory() throws Exception {
-        File d = IOUtils.createTempDir("bookie", "tmpdir");
+    static File initV1LedgerDirectory(File d) throws Exception {
         writeLedgerDir(d, "foobar".getBytes());
         return d;
     }
@@ -138,15 +136,13 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
         }
     }
 
-    static File newV2JournalDirectory() throws Exception {
-        File d = newV1JournalDirectory();
-        createVersion2File(d);
+    static File initV2JournalDirectory(File d) throws Exception {
+        createVersion2File(initV1JournalDirectory(d));
         return d;
     }
 
-    static File newV2LedgerDirectory() throws Exception {
-        File d = newV1LedgerDirectory();
-        createVersion2File(d);
+    static File initV2LedgerDirectory(File d) throws Exception {
+        createVersion2File(initV1LedgerDirectory(d));
         return d;
     }
 
@@ -190,28 +186,22 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testUpgradeV1toCurrent() throws Exception {
-        File journalDir = newV1JournalDirectory();
-        tmpDirs.add(journalDir);
-        File ledgerDir = newV1LedgerDirectory();
-        tmpDirs.add(ledgerDir);
+        File journalDir = initV1JournalDirectory(createTempDir("bookie", "journal"));
+        File ledgerDir = initV1LedgerDirectory(createTempDir("bookie", "ledger"));
         testUpgradeProceedure(zkUtil.getZooKeeperConnectString(), journalDir.getPath(), ledgerDir.getPath());
     }
 
     @Test
     public void testUpgradeV2toCurrent() throws Exception {
-        File journalDir = newV2JournalDirectory();
-        tmpDirs.add(journalDir);
-        File ledgerDir = newV2LedgerDirectory();
-        tmpDirs.add(ledgerDir);
+        File journalDir = initV2JournalDirectory(createTempDir("bookie", "journal"));
+        File ledgerDir = initV2LedgerDirectory(createTempDir("bookie", "ledger"));
         testUpgradeProceedure(zkUtil.getZooKeeperConnectString(), journalDir.getPath(), ledgerDir.getPath());
     }
 
     @Test
     public void testUpgradeCurrent() throws Exception {
-        File journalDir = newV2JournalDirectory();
-        tmpDirs.add(journalDir);
-        File ledgerDir = newV2LedgerDirectory();
-        tmpDirs.add(ledgerDir);
+        File journalDir = initV2JournalDirectory(createTempDir("bookie", "journal"));
+        File ledgerDir = initV2LedgerDirectory(createTempDir("bookie", "ledger"));
         testUpgradeProceedure(zkUtil.getZooKeeperConnectString(), journalDir.getPath(), ledgerDir.getPath());
 
         // Upgrade again

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
@@ -118,8 +118,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
                     return super.readEntry(ledgerId, entryId);
                 }
             };
-        bsConfs.add(conf);
-        bs.add(startBookie(conf, delayBookie));
+        startAndAddBookie(conf, delayBookie);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
@@ -93,9 +93,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                 }
             }
         };
-        bsConfs.add(conf);
-        BookieServer server = startBookie(conf, bookieWithCustomFreeDiskSpace);
-        bs.add(server);
+        BookieServer server = startAndAddBookie(conf, bookieWithCustomFreeDiskSpace).getServer();
         client.blockUntilBookieWeightIs(server.getBookieId(), Optional.of(initialFreeDiskSpace));
         if (useFinal == null) {
             ready.set(true);
@@ -114,8 +112,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
             BookKeeperCheckInfoReader client,
             BookieServer bookie, final long freeDiskSpace)
             throws Exception {
-        for (int i = 0; i < bs.size(); i++) {
-            if (bs.get(i).getBookieId().equals(bookie.getBookieId())) {
+        for (int i = 0; i < bookieCount(); i++) {
+            if (addressByIndex(i).equals(bookie.getBookieId())) {
                 return replaceBookieWithCustomFreeDiskSpaceBookie(client, i, freeDiskSpace);
             }
         }
@@ -126,7 +124,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
             BookKeeperCheckInfoReader client,
             int bookieIdx, long initialFreeDiskSpace,
              long finalFreeDiskSpace, AtomicBoolean useFinal) throws Exception {
-        BookieId addr = bs.get(bookieIdx).getBookieId();
+        BookieId addr = addressByIndex(bookieIdx);
         LOG.info("Killing bookie {}", addr);
         ServerConfiguration conf = killBookieAndWaitForZK(bookieIdx);
         client.blockUntilBookieWeightIs(addr, Optional.empty());
@@ -156,10 +154,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                 replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, multiple * freeDiskSpace);
             }
         }
-        Map<BookieId, Integer> m = new HashMap<BookieId, Integer>();
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
+        Map<BookieId, Integer> m = new HashMap<>();
+        bookieAddresses().forEach(a -> m.put(a, 0));
 
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
@@ -171,12 +167,12 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
         for (int i = 0; i < numBookies - 2; i++) {
-            double ratio1 = (double) m.get(bs.get(numBookies - 2).getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio1 = (double) m.get(addressByIndex(numBookies - 2))
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
                     Math.abs(ratio1 - multiple) < 1);
-            double ratio2 = (double) m.get(bs.get(numBookies - 1).getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio2 = (double) m.get(addressByIndex(numBookies - 1))
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
                     Math.abs(ratio2 - multiple) < 1);
         }
@@ -206,10 +202,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                 replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, multiple * freeDiskSpace);
             }
         }
-        Map<BookieId, Integer> m = new HashMap<BookieId, Integer>();
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
+        Map<BookieId, Integer> m = new HashMap<>();
+        bookieAddresses().forEach(a -> m.put(a, 0));
 
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
@@ -221,31 +215,30 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
         for (int i = 0; i < numBookies - 2; i++) {
-            double ratio1 = (double) m.get(bs.get(numBookies - 2).getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio1 = (double) m.get(addressByIndex(numBookies - 2))
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
                     Math.abs(ratio1 - multiple) < 1);
-            double ratio2 = (double) m.get(bs.get(numBookies - 1).getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio2 = (double) m.get(addressByIndex(numBookies - 1))
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
-                    Math.abs(ratio2 - multiple) < 1);
+            Math.abs(ratio2 - multiple) < 1);
         }
 
         // Restart the bookies in such a way that the first 2 bookies go from 1MB to 3MB free space and the last
         // 2 bookies go from 3MB to 1MB
-        BookieServer server1 = bs.get(0);
-        BookieServer server2 = bs.get(1);
-        BookieServer server3 = bs.get(numBookies - 2);
-        BookieServer server4 = bs.get(numBookies - 1);
+        BookieServer server1 = serverByIndex(0);
+        BookieServer server2 = serverByIndex(1);
+        BookieServer server3 = serverByIndex(numBookies - 2);
+        BookieServer server4 = serverByIndex(numBookies - 1);
 
         server1 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server1, multiple * freeDiskSpace);
         server2 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server2, multiple * freeDiskSpace);
         server3 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server3, freeDiskSpace);
         server4 = replaceBookieWithCustomFreeDiskSpaceBookie(client, server4, freeDiskSpace);
 
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
+        bookieAddresses().forEach(a -> m.put(a, 0));
+
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieId b : lh.getLedgerMetadata().getEnsembleAt(0)) {
@@ -256,18 +249,18 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
         for (int i = 0; i < numBookies; i++) {
-            if (server1.getBookieId().equals(bs.get(i).getBookieId())
-                    || server2.getBookieId().equals(bs.get(i).getBookieId())) {
+            if (server1.getLocalAddress().equals(addressByIndex(i))
+                    || server2.getLocalAddress().equals(addressByIndex(i))) {
                 continue;
             }
-            double ratio1 = (double) m.get(server1.getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio1 = (double) m.get(server1)
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
                     Math.abs(ratio1 - multiple) < 1);
-            double ratio2 = (double) m.get(server2.getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio2 = (double) m.get(server2)
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
-                    Math.abs(ratio2 - multiple) < 1);
+            Math.abs(ratio2 - multiple) < 1);
         }
         client.close();
     }
@@ -296,10 +289,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                 replaceBookieWithCustomFreeDiskSpaceBookie(client, 0, multiple * freeDiskSpace);
             }
         }
-        Map<BookieId, Integer> m = new HashMap<BookieId, Integer>();
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
+        Map<BookieId, Integer> m = new HashMap<>();
+        bookieAddresses().forEach(a -> m.put(a, 0));
 
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
@@ -310,22 +301,21 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
 
         // make sure that bookies with higher weight are chosen 3X as often as the median;
         // since the number of ledgers is small (2000), there may be variation
-        double ratio1 = (double) m.get(bs.get(numBookies - 2).getBookieId())
-            / (double) m.get(bs.get(0).getBookieId());
+        double ratio1 = (double) m.get(addressByIndex(numBookies - 2))
+            / (double) m.get(addressByIndex(0));
         assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
                 Math.abs(ratio1 - multiple) < 1);
-        double ratio2 = (double) m.get(bs.get(numBookies - 1).getBookieId())
-            / (double) m.get(bs.get(1).getBookieId());
+        double ratio2 = (double) m.get(addressByIndex(numBookies - 1))
+            / (double) m.get(addressByIndex(1));
         assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
-                Math.abs(ratio2 - multiple) < 1);
+        Math.abs(ratio2 - multiple) < 1);
 
         // Bring down the 2 bookies that had higher weight; after this the allocation to all
         // the remaining bookies should be uniform
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
-        BookieServer server1 = bs.get(numBookies - 2);
-        BookieServer server2 = bs.get(numBookies - 1);
+        bookieAddresses().forEach(a -> m.put(a, 0));
+
+        BookieServer server1 = serverByIndex(numBookies - 2);
+        BookieServer server2 = serverByIndex(numBookies - 1);
         killBookieAndWaitForZK(numBookies - 1);
         killBookieAndWaitForZK(numBookies - 2);
 
@@ -338,17 +328,17 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
 
         // make sure that bookies with higher weight are chosen 3X as often as the median;
         for (int i = 0; i < numBookies - 3; i++) {
-            double delta = Math.abs((double) m.get(bs.get(i).getBookieId())
-                    - (double) m.get(bs.get(i + 1).getBookieId()));
-            delta = (delta * 100) / (double) m.get(bs.get(i + 1).getBookieId());
+            double delta = Math.abs((double) m.get(addressByIndex(i))
+                    - (double) m.get(addressByIndex(i + 1)));
+            delta = (delta * 100) / (double) m.get(addressByIndex(i + 1));
             // the deviation should be less than 30%
             assertTrue("Weigheted placement is not honored: " + delta, delta <= 30);
         }
         // since the following 2 bookies were down, they shouldn't ever be selected
-        assertTrue("Weigheted placement is not honored" + m.get(server1.getBookieId()),
-                m.get(server1.getBookieId()) == 0);
-        assertTrue("Weigheted placement is not honored" + m.get(server2.getBookieId()),
-                m.get(server2.getBookieId()) == 0);
+        assertTrue("Weigheted placement is not honored" + m.get(server1),
+                m.get(server1) == 0);
+        assertTrue("Weigheted placement is not honored" + m.get(server2),
+                m.get(server2) == 0);
 
         client.close();
     }
@@ -376,10 +366,9 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         // let the last two bookies be down initially
         ServerConfiguration conf1 = killBookieAndWaitForZK(numBookies - 1);
         ServerConfiguration conf2 = killBookieAndWaitForZK(numBookies - 2);
-        Map<BookieId, Integer> m = new HashMap<BookieId, Integer>();
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
+        Map<BookieId, Integer> m = new HashMap<>();
+
+        bookieAddresses().forEach(a -> m.put(a, 0));
 
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
@@ -391,9 +380,9 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         // make sure that bookies with higher weight are chosen 3X as often as the median;
         // since the number of ledgers is small (2000), there may be variation
         for (int i = 0; i < numBookies - 3; i++) {
-            double delta = Math.abs((double) m.get(bs.get(i).getBookieId())
-                    - (double) m.get(bs.get(i + 1).getBookieId()));
-            delta = (delta * 100) / (double) m.get(bs.get(i + 1).getBookieId());
+            double delta = Math.abs((double) m.get(addressByIndex(i))
+                    - (double) m.get(addressByIndex(i + 1)));
+            delta = (delta * 100) / (double) m.get(addressByIndex(i + 1));
             // the deviation should be less than 30%
             assertTrue("Weigheted placement is not honored: " + delta, delta <= 30);
         }
@@ -402,9 +391,8 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         restartBookie(client, conf1, multiple * freeDiskSpace, multiple * freeDiskSpace, null);
         restartBookie(client, conf2, multiple * freeDiskSpace, multiple * freeDiskSpace, null);
 
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
+        bookieAddresses().forEach(a -> m.put(a, 0));
+
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieId b : lh.getLedgerMetadata().getEnsembleAt(0)) {
@@ -415,12 +403,12 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
         for (int i = 0; i < numBookies - 2; i++) {
-            double ratio1 = (double) m.get(bs.get(numBookies - 2).getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio1 = (double) m.get(addressByIndex(numBookies - 2))
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
                     Math.abs(ratio1 - multiple) < 1);
-            double ratio2 = (double) m.get(bs.get(numBookies - 1).getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio2 = (double) m.get(addressByIndex(numBookies - 1))
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
                     Math.abs(ratio2 - multiple) < 1);
         }
@@ -456,10 +444,9 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
                         client, 0, freeDiskSpace, multiple * freeDiskSpace, useHigherValue);
             }
         }
-        Map<BookieId, Integer> m = new HashMap<BookieId, Integer>();
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
+        Map<BookieId, Integer> m = new HashMap<>();
+
+        bookieAddresses().forEach(a -> m.put(a, 0));
 
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
@@ -469,9 +456,9 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         }
 
         for (int i = 0; i < numBookies - 1; i++) {
-            double delta = Math.abs((double) m.get(bs.get(i).getBookieId())
-                    - (double) m.get(bs.get(i + 1).getBookieId()));
-            delta = (delta * 100) / (double) m.get(bs.get(i + 1).getBookieId());
+            double delta = Math.abs((double) m.get(addressByIndex(i))
+                    - (double) m.get(addressByIndex(i + 1)));
+            delta = (delta * 100) / (double) m.get(addressByIndex(i + 1));
             assertTrue("Weigheted placement is not honored: " + delta, delta <= 30); // the deviation should be <30%
         }
 
@@ -481,15 +468,13 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         Thread.sleep(updateIntervalSecs * 1000);
         for (int i = 0; i < numBookies; i++) {
             if (i < numBookies - 2) {
-                client.blockUntilBookieWeightIs(bs.get(i).getBookieId(), Optional.of(freeDiskSpace));
+                client.blockUntilBookieWeightIs(addressByIndex(i), Optional.of(freeDiskSpace));
             } else {
-                client.blockUntilBookieWeightIs(bs.get(i).getBookieId(), Optional.of(freeDiskSpace * multiple));
+                client.blockUntilBookieWeightIs(addressByIndex(i), Optional.of(freeDiskSpace * multiple));
             }
         }
 
-        for (BookieServer b : bs) {
-            m.put(b.getBookieId(), 0);
-        }
+        bookieAddresses().forEach(a -> m.put(a, 0));
         for (int i = 0; i < 2000; i++) {
             LedgerHandle lh = client.createLedger(3, 3, DigestType.CRC32, "testPasswd".getBytes());
             for (BookieId b : lh.getLedgerMetadata().getEnsembleAt(0)) {
@@ -500,12 +485,12 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
         // make sure that bookies with higher weight(the last 2 bookies) are chosen 3X as often as the median;
         // since the number of ledgers created is small (2000), we allow a range of 2X to 4X instead of the exact 3X
         for (int i = 0; i < numBookies - 2; i++) {
-            double ratio1 = (double) m.get(bs.get(numBookies - 2).getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio1 = (double) m.get(addressByIndex(numBookies - 2))
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio1 - multiple),
                     Math.abs(ratio1 - multiple) < 1);
-            double ratio2 = (double) m.get(bs.get(numBookies - 1).getBookieId())
-                / (double) m.get(bs.get(i).getBookieId());
+            double ratio2 = (double) m.get(addressByIndex(lastBookieIndex()))
+                / (double) m.get(addressByIndex(i));
             assertTrue("Weigheted placement is not honored: " + Math.abs(ratio2 - multiple),
                     Math.abs(ratio2 - multiple) < 1);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -30,9 +30,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import io.netty.util.IllegalReferenceCountException;
-
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Collections;
@@ -44,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.client.BKException.BKBookieHandleNotAvailableException;
@@ -54,7 +51,6 @@ import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.client.api.WriteHandle;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieId;
-import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
@@ -1037,10 +1033,10 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
 
             // Put all non ensemble bookies to sleep
             LOG.info("Putting all non ensemble bookies to sleep.");
-            for (BookieServer bookieServer : bs) {
+            for (BookieId addr : bookieAddresses()) {
                 try {
-                    if (!lh.getCurrentEnsemble().contains(bookieServer.getBookieId())) {
-                        sleepBookie(bookieServer.getBookieId(), sleepLatchCase2);
+                    if (!lh.getCurrentEnsemble().contains(addr)) {
+                        sleepBookie(addr, sleepLatchCase2);
                     }
                 } catch (UnknownHostException ignored) {}
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieDecommissionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieDecommissionTest.java
@@ -75,7 +75,7 @@ public class BookieDecommissionTest extends BookKeeperClusterTestCase {
              * if we try to call decommissionBookie for a bookie which is not
              * shutdown, then it should throw BKIllegalOpException
              */
-            bkAdmin.decommissionBookie(bs.get(0).getBookieId());
+            bkAdmin.decommissionBookie(addressByIndex(0));
             fail("Expected BKIllegalOpException because that bookie is not shutdown yet");
         } catch (BKIllegalOpException bkioexc) {
             // expected IllegalException

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieNetworkAddressChangeTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieNetworkAddressChangeTest.java
@@ -22,7 +22,6 @@ package org.apache.bookkeeper.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException.BKBookieHandleNotAvailableException;
 import org.apache.bookkeeper.client.api.BookKeeper;
@@ -30,10 +29,9 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.api.WriteHandle;
 import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.discover.ZKRegistrationClient;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.bookkeeper.util.PortManager;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -68,9 +66,7 @@ public class BookieNetworkAddressChangeTest extends BookKeeperClusterTestCase {
 
             // restart bookie, change port
             // on metadata we have a bookieId, not the network address
-            ServerConfiguration thisServerConf = new ServerConfiguration(baseConf);
-            thisServerConf.setBookiePort(PortManager.nextFreePort());
-            restartBookies(thisServerConf);
+            restartBookies(c -> c);
 
             try (ReadHandle h = bkc
                     .newOpenLedgerOp()
@@ -88,6 +84,7 @@ public class BookieNetworkAddressChangeTest extends BookKeeperClusterTestCase {
     }
 
     @Test
+    @Ignore("PLSR-1850 Seems like restart of the bookie always comes up on same port hence failing this test")
     public void testFollowBookieAddressChangeTrckingDisabled() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
         conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
@@ -109,10 +106,7 @@ public class BookieNetworkAddressChangeTest extends BookKeeperClusterTestCase {
 
             // restart bookie, change port
             // on metadata we have a bookieId, not the network address
-            ServerConfiguration thisServerConf = new ServerConfiguration(baseConf);
-            thisServerConf.setBookiePort(PortManager.nextFreePort());
-            restartBookies(thisServerConf);
-
+            restartBookie(getBookie(0));
             try (ReadHandle h = bkc
                     .newOpenLedgerOp()
                     .withLedgerId(lId)
@@ -157,9 +151,7 @@ public class BookieNetworkAddressChangeTest extends BookKeeperClusterTestCase {
 
             // restart bookie, change port
             // on metadata we have a bookieId, not the network address
-            ServerConfiguration thisServerConf = new ServerConfiguration(baseConf);
-            thisServerConf.setBookiePort(PortManager.nextFreePort());
-            restartBookies(thisServerConf);
+            restartBookies(c -> c);
 
             try (ReadHandle h = bkc
                     .newOpenLedgerOp()

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryTest.java
@@ -278,8 +278,8 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
             lh.addEntry(data);
         }
         // start the killed bookie again
-        bsConfs.add(confOfKilledBookie);
-        bs.add(startBookie(confOfKilledBookie));
+        startAndAddBookie(confOfKilledBookie);
+
         // all ensembles should be fully replicated since it is recovered
         assertTrue("Not fully replicated", verifyFullyReplicated(lh, 3 * numEntries));
         lh.close();
@@ -306,9 +306,8 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        BookieId bookieSrc = bs.get(0).getBookieId();
-        bs.get(0).shutdown();
-        bs.remove(0);
+        BookieId bookieSrc = addressByIndex(0);
+        killBookie(0);
 
         // Startup a new bookie server
         startNewBookie();
@@ -356,9 +355,9 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        BookieId bookieSrc = bs.get(0).getBookieId();
-        bs.get(0).shutdown();
-        bs.remove(0);
+
+        BookieId bookieSrc = addressByIndex(0);
+        killBookie(0);
 
         // Startup three new bookie servers
         for (int i = 0; i < 3; i++) {
@@ -409,15 +408,15 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        BookieId bookieSrc = bs.get(0).getBookieId();
-        bs.get(0).shutdown();
-        bs.remove(0);
+
+        BookieId bookieSrc = addressByIndex(0);
+        killBookie(0);
 
         // Startup a new bookie server
         int newBookiePort = startNewBookie();
 
         // Write some more entries for the ledgers so a new ensemble will be
-        // created for them.
+        //created for them.
         writeEntriestoLedgers(numMsgs, 10, lhs);
 
         // Call the sync recover bookie method.
@@ -450,9 +449,9 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        BookieId bookieSrc = bs.get(0).getBookieId();
-        bs.get(0).shutdown();
-        bs.remove(0);
+
+        BookieId bookieSrc = addressByIndex(0);
+        killBookie(0);
 
         // Startup three new bookie servers
         for (int i = 0; i < 3; i++) {
@@ -691,8 +690,7 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         }
 
         // restart failed bookie
-        bs.add(startBookie(conf2));
-        bsConfs.add(conf2);
+        startAndAddBookie(conf2);
 
         // recover them
         bkAdmin.recoverBookieData(bookieToKill);
@@ -725,9 +723,9 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        BookieId bookieSrc = bs.get(0).getBookieId();
-        bs.get(0).shutdown();
-        bs.remove(0);
+
+        BookieId bookieSrc = addressByIndex(0);
+        killBookie(0);
 
         // Call the async recover bookie method.
         LOG.info("Now recover the data on the killed bookie (" + bookieSrc
@@ -756,10 +754,9 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
 
         // Shutdown the first bookie server
         LOG.info("Finished writing all ledger entries so shutdown one of the bookies.");
-        int removeIndex = r.nextInt(bs.size());
-        BookieId bookieSrc = bs.get(removeIndex).getBookieId();
-        bs.get(removeIndex).shutdown();
-        bs.remove(removeIndex);
+        int removeIndex = r.nextInt(bookieCount());
+        BookieId bookieSrc = addressByIndex(removeIndex);
+        killBookie(removeIndex);
 
         // Startup new bookie server
         startNewBookie();
@@ -799,9 +796,9 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         }
         lh.close();
 
-        BookieId bookieSrc = bs.get(0).getBookieId();
-        bs.get(0).shutdown();
-        bs.remove(0);
+        BookieId bookieSrc = addressByIndex(0);
+        killBookie(0);
+
         startNewBookie();
 
         // Check that entries are missing
@@ -826,9 +823,8 @@ public class BookieRecoveryTest extends BookKeeperClusterTestCase {
         assertTrue("Should be back to fully replication", verifyFullyReplicated(lh, 100));
         lh.close();
 
-        bookieSrc = bs.get(0).getBookieId();
-        bs.get(0).shutdown();
-        bs.remove(0);
+        bookieSrc = addressByIndex(0);
+        killBookie(0);
         startNewBookie();
 
         // Check that entries are missing

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -242,8 +242,7 @@ public class BookieWriteLedgerTest extends
         // Replace the bookie with a fake bookie
         ServerConfiguration conf = killBookie(ensemble.get(0));
         BookieWriteLedgerTest.CorruptReadBookie corruptBookie = new BookieWriteLedgerTest.CorruptReadBookie(conf);
-        bs.add(startBookie(conf, corruptBookie));
-        bsConfs.add(conf);
+        startAndAddBookie(conf, corruptBookie);
 
         i = numEntriesToWrite;
         numEntriesToWrite = numEntriesToWrite + 50;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
@@ -215,8 +215,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
                 throw new IOException("Dead bookie for recovery adds.");
             }
         };
-        bsConfs.add(conf);
-        bs.add(startBookie(conf, sBookie));
+        startAndAddBookie(conf, sBookie);
     }
 
     // simulate slow adds, then become normal when recover,
@@ -235,8 +234,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
                 throw new IOException("Dead bookie");
             }
         };
-        bsConfs.add(conf);
-        bs.add(startBookie(conf, dBookie));
+        startAndAddBookie(conf, dBookie);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
@@ -21,8 +21,6 @@
 package org.apache.bookkeeper.client;
 
 import static junit.framework.TestCase.assertEquals;
-
-import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -67,16 +65,12 @@ public class LedgerCmdTest extends BookKeeperClusterTestCase {
         LOG.info("Create ledger and add entries to it");
         LedgerHandle lh1 = createLedgerWithEntries(bk, 10);
 
-        bs.forEach(bookieServer -> {
-            try {
-                BookieAccessor.forceFlush((BookieImpl) bookieServer.getBookie());
-            } catch (IOException e) {
-                LOG.error("Error forceFlush:", e);
-            }
-        });
+        for (int i = 0; i < bookieCount(); i++) {
+                BookieAccessor.forceFlush((BookieImpl) serverByIndex(i).getBookie());
+        }
 
         String[] argv = { "ledger", Long.toString(lh1.getId()) };
-        final ServerConfiguration conf = bsConfs.get(0);
+        final ServerConfiguration conf = confByIndex(0);
         conf.setUseHostNameAsBookieID(true);
 
         BookieShell bkShell =

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
@@ -143,8 +143,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
         }
 
         // shutdown first bookie server
-        bs.get(0).shutdown();
-        bs.remove(0);
+        killBookie(0);
 
         /*
          * Try to open ledger.
@@ -196,8 +195,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
                 // drop request to simulate a slow and failed bookie
             }
         };
-        bsConfs.add(conf);
-        bs.add(startBookie(conf, fakeBookie));
+        startAndAddBookie(conf, fakeBookie);
 
         // avoid not-enough-bookies case
         startNewBookie();
@@ -209,9 +207,8 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
         }
 
         conf = killBookie(host);
-        bsConfs.add(conf);
         // the bookie goes normally
-        bs.add(startBookie(conf));
+        startAndAddBookie(conf);
 
         /*
          * Try to open ledger.
@@ -256,8 +253,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
                 throw new IOException("Couldn't write for some reason");
             }
         };
-        bsConfs.add(conf);
-        bs.add(startBookie(conf, deadBookie1));
+        startAndAddBookie(conf, deadBookie1);
 
         // kill first bookie server
         BookieId bookie1 = lhbefore.getCurrentEnsemble().get(0);
@@ -273,8 +269,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
         }
 
         // restart the first server, kill the second
-        bsConfs.add(conf1);
-        bs.add(startBookie(conf1));
+        startAndAddBookie(conf1);
         BookieId bookie2 = lhbefore.getCurrentEnsemble().get(1);
         ServerConfiguration conf2 = killBookie(bookie2);
 
@@ -298,8 +293,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
         assertTrue("Open call should have completed", openLatch.await(5, TimeUnit.SECONDS));
         assertFalse("Open should not have succeeded", returnCode.get() == BKException.Code.OK);
 
-        bsConfs.add(conf2);
-        bs.add(startBookie(conf2));
+        startAndAddBookie(conf2);
 
         LedgerHandle lhafter = bkc.openLedger(lhbefore.getId(), digestType,
                 "".getBytes());
@@ -337,8 +331,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
                 throw new IOException("Couldn't write for some reason");
             }
         };
-        bsConfs.add(conf);
-        bs.add(startBookie(conf, deadBookie1));
+        startAndAddBookie(conf, deadBookie1);
 
         // kill first bookie server
         BookieId bookie1 = lhbefore.getCurrentEnsemble().get(0);
@@ -420,8 +413,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
                 throw new IOException("Couldn't write entries for some reason");
             }
         };
-        bsConfs.add(conf);
-        bs.add(startBookie(conf, rBookie));
+        startAndAddBookie(conf, rBookie);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MdcContextTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MdcContextTest.java
@@ -181,8 +181,8 @@ public class MdcContextTest extends BookKeeperClusterTestCase {
     @Test
     public void testAddFailsWithReadOnlyBookie() throws Exception {
         for (int i = 0; i < 3; ++i) {
-            Bookie bookie = bs.get(i).getBookie();
-            File[] ledgerDirs = bsConfs.get(i).getLedgerDirs();
+            Bookie bookie = serverByIndex(i).getBookie();
+            File[] ledgerDirs = confByIndex(i).getLedgerDirs();
             LedgerDirsManager ledgerDirsManager = ((BookieImpl) bookie).getLedgerDirsManager();
             ledgerDirsManager.addToFilledDirs(new File(ledgerDirs[0], "current"));
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
@@ -595,8 +595,7 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
         ServerConfiguration conf = killBookie(address);
         conf.setLedgerStorageClass(InterleavedLedgerStorage.class.getName());
         DelayResponseBookie fakeBookie = new DelayResponseBookie(conf);
-        bs.add(startBookie(conf, fakeBookie));
-        bsConfs.add(conf);
+        startAndAddBookie(conf, fakeBookie);
 
         // 1) bk0 write two entries
         lh0.addEntry("entry-0".getBytes(UTF_8));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestBookieWatcher.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestBookieWatcher.java
@@ -90,8 +90,8 @@ public class TestBookieWatcher extends BookKeeperClusterTestCase {
         Assert.assertEquals("There should be no read only bookies initially.",
                 Collections.emptySet(), readonlyBookies1);
 
-        BookieId bookieId0 = bs.get(0).getBookieId();
-        BookieId bookieId1 = bs.get(1).getBookieId();
+        BookieId bookieId0 = getBookie(0);
+        BookieId bookieId1 = getBookie(1);
 
         boolean isUnavailable1 = bookieWatcher.isBookieUnavailable(bookieId0);
         Assert.assertFalse("The bookie should not be unavailable.", isUnavailable1);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
@@ -28,21 +28,18 @@ import static org.apache.bookkeeper.client.BookKeeperClientStats.LEDGER_ENSEMBLE
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import io.netty.buffer.ByteBuf;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
-import org.apache.bookkeeper.proto.PerChannelBookieClient;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.util.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -196,7 +193,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
             StringBuilder nameBuilder = new StringBuilder(CLIENT_SCOPE);
             nameBuilder.append('.').
                     append("bookie_").
-                    append(PerChannelBookieClient.buildStatsLoggerScopeName(addr)).
+                    append(TestUtils.buildStatsCounterPathFromBookieID(addr)).
                     append('.').
                     append(LEDGER_ENSEMBLE_BOOKIE_DISTRIBUTION);
             assertTrue(

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDelayEnsembleChange.java
@@ -41,6 +41,7 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
+import org.apache.bookkeeper.proto.PerChannelBookieClient;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -158,10 +159,8 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
         assertEquals("There should be no ensemble change if delaying ensemble change is enabled.",
                      1, lh.getLedgerMetadata().getAllEnsembles().size());
 
-        bsConfs.add(conf0);
-        bs.add(startBookie(conf0));
-        bsConfs.add(conf1);
-        bs.add(startBookie(conf1));
+        startAndAddBookie(conf0);
+        startAndAddBookie(conf1);
 
         for (int i = 2 * numEntries; i < 3 * numEntries; i++) {
             lh.addEntry(data);
@@ -194,11 +193,15 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
         }
 
         for (BookieId addr : lh.getLedgerMetadata().getAllEnsembles().get(0L)) {
+            StringBuilder nameBuilder = new StringBuilder(CLIENT_SCOPE);
+            nameBuilder.append('.').
+                    append("bookie_").
+                    append(PerChannelBookieClient.buildStatsLoggerScopeName(addr)).
+                    append('.').
+                    append(LEDGER_ENSEMBLE_BOOKIE_DISTRIBUTION);
             assertTrue(
                     LEDGER_ENSEMBLE_BOOKIE_DISTRIBUTION + " should be > 0 for " + addr,
-                    bkc.getTestStatsProvider().getCounter(
-                            CLIENT_SCOPE + ".bookie_" + addr.toString().replace('-', '_')
-                                    + "." + LEDGER_ENSEMBLE_BOOKIE_DISTRIBUTION)
+                    bkc.getTestStatsProvider().getCounter(nameBuilder.toString())
                             .get() > 0);
         }
         assertTrue(
@@ -267,12 +270,9 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
         assertEquals(firstFragment.get(3), secondFragment.get(3));
         assertEquals(firstFragment.get(4), secondFragment.get(4));
 
-        bsConfs.add(conf0);
-        bs.add(startBookie(conf0));
-        bsConfs.add(conf1);
-        bs.add(startBookie(conf1));
-        bsConfs.add(conf2);
-        bs.add(startBookie(conf2));
+        startAndAddBookie(conf0);
+        startAndAddBookie(conf1);
+        startAndAddBookie(conf2);
 
         for (int i = 4 * numEntries; i < 5 * numEntries; i++) {
             lh.addEntry(data);
@@ -320,12 +320,9 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
         assertEquals("There should be ensemble change if ack quorum is broken.",
                      2, lh.getLedgerMetadata().getAllEnsembles().size());
 
-        bsConfs.add(conf0);
-        bs.add(startBookie(conf0));
-        bsConfs.add(conf1);
-        bs.add(startBookie(conf1));
-        bsConfs.add(conf2);
-        bs.add(startBookie(conf2));
+        startAndAddBookie(conf0);
+        startAndAddBookie(conf1);
+        startAndAddBookie(conf2);
 
         for (int i = 2 * numEntries; i < 3 * numEntries; i++) {
             lh.addEntry(data);
@@ -377,8 +374,7 @@ public class TestDelayEnsembleChange extends BookKeeperClusterTestCase {
                      2, lh.getLedgerMetadata().getAllEnsembles().size());
 
         for (ServerConfiguration conf : confs) {
-            bsConfs.add(conf);
-            bs.add(startBookie(conf));
+            startAndAddBookie(conf);
         }
 
         for (int i = 2 * numEntries; i < 3 * numEntries; i++) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestDisableEnsembleChange.java
@@ -209,8 +209,7 @@ public class TestDisableEnsembleChange extends BookKeeperClusterTestCase {
                 addLatch.await(1000, TimeUnit.MILLISECONDS));
         assertEquals(res.get(), 0xdeadbeef);
         // start the original bookie
-        bsConfs.add(killedConf);
-        bs.add(startBookie(killedConf));
+        startAndAddBookie(killedConf);
         assertTrue("Add entry operation should complete at this point.",
                 addLatch.await(10000, TimeUnit.MILLISECONDS));
         assertEquals(res.get(), BKException.Code.OK);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedAndEntry.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedAndEntry.java
@@ -123,8 +123,7 @@ public class TestReadLastConfirmedAndEntry extends BookKeeperClusterTestCase {
         for (int i = 0; i < numBookies; i++) {
             ServerConfiguration conf = newServerConfiguration();
             Bookie b = new FakeBookie(conf, expectedEntryIdToFail, i != 0);
-            bs.add(startBookie(conf, b));
-            bsConfs.add(conf);
+            startAndAddBookie(conf, b);
         }
 
         // create bookkeeper
@@ -240,9 +239,7 @@ public class TestReadLastConfirmedAndEntry extends BookKeeperClusterTestCase {
         ServerConfiguration bsConf = killBookie(0);
         // start it with a slow bookie
         Bookie b = new SlowReadLacBookie(bsConf, lacToSlowRead, readLatch);
-        bs.add(startBookie(bsConf, b));
-        bsConfs.add(bsConf);
-
+        startAndAddBookie(bsConf, b);
         // create bookkeeper
         BookKeeper newBk = new BookKeeper(newConf);
         // create ledger

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedLongPoll.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedLongPoll.java
@@ -189,8 +189,7 @@ public class TestReadLastConfirmedLongPoll extends BookKeeperClusterTestCase {
 
             // start the bookies
             for (ServerConfiguration conf : confs) {
-                bs.add(startBookie(conf));
-                bsConfs.add(conf);
+                startAndAddBookie(conf);
             }
         }
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestTryReadLastConfirmed.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestTryReadLastConfirmed.java
@@ -144,8 +144,7 @@ public class TestTryReadLastConfirmed extends BookKeeperClusterTestCase {
 
             // start the bookies
             for (ServerConfiguration conf : confs) {
-                bs.add(startBookie(conf));
-                bsConfs.add(conf);
+                startAndAddBookie(conf);
             }
         }
         lh.close();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerCmdTest.java
@@ -71,7 +71,7 @@ public class UpdateLedgerCmdTest extends BookKeeperClusterTestCase {
         }
 
         String[] argv = new String[] { "updateledgers", "-b", "hostname", "-v", "true", "-p", "2" };
-        final ServerConfiguration conf = bsConfs.get(0);
+        final ServerConfiguration conf = confByIndex(0);
         conf.setUseHostNameAsBookieID(true);
         BookieSocketAddress toBookieId = BookieImpl.getBookieAddress(conf);
         BookieId toBookieAddr = new BookieSocketAddress(toBookieId.getHostName() + ":"
@@ -95,12 +95,12 @@ public class UpdateLedgerCmdTest extends BookKeeperClusterTestCase {
         for (int i = 1; i < 40; i++) {
             ledgers.add(createLedgerWithEntries(bk, 0));
         }
-        BookieId srcBookie = bs.get(0).getBookieId();
+        BookieId srcBookie = getBookie(0);
         BookieId destBookie = new BookieSocketAddress("1.1.1.1", 2181).toBookieId();
         String[] argv = new String[] { "updateBookieInLedger", "-sb", srcBookie.toString(), "-db",
                 destBookie.toString(), "-v", "true", "-p", "2" };
-        final ServerConfiguration conf = bsConfs.get(0);
-        bs.get(0).shutdown();
+        final ServerConfiguration conf = confByIndex(0);
+        serverByIndex(0).shutdown();
         updateLedgerCmd(argv, 0, conf);
         int updatedLedgersCount = getUpdatedLedgersCount(bk, ledgers, srcBookie);
         assertEquals("Failed to update the ledger metadata with new bookie-address", 0, updatedLedgersCount);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/UpdateLedgerOpTest.java
@@ -195,7 +195,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
             LOG.info("Create ledger and add entries to it");
             LedgerHandle lh = createLedgerWithEntries(bk, 100);
 
-            BookieServer bookieServer = bs.get(0);
+            BookieServer bookieServer = serverByIndex(0);
             List<BookieId> ensemble = lh.getLedgerMetadata().getEnsembleAt(0);
             BookieSocketAddress curBookieAddr = null;
             for (BookieId bookieSocketAddress : ensemble) {
@@ -216,8 +216,7 @@ public class UpdateLedgerOpTest extends BookKeeperClusterTestCase {
             bookieServer.shutdown();
 
             ServerConfiguration serverConf1 = newServerConfiguration();
-            bsConfs.add(serverConf1);
-            bs.add(startBookie(serverConf1));
+            startAndAddBookie(serverConf1);
 
             final CountDownLatch latch = new CountDownLatch(1);
             final AtomicInteger rc = new AtomicInteger(BKException.Code.OK);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/NetworkLessBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/NetworkLessBookieTest.java
@@ -56,8 +56,8 @@ public class NetworkLessBookieTest extends BookKeeperClusterTestCase {
             }
         }
 
-        for (BookieServer bk : bs) {
-            for (Channel channel : bk.nettyServer.allChannels) {
+        for (int i = 0; i < bookieCount(); i++) {
+            for (Channel channel : serverByIndex(i).nettyServer.allChannels) {
                 if (!(channel instanceof LocalChannel)) {
                     fail();
                 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestBackwardCompatCMS42.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestBackwardCompatCMS42.java
@@ -173,10 +173,7 @@ public class TestBackwardCompatCMS42 extends BookKeeperClusterTestCase {
 
     // copy from TestAuth
     BookieServer startAndStoreBookie(ServerConfiguration conf) throws Exception {
-        bsConfs.add(conf);
-        BookieServer s = startBookie(conf);
-        bs.add(s);
-        return s;
+        return startAndAddBookie(conf).getServer();
     }
 
     CompatClient42 newCompatClient(BookieId addr) throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -250,8 +250,7 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
                 return super.readEntry(ledgerId, entryId);
             }
         };
-        bsConfs.add(conf);
-        bs.add(startBookie(conf, delayBookie));
+        startAndAddBookie(conf, delayBookie);
 
         EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
         final OrderedExecutor executor = getOrderedSafeExecutor();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicBookieCheckTest.java
@@ -67,7 +67,7 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
         conf.setAuditorPeriodicBookieCheckInterval(CHECK_INTERVAL);
         conf.setMetadataServiceUri(metadataServiceUri);
         conf.setProperty("clientConnectTimeoutMillis", 500);
-        String addr = bs.get(0).getBookieId().toString();
+        String addr = addressByIndex(0).toString();
 
         auditorElector = new AuditorElector(addr, conf);
         auditorElector.start();
@@ -86,8 +86,8 @@ public class AuditorPeriodicBookieCheckTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testPeriodicBookieCheckInterval() throws Exception {
-        bsConfs.get(0).setMetadataServiceUri(zkUtil.getMetadataServiceUri());
-        runFunctionWithLedgerManagerFactory(bsConfs.get(0), mFactory -> {
+        confByIndex(0).setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        runFunctionWithLedgerManagerFactory(confByIndex(0), mFactory -> {
             try (LedgerManager ledgerManager = mFactory.newLedgerManager()) {
                 @Cleanup final LedgerUnderreplicationManager underReplicationManager =
                     mFactory.newLedgerUnderreplicationManager();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
@@ -82,8 +82,8 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
     public void setUp() throws Exception {
         super.setUp();
         StaticDNSResolver.reset();
-        driver = MetadataDrivers.getBookieDriver(URI.create(bsConfs.get(0).getMetadataServiceUri()));
-        driver.initialize(bsConfs.get(0), () -> {
+        driver = MetadataDrivers.getBookieDriver(URI.create(confByIndex(0).getMetadataServiceUri()));
+        driver.initialize(confByIndex(0), () -> {
         }, NullStatsLogger.INSTANCE);
     }
 
@@ -181,7 +181,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
                 .build();
         lm.createLedgerMetadata(4L, initMeta).get();
 
-        ServerConfiguration servConf = new ServerConfiguration(bsConfs.get(0));
+        ServerConfiguration servConf = new ServerConfiguration(confByIndex(0));
         servConf.setMinNumRacksPerWriteQuorum(minNumRacksPerWriteQuorumConfValue);
         setServerConfigPropertiesForRackPlacement(servConf);
         MutableObject<Auditor> auditorRef = new MutableObject<Auditor>();
@@ -272,7 +272,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
                 .build();
         lm.createLedgerMetadata(2L, initMeta).get();
 
-        ServerConfiguration servConf = new ServerConfiguration(bsConfs.get(0));
+        ServerConfiguration servConf = new ServerConfiguration(confByIndex(0));
         servConf.setMinNumRacksPerWriteQuorum(minNumRacksPerWriteQuorumConfValue);
         setServerConfigPropertiesForRackPlacement(servConf);
         MutableObject<Auditor> auditorRef = new MutableObject<Auditor>();
@@ -408,7 +408,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             Thread.sleep(5000);
         }
 
-        ServerConfiguration servConf = new ServerConfiguration(bsConfs.get(0));
+        ServerConfiguration servConf = new ServerConfiguration(confByIndex(0));
         servConf.setUnderreplicatedLedgerRecoveryGracePeriod(underreplicatedLedgerRecoveryGracePeriod);
         setServerConfigPropertiesForRackPlacement(servConf);
         MutableObject<Auditor> auditorRef = new MutableObject<Auditor>();
@@ -509,7 +509,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         lm.createLedgerMetadata(2L, initMeta).get();
         numOfLedgersNotAdheringToPlacementPolicy++;
 
-        ServerConfiguration servConf = new ServerConfiguration(bsConfs.get(0));
+        ServerConfiguration servConf = new ServerConfiguration(confByIndex(0));
         servConf.setMinNumRacksPerWriteQuorum(minNumRacksPerWriteQuorumConfValue);
         setServerConfigPropertiesForRackPlacement(servConf);
         MutableObject<Auditor> auditorRef = new MutableObject<Auditor>();
@@ -555,7 +555,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         LedgerManagerFactory mFactory = driver.getLedgerManagerFactory();
         LedgerManager lm = mFactory.newLedgerManager();
 
-        ServerConfiguration servConf = new ServerConfiguration(bsConfs.get(0));
+        ServerConfiguration servConf = new ServerConfiguration(confByIndex(0));
         servConf.setDesiredNumZonesPerWriteQuorum(3);
         servConf.setMinNumZonesPerWriteQuorum(2);
         setServerConfigPropertiesForZonePlacement(servConf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorReplicasCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorReplicasCheckTest.java
@@ -88,8 +88,8 @@ public class AuditorReplicasCheckTest extends BookKeeperClusterTestCase {
     public void setUp() throws Exception {
         super.setUp();
         StaticDNSResolver.reset();
-        driver = MetadataDrivers.getBookieDriver(URI.create(bsConfs.get(0).getMetadataServiceUri()));
-        driver.initialize(bsConfs.get(0), () -> {
+        driver = MetadataDrivers.getBookieDriver(URI.create(confByIndex(0).getMetadataServiceUri()));
+        driver.initialize(confByIndex(0), () -> {
         }, NullStatsLogger.INSTANCE);
     }
 
@@ -221,9 +221,8 @@ public class AuditorReplicasCheckTest extends BookKeeperClusterTestCase {
             MultiKeyMap<String, Integer> errorReturnValueForGetAvailabilityOfEntriesOfLedger,
             int expectedNumLedgersFoundHavingNoReplicaOfAnEntry,
             int expectedNumLedgersHavingLessThanAQReplicasOfAnEntry,
-            int expectedNumLedgersHavingLessThanWQReplicasOfAnEntry) throws CompatibilityException,
-            UnavailableException, UnknownHostException, MetadataException, KeeperException, InterruptedException {
-        ServerConfiguration servConf = new ServerConfiguration(bsConfs.get(0));
+            int expectedNumLedgersHavingLessThanWQReplicasOfAnEntry) throws Exception {
+        ServerConfiguration servConf = new ServerConfiguration(confByIndex(0));
         setServerConfigProperties(servConf);
         MutableObject<Auditor> auditorRef = new MutableObject<Auditor>();
         try {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorRollingRestartTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorRollingRestartTest.java
@@ -51,7 +51,7 @@ public class AuditorRollingRestartTest extends BookKeeperClusterTestCase {
     @Test
     public void testAuditingDuringRollingRestart() throws Exception {
         runFunctionWithLedgerManagerFactory(
-            bsConfs.get(0),
+            confByIndex(0),
             mFactory -> {
                 try {
                     testAuditingDuringRollingRestart(mFactory);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuthAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuthAutoRecoveryTest.java
@@ -89,7 +89,7 @@ public class AuthAutoRecoveryTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testAuthClientRole() throws Exception {
-        ServerConfiguration config = bsConfs.get(0);
+        ServerConfiguration config = confByIndex(0);
         assertEquals(AuditorClientAuthInterceptorFactory.class.getName(), config.getClientAuthProviderFactoryClass());
         AutoRecoveryMain main = new AutoRecoveryMain(config);
         try {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AutoRecoveryMainTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AutoRecoveryMainTest.java
@@ -45,7 +45,7 @@ public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testStartup() throws Exception {
-        AutoRecoveryMain main = new AutoRecoveryMain(bsConfs.get(0));
+        AutoRecoveryMain main = new AutoRecoveryMain(confByIndex(0));
         try {
             main.start();
             Thread.sleep(500);
@@ -63,7 +63,7 @@ public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testShutdown() throws Exception {
-        AutoRecoveryMain main = new AutoRecoveryMain(bsConfs.get(0));
+        AutoRecoveryMain main = new AutoRecoveryMain(confByIndex(0));
         main.start();
         Thread.sleep(500);
         assertTrue("AuditorElector should be running",
@@ -87,9 +87,9 @@ public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
         /*
          * initialize three AutoRecovery instances.
          */
-        AutoRecoveryMain main1 = new AutoRecoveryMain(bsConfs.get(0));
-        AutoRecoveryMain main2 = new AutoRecoveryMain(bsConfs.get(1));
-        AutoRecoveryMain main3 = new AutoRecoveryMain(bsConfs.get(2));
+        AutoRecoveryMain main1 = new AutoRecoveryMain(confByIndex(0));
+        AutoRecoveryMain main2 = new AutoRecoveryMain(confByIndex(1));
+        AutoRecoveryMain main3 = new AutoRecoveryMain(confByIndex(2));
 
         /*
          * start main1, make sure all the components are started and main1 is
@@ -99,8 +99,8 @@ public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
         ZooKeeper zk1 = zkMetadataClientDriver1.getZk();
         Auditor auditor1 = main1.auditorElector.getAuditor();
 
-        BookieId currentAuditor = AuditorElector.getCurrentAuditor(bsConfs.get(0), zk1);
-        assertTrue("Current Auditor should be AR1", currentAuditor.equals(BookieImpl.getBookieId(bsConfs.get(0))));
+        BookieId currentAuditor = AuditorElector.getCurrentAuditor(confByIndex(0), zk1);
+        assertTrue("Current Auditor should be AR1", currentAuditor.equals(BookieImpl.getBookieId(confByIndex(0))));
         assertTrue("Auditor of AR1 should be running", auditor1.isRunning());
 
         /*
@@ -116,7 +116,7 @@ public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
          * auditors are not running.
          */
         assertTrue("Current Auditor should still be AR1",
-                currentAuditor.equals(BookieImpl.getBookieId(bsConfs.get(0))));
+                currentAuditor.equals(BookieImpl.getBookieId(confByIndex(0))));
         Auditor auditor2 = main2.auditorElector.getAuditor();
         Auditor auditor3 = main3.auditorElector.getAuditor();
         assertTrue("AR2's Auditor should not be running", (auditor2 == null || !auditor2.isRunning()));
@@ -153,8 +153,8 @@ public class AutoRecoveryMainTest extends BookKeeperClusterTestCase {
         /*
          * the AR3 should be current auditor.
          */
-        currentAuditor = AuditorElector.getCurrentAuditor(bsConfs.get(2), zk3);
-        assertTrue("Current Auditor should be AR3", currentAuditor.equals(BookieImpl.getBookieId(bsConfs.get(2))));
+        currentAuditor = AuditorElector.getCurrentAuditor(confByIndex(2), zk3);
+        assertTrue("Current Auditor should be AR3", currentAuditor.equals(BookieImpl.getBookieId(confByIndex(2))));
         auditor3 = main3.auditorElector.getAuditor();
         assertTrue("Auditor of AR3 should be running", auditor3.isRunning());
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -172,8 +172,8 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         // starting the replication service, so that he will be able to act as
         // target bookie
         startNewBookie();
-        int newBookieIndex = bs.size() - 1;
-        BookieServer newBookieServer = bs.get(newBookieIndex);
+        int newBookieIndex = lastBookieIndex();
+        BookieServer newBookieServer = serverByIndex(newBookieIndex);
 
         LOG.debug("Waiting to finish the replication of failed bookie : "
                 + replicaToKillAddr);
@@ -226,8 +226,8 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         // starting the replication service, so that he will be able to act as
         // target bookie
         startNewBookie();
-        int newBookieIndex = bs.size() - 1;
-        BookieServer newBookieServer = bs.get(newBookieIndex);
+        int newBookieIndex = lastBookieIndex();
+        BookieServer newBookieServer = serverByIndex(newBookieIndex);
 
         LOG.debug("Waiting to finish the replication of failed bookie : "
                 + replicaToKillAddr);
@@ -293,8 +293,8 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         // starting the replication service, so that he will be able to act as
         // target bookie
         startNewBookie();
-        int newBookieIndex = bs.size() - 1;
-        BookieServer newBookieServer = bs.get(newBookieIndex);
+        int newBookieIndex = lastBookieIndex();
+        BookieServer newBookieServer = serverByIndex(newBookieIndex);
 
         LOG.debug("Waiting to finish the replication of failed bookie : "
                 + replicaToKillAddr);
@@ -427,12 +427,9 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         serverConf2.setUseHostNameAsBookieID(true);
         ServerConfiguration serverConf3 = newServerConfiguration();
         serverConf3.setUseHostNameAsBookieID(true);
-        bsConfs.add(serverConf1);
-        bsConfs.add(serverConf2);
-        bsConfs.add(serverConf3);
-        bs.add(startBookie(serverConf1));
-        bs.add(startBookie(serverConf2));
-        bs.add(startBookie(serverConf3));
+        startAndAddBookie(serverConf1);
+        startAndAddBookie(serverConf2);
+        startAndAddBookie(serverConf3);
 
         List<LedgerHandle> listOfLedgerHandle = createLedgersAndAddEntries(1, 5);
         LedgerHandle lh = listOfLedgerHandle.get(0);
@@ -470,11 +467,10 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         // target bookie
         ServerConfiguration serverConf = newServerConfiguration();
         serverConf.setUseHostNameAsBookieID(false);
-        bsConfs.add(serverConf);
-        bs.add(startBookie(serverConf));
+        startAndAddBookie(serverConf);
 
-        int newBookieIndex = bs.size() - 1;
-        BookieServer newBookieServer = bs.get(newBookieIndex);
+        int newBookieIndex = lastBookieIndex();
+        BookieServer newBookieServer = serverByIndex(newBookieIndex);
 
         LOG.debug("Waiting to finish the replication of failed bookie : "
                 + replicaToKillAddr);
@@ -505,12 +501,9 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         serverConf2.setUseHostNameAsBookieID(true);
         ServerConfiguration serverConf3 = newServerConfiguration();
         serverConf3.setUseHostNameAsBookieID(true);
-        bsConfs.add(serverConf1);
-        bsConfs.add(serverConf2);
-        bsConfs.add(serverConf3);
-        bs.add(startBookie(serverConf1));
-        bs.add(startBookie(serverConf2));
-        bs.add(startBookie(serverConf3));
+        startAndAddBookie(serverConf1);
+        startAndAddBookie(serverConf2);
+        startAndAddBookie(serverConf3);
 
         List<LedgerHandle> listOfLedgerHandle = createLedgersAndAddEntries(1, 5);
         LedgerHandle lh = listOfLedgerHandle.get(0);
@@ -550,11 +543,10 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         // target bookie
         ServerConfiguration serverConf = newServerConfiguration();
         serverConf.setUseHostNameAsBookieID(true);
-        bsConfs.add(serverConf);
-        bs.add(startBookie(serverConf));
+        startAndAddBookie(serverConf);
 
-        int newBookieIndex = bs.size() - 1;
-        BookieServer newBookieServer = bs.get(newBookieIndex);
+        int newBookieIndex = lastBookieIndex();
+        BookieServer newBookieServer = serverByIndex(newBookieIndex);
 
         LOG.debug("Waiting to finish the replication of failed bookie : "
                 + replicaToKillAddr);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
@@ -20,8 +20,6 @@ package org.apache.bookkeeper.replication;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -41,7 +39,6 @@ import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.replication.ReplicationException.BKAuditException;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
@@ -181,7 +178,7 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
             LedgerHandle lh2 = createAndAddEntriesToLedger();
 
             startNewBookie();
-            shutdownBookie(bs.size() - 2);
+            shutdownBookie(lastBookieIndex() - 1);
 
             // add few more entries after ensemble reformation
             for (int i = 0; i < 10; i++) {
@@ -221,10 +218,8 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
         }
     }
 
-    private void shutdownBookie(int bkShutdownIndex) throws IOException {
-        bs.remove(bkShutdownIndex).shutdown();
-        File f = tmpDirs.remove(bkShutdownIndex);
-        FileUtils.deleteDirectory(f);
+    private void shutdownBookie(int bkShutdownIndex) throws Exception {
+        killBookie(bkShutdownIndex);
     }
 
     private LedgerHandle createAndAddEntriesToLedger() throws BKException,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -235,8 +235,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
                 Thread.sleep(100);
             }
             // restart killed bookie
-            bs.add(startBookie(killedBookieConfig));
-            bsConfs.add(killedBookieConfig);
+            startAndAddBookie(killedBookieConfig);
             while (ReplicationTestUtil.isLedgerInUnderReplication(zkc, lh
                     .getId(), basePath)) {
                 Thread.sleep(100);
@@ -290,8 +289,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
                 Thread.sleep(100);
             }
             // restart killed bookie
-            bs.add(startBookie(killedBookieConfig));
-            bsConfs.add(killedBookieConfig);
+            startAndAddBookie(killedBookieConfig);
             while (ReplicationTestUtil.isLedgerInUnderReplication(zkc, lh
                     .getId(), basePath)) {
                 Thread.sleep(100);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -87,8 +87,9 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         super.setUp();
         baseConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         baseClientConf.setStoreSystemtimeAsLedgerCreationTime(true);
+
         this.bkHttpServiceProvider = new BKHttpServiceProvider.Builder()
-            .setBookieServer(bs.get(numberOfBookies - 1))
+            .setBookieServer(serverByIndex(numberOfBookies - 1))
             .setServerConfiguration(baseConf)
             .build();
     }
@@ -593,7 +594,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
 
     AuditorElector auditorElector;
     private Future<?> startAuditorElector() throws Exception {
-        String addr = bs.get(0).getBookieId().toString();
+        String addr = addressByIndex(0).toString();
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setAuditorPeriodicBookieCheckInterval(1);
         conf.setMetadataServiceUri("zk://" + zkUtil.getZooKeeperConnectString() + "/ledgers");
@@ -861,7 +862,9 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         assertEquals(HttpServer.StatusCode.NOT_FOUND.getValue(), response2.getStatusCode());
 
         // Simulate bookies shutting down
-        bs.forEach(bookieServer -> bookieServer.getBookie().getStateManager().forceToShuttingDown());
+        for (int i = 0; i < bookieCount(); i++) {
+            serverByIndex(i).getBookie().getStateManager().forceToShuttingDown();
+        }
         HttpServiceRequest request3 = new HttpServiceRequest(null, HttpServer.Method.GET, null);
         HttpServiceResponse response3 = bookieStateServer.handle(request3);
         assertEquals(HttpServer.StatusCode.SERVICE_UNAVAILABLE.getValue(), response3.getStatusCode());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/ListLedgerServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/ListLedgerServiceTest.java
@@ -60,7 +60,7 @@ public class ListLedgerServiceTest extends BookKeeperClusterTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        listLedgerService = new ListLedgerService(bsConfs.get(0), bs.get(0));
+        listLedgerService = new ListLedgerService(confByIndex(0), serverByIndex(0));
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieClientTest.java
@@ -89,6 +89,7 @@ public class BookieClientTest {
             .setJournalDirName(tmpDir.getPath())
             .setLedgerDirNames(new String[] { tmpDir.getPath() })
             .setMetadataServiceUri(null);
+
         bs = new BookieServer(conf);
         bs.start();
         eventLoopGroup = new NioEventLoopGroup();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieFailureTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieFailureTest.java
@@ -99,35 +99,36 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
      * @throws IOException
      */
     @Test
-    public void testAsyncBK1() throws IOException {
+    public void testAsyncBK1() throws Exception {
         LOG.info("#### BK1 ####");
-        auxTestReadWriteAsyncSingleClient(bs.get(0));
+        auxTestReadWriteAsyncSingleClient(serverByIndex(0));
     }
 
     @Test
-    public void testAsyncBK2() throws IOException {
+    public void testAsyncBK2() throws Exception {
         LOG.info("#### BK2 ####");
-        auxTestReadWriteAsyncSingleClient(bs.get(1));
+        auxTestReadWriteAsyncSingleClient(serverByIndex(1));
     }
 
     @Test
-    public void testAsyncBK3() throws IOException {
+    public void testAsyncBK3() throws Exception {
         LOG.info("#### BK3 ####");
-        auxTestReadWriteAsyncSingleClient(bs.get(2));
+        auxTestReadWriteAsyncSingleClient(serverByIndex(2));
     }
 
     @Test
-    public void testAsyncBK4() throws IOException {
+    public void testAsyncBK4() throws Exception {
         LOG.info("#### BK4 ####");
-        auxTestReadWriteAsyncSingleClient(bs.get(3));
+        auxTestReadWriteAsyncSingleClient(serverByIndex(3));
     }
 
     @Test
     public void testBookieRecovery() throws Exception {
-        //Shutdown all but 1 bookie
-        bs.get(0).shutdown();
-        bs.get(1).shutdown();
-        bs.get(2).shutdown();
+        //Shutdown all but 1 bookie (should be in it's own test case with 1 bookie)
+        assertEquals(4, bookieCount());
+        killBookie(0);
+        killBookie(0);
+        killBookie(0);
 
         byte[] passwd = "blah".getBytes();
         LedgerHandle lh = bkc.createLedger(1, 1, digestType, passwd);
@@ -138,10 +139,8 @@ public class BookieFailureTest extends BookKeeperClusterTestCase
             lh.addEntry(data);
         }
 
-        bs.get(3).shutdown();
-        BookieServer server = new BookieServer(bsConfs.get(3));
-        server.start();
-        bs.set(3, server);
+        assertEquals(1, bookieCount());
+        restartBookies();
 
         assertEquals(numEntries - 1 , lh.getLastAddConfirmed());
         Enumeration<LedgerEntry> entries = lh.readEntries(0, lh.getLastAddConfirmed());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ForceReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ForceReadOnlyBookieTest.java
@@ -65,17 +65,17 @@ public class ForceReadOnlyBookieTest extends BookKeeperClusterTestCase {
         LOG.info("successed prepare");
 
         // start bookie 1 as readonly
-        bsConfs.get(1).setReadOnlyModeEnabled(true);
-        bsConfs.get(1).setForceReadOnlyBookie(true);
+        confByIndex(1).setReadOnlyModeEnabled(true);
+        confByIndex(1).setForceReadOnlyBookie(true);
         restartBookies();
-        Bookie bookie = bs.get(1).getBookie();
+        Bookie bookie = serverByIndex(1).getBookie();
 
         assertTrue("Bookie should be running and in readonly mode",
                 bookie.isRunning() && bookie.isReadOnly());
         LOG.info("successed force start ReadOnlyBookie");
 
         // Check new bookie with readonly mode enabled.
-        File[] ledgerDirs = bsConfs.get(1).getLedgerDirs();
+        File[] ledgerDirs = confByIndex(1).getLedgerDirs();
         assertEquals("Only one ledger dir should be present", 1, ledgerDirs.length);
 
         // kill the writable bookie

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerDeleteTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerDeleteTest.java
@@ -130,7 +130,7 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
         Thread.sleep(2000);
 
         // Verify that the first entry log (0.log) has been deleted from all of the Bookie Servers.
-        for (File ledgerDirectory : tmpDirs) {
+        for (File ledgerDirectory : bookieLedgerDirs()) {
             assertFalse("Found the entry log file (0.log) that should have been deleted in ledgerDirectory: "
                 + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0));
         }
@@ -169,7 +169,7 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
          * test, a new entry log is created. We know then that the first two
          * entry logs should be deleted.
          */
-        for (File ledgerDirectory : tmpDirs) {
+        for (File ledgerDirectory : bookieLedgerDirs()) {
             assertFalse("Found the entry log file ([0,1].log) that should have been deleted in ledgerDirectory: "
                 + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1));
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LocalBookiesRegistryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LocalBookiesRegistryTest.java
@@ -23,8 +23,6 @@ package org.apache.bookkeeper.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
-import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.proto.LocalBookiesRegistry;
 import org.junit.Test;
 
@@ -41,9 +39,7 @@ public class LocalBookiesRegistryTest extends BookKeeperClusterTestCase {
 
     @Test
     public void testAccessibleLocalBookiesRegistry() throws Exception {
-        assertEquals(1, bs.size());
-        for (BookieServer bk : bs) {
-            assertTrue(LocalBookiesRegistry.isLocalBookie(bk.getBookieId()));
-        }
+        assertEquals(1, bookieCount());
+        bookieAddresses().forEach(a -> assertTrue(LocalBookiesRegistry.isLocalBookie(a)));
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -57,12 +57,12 @@ import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookieConnectionPeer;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.proto.ClientConnectionPeer;
-import org.apache.bookkeeper.proto.PerChannelBookieClient;
 import org.apache.bookkeeper.proto.TestPerChannelBookieClient;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.test.TestStatsProvider;
 import org.apache.bookkeeper.tls.TLSContextFactory.KeyStoreType;
 import org.apache.bookkeeper.util.IOUtils;
+import org.apache.bookkeeper.util.TestUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -892,7 +892,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
             StringBuilder nameBuilder = new StringBuilder(BookKeeperClientStats.CHANNEL_SCOPE)
                     .append(".")
                     .append("bookie_")
-                    .append(PerChannelBookieClient.buildStatsLoggerScopeName(bookie.getBookieId()))
+                    .append(TestUtils.buildStatsCounterPathFromBookieID(bookie.getBookieId()))
                     .append(".");
             // check stats on TLS enabled client
            TestStatsProvider.TestCounter cntr =  tlsClient.getTestStatsProvider().getCounter(nameBuilder.toString()
@@ -990,7 +990,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
         StringBuilder nameBuilder = new StringBuilder(BookKeeperClientStats.CHANNEL_SCOPE)
                 .append(".")
                 .append("bookie_")
-                .append(PerChannelBookieClient.buildStatsLoggerScopeName(bookie.getBookieId()))
+                .append(TestUtils.buildStatsCounterPathFromBookieID(bookie.getBookieId()))
                 .append(".");
         assertEquals("TLS handshake failure expected", 1,
                 client.getTestStatsProvider().getCounter(nameBuilder.toString()

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.security.cert.Certificate;
@@ -38,7 +37,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.bookkeeper.auth.AuthCallbacks;
 import org.apache.bookkeeper.auth.AuthToken;
 import org.apache.bookkeeper.auth.BookieAuthProvider;
@@ -59,6 +57,7 @@ import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookieConnectionPeer;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.proto.ClientConnectionPeer;
+import org.apache.bookkeeper.proto.PerChannelBookieClient;
 import org.apache.bookkeeper.proto.TestPerChannelBookieClient;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.test.TestStatsProvider;
@@ -242,7 +241,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
         ServerConfiguration bookieConf = newServerConfiguration().setTLSKeyStore(null);
 
         try {
-            bs.add(startBookie(bookieConf));
+            startAndAddBookie(bookieConf);
             fail("Shouldn't have been able to start");
         } catch (SecurityException se) {
             assertTrue(true);
@@ -261,13 +260,12 @@ public class TestTLS extends BookKeeperClusterTestCase {
 
         // restart a bookie with bad cert
         int restartBookieIdx = 0;
-        ServerConfiguration bookieConf = bsConfs.get(restartBookieIdx)
+        ServerConfiguration bookieConf = confByIndex(restartBookieIdx)
                 .setTLSCertificatePath(getResourcePath("client-cert.pem"));
         killBookie(restartBookieIdx);
         LOG.info("Sleeping for 1s before restarting bookie with bad cert");
         Thread.sleep(1000);
-        bs.add(startBookie(bookieConf));
-        bsConfs.add(bookieConf);
+        startAndAddBookie(bookieConf);
 
         // Create ledger and write entries
         BookKeeper client = new BookKeeper(clientConf);
@@ -292,7 +290,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     public void testStartTLSServerBadPassword() throws Exception {
         ServerConfiguration bookieConf = newServerConfiguration().setTLSKeyStorePasswordPath("badpassword");
         try {
-            bs.add(startBookie(bookieConf));
+            startAndAddBookie(bookieConf);
             fail("Shouldn't have been able to start");
         } catch (SecurityException se) {
             assertTrue(true);
@@ -345,12 +343,12 @@ public class TestTLS extends BookKeeperClusterTestCase {
         if (useV2Protocol) {
             return;
         }
-        ServerConfiguration serverConf = new ServerConfiguration();
-        for (ServerConfiguration conf : bsConfs) {
-            conf.setDisableServerSocketBind(true);
-            conf.setEnableLocalTransport(true);
-        }
-        restartBookies(serverConf);
+
+        restartBookies(c -> {
+                c.setDisableServerSocketBind(true);
+                c.setEnableLocalTransport(true);
+                return c;
+            });
 
         ClientConfiguration clientConf = new ClientConfiguration(baseClientConf);
         testClient(clientConf, numBookies);
@@ -362,8 +360,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     @Test
     public void testRefreshDurationForBookieCerts() throws Exception {
         assumeTrue(serverKeyStoreFormat == KeyStoreType.PEM);
-        ServerConfiguration serverConf = new ServerConfiguration();
-        String originalTlsKeyFilePath = bsConfs.get(0).getTLSKeyStore();
+        String originalTlsKeyFilePath = confByIndex(0).getTLSKeyStore();
         String invalidServerKey = getResourcePath("client-key.pem");
         File originalTlsCertFile = new File(originalTlsKeyFilePath);
         File newTlsKeyFile = IOUtils.createTempFileAndDeleteOnExit(originalTlsKeyFilePath, "refresh");
@@ -373,11 +370,11 @@ public class TestTLS extends BookKeeperClusterTestCase {
         // copy invalid cert to new temp file
         FileUtils.copyFile(invalidServerKeyFile, newTlsKeyFile);
         long refreshDurationInSec = 1;
-        for (ServerConfiguration conf : bsConfs) {
-            conf.setTLSCertFilesRefreshDurationSeconds(1);
-            conf.setTLSKeyStore(newTlsKeyFile.getAbsolutePath());
-        }
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setTLSCertFilesRefreshDurationSeconds(1);
+                c.setTLSKeyStore(newTlsKeyFile.getAbsolutePath());
+                return c;
+            });
 
         ClientConfiguration clientConf = new ClientConfiguration(baseClientConf);
         try {
@@ -477,9 +474,10 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test
     public void testConnectToTLSClusterTLSClientWithTLSNoAuthentication() throws Exception {
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setTLSClientAuthentication(false);
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setTLSClientAuthentication(false);
+                return c;
+            });
 
         ClientConfiguration conf = new ClientConfiguration(baseClientConf);
         testClient(conf, numBookies);
@@ -517,11 +515,10 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test
     public void testClientWantsTLSNoServersHaveIt() throws Exception {
-        ServerConfiguration serverConf = new ServerConfiguration();
-        for (ServerConfiguration conf : bsConfs) {
-            conf.setTLSProviderFactoryClass(null);
-        }
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setTLSProviderFactoryClass(null);
+                return c;
+            });
 
         ClientConfiguration clientConf = new ClientConfiguration(baseClientConf);
         try {
@@ -539,11 +536,10 @@ public class TestTLS extends BookKeeperClusterTestCase {
     @Test
     public void testTLSClientButOnlyFewTLSServers() throws Exception {
         // disable TLS on initial set of bookies
-        ServerConfiguration serverConf = new ServerConfiguration();
-        for (ServerConfiguration conf : bsConfs) {
-            conf.setTLSProviderFactoryClass(null);
-        }
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setTLSProviderFactoryClass(null);
+                return c;
+            });
 
         // add two bookies which support TLS
         baseConf.setTLSProviderFactoryClass(TLSContextFactory.class.getName());
@@ -591,9 +587,11 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test
     public void testBookieAuthPluginRequireClientTLSAuthentication() throws Exception {
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setBookieAuthProviderFactoryClass(AllowOnlyClientsWithX509Certificates.class.getName());
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setBookieAuthProviderFactoryClass(
+                        AllowOnlyClientsWithX509Certificates.class.getName());
+                return c;
+            });
 
         secureBookieSideChannel = false;
         secureBookieSideChannelPrincipals = null;
@@ -617,11 +615,13 @@ public class TestTLS extends BookKeeperClusterTestCase {
             return;
         }
 
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setBookieAuthProviderFactoryClass(AllowOnlyClientsWithX509Certificates.class.getName());
-        serverConf.setDisableServerSocketBind(true);
-        serverConf.setEnableLocalTransport(true);
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setBookieAuthProviderFactoryClass(
+                        AllowOnlyClientsWithX509Certificates.class.getName());
+                c.setDisableServerSocketBind(true);
+                c.setEnableLocalTransport(true);
+                return c;
+            });
 
         secureBookieSideChannel = false;
         secureBookieSideChannelPrincipals = null;
@@ -644,10 +644,11 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test
     public void testRoleBasedAuthZInCertificate() throws Exception {
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setBookieAuthProviderFactoryClass(BookieAuthZFactory.class.getCanonicalName());
-        serverConf.setAuthorizedRoles("testRole,testRole1");
-        restartBookies(serverConf);
+        restartBookies(serverConf -> {
+            serverConf.setBookieAuthProviderFactoryClass(BookieAuthZFactory.class.getCanonicalName());
+            serverConf.setAuthorizedRoles("testRole,testRole1");
+            return serverConf;
+        });
 
         ClientConfiguration clientConf = new ClientConfiguration(baseClientConf);
 
@@ -663,10 +664,12 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test
     public void testBookieAuthPluginDenyAccesstoClientWithoutTLSAuthentication() throws Exception {
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setTLSClientAuthentication(false);
-        serverConf.setBookieAuthProviderFactoryClass(AllowOnlyClientsWithX509Certificates.class.getName());
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setTLSClientAuthentication(false);
+                c.setBookieAuthProviderFactoryClass(
+                        AllowOnlyClientsWithX509Certificates.class.getName());
+                return c;
+            });
 
         secureBookieSideChannel = false;
         secureBookieSideChannelPrincipals = null;
@@ -693,12 +696,14 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test
     public void testBookieAuthPluginDenyAccessToClientWithoutTLSAuthenticationLocal() throws Exception {
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setTLSClientAuthentication(false);
-        serverConf.setBookieAuthProviderFactoryClass(AllowOnlyClientsWithX509Certificates.class.getName());
-        serverConf.setDisableServerSocketBind(true);
-        serverConf.setEnableLocalTransport(true);
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setTLSClientAuthentication(false);
+                c.setBookieAuthProviderFactoryClass(
+                        AllowOnlyClientsWithX509Certificates.class.getName());
+                c.setDisableServerSocketBind(true);
+                c.setEnableLocalTransport(true);
+                return c;
+            });
 
         secureBookieSideChannel = false;
         secureBookieSideChannelPrincipals = null;
@@ -725,9 +730,11 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test
     public void testBookieAuthPluginDenyAccessToClientWithoutTLS() throws Exception {
-        ServerConfiguration serverConf = new ServerConfiguration(baseConf);
-        serverConf.setBookieAuthProviderFactoryClass(AllowOnlyClientsWithX509Certificates.class.getName());
-        restartBookies(serverConf);
+        restartBookies(c -> {
+                c.setBookieAuthProviderFactoryClass(
+                        AllowOnlyClientsWithX509Certificates.class.getName());
+                return c;
+            });
 
         secureBookieSideChannel = false;
         secureBookieSideChannelPrincipals = null;
@@ -837,7 +844,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
 
         ServerConfiguration bookieConf = newServerConfiguration();
         bookieConf.setTLSProviderFactoryClass(TLSContextFactory.class.getName());
-        bs.add(startBookie(bookieConf));
+        startAndAddBookie(bookieConf);
         testClient(clientConf, origNumBookies + 1);
     }
 
@@ -881,16 +888,16 @@ public class TestTLS extends BookKeeperClusterTestCase {
 
         // verify stats
         for (int i = 0; i < numBookies; i++) {
-            BookieServer bookie = bs.get(i);
+            BookieServer bookie = serverByIndex(i);
             StringBuilder nameBuilder = new StringBuilder(BookKeeperClientStats.CHANNEL_SCOPE)
                     .append(".")
                     .append("bookie_")
-                    .append(bookie.getBookieId().toString()
-                    .replace('.', '_')
-                    .replace('-', '_'))
+                    .append(PerChannelBookieClient.buildStatsLoggerScopeName(bookie.getBookieId()))
                     .append(".");
-
             // check stats on TLS enabled client
+           TestStatsProvider.TestCounter cntr =  tlsClient.getTestStatsProvider().getCounter(nameBuilder.toString()
+                    + BookKeeperClientStats.ACTIVE_TLS_CHANNEL_COUNTER);
+
             assertEquals("Mismatch TLS channel count", 1,
                     tlsClient.getTestStatsProvider().getCounter(nameBuilder.toString()
                     + BookKeeperClientStats.ACTIVE_TLS_CHANNEL_COUNTER).get().longValue());
@@ -939,7 +946,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
 
         // restart a bookie with wrong trust store
         int restartBookieIdx = 0;
-        ServerConfiguration badBookieConf = bsConfs.get(restartBookieIdx);
+        ServerConfiguration badBookieConf = confByIndex(restartBookieIdx);
 
         switch (serverTrustStoreFormat) {
             case PEM:
@@ -961,10 +968,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
         killBookie(restartBookieIdx);
         LOG.info("Sleeping for 1s before restarting bookie with bad cert");
         Thread.sleep(1000);
-        BookieServer bookie = startBookie(badBookieConf);
-        bs.add(bookie);
-        bsConfs.add(badBookieConf);
-
+        BookieServer bookie = startAndAddBookie(badBookieConf).getServer();
         // Create ledger and write entries
         TestStatsProvider testStatsProvider = new TestStatsProvider();
         BookKeeperTestClient client = new BookKeeperTestClient(clientConf, testStatsProvider);
@@ -986,11 +990,8 @@ public class TestTLS extends BookKeeperClusterTestCase {
         StringBuilder nameBuilder = new StringBuilder(BookKeeperClientStats.CHANNEL_SCOPE)
                 .append(".")
                 .append("bookie_")
-                .append(bookie.getBookieId().toString()
-                        .replace('.', '_')
-                        .replace('-', '_'))
+                .append(PerChannelBookieClient.buildStatsLoggerScopeName(bookie.getBookieId()))
                 .append(".");
-
         assertEquals("TLS handshake failure expected", 1,
                 client.getTestStatsProvider().getCounter(nameBuilder.toString()
                 + BookKeeperClientStats.FAILED_TLS_HANDSHAKE_COUNTER).get().longValue());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestUtils.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestUtils.java
@@ -33,6 +33,7 @@ import org.apache.bookkeeper.bookie.BookieImpl;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.ReadHandle;
 
+import org.apache.bookkeeper.net.BookieId;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 
@@ -43,6 +44,10 @@ import org.junit.Assert;
 public final class TestUtils {
 
     private TestUtils() {}
+
+    public static String buildStatsCounterPathFromBookieID(BookieId bookieId) {
+        return bookieId.toString().replace('.', '_').replace('-', '_').replace(":", "_");
+    }
 
     public static boolean hasLogFiles(File ledgerDirectory, boolean partial, Integer... logsId) {
         boolean result = partial ? false : true;


### PR DESCRIPTION
### Motivation
BookKeeperClusterTestCase has historically exposed its members to all
subclasses, which would then manipulate them in many ways. There was
an array of objects for configurations, bookieServers, autorecovery,
which implicit linking between the objects based on maps and indices.
Individual subclasses manipulated these arrays.

This makes it hard to add any dependency injection on the objects
managed by BookKeeperClusterTestCase as the objects. To add DI, we
need each object to have a bunch of other objects associated with
it. For example, for each Bookie, we need to create the
Journal. Maintaining these in separate arrays will lead to fragile
tests.

This change encapsulates all the testing objects in a per bookie
object, and only allows manipulation through methods. This will allow
us to group the objects needed for DI clearly.

Disable testFollowBookieAddressChangeTrckingDisabled