### PR TITLE
[Security] Exclude grpc-okhttp dependency

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -263,8 +263,6 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/com.squareup.okhttp-okhttp-2.7.4.jar [31]
-- lib/com.squareup.okio-okio-1.13.0.jar [32]
 - lib/io.grpc-grpc-all-1.33.0.jar [33]
 - lib/io.grpc-grpc-alts-1.33.0.jar [33]
 - lib/io.grpc-grpc-api-1.33.0.jar [33]
@@ -273,7 +271,6 @@ Apache Software License, Version 2.
 - lib/io.grpc-grpc-core-1.33.0.jar [33]
 - lib/io.grpc-grpc-grpclb-1.33.0.jar [33]
 - lib/io.grpc-grpc-netty-1.33.0.jar [33]
-- lib/io.grpc-grpc-okhttp-1.33.0.jar [33]
 - lib/io.grpc-grpc-protobuf-1.33.0.jar [33]
 - lib/io.grpc-grpc-protobuf-lite-1.33.0.jar [33]
 - lib/io.grpc-grpc-services-1.33.0.jar [33]
@@ -332,8 +329,6 @@ Apache Software License, Version 2.
 [28] Source available at https://github.com/googleapis/googleapis
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
-[31] Source available at https://github.com/square/okhttp/tree/parent-2.7.4
-[32] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
 [33] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -244,8 +244,6 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.24.0.jar [29]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [29]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [29]
-- lib/com.squareup.okhttp-okhttp-2.7.4.jar [30]
-- lib/com.squareup.okio-okio-1.13.0.jar [31]
 - lib/io.grpc-grpc-all-1.33.0.jar [32]
 - lib/io.grpc-grpc-alts-1.33.0.jar [32]
 - lib/io.grpc-grpc-api-1.33.0.jar [32]
@@ -254,7 +252,6 @@ Apache Software License, Version 2.
 - lib/io.grpc-grpc-core-1.33.0.jar [32]
 - lib/io.grpc-grpc-grpclb-1.33.0.jar [32]
 - lib/io.grpc-grpc-netty-1.33.0.jar [32]
-- lib/io.grpc-grpc-okhttp-1.33.0.jar [32]
 - lib/io.grpc-grpc-protobuf-1.33.0.jar [32]
 - lib/io.grpc-grpc-protobuf-lite-1.33.0.jar [32]
 - lib/io.grpc-grpc-services-1.33.0.jar [32]
