### PR TITLE
BP-45: a pluggable way to modify payload sent to the ledger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -34,7 +34,6 @@ import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,7 +158,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     boolean closed = false;
     final ReentrantReadWriteLock closeLock = new ReentrantReadWriteLock();
 
-    final private List<LedgerPayloadInterceptor> ledgerPayloadInterceptors = new ArrayList<>();
+    private final List<LedgerPayloadInterceptor> ledgerPayloadInterceptors = new ArrayList<>();
 
     /**
      * BookKeeper Client Builder to build client instances.
@@ -559,7 +558,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             throws BKException {
         String lpInterceptors = conf.getLedgerPayloadInterceptors();
         if (!Strings.isNullOrEmpty(lpInterceptors)) {
-            for(String name: lpInterceptors.split(Pattern.quote(","))) {
+            for (String name: lpInterceptors.split(Pattern.quote(","))) {
                 try {
                     LedgerPayloadInterceptor lpi = (LedgerPayloadInterceptor) Class.forName(name)
                             .getConstructor().newInstance();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientContext.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientContext.java
@@ -27,6 +27,8 @@ import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.proto.BookieClient;
 
+import java.util.List;
+
 /**
  * Collection of client objects used by LedgerHandle to interact with
  * the outside world. Normally these are instantiated by the BookKeeper object
@@ -44,4 +46,5 @@ interface ClientContext {
     OrderedScheduler getScheduler();
     BookKeeperClientStats getClientStats();
     boolean isClientClosed();
+    List<LedgerPayloadInterceptor> getLedgerPayloadInterceptors();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientContext.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientContext.java
@@ -22,12 +22,12 @@ package org.apache.bookkeeper.client;
 
 import io.netty.buffer.ByteBufAllocator;
 
+import java.util.List;
+
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.proto.BookieClient;
-
-import java.util.List;
 
 /**
  * Collection of client objects used by LedgerHandle to interact with

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
@@ -20,6 +20,8 @@
  */
 package org.apache.bookkeeper.client;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -49,6 +51,8 @@ class ClientInternalConf {
     final boolean enableBookieFailureTracking;
     final boolean useV2WireProtocol;
     final boolean enforceMinNumFaultDomainsForWrite;
+
+    final List<LedgerPayloadInterceptor> payloadInterceptors = new ArrayList<>();
 
     static ClientInternalConf defaultValues() {
         return fromConfig(new ClientConfiguration());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -25,7 +25,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -115,8 +114,10 @@ class LedgerCreateOp {
 
         List<LedgerPayloadInterceptor> interceptors = bk.getClientCtx().getLedgerPayloadInterceptors();
         if (interceptors != null && !interceptors.isEmpty()) {
-            Map<String, byte[]> md = customMetadata == null ? new HashMap<>() : customMetadata;
-            interceptors.forEach(lpi -> lpi.beforeCreate(md));
+            Map<String, byte[]> md = customMetadata;
+            for (LedgerPayloadInterceptor lpi: interceptors) {
+                md = lpi.beforeCreate(md);
+            }
             this.customMetadata = md;
         } else {
             this.customMetadata = customMetadata;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -25,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -111,7 +112,15 @@ class LedgerCreateOp {
         this.writeQuorumSize = writeQuorumSize;
         this.ackQuorumSize = ackQuorumSize;
         this.digestType = digestType;
-        this.customMetadata = customMetadata;
+
+        List<LedgerPayloadInterceptor> interceptors = bk.getClientCtx().getLedgerPayloadInterceptors();
+        if (interceptors != null && !interceptors.isEmpty()) {
+            Map<String, byte[]> md = customMetadata == null ? new HashMap<>() : customMetadata;
+            interceptors.forEach(lpi -> lpi.beforeCreate(md));
+            this.customMetadata = md;
+        } else {
+            this.customMetadata = customMetadata;
+        }
         this.writeFlags = writeFlags;
         this.passwd = passwd;
         this.cb = cb;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerPayloadInterceptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerPayloadInterceptor.java
@@ -21,9 +21,10 @@
 package org.apache.bookkeeper.client;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.configuration.Configuration;
 
 import java.util.Map;
+
+import org.apache.commons.configuration.Configuration;
 
 /**
  * Interface for the interceptors that may need to modify
@@ -32,7 +33,7 @@ import java.util.Map;
 public interface LedgerPayloadInterceptor {
 
     /**
-     * Called after interceptor creation (once)
+     * Called after interceptor creation (once).
      * @param ctx - ClientContext
      * @param interceptorsCfg - configuration prefixed by "interceptor.lpi"
      *                        (without the prefix for keys)
@@ -43,9 +44,10 @@ public interface LedgerPayloadInterceptor {
      * Executed before creating the ledger.
      * Gives opportunity to modify ledger's custom metadata.
      * Modified metadata will be persisted.
-     * @param customMetadata - ledger's custom metadata
+     * @param customMetadata - ledger's custom metadata (can be null or ImmutableMap)
+     * @return modified metadata or the original metadata
      */
-    void beforeCreate(final Map<String, byte[]> customMetadata);
+    Map<String, byte[]> beforeCreate(final Map<String, byte[]> customMetadata);
 
     /**
      * Executed before adding entry to the ledger.
@@ -66,7 +68,7 @@ public interface LedgerPayloadInterceptor {
     ByteBuf afterRead(final Map<String, byte[]> customMetadata, final ByteBuf payload);
 
     /**
-     * called after the client is closed / interceptor is no longer usable.
+     * Called after the client is closed / interceptor is no longer usable.
      */
     void close();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerPayloadInterceptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerPayloadInterceptor.java
@@ -1,0 +1,72 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.commons.configuration.Configuration;
+
+import java.util.Map;
+
+/**
+ * Interface for the interceptors that may need to modify
+ * data written to the ledger.
+ */
+public interface LedgerPayloadInterceptor {
+
+    /**
+     * Called after interceptor creation (once)
+     * @param ctx - ClientContext
+     * @param interceptorsCfg - configuration prefixed by "interceptor.lpi"
+     *                        (without the prefix for keys)
+     */
+    void init(final ClientContext ctx, final Configuration interceptorsCfg);
+
+    /**
+     * Executed before creating the ledger.
+     * Gives opportunity to modify ledger's custom metadata.
+     * Modified metadata will be persisted.
+     * @param customMetadata - ledger's custom metadata
+     */
+    void beforeCreate(final Map<String, byte[]> customMetadata);
+
+    /**
+     * Executed before adding entry to the ledger.
+     * Gives opportunity to modify the payload.
+     * @param customMetadata - ledger's custom metadata
+     * @param payload - data being added to the ledger
+     * @return modified payload or the original payload
+     */
+    ByteBuf beforeAdd(final Map<String, byte[]> customMetadata, final ByteBuf payload);
+
+    /**
+     * Executed after receiving the payload from the bookie.
+     * Gives opportunity to modify the payload.
+     * @param customMetadata - ledger's custom metadata
+     * @param payload - data read from the bookie
+     * @return modified payload or the original payload
+     */
+    ByteBuf afterRead(final Map<String, byte[]> customMetadata, final ByteBuf payload);
+
+    /**
+     * called after the client is closed / interceptor is no longer usable.
+     */
+    void close();
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -30,7 +30,6 @@ import io.netty.util.Recycler.Handle;
 import io.netty.util.ReferenceCountUtil;
 import java.util.EnumSet;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -22,6 +22,7 @@ import static org.apache.bookkeeper.util.BookKeeperConstants.FEATURE_DISABLE_ENS
 
 import io.netty.buffer.ByteBuf;
 
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -33,6 +34,7 @@ import org.apache.bookkeeper.common.util.ReflectionUtils;
 import org.apache.bookkeeper.discover.RegistrationClient;
 import org.apache.bookkeeper.discover.ZKRegistrationClient;
 import org.apache.bookkeeper.replication.Auditor;
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 
 
@@ -197,6 +199,11 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     // Logs
     protected static final String CLIENT_CONNECT_BOOKIE_UNAVAILABLE_LOG_THROTTLING =
             "clientConnectBookieUnavailableLogThrottling";
+
+    protected static final String LEDGER_PAYLOAD_INTERCEPTORS = "ledgerPayloadInterceptors";
+    protected static final String INTERCEPTORS_CONFIG_PREFIX = "interceptor";
+    protected static final String LEDGER_PAYLOAD_INTERCEPTORS_CONFIG_PREFIX = "lpi";
+
 
     /**
      * Construct a default client-side configuration.
@@ -2007,6 +2014,33 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     public long getClientConnectBookieUnavailableLogThrottlingMs() {
         return getLong(CLIENT_CONNECT_BOOKIE_UNAVAILABLE_LOG_THROTTLING, 5_000L);
     }
+
+    /**
+     * Sets comma-separated list of fully-qualified names of interceptors
+     * @param val
+     * @return
+     */
+    public ClientConfiguration setLedgerPayloadInterceptors(String val) {
+        setProperty(LEDGER_PAYLOAD_INTERCEPTORS, val);
+        return this;
+    }
+
+    /**
+     * gets comma-separated list of fully-qualified names of interceptors
+     * @return
+     */
+    public String getLedgerPayloadInterceptors() {
+        return getString(LEDGER_PAYLOAD_INTERCEPTORS, "");
+    }
+
+    /**
+     * Configuration for the interceptors
+     * @return
+     */
+    public Configuration getLedgerPayloadInterceptorsConfiguration() {
+        return subset(INTERCEPTORS_CONFIG_PREFIX).subset(LEDGER_PAYLOAD_INTERCEPTORS_CONFIG_PREFIX);
+    }
+
 
     @Override
     protected ClientConfiguration getThis() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -22,7 +22,6 @@ import static org.apache.bookkeeper.util.BookKeeperConstants.FEATURE_DISABLE_ENS
 
 import io.netty.buffer.ByteBuf;
 
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -2016,7 +2015,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     }
 
     /**
-     * Sets comma-separated list of fully-qualified names of interceptors
+     * Sets comma-separated list of fully-qualified names of interceptors.
      * @param val
      * @return
      */
@@ -2026,7 +2025,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     }
 
     /**
-     * gets comma-separated list of fully-qualified names of interceptors
+     * gets comma-separated list of fully-qualified names of interceptors.
      * @return
      */
     public String getLedgerPayloadInterceptors() {
@@ -2034,7 +2033,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     }
 
     /**
-     * Configuration for the interceptors
+     * Configuration for the interceptors.
      * @return
      */
     public Configuration getLedgerPayloadInterceptorsConfiguration() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -175,6 +175,8 @@ public abstract class MockBookKeeperTestCase {
         when(bk.getStatsLogger()).thenReturn(NullStatsLogger.INSTANCE);
         BookKeeperClientStats clientStats = BookKeeperClientStats.newInstance(NullStatsLogger.INSTANCE);
         ClientContext clientCtx = new ClientContext() {
+                final List<LedgerPayloadInterceptor> lpis = new ArrayList<>();
+
                 @Override
                 public ClientInternalConf getConf() {
                     return ClientInternalConf.fromConfig(bk.getConf());
@@ -218,6 +220,11 @@ public abstract class MockBookKeeperTestCase {
                 @Override
                 public boolean isClientClosed() {
                     return bk.isClosed();
+                }
+
+                @Override
+                public List<LedgerPayloadInterceptor> getLedgerPayloadInterceptors() {
+                    return lpis;
                 }
 
                 @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
@@ -21,7 +21,6 @@
 package org.apache.bookkeeper.client;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.apache.bookkeeper.client.BookKeeper.initInterceptors;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -30,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 
-import lombok.SneakyThrows;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.conf.ClientConfiguration;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
@@ -21,12 +21,16 @@
 package org.apache.bookkeeper.client;
 
 import static com.google.common.base.Preconditions.checkState;
+import static org.apache.bookkeeper.client.BookKeeper.initInterceptors;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BooleanSupplier;
 
+import lombok.SneakyThrows;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -55,6 +59,7 @@ public class MockClientContext implements ClientContext {
     private BooleanSupplier isClientClosed;
     private MockRegistrationClient regClient;
     private ByteBufAllocator allocator;
+    private List<LedgerPayloadInterceptor> ledgerPayloadInterceptors = new ArrayList<>();
 
     static MockClientContext create(MockBookies mockBookies) throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
@@ -221,6 +226,11 @@ public class MockClientContext implements ClientContext {
     @Override
     public boolean isClientClosed() {
         return isClientClosed.getAsBoolean();
+    }
+
+    @Override
+    public List<LedgerPayloadInterceptor> getLedgerPayloadInterceptors() {
+        return ledgerPayloadInterceptors;
     }
 
     @Override

--- a/site/bps/BP-45-LedgerPayloadInterceptor.md
+++ b/site/bps/BP-45-LedgerPayloadInterceptor.md
@@ -1,0 +1,182 @@
+---
+title: "BP-45: Add interceptor interface allowing modifications of the payload"
+issue: https://github.com/apache/bookkeeper/<issue-number>
+state: Under Discussion
+release: "4.15.0"
+---
+
+### Motivation
+
+The proposed change targets addition of a pluggable way to modify payload sent to the ledger. 
+Specific use cases include GDPR compliance, encryption, and compression. 
+While these can be implemented at the application level, having this as a BK client level 
+extension unlocks such functionality to any application built on top of Bookkeeper.
+
+Let’s dig deeper into specific use cases: 
+
+#### GDPR
+
+Ledger's data on the bookie servers is stored in the immutable EntryLog files. The files, 
+in the most common case, mix the data from multiple ledgers. There is no guarantee of immediate 
+erasure from the disk upon the ledger deletion, the entry logs are "compacted" with some delay. 
+The amount of the delay is not guaranteed and, in an extreme case, can be infinite if the data 
+from a deleted small short-lived ledger gets mixed in the entry log with data from the long-lived 
+ledgers. 
+
+Such behavior of compaction is a trade-off between performance and disk space utilization. 
+
+The data is also stored in the journal file and, in an extreme case 
+(low TTL for deletion and low traffic volume), can be recoverable from the journal after the 
+ledger deletion.
+
+Modern global businesses are affected by privacy laws [1] and obligations, the most notable 
+of which is "Art. 17 GDPR: Right to be forgotten" [2]. Privacy policies require setting deadlines 
+after which the data cannot be used.
+
+"Forgotten" encryption keys are an acceptable alternative to the actual deletion of the data. 
+Encrypting the data with a ledger-specific key that is stored with ledger metadata and 
+automatically deleted with the ledger is a sufficient option.
+
+In proposed implementation, this will work as outlined below:
+
+
+* On ledger creation, the interceptor generates a random key of configurable length for use 
+with a configurable encryption method. The key and encryption method added into the ledger’s 
+custom metadata
+* On entry add, interceptor gets the key and encryption method, encrypts the data and replaces 
+the original payload; Mac Digest and the rest of the processing happens as usual, without any 
+changes on the bookie side/in the protocol
+* Bookies receive the encrypted data
+* On read, interceptor decrypts the data (using the key etc from the ledger’s custom metadata) 
+and replaces the payload.
+* On ledger delete, the metadata is deleted and the key is lost.
+
+
+#### Encryption
+
+Security-conscious organizations (financial institutions etc.) may have requirements to encrypt the data with the securely stored key.
+This can be implemented similarly to the GDPR case but the key requested from the third party key management system.
+
+#### Compression
+
+
+Similar to GDPR/encryption minus the need to deal with the keys.
+
+
+### Public Interfaces
+
+
+```
+package org.apache.bookkeeper.client;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.commons.configuration.Configuration;
+
+import java.util.Map;
+
+/**
+ * Interface for the interceptors that may need to modify
+ * data written to the ledger.
+ */
+public interface LedgerPayloadInterceptor {
+
+    /**
+     * Called after interceptor creation (once)
+     * @param ctx - ClientContext
+     * @param interceptorsCfg - configuration prefixed by "interceptor.lpi"
+     *                        (without the prefix for keys)
+     */
+    void init(final ClientContext ctx, final Configuration interceptorsCfg);
+
+    /**
+     * Executed before creating the ledger.
+     * Gives opportunity to modify ledger's custom metadata.
+     * Modified metadata will be persisted.
+     * @param customMetadata - ledger's custom metadata
+     */
+    void beforeCreate(final Map<String, byte[]> customMetadata);
+
+    /**
+     * Executed before adding entry to the ledger.
+     * Gives opportunity to modify the payload.
+     * @param customMetadata - ledger's custom metadata
+     * @param payload - data being added to the ledger
+     * @return modified payload or the original payload
+     */
+    ByteBuf beforeAdd(final Map<String, byte[]> customMetadata, final ByteBuf payload);
+
+    /**
+     * Executed after receiving the payload from the bookie.
+     * Gives opportunity to modify the payload.
+     * @param customMetadata - ledger's custom metadata
+     * @param payload - data read from the bookie
+     * @return modified payload or the original payload
+     */
+    ByteBuf afterRead(final Map<String, byte[]> customMetadata, final ByteBuf payload);
+
+    /**
+     * called after the client is closed / interceptor is no longer usable.
+     */
+    void close();
+}
+
+```
+
+### Proposed Changes
+
+* Add an interface that allows modification of the payload: LedgerPayloadInterceptor is outlined above
+* Configuration option to enable the interceptors, like
+payloadInterceptor=org.apache.bookkeeper.CompressingPayloadInterceptor,org.apache.bookkeeper.EncryptingPayloadInterceptor
+* configuration options to pass to interceptor (payloadInterceptor.<option name>=<value>)
+* Client config to return the instances of configured interceptors
+* Change LedgerCreateOp/PendingAddOp/PendingReadOp to call the interceptor (it is easier to avoid extra data copy there AFAICT)
+* Change ClientContext to pass the interceptor to the <LC/PA/PR>Ops.
+* Implement simple EncryptingLedgerPayloadInterceptor
+
+All the changes affect the client only. 
+
+### Compatibility, Deprecation, and Migration Plan
+
+- What impact (if any) will there be on existing users? 
+
+Disabled by default
+
+- If we are changing behavior how will we phase out the older behavior? 
+
+No change to the existing behavior.
+
+### Test Plan
+
+* existing unit tests
+* additional unit tests for configuration/use of noop implementations of LedgerPayloadInterceptor
+* Implementation of data encrypting LedgerPayloadInterceptor, unit tests, perf tests. 
+* existing unit tests with data encrypting LedgerPayloadInterceptor on/off
+
+### Rejected Alternatives
+
+#### Tune/modify major compaction to compact everything (potentially track time-since-deletion 
+   or something along these lines) to satisfy GDPR requirements. 
+   
+Rejected due to performance impact.
+
+#### Encrypt the disks. 
+   
+Does not cover the GDPR requirements as anyone with permission to access the disks can 
+potentially read the data/use tools to reconstruct the entries.
+
+#### Encrypt data before writing it to the bookie. 
+   
+This might work in some cases when the bookkeeper is used directly. 
+
+The specific problem for the GDPR case is the security key deletion.
+It is not easy if it is used via i.e. Apache Pulsar, where end user does not have control over the ledger deletion 
+and need to either find a way to track which keys can be deleted (and coordinate this process). 
+It is also tricky if the user relies on the State Storage [3] to store state.
+
+### References
+
+[1] https://en.wikipedia.org/wiki/General_Data_Protection_Regulation
+
+[2] https://gdpr-info.eu/art-17-gdpr/
+
+[3] https://pulsar.apache.org/docs/en/functions-develop/#state-storage

--- a/site/bps/BP-45-LedgerPayloadInterceptor.md
+++ b/site/bps/BP-45-LedgerPayloadInterceptor.md
@@ -1,6 +1,6 @@
 ---
 title: "BP-45: Add interceptor interface allowing modifications of the payload"
-issue: https://github.com/apache/bookkeeper/<issue-number>
+issue: https://github.com/apache/bookkeeper/issues/2731
 state: Under Discussion
 release: "4.15.0"
 ---

--- a/site/bps/BP-45-LedgerPayloadInterceptor.md
+++ b/site/bps/BP-45-LedgerPayloadInterceptor.md
@@ -92,9 +92,10 @@ public interface LedgerPayloadInterceptor {
      * Executed before creating the ledger.
      * Gives opportunity to modify ledger's custom metadata.
      * Modified metadata will be persisted.
-     * @param customMetadata - ledger's custom metadata
+     * @param customMetadata - ledger's custom metadata (can be null or ImmutableMap)
+     * @return modified metadata or the original metadata
      */
-    void beforeCreate(final Map<String, byte[]> customMetadata);
+    Map<String, byte[]> beforeCreate(final Map<String, byte[]> customMetadata);
 
     /**
      * Executed before adding entry to the ledger.

--- a/site/community/bookkeeper_proposals.md
+++ b/site/community/bookkeeper_proposals.md
@@ -85,7 +85,7 @@ using Google Doc.
 
 This section lists all the _bookkeeper proposals_ made to BookKeeper.
 
-*Next Proposal Number: 43*
+*Next Proposal Number: 46*
 
 ### Inprogress
 
@@ -112,6 +112,8 @@ Proposal | State
 [BP-41: Separate BookieId from Separate BookieId from Bookie Network Address](../../bps/BP-41-bookieid) | Accepted
 [BP-42: New Client API - list ledgers](../../bps/BP-42-new-api-list-ledgers) | Accepted
 [BP-43: Migration to gradle](../../bps/BP-43-gradle-migration) | Draft
+[BP-44: Running without a journal](https://github.com/apache/bookkeeper/issues/2705) | Draft
+[BP-45: Payload interceptors](../../bps/BP-45-LedgerPayloadInterceptor) | Draft
 
 
 ### Adopted


### PR DESCRIPTION
Descriptions of the changes in this PR:

The proposed change targets addition of a pluggable way to modify payload sent to the ledger. Specific use cases include GDPR compliance, encryption, and compression. While these can be implemented at the application level, having this as a BK client level extension unlocks such functionality to any application built on top of Bookkeeper.

### Motivation

see site/bps/BP-45-LedgerPayloadInterceptor.md for details

### Changes

Added interceptor that can modify ledger's custom metadata, payload before add, and payload after read.

Master Issue: #2731 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
