### PR TITLE
ISSUE #2726 Fix JAVA_HOME containing spaces

### DIFF
--- a/bin/bkctl
+++ b/bin/bkctl
@@ -64,4 +64,4 @@ OPTS="${OPTS} -cp ${CLI_CLASSPATH} ${BOOKIE_OPTS} ${GC_OPTS} ${NETTY_OPTS} ${LOG
 
 #Change to BK_HOME to support relative paths
 cd "$BK_HOME"
-exec ${JAVA} ${OPTS} org.apache.bookkeeper.tools.cli.BKCtl --conf ${CLI_CONF} $@
+exec "${JAVA}" ${OPTS} org.apache.bookkeeper.tools.cli.BKCtl --conf ${CLI_CONF} $@

--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -157,26 +157,26 @@ fi
 #Change to BK_HOME to support relative paths
 cd "$BK_HOME"
 if [ ${COMMAND} == "bookie" ]; then
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.Main --conf ${BOOKIE_CONF} $@
+  exec "${JAVA}" ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.Main --conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "autorecovery" ]; then
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.replication.AutoRecoveryMain --conf ${BOOKIE_CONF} $@
+  exec "${JAVA}" ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.replication.AutoRecoveryMain --conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "localbookie" ]; then
   NUMBER=$1
   shift
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.util.LocalBookKeeper ${NUMBER} ${BOOKIE_CONF} $@
+  exec "${JAVA}" ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.util.LocalBookKeeper ${NUMBER} ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "standalone" ]; then
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.stream.cluster.StandaloneStarter --conf ${BK_HOME}/conf/standalone.conf $@
+  exec "${JAVA}" ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.bookkeeper.stream.cluster.StandaloneStarter --conf ${BK_HOME}/conf/standalone.conf $@
 elif [ ${COMMAND} == "upgrade" ]; then
-  exec ${JAVA} ${OPTS} org.apache.bookkeeper.bookie.FileSystemUpgrade --conf ${BOOKIE_CONF} $@
+  exec "${JAVA}" ${OPTS} org.apache.bookkeeper.bookie.FileSystemUpgrade --conf ${BOOKIE_CONF} $@
 elif [ $COMMAND == "zookeeper" ]; then
     BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"zookeeper.log"}
-    exec $JAVA $OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE org.apache.zookeeper.server.quorum.QuorumPeerMain $BOOKIE_ZK_CONF $@
+    exec "${JAVA}" $OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE org.apache.zookeeper.server.quorum.QuorumPeerMain $BOOKIE_ZK_CONF $@
 elif [ ${COMMAND} == "shell" ]; then
   ENTRY_FORMATTER_ARG="-DentryFormatterClass=${ENTRY_FORMATTER_CLASS:-org.apache.bookkeeper.util.StringEntryFormatter}"
-  exec ${JAVA} ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
+  exec "${JAVA}" ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "help" ]; then
   bookkeeper_help;
 else
-  exec ${JAVA} ${OPTS} ${COMMAND} $@
+  exec "${JAVA}" ${OPTS} ${COMMAND} $@
 fi
 

--- a/bin/dlog
+++ b/bin/dlog
@@ -113,19 +113,19 @@ fi
 cd "$BK_HOME"
 case "${COMMAND}" in
   local)
-    exec ${JAVA} ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.distributedlog.LocalDLMEmulator $@
+    exec "${JAVA}" ${OPTS} ${JMX_ARGS} -Dzookeeper.4lw.commands.whitelist='*' org.apache.distributedlog.LocalDLMEmulator $@
     ;;
   tool)
-    exec ${JAVA} ${OPTS} org.apache.distributedlog.tools.Tool org.apache.distributedlog.tools.DistributedLogTool $@
+    exec "${JAVA}" ${OPTS} org.apache.distributedlog.tools.Tool org.apache.distributedlog.tools.DistributedLogTool $@
     ;;
   admin)
-    exec ${JAVA} ${OPTS} org.apache.distributedlog.tools.Tool org.apache.distributedlog.admin.DistributedLogAdmin $@
+    exec "${JAVA}" ${OPTS} org.apache.distributedlog.tools.Tool org.apache.distributedlog.admin.DistributedLogAdmin $@
     ;;
   help)
     dlog_help
     ;;
   *)
-    exec ${JAVA} ${OPTS} ${COMMAND} $@
+    exec "${JAVA}" ${OPTS} ${COMMAND} $@
     ;;
 esac
 

--- a/stream/bin/streamstorage
+++ b/stream/bin/streamstorage
@@ -145,9 +145,9 @@ OPTS="$OPTS -Dstreamstorage.log.file=$SS_LOG_FILE"
 #Change to SS_HOME to support relative paths
 cd "$SS_HOME"
 if [ $COMMAND == "standalone" ]; then
-    exec $JAVA $OPTS -Dzookeeper.4lw.commands.whitelist="*" org.apache.bookkeeper.stream.cluster.StandaloneStarter -c $SS_STANDALONE_CONF $@
+    exec "${JAVA}" $OPTS -Dzookeeper.4lw.commands.whitelist="*" org.apache.bookkeeper.stream.cluster.StandaloneStarter -c $SS_STANDALONE_CONF $@
 elif [ $COMMAND == "help" ]; then
     streamstorage_help;
 else
-    exec $JAVA $OPTS $COMMAND $@
+    exec "${JAVA}" $OPTS $COMMAND $@
 fi

--- a/stream/bin/streamstorage-cli
+++ b/stream/bin/streamstorage-cli
@@ -108,4 +108,4 @@ OPTS="$OPTS -Dstreamstorage.log.file=$SS_LOG_FILE"
 #Change to SS_HOME to support relative paths
 cd "$SS_HOME"
     
-exec $JAVA $OPTS org.apache.bookkeeper.stream.cli.StreamStorageCli "$@"
+exec "${JAVA}" $OPTS org.apache.bookkeeper.stream.cli.StreamStorageCli "$@"


### PR DESCRIPTION
### Motivation

Fix issue [#3726](https://github.com/apache/bookkeeper/issues/2726)


### Changes

Add double quotation around `${JAVA}`  in `/bin/bookkeeper`.