@@ -303,8 +300,6 @@ Apache Software License, Version 2.
 [27] Source available at https://github.com/googleapis/googleapis
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
 [29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
-[30] Source available at https://github.com/square/okhttp/tree/parent-2.7.4
-[31] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
 [32] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.1.0
 [34] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -263,8 +263,6 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/com.squareup.okhttp-okhttp-2.7.4.jar [31]
-- lib/com.squareup.okio-okio-1.13.0.jar [32]
 - lib/io.grpc-grpc-all-1.33.0.jar [33]
 - lib/io.grpc-grpc-alts-1.33.0.jar [33]
 - lib/io.grpc-grpc-api-1.33.0.jar [33]
@@ -273,7 +271,6 @@ Apache Software License, Version 2.
 - lib/io.grpc-grpc-core-1.33.0.jar [33]
 - lib/io.grpc-grpc-grpclb-1.33.0.jar [33]
 - lib/io.grpc-grpc-netty-1.33.0.jar [33]
-- lib/io.grpc-grpc-okhttp-1.33.0.jar [33]
 - lib/io.grpc-grpc-protobuf-1.33.0.jar [33]
 - lib/io.grpc-grpc-protobuf-lite-1.33.0.jar [33]
 - lib/io.grpc-grpc-services-1.33.0.jar [33]
@@ -330,8 +327,6 @@ Apache Software License, Version 2.
 [28] Source available at https://github.com/googleapis/googleapis
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
-[31] Source available at https://github.com/square/okhttp/tree/parent-2.7.4
-[32] Source available at https://github.com/square/okio/tree/okio-parent-1.13.0
 [33] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v1.14.9

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -124,7 +124,6 @@ Copyright 2010 Cedric Beust cedric@beust.com
 - lib/io.grpc-grpc-context-1.33.0.jar
 - lib/io.grpc-grpc-core-1.33.0.jar
 - lib/io.grpc-grpc-netty-1.33.0.jar
-- lib/io.grpc-grpc-okhttp-1.33.0.jar
 - lib/io.grpc-grpc-protobuf-1.33.0.jar
 - lib/io.grpc-grpc-protobuf-lite-1.33.0.jar
 - lib/io.grpc-grpc-stub-1.33.0.jar
@@ -143,17 +142,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-This product contains a modified portion of 'OkHttp', an open source
-HTTP & SPDY client for Android and Java applications, which can be obtained
-at:
-
-  * LICENSE:
-    * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
-  * HOMEPAGE:
-    * https://github.com/square/okhttp
-  * LOCATION_IN_GRPC:
-    * okhttp/third_party/okhttp
 
 This product contains a modified portion of 'Netty', an open source
 networking library, which can be obtained at:

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -52,7 +52,6 @@ Copyright 2010 Cedric Beust cedric@beust.com
 - lib/io.grpc-grpc-context-1.33.0.jar
 - lib/io.grpc-grpc-core-1.33.0.jar
 - lib/io.grpc-grpc-netty-1.33.0.jar
-- lib/io.grpc-grpc-okhttp-1.33.0.jar
 - lib/io.grpc-grpc-protobuf-1.33.0.jar
 - lib/io.grpc-grpc-protobuf-lite-1.33.0.jar
 - lib/io.grpc-grpc-stub-1.33.0.jar
@@ -71,17 +70,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-This product contains a modified portion of 'OkHttp', an open source
-HTTP & SPDY client for Android and Java applications, which can be obtained
-at:
-
-  * LICENSE:
-    * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
-  * HOMEPAGE:
-    * https://github.com/square/okhttp
-  * LOCATION_IN_GRPC:
-    * okhttp/third_party/okhttp
 
 This product contains a modified portion of 'Netty', an open source
 networking library, which can be obtained at:

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -107,7 +107,6 @@ Copyright 2010 Cedric Beust cedric@beust.com
 - lib/io.grpc-grpc-context-1.33.0.jar
 - lib/io.grpc-grpc-core-1.33.0.jar
 - lib/io.grpc-grpc-netty-1.33.0.jar
-- lib/io.grpc-grpc-okhttp-1.33.0.jar
 - lib/io.grpc-grpc-protobuf-1.33.0.jar
 - lib/io.grpc-grpc-protobuf-lite-1.33.0.jar
 - lib/io.grpc-grpc-stub-1.33.0.jar
@@ -126,17 +125,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-This product contains a modified portion of 'OkHttp', an open source
-HTTP & SPDY client for Android and Java applications, which can be obtained
-at:
-
-  * LICENSE:
-    * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
-  * HOMEPAGE:
-    * https://github.com/square/okhttp
-  * LOCATION_IN_GRPC:
-    * okhttp/third_party/okhttp
 
 This product contains a modified portion of 'Netty', an open source
 networking library, which can be obtained at:

--- a/metadata-drivers/etcd/pom.xml
+++ b/metadata-drivers/etcd/pom.xml
@@ -54,6 +54,10 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcpkix-jdk15on</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-okhttp</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/stream/common/pom.xml
+++ b/stream/common/pom.xml
@@ -48,6 +48,10 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcpkix-jdk15on</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-okhttp</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/stream/tests-common/pom.xml
+++ b/stream/tests-common/pom.xml
@@ -40,6 +40,10 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcpkix-jdk15on</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-okhttp</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixes #2733

### Motivation

The okhttp dependency version 2.7.4 is old and vulnerable. This dependency isn't needed and it causes Bookkeeper to be flagged for security vulnerabilities.

### Changes

- exclude grpc-okhttp dependency which pulls in okhttp 2.7.4 
- update license files