### PR TITLE
[Build/Security] Upgrade Freebuilder version and fix the dependency

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -283,7 +283,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
-- lib/org.inferred-freebuilder-1.14.9.jar [35]
+- lib/org.inferred-freebuilder-2.7.0.jar [35]
 - lib/com.google.errorprone-error_prone_annotations-2.4.0.jar [36]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [37]
 - lib/org.jctools-jctools-core-2.1.2.jar [38]
@@ -336,7 +336,7 @@ Apache Software License, Version 2.
 [32] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
 [33] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
-[35] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9
+[35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.4.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
 [38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -264,7 +264,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-client-5.1.0.jar [33]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [33]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [33]
-- lib/org.inferred-freebuilder-1.14.9.jar [34]
+- lib/org.inferred-freebuilder-2.7.0.jar [34]
 - lib/com.google.errorprone-error_prone_annotations-2.4.0.jar [35]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [36]
 - lib/org.jctools-jctools-core-2.1.2.jar [37]
@@ -307,7 +307,7 @@ Apache Software License, Version 2.
 [31] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
 [32] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.1.0
-[34] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9
+[34] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [35] Source available at https://github.com/google/error-prone/tree/v2.4.0
 [36] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
 [37] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -283,7 +283,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
-- lib/org.inferred-freebuilder-1.14.9.jar [35]
+- lib/org.inferred-freebuilder-2.7.0.jar [35]
 - lib/com.google.errorprone-error_prone_annotations-2.4.0.jar [36]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [37]
 - lib/org.jctools-jctools-core-2.1.2.jar [38]
@@ -334,7 +334,7 @@ Apache Software License, Version 2.
 [32] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
 [33] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
-[35] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9
+[35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.4.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
 [38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,7 +39,7 @@ depVersions = [
     dockerJava: "3.2.5",
     dropwizard: "3.2.5",
     errorprone: "2.1.2",
-    freebuilder: "1.14.9",
+    freebuilder: "2.7.0",
     gradleTooling: "4.0.1",
     grpc: "1.33.0",
     groovy: "2.5.8",

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <curator.version>5.1.0</curator.version>
     <dropwizard.version>3.2.5</dropwizard.version>
     <etcd.version>0.5.4</etcd.version>
-    <freebuilder.version>1.14.9</freebuilder.version>
+    <freebuilder.version>2.7.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.4.0</google.errorprone.version>
     <grpc.version>1.33.0</grpc.version>
@@ -233,6 +233,7 @@
         <groupId>org.inferred</groupId>
         <artifactId>freebuilder</artifactId>
         <version>${freebuilder.version}</version>
+        <optional>true</optional>
       </dependency>
 
       <!-- logging dependencies -->

--- a/stream/clients/java/base/build.gradle
+++ b/stream/clients/java/base/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation project(':stream:proto')
 
     implementation depLibs.commonsLang2
-    implementation depLibs.freebuilder
+    compileOnly depLibs.freebuilder
     implementation depLibs.grpc
     implementation depLibs.lombok
     implementation depLibs.slf4j


### PR DESCRIPTION
Fixes #2732

### Motivation

- Freebuilder 1.14.9 contains an outdate jquery js file which causes the library to be flagged as vulnerable with the highest threat level in Sonatype IQ vulnerability scanner. This also flags Bookkeeper and Pulsar as vulnerable with the highest threat level although it is a false positive and not an actual threat.

- Freebuilder shouldn't be exposed as a transitive dependency
  - it's an annotation processor which should be defined
    - [optional in maven](https://github.com/inferred/FreeBuilder#maven)
    - [compileOnly in gradle](https://github.com/inferred/FreeBuilder#gradle)

### Changes

- upgrade [Freebuilder](https://github.com/inferred/FreeBuilder) from 1.14.9 to 2.7.0
- make dependency optional in maven pom.xml
- use `compileOnly` instead of `implementation` in gradle build