### PR TITLE
[statestore] Cleanup local storage for statestore storage container

### DIFF
--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/api/StateStoreSpec.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/api/StateStoreSpec.java
@@ -55,4 +55,7 @@ public class StateStoreSpec {
     private boolean checkpointChecksumEnable = true;
     @Default
     private boolean checkpointChecksumCompatible = true;
+
+    @Default
+    private boolean localStorageCleanupEnable = false;
 }

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVStoreCheckpoint.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVStoreCheckpoint.java
@@ -103,6 +103,7 @@ public class TestRocksdbKVStoreCheckpoint {
 
         store.setRemoveLocal(true);
         store.setRemoveRemote(true);
+        store.setLocalStorageCleanup(true);
 
         String[] checkpoints = checkpointDir.list();
         // Initially there is only one checkpoint directory that is used by the statestore
@@ -129,7 +130,7 @@ public class TestRocksdbKVStoreCheckpoint {
 
             checkpoints = checkpointDir.list();
             // We should only have one checkpoint in the local directory.
-            assertEquals(i, checkpoints.length);
+            assertEquals(1, checkpoints.length);
         }
 
         store.close();

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVStoreCheckpoint.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVStoreCheckpoint.java
@@ -21,6 +21,8 @@
 package org.apache.bookkeeper.statelib.impl.kv;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import java.io.File;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.CheckpointInfo;
 import org.junit.After;
@@ -93,5 +95,47 @@ public class TestRocksdbKVStoreCheckpoint {
         store.restore();
         // We should fallback to checkpoint-1
         assertEquals("transaction-1", store.get("transaction-id"));
+    }
+
+    @Test
+    public void testLocalStoreCleanup() throws Exception {
+        File checkpointDir = new File(store.getLocalDir(), "checkpoints");
+
+        store.setRemoveLocal(true);
+        store.setRemoveRemote(true);
+
+        String[] checkpoints = checkpointDir.list();
+        // Initially there is only one checkpoint directory that is used by the statestore
+        assertEquals(1, checkpoints.length);
+
+        store.restore();
+
+        checkpoints = checkpointDir.list();
+        // We should only have one checkpoint in the local directory.
+        assertEquals(1, checkpoints.length);
+
+        int numKvs = 100;
+        for (int i = 0; i < 3; i++) {
+            String txid = "txid-" + i;
+            store.addNumKVs(txid, numKvs, i * numKvs);
+            String checkpoint1 = store.checkpoint("checkpoint-1");
+
+            checkpoints = checkpointDir.list();
+            // Ensure the checkpoints are cleaned up
+            assertEquals(1, checkpoints.length);
+
+            store.restore();
+            assertEquals(txid, store.get("transaction-id"));
+
+            checkpoints = checkpointDir.list();
+            // We should only have one checkpoint in the local directory.
+            assertEquals(i, checkpoints.length);
+        }
+
+        store.close();
+
+        checkpoints = checkpointDir.list();
+        // We should not have any checkpoints af the store is closed.
+        assertNull(checkpoints);
     }
 }

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestStateStore.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestStateStore.java
@@ -53,8 +53,8 @@ import org.rocksdb.Checkpoint;
 public class TestStateStore {
 
     private final String dbName;
-    private final boolean removeLocal;
-    private final boolean removeRemote;
+    private boolean removeLocal;
+    private boolean removeRemote;
 
     private File localDir;
     private File localCheckpointsDir;
@@ -69,6 +69,7 @@ public class TestStateStore {
     private boolean checkpointChecksumEnable;
     private boolean checkpointChecksumCompatible;
     private boolean enableNonChecksumCompatibility;
+    private boolean localStorageCleanup;
 
     public TestStateStore(String dbName,
                           File localDir,
@@ -82,6 +83,7 @@ public class TestStateStore {
         this.removeRemote = removeRemote;
         this.checkpointChecksumEnable = true;
         this.checkpointChecksumCompatible = true;
+        this.localStorageCleanup = false;
         localCheckpointsDir = new File(localDir, "checkpoints");
         remoteCheckpointsPath = Paths.get(remoteDir.getAbsolutePath(), dbName);
         enableNonChecksumCompatibility = false;
@@ -129,6 +131,10 @@ public class TestStateStore {
         removeRemote = enable;
     }
 
+    public void setLocalStorageCleanup(boolean enable) {
+        localStorageCleanup = enable;
+    }
+
     public void init() throws StateStoreException {
         checkpointStore = new FSCheckpointManager(remoteDir);
         StateStoreSpec.StateStoreSpecBuilder builder = StateStoreSpec.builder()
@@ -138,6 +144,7 @@ public class TestStateStore {
             .localStateStoreDir(localDir)
             .checkpointChecksumEnable(checkpointChecksumEnable)
             .checkpointChecksumCompatible(checkpointChecksumCompatible)
+            .localStorageCleanupEnable(localStorageCleanup)
             .stream(dbName);
         if (checkpointExecutor != null) {
             builder = builder.checkpointStore(checkpointStore)

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestStateStore.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestStateStore.java
@@ -121,6 +121,14 @@ public class TestStateStore {
         }
     }
 
+    public void setRemoveLocal(boolean enable) {
+        removeLocal = enable;
+    }
+
+    public void setRemoveRemote(boolean enable) {
+        removeRemote = enable;
+    }
+
     public void init() throws StateStoreException {
         checkpointStore = new FSCheckpointManager(remoteDir);
         StateStoreSpec.StateStoreSpecBuilder builder = StateStoreSpec.builder()

--- a/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/conf/StorageConfiguration.java
+++ b/stream/storage/api/src/main/java/org/apache/bookkeeper/stream/storage/conf/StorageConfiguration.java
@@ -35,6 +35,8 @@ public class StorageConfiguration extends ComponentConfiguration {
 
     private static final String CHECKPOINT_CHECKSUM_COMPATIBLE = "checkpoint.checksum.compatible";
 
+    private static final String LOCAL_STORAGE_CLEANUP_ENABLE = "local.storage.cleanup.enable";
+
     public StorageConfiguration(CompositeConfiguration conf) {
         super(conf, COMPONENT_PREFIX);
     }
@@ -101,4 +103,7 @@ public class StorageConfiguration extends ComponentConfiguration {
         return getBoolean(CHECKPOINT_CHECKSUM_COMPATIBLE, true);
     }
 
+    public boolean getLocalStorageCleanupEnable() {
+        return getBoolean(LOCAL_STORAGE_CLEANUP_ENABLE, true);
+    }
 }

--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/store/MVCCStoreFactoryImpl.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/store/MVCCStoreFactoryImpl.java
@@ -211,6 +211,7 @@ public class MVCCStoreFactoryImpl implements MVCCStoreFactory {
             .isReadonly(serveReadOnlyTable)
             .checkpointChecksumEnable(storageConf.getCheckpointChecksumEnable())
             .checkpointChecksumCompatible(storageConf.getCheckpointChecksumCompatible())
+            .localStorageCleanupEnable(storageConf.getLocalStorageCleanupEnable())
             .build();
 
 


### PR DESCRIPTION
### Motivation

While restoring a storage container, we fetch the checkpoint from the
checkpoint store. Currently this checkpoint will never get cleaned up. Every
time we restore the storage container on pod, a new checkpoint will get added.
Over period of time the disk usage keeps going up and eventually we have to
manually delete these stale checkpoints.

### Changes

With this change, we will cleanup the local storage for a storage container
whenever we close the KVStore. This will ensure that stale checkpoints are not
left behind. It is possible that POD may restart before the cleanup can be
done. To avoid these, we will also ensure that local storage for the storage
container is cleaned up before we restore the storage container.
