### PR TITLE
Abstract the FileChannel in the JournalChannel

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.bookie;
 
 import java.io.File;
 import java.io.FileDescriptor;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 
@@ -33,7 +34,7 @@ interface BookieFileChannel {
      * An interface for get the FileChannel from the provider.
      * @return
      */
-    FileChannel getFileChannel();
+    FileChannel getFileChannel() throws FileNotFoundException;
 
     /**
      * Check the given file if exists.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
@@ -34,7 +34,7 @@ interface BookieFileChannel {
      * An interface for get the FileChannel from the provider.
      * @return
      */
-    FileChannel getFileChannel() throws FileNotFoundException;
+    FileChannel getFileChannel() throws FileNotFoundException, IOException;
 
     /**
      * Check the given file if exists.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
@@ -51,4 +51,9 @@ interface BookieFileChannel {
      * @throws IOException
      */
     FileDescriptor getFD() throws IOException;
+
+    /**
+     * Close file channel and release all resources.
+     */
+    void close() throws IOException;
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.bookie;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+/**
+ * A FileChannel for the JournalChannel read and write, we can use this interface to extend the FileChannel
+ * which we use in the JournalChannel.
+ */
+interface BookieFileChannel {
+
+    /**
+     * An interface for get the FileChannel from the provider.
+     * @return
+     */
+    FileChannel getFileChannel();
+
+    /**
+     * Check the given file if exists.
+     *
+     * @param file
+     * @return
+     */
+    boolean fileExists(File file);
+
+    /**
+     * Get the file descriptor of the opened file.
+     *
+     * @return
+     * @throws IOException
+     */
+    FileDescriptor getFD() throws IOException;
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
@@ -1,3 +1,24 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 package org.apache.bookkeeper.bookie;
 
 import java.io.File;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
@@ -67,7 +67,7 @@ class DefaultFileChannel implements BookieFileChannel {
     @Override
     public void close() throws IOException {
         synchronized (this) {
-            if(randomAccessFile != null) {
+            if (randomAccessFile != null) {
                 randomAccessFile.close();
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
@@ -1,0 +1,54 @@
+package org.apache.bookkeeper.bookie;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+
+class DefaultFileChannel implements BookieFileChannel {
+    private final File file;
+    private RandomAccessFile randomAccessFile;
+    private final ServerConfiguration configuration;
+
+    DefaultFileChannel(File file, ServerConfiguration serverConfiguration) throws IOException {
+        this.file = file;
+        this.configuration = serverConfiguration;
+    }
+
+    @Override
+    public FileChannel getFileChannel() throws FileNotFoundException {
+        synchronized (this) {
+            if (randomAccessFile == null) {
+                randomAccessFile = new RandomAccessFile(file, "rw");
+            }
+            return randomAccessFile.getChannel();
+        }
+    }
+
+    @Override
+    public boolean fileExists(File file) {
+        return file.exists();
+    }
+
+    @Override
+    public FileDescriptor getFD() throws IOException {
+        synchronized (this) {
+            if (randomAccessFile == null) {
+                throw new IOException("randomAccessFile is null, please initialize it by calling getFileChannel");
+            }
+            return randomAccessFile.getFD();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (this) {
+            if(randomAccessFile != null) {
+                randomAccessFile.close();
+            }
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.bookie;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+
+public class DefaultFileChannelProvider implements FileChannelProvider{
+    @Override
+    public BookieFileChannel open(File file, ServerConfiguration configuration) throws IOException {
+        return new DefaultFileChannel(file, configuration);
+    }
+
+    static class DefaultFileChannel implements BookieFileChannel {
+        private final File file;
+        private final RandomAccessFile randomAccessFile;
+        private final ServerConfiguration configuration;
+
+        DefaultFileChannel(File file, ServerConfiguration serverConfiguration) throws IOException {
+            this.file = file;
+            this.randomAccessFile = new RandomAccessFile(file, "rw");
+            this.configuration = serverConfiguration;
+        }
+
+        @Override
+        public FileChannel getFileChannel() {
+            return randomAccessFile.getChannel();
+        }
+
+        @Override
+        public boolean fileExists(File file) {
+            return file.exists();
+        }
+
+        @Override
+        public FileDescriptor getFD() throws IOException {
+            return randomAccessFile.getFD();
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -19,11 +19,7 @@
 package org.apache.bookkeeper.bookie;
 
 import java.io.File;
-import java.io.FileDescriptor;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 
 /**
@@ -35,36 +31,9 @@ public class DefaultFileChannelProvider implements FileChannelProvider{
         return new DefaultFileChannel(file, configuration);
     }
 
-    static class DefaultFileChannel implements BookieFileChannel {
-        private final File file;
-        private RandomAccessFile randomAccessFile;
-        private final ServerConfiguration configuration;
-
-        DefaultFileChannel(File file, ServerConfiguration serverConfiguration) throws IOException {
-            this.file = file;
-            this.configuration = serverConfiguration;
-        }
-
-        @Override
-        public FileChannel getFileChannel() throws FileNotFoundException {
-            synchronized (this) {
-                if (randomAccessFile == null) {
-                    randomAccessFile = new RandomAccessFile(file, "rw");
-                }
-                return randomAccessFile.getChannel();
-            }
-        }
-
-        @Override
-        public boolean fileExists(File file) {
-            return file.exists();
-        }
-
-        @Override
-        public FileDescriptor getFD() throws IOException {
-            synchronized (this) {
-                return randomAccessFile.getFD();
-            }
-        }
+    @Override
+    public void close(BookieFileChannel bookieFileChannel) throws IOException {
+        bookieFileChannel.close();
     }
+
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -62,7 +62,9 @@ public class DefaultFileChannelProvider implements FileChannelProvider{
 
         @Override
         public FileDescriptor getFD() throws IOException {
-            return randomAccessFile.getFD();
+            synchronized (this) {
+                return randomAccessFile.getFD();
+            }
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -37,7 +37,7 @@ public class DefaultFileChannelProvider implements FileChannelProvider{
 
     static class DefaultFileChannel implements BookieFileChannel {
         private final File file;
-        private static RandomAccessFile randomAccessFile;
+        private RandomAccessFile randomAccessFile;
         private final ServerConfiguration configuration;
 
         DefaultFileChannel(File file, ServerConfiguration serverConfiguration) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -51,8 +51,8 @@ public class DefaultFileChannelProvider implements FileChannelProvider{
                 if (randomAccessFile == null) {
                     randomAccessFile = new RandomAccessFile(file, "rw");
                 }
+                return randomAccessFile.getChannel();
             }
-            return randomAccessFile.getChannel();
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -22,6 +22,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 
 import java.io.File;
 import java.io.FileDescriptor;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
@@ -34,17 +35,19 @@ public class DefaultFileChannelProvider implements FileChannelProvider{
 
     static class DefaultFileChannel implements BookieFileChannel {
         private final File file;
-        private final RandomAccessFile randomAccessFile;
+        private static RandomAccessFile randomAccessFile;
         private final ServerConfiguration configuration;
 
         DefaultFileChannel(File file, ServerConfiguration serverConfiguration) throws IOException {
             this.file = file;
-            this.randomAccessFile = new RandomAccessFile(file, "rw");
             this.configuration = serverConfiguration;
         }
 
         @Override
-        public FileChannel getFileChannel() {
+        public FileChannel getFileChannel() throws FileNotFoundException {
+            if (randomAccessFile == null) {
+                randomAccessFile = new RandomAccessFile(file, "rw");
+            }
             return randomAccessFile.getChannel();
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -18,15 +18,17 @@
  */
 package org.apache.bookkeeper.bookie;
 
-import org.apache.bookkeeper.conf.ServerConfiguration;
-
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
+import org.apache.bookkeeper.conf.ServerConfiguration;
 
+/**
+ * A wrapper of FileChannel.
+ */
 public class DefaultFileChannelProvider implements FileChannelProvider{
     @Override
     public BookieFileChannel open(File file, ServerConfiguration configuration) throws IOException {
@@ -45,8 +47,10 @@ public class DefaultFileChannelProvider implements FileChannelProvider{
 
         @Override
         public FileChannel getFileChannel() throws FileNotFoundException {
-            if (randomAccessFile == null) {
-                randomAccessFile = new RandomAccessFile(file, "rw");
+            synchronized (this) {
+                if (randomAccessFile == null) {
+                    randomAccessFile = new RandomAccessFile(file, "rw");
+                }
             }
             return randomAccessFile.getChannel();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -40,7 +40,7 @@ public class DefaultFileChannelProvider implements FileChannelProvider{
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
 
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -39,4 +39,8 @@ public class DefaultFileChannelProvider implements FileChannelProvider{
         bookieFileChannel.close();
     }
 
+    @Override
+    public void close() throws Exception {
+
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannelProvider.java
@@ -1,4 +1,5 @@
-/**
+/*
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,7 +16,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
  */
+
 package org.apache.bookkeeper.bookie;
 
 import java.io.File;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.bookkeeper.bookie;
 
 import java.io.File;
@@ -25,12 +26,12 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 /**
  * An interface of the FileChannelProvider.
  */
-public interface FileChannelProvider {
+public interface FileChannelProvider extends AutoCloseable{
     /**
      *
      * @param providerClassName Provided class name for file channel.
      * @return FileChannelProvider. A file channel provider loaded from providerClassName
-     * @throws IOException
+     * @throws IOException Possible IOException.
      */
     static FileChannelProvider newProvider(String providerClassName) throws IOException {
         try {
@@ -45,12 +46,17 @@ public interface FileChannelProvider {
     /**
      * Get the BookieFileChannel with the given file and configuration.
      *
-     * @param file
-     * @param configuration
+     * @param file File path related to bookie.
+     * @param configuration Server configuration.
      * @return BookieFileChannel related to file parameter.
-     * @throws IOException
+     * @throws IOException Possible IOException.
      */
     BookieFileChannel open(File file, ServerConfiguration configuration) throws IOException;
 
+    /**
+     * Close bookieFileChannel.
+     * @param bookieFileChannel The bookieFileChannel to be closed.
+     * @throws IOException Possible IOException.
+     */
     void close(BookieFileChannel bookieFileChannel) throws IOException;
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
@@ -35,7 +35,7 @@ public interface FileChannelProvider {
     static FileChannelProvider newProvider(String providerClassName) throws IOException {
         try {
             Class<?> providerClass = Class.forName(providerClassName);
-            Object obj = providerClass.newInstance();
+            Object obj = providerClass.getDeclaredConstructor().newInstance();
             return (FileChannelProvider) obj;
         } catch (Exception e) {
             throw new IOException(e);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
@@ -35,7 +35,7 @@ public interface FileChannelProvider {
     static FileChannelProvider newProvider(String providerClassName) throws IOException {
         try {
             Class<?> providerClass = Class.forName(providerClassName);
-            Object obj = providerClass.getDeclaredConstructor().newInstance();
+            Object obj = providerClass.getConstructor().newInstance();
             return (FileChannelProvider) obj;
         } catch (Exception e) {
             throw new IOException(e);
@@ -51,4 +51,6 @@ public interface FileChannelProvider {
      * @throws IOException
      */
     BookieFileChannel open(File file, ServerConfiguration configuration) throws IOException;
+
+    void close(BookieFileChannel bookieFileChannel) throws IOException;
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
@@ -19,6 +19,7 @@
 
 package org.apache.bookkeeper.bookie;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -26,7 +27,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 /**
  * An interface of the FileChannelProvider.
  */
-public interface FileChannelProvider extends AutoCloseable{
+public interface FileChannelProvider extends Closeable {
     /**
      *
      * @param providerClassName Provided class name for file channel.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
@@ -18,15 +18,20 @@
  */
 package org.apache.bookkeeper.bookie;
 
-import org.apache.bookkeeper.conf.ServerConfiguration;
-
 import java.io.File;
 import java.io.IOException;
+import org.apache.bookkeeper.conf.ServerConfiguration;
 
 /**
  * An interface of the FileChannelProvider.
  */
 public interface FileChannelProvider {
+    /**
+     *
+     * @param providerClassName Provided class name for file channel.
+     * @return
+     * @throws IOException
+     */
     static FileChannelProvider newProvider(String providerClassName) throws IOException {
         try {
             Class<?> providerClass = Class.forName(providerClassName);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.bookie;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * An interface of the FileChannelProvider.
+ */
+public interface FileChannelProvider {
+    static FileChannelProvider newProvider(String providerClassName) throws IOException {
+        try {
+            Class<?> providerClass = Class.forName(providerClassName);
+            Object obj = providerClass.newInstance();
+            return (FileChannelProvider) obj;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Get the BookieFileChannel with the given file and configuration.
+     *
+     * @param file
+     * @param configuration
+     * @return
+     * @throws IOException
+     */
+    BookieFileChannel open(File file, ServerConfiguration configuration) throws IOException;
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileChannelProvider.java
@@ -29,7 +29,7 @@ public interface FileChannelProvider {
     /**
      *
      * @param providerClassName Provided class name for file channel.
-     * @return
+     * @return FileChannelProvider. A file channel provider loaded from providerClassName
      * @throws IOException
      */
     static FileChannelProvider newProvider(String providerClassName) throws IOException {
@@ -47,7 +47,7 @@ public interface FileChannelProvider {
      *
      * @param file
      * @param configuration
-     * @return
+     * @return BookieFileChannel related to file parameter.
      * @throws IOException
      */
     BookieFileChannel open(File file, ServerConfiguration configuration) throws IOException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -782,10 +782,10 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         throws IOException {
         JournalChannel recLog;
         if (journalPos <= 0) {
-            recLog = new JournalChannel(journalDirectory, journalId, journalPreAllocSize, journalWriteBufferSize);
+            recLog = new JournalChannel(journalDirectory, journalId, journalPreAllocSize, journalWriteBufferSize, conf);
         } else {
             recLog = new JournalChannel(journalDirectory, journalId, journalPreAllocSize, journalWriteBufferSize,
-                    journalPos);
+                    journalPos, conf);
         }
         int journalVersion = recLog.getFormatVersion();
         try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -960,7 +960,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     journalCreationWatcher.reset().start();
                     logFile = new JournalChannel(journalDirectory, logId, journalPreAllocSize, journalWriteBufferSize,
                                         journalAlignmentSize, removePagesFromCache,
-                                        journalFormatVersionToWrite, getBufferedChannelBuilder());
+                                        journalFormatVersionToWrite, getBufferedChannelBuilder(), conf);
 
                     journalStats.getJournalCreationStats().registerSuccessfulEvent(
                             journalCreationWatcher.stop().elapsed(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 class JournalChannel implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(JournalChannel.class);
 
+    static final long MB = 1024 * 1024L;
     final BookieFileChannel channel;
     final int fd;
     final FileChannel fc;
@@ -57,7 +58,7 @@ class JournalChannel implements Closeable {
 
     static final int SECTOR_SIZE = 512;
     private static final int START_OF_FILE = -12345;
-    private static long cacheDropLagBytes = 8 * 1024 * 1024;
+    private static long cacheDropLagBytes = 8 * MB;
 
     // No header
     static final int V1 = 1;
@@ -90,7 +91,7 @@ class JournalChannel implements Closeable {
 
     // Mostly used by tests
     JournalChannel(File journalDirectory, long logId) throws IOException {
-        this(journalDirectory, logId, 4 * 1024 * 1024, 65536, START_OF_FILE, new ServerConfiguration());
+        this(journalDirectory, logId, 4 * MB, 65536, START_OF_FILE, new ServerConfiguration());
     }
 
     // Open journal for scanning starting from the first record in journal.
@@ -157,8 +158,7 @@ class JournalChannel implements Closeable {
         this.configuration = configuration;
 
         File fn = new File(journalDirectory, Long.toHexString(logId) + ".txn");
-        FileChannelProvider provider;
-        provider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
+        FileChannelProvider provider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
         channel = provider.open(fn, configuration);
 
         if (formatVersionToWrite < V4) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -47,6 +47,7 @@ class JournalChannel implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(JournalChannel.class);
 
     static final long MB = 1024 * 1024L;
+    final FileChannelProvider fileChannelProvider;
     final BookieFileChannel channel;
     final int fd;
     final FileChannel fc;
@@ -158,8 +159,8 @@ class JournalChannel implements Closeable {
         this.configuration = configuration;
 
         File fn = new File(journalDirectory, Long.toHexString(logId) + ".txn");
-        FileChannelProvider provider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
-        channel = provider.open(fn, configuration);
+        fileChannelProvider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
+        channel = fileChannelProvider.open(fn, configuration);
 
         if (formatVersionToWrite < V4) {
             throw new IOException("Invalid journal format to write : version = " + formatVersionToWrite);
@@ -274,6 +275,9 @@ class JournalChannel implements Closeable {
     public void close() throws IOException {
         if (bc != null) {
             bc.close();
+        }
+        if(fileChannelProvider != null) {
+            fileChannelProvider.close();
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -276,7 +276,7 @@ class JournalChannel implements Closeable {
         if (bc != null) {
             bc.close();
         }
-        if(fileChannelProvider != null) {
+        if (fileChannelProvider != null) {
             fileChannelProvider.close();
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
 
+import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.util.NativeIO;
 import org.apache.bookkeeper.util.ZeroBuffer;
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ import org.slf4j.LoggerFactory;
 class JournalChannel implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(JournalChannel.class);
 
-    final RandomAccessFile randomAccessFile;
+    final BookieFileChannel channel;
     final int fd;
     final FileChannel fc;
     final BufferedChannel bc;
@@ -85,21 +86,23 @@ class JournalChannel implements Closeable {
     // The position of the file channel's last drop position
     private long lastDropPosition = 0L;
 
+    final ServerConfiguration configuration;
+
     // Mostly used by tests
     JournalChannel(File journalDirectory, long logId) throws IOException {
-        this(journalDirectory, logId, 4 * 1024 * 1024, 65536, START_OF_FILE);
+        this(journalDirectory, logId, 4 * 1024 * 1024, 65536, START_OF_FILE, new ServerConfiguration());
     }
 
     // Open journal for scanning starting from the first record in journal.
-    JournalChannel(File journalDirectory, long logId, long preAllocSize, int writeBufferSize) throws IOException {
-        this(journalDirectory, logId, preAllocSize, writeBufferSize, START_OF_FILE);
+    JournalChannel(File journalDirectory, long logId, long preAllocSize, int writeBufferSize, ServerConfiguration conf) throws IOException {
+        this(journalDirectory, logId, preAllocSize, writeBufferSize, START_OF_FILE, conf);
     }
 
     // Open journal for scanning starting from given position.
     JournalChannel(File journalDirectory, long logId,
-                   long preAllocSize, int writeBufferSize, long position) throws IOException {
+                   long preAllocSize, int writeBufferSize, long position, ServerConfiguration conf) throws IOException {
          this(journalDirectory, logId, preAllocSize, writeBufferSize, SECTOR_SIZE,
-                 position, false, V5, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER);
+                 position, false, V5, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER, conf);
     }
 
     // Open journal to write
@@ -115,7 +118,7 @@ class JournalChannel implements Closeable {
                    boolean fRemoveFromPageCache, int formatVersionToWrite,
                    Journal.BufferedChannelBuilder bcBuilder) throws IOException {
         this(journalDirectory, logId, preAllocSize, writeBufferSize, journalAlignSize,
-                START_OF_FILE, fRemoveFromPageCache, formatVersionToWrite, bcBuilder);
+                START_OF_FILE, fRemoveFromPageCache, formatVersionToWrite, bcBuilder, new ServerConfiguration());
     }
 
     /**
@@ -143,27 +146,39 @@ class JournalChannel implements Closeable {
     private JournalChannel(File journalDirectory, long logId,
                            long preAllocSize, int writeBufferSize, int journalAlignSize,
                            long position, boolean fRemoveFromPageCache,
-                           int formatVersionToWrite, Journal.BufferedChannelBuilder bcBuilder) throws IOException {
+                           int formatVersionToWrite, Journal.BufferedChannelBuilder bcBuilder,
+                           ServerConfiguration configuration) throws IOException {
         this.journalAlignSize = journalAlignSize;
         this.zeros = ByteBuffer.allocate(journalAlignSize);
         this.preAllocSize = preAllocSize - preAllocSize % journalAlignSize;
         this.fRemoveFromPageCache = fRemoveFromPageCache;
+        this.configuration = configuration;
+
         File fn = new File(journalDirectory, Long.toHexString(logId) + ".txn");
+        FileChannelProvider provider;
+        // Create the file channel provider with given configuration. Fallback to use default FileChannel if
+        // load failed.
+        try {
+            provider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
+        } catch (IOException e) {
+            LOG.warn("Failed to load journal channel provider '{}', fallback to the default JournalChannel", configuration.getJournalChannelProvider(), e);
+            provider = new DefaultFileChannelProvider();
+        }
+        channel = provider.open(fn, configuration);
 
         if (formatVersionToWrite < V4) {
             throw new IOException("Invalid journal format to write : version = " + formatVersionToWrite);
         }
 
         LOG.info("Opening journal {}", fn);
-        if (!fn.exists()) { // new file, write version
+        if (!channel.fileExists(fn)) { // new file, write version
             if (!fn.createNewFile()) {
                 LOG.error("Journal file {}, that shouldn't exist, already exists. "
                           + " is there another bookie process running?", fn);
                 throw new IOException("File " + fn
                         + " suddenly appeared, is another bookie process running?");
             }
-            randomAccessFile = new RandomAccessFile(fn, "rw");
-            fc = openFileChannel(randomAccessFile);
+            fc = channel.getFileChannel();
             formatVersion = formatVersionToWrite;
 
             int headerSize = (V4 == formatVersion) ? VERSION_HEADER_SIZE : HEADER_SIZE;
@@ -180,8 +195,7 @@ class JournalChannel implements Closeable {
             nextPrealloc = this.preAllocSize;
             fc.write(zeros, nextPrealloc - journalAlignSize);
         } else {  // open an existing file
-            randomAccessFile = new RandomAccessFile(fn, "r");
-            fc = openFileChannel(randomAccessFile);
+            fc = channel.getFileChannel();
             bc = null; // readonly
 
             ByteBuffer bb = ByteBuffer.allocate(VERSION_HEADER_SIZE);
@@ -231,7 +245,7 @@ class JournalChannel implements Closeable {
             }
         }
         if (fRemoveFromPageCache) {
-            this.fd = NativeIO.getSysFileDescriptor(randomAccessFile.getFD());
+            this.fd = NativeIO.getSysFileDescriptor(channel.getFD());
         } else {
             this.fd = -1;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -158,15 +158,7 @@ class JournalChannel implements Closeable {
 
         File fn = new File(journalDirectory, Long.toHexString(logId) + ".txn");
         FileChannelProvider provider;
-        // Create the file channel provider with given configuration. Fallback to use default FileChannel if
-        // load failed.
-        try {
-            provider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
-        } catch (IOException e) {
-            LOG.warn("Failed to load journal channel provider '{}', fallback to the default JournalChannel",
-            configuration.getJournalChannelProvider(), e);
-            provider = new DefaultFileChannelProvider();
-        }
+        provider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
         channel = provider.open(fn, configuration);
 
         if (formatVersionToWrite < V4) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -94,7 +94,8 @@ class JournalChannel implements Closeable {
     }
 
     // Open journal for scanning starting from the first record in journal.
-    JournalChannel(File journalDirectory, long logId, long preAllocSize, int writeBufferSize, ServerConfiguration conf) throws IOException {
+    JournalChannel(File journalDirectory, long logId,
+                   long preAllocSize, int writeBufferSize, ServerConfiguration conf) throws IOException {
         this(journalDirectory, logId, preAllocSize, writeBufferSize, START_OF_FILE, conf);
     }
 
@@ -108,9 +109,10 @@ class JournalChannel implements Closeable {
     // Open journal to write
     JournalChannel(File journalDirectory, long logId,
                    long preAllocSize, int writeBufferSize, int journalAlignSize,
-                   boolean fRemoveFromPageCache, int formatVersionToWrite, ServerConfiguration configuration) throws IOException {
-        this(journalDirectory, logId, preAllocSize, writeBufferSize, journalAlignSize,
-             fRemoveFromPageCache, formatVersionToWrite, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER, configuration);
+                   boolean fRemoveFromPageCache, int formatVersionToWrite,
+                   ServerConfiguration configuration) throws IOException {
+        this(journalDirectory, logId, preAllocSize, writeBufferSize, journalAlignSize, fRemoveFromPageCache,
+                formatVersionToWrite, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER, configuration);
     }
 
     JournalChannel(File journalDirectory, long logId,
@@ -161,7 +163,8 @@ class JournalChannel implements Closeable {
         try {
             provider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
         } catch (IOException e) {
-            LOG.warn("Failed to load journal channel provider '{}', fallback to the default JournalChannel", configuration.getJournalChannelProvider(), e);
+            LOG.warn("Failed to load journal channel provider '{}', fallback to the default JournalChannel",
+            configuration.getJournalChannelProvider(), e);
             provider = new DefaultFileChannelProvider();
         }
         channel = provider.open(fn, configuration);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -108,17 +108,17 @@ class JournalChannel implements Closeable {
     // Open journal to write
     JournalChannel(File journalDirectory, long logId,
                    long preAllocSize, int writeBufferSize, int journalAlignSize,
-                   boolean fRemoveFromPageCache, int formatVersionToWrite) throws IOException {
+                   boolean fRemoveFromPageCache, int formatVersionToWrite, ServerConfiguration configuration) throws IOException {
         this(journalDirectory, logId, preAllocSize, writeBufferSize, journalAlignSize,
-             fRemoveFromPageCache, formatVersionToWrite, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER);
+             fRemoveFromPageCache, formatVersionToWrite, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER, configuration);
     }
 
     JournalChannel(File journalDirectory, long logId,
                    long preAllocSize, int writeBufferSize, int journalAlignSize,
                    boolean fRemoveFromPageCache, int formatVersionToWrite,
-                   Journal.BufferedChannelBuilder bcBuilder) throws IOException {
+                   Journal.BufferedChannelBuilder bcBuilder, ServerConfiguration configuration) throws IOException {
         this(journalDirectory, logId, preAllocSize, writeBufferSize, journalAlignSize,
-                START_OF_FILE, fRemoveFromPageCache, formatVersionToWrite, bcBuilder, new ServerConfiguration());
+                START_OF_FILE, fRemoveFromPageCache, formatVersionToWrite, bcBuilder, configuration);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -146,6 +146,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String JOURNAL_QUEUE_SIZE = "journalQueueSize";
     protected static final String JOURNAL_MAX_MEMORY_SIZE_MB = "journalMaxMemorySizeMb";
     protected static final String JOURNAL_PAGECACHE_FLUSH_INTERVAL_MSEC = "journalPageCacheFlushIntervalMSec";
+    protected static final String JOURNAL_CHANNEL_PROVIDER = "journalChannelProvider";
     // backpressure control
     protected static final String MAX_ADDS_IN_PROGRESS_LIMIT = "maxAddsInProgressLimit";
     protected static final String MAX_READS_IN_PROGRESS_LIMIT = "maxReadsInProgressLimit";
@@ -866,6 +867,15 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public long getJournalPageCacheFlushIntervalMSec() {
         return this.getLong(JOURNAL_PAGECACHE_FLUSH_INTERVAL_MSEC, 1000);
+    }
+
+    public ServerConfiguration setJournalChannelProvider(String journalChannelProvider) {
+        this.setProperty(JOURNAL_CHANNEL_PROVIDER, journalChannelProvider);
+        return this;
+    }
+
+    public String getJournalChannelProvider() {
+        return this.getString(JOURNAL_CHANNEL_PROVIDER);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -875,7 +875,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     public String getJournalChannelProvider() {
-        return this.getString(JOURNAL_CHANNEL_PROVIDER);
+        return this.getString(JOURNAL_CHANNEL_PROVIDER, "org.apache.bookkeeper.bookie.DefaultFileChannelProvider");
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -27,6 +27,7 @@ import io.netty.util.internal.PlatformDependent;
 // CHECKSTYLE.ON: IllegalImport
 import java.io.File;
 import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.bookie.FileChannelProvider;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.bookie.SortedLedgerStorage;
@@ -869,11 +870,22 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
         return this.getLong(JOURNAL_PAGECACHE_FLUSH_INTERVAL_MSEC, 1000);
     }
 
+    /**
+     * Set JournalChannelProvider classname.
+     * @param journalChannelProvider
+     *          The JournalChannelProvider classname. The class must implements {@link FileChannelProvider} and
+     *          no args constructor is needed.
+     * @return
+     */
     public ServerConfiguration setJournalChannelProvider(String journalChannelProvider) {
         this.setProperty(JOURNAL_CHANNEL_PROVIDER, journalChannelProvider);
         return this;
     }
 
+    /**
+     *
+     * @return
+     */
     public String getJournalChannelProvider() {
         return this.getString(JOURNAL_CHANNEL_PROVIDER, "org.apache.bookkeeper.bookie.DefaultFileChannelProvider");
     }

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -678,7 +678,7 @@ ledgerDirectories=/tmp/bk-data
 # If pageLimit is -1, bookie server will use 1/3 of JVM memory to compute
 # the limitation of number of index pages.
 # pageLimit=-1
-journalChannelProvider=org.apache.bookkeeper.bookie.PMemChannelProvider
+
 #############################################################################
 ## DB Ledger storage configuration
 #############################################################################

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -678,7 +678,7 @@ ledgerDirectories=/tmp/bk-data
 # If pageLimit is -1, bookie server will use 1/3 of JVM memory to compute
 # the limitation of number of index pages.
 # pageLimit=-1
-
+journalChannelProvider=org.apache.bookkeeper.bookie.PMemChannelProvider
 #############################################################################
 ## DB Ledger storage configuration
 #############################################################################

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -374,6 +374,9 @@ journalDirectories=/tmp/bk-txn
 # Set PageCache flush interval (millisecond) when journalSyncData disabled
 # journalPageCacheFlushIntervalMSec = 1000
 
+# Set the Channel Provider for journal.
+# The default value is
+# journalChannelProvider=org.apache.bookkeeper.bookie.DefaultFileChannelProvider
 #############################################################################
 ## Ledger storage settings
 #############################################################################
@@ -834,7 +837,7 @@ zkEnableSecurity=false
 #############################################################################
 
 # These configs are used when using `CodahaleMetricsProvider`.
-# statsProviderClass=org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider
+# statsProviderClass=org.apache.bookkeeper.stats.codahale.CodahaleMetricsProviderjournalChannelProvider
 
 # metric name prefix, default is ""
 # codahaleStatsPrefix=

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -837,7 +837,7 @@ zkEnableSecurity=false
 #############################################################################
 
 # These configs are used when using `CodahaleMetricsProvider`.
-# statsProviderClass=org.apache.bookkeeper.stats.codahale.CodahaleMetricsProviderjournalChannelProvider
+# statsProviderClass=org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider
 
 # metric name prefix, default is ""
 # codahaleStatsPrefix=


### PR DESCRIPTION
### Motivation

Make the FileChannel in the JournalChannel can use different implement.
We found we can use [pmemstore](https://github.com/pmem/pcj)
as the JournalChannel read from. So abstract the FileChannel in the
JournnalChannel to make us can have a different implementation.

### Changes

- Add interface for supporting implement different FileChannel

This PR doesn't introduce any new things in the code. So make sure it can pass the CI
