### PR TITLE
Print usage in autorecovery command if needed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -286,14 +286,14 @@ public class AutoRecoveryMain {
 
             if (cmdLine.hasOption('c')) {
                 if (null != leftArgs && leftArgs.length > 0) {
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unexpected arguments [" + String.join(" ", leftArgs) + "]");
                 }
                 String confFile = cmdLine.getOptionValue("c");
                 loadConfFile(conf, confFile);
             }
 
             if (null != leftArgs && leftArgs.length > 0) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unexpected arguments [" + String.join(" ", leftArgs) + "]");
             }
             return conf;
         } catch (ParseException e) {
@@ -314,6 +314,11 @@ public class AutoRecoveryMain {
         try {
             conf = parseArgs(args);
         } catch (IllegalArgumentException iae) {
+            LOG.error("Error parsing command line arguments : ", iae);
+            if (iae.getMessage() != null) {
+                System.err.println(iae.getMessage());
+            }
+            printUsage();
             return ExitCode.INVALID_CONF;
         }
 


### PR DESCRIPTION
### Motivation

I was trying to read the code to see how auto-recovery service works, just noticed the method `printUsage` was never called and the program doesn't print the usage even when '-h' is specified.

### Changes

Print the usage of auto-recovery if '-h' is specified or additional unexpected arguments are provided when running the auto-recovery command.