### PR TITLE
Fix the typo in Auditor.java

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -468,7 +468,7 @@ public class Auditor implements AutoCloseable {
                 admin.getConf().getClientAuthProviderFactoryClass());
             if (this.ledgerUnderreplicationManager
                     .initializeLostBookieRecoveryDelay(conf.getLostBookieRecoveryDelay())) {
-                LOG.info("Initializing lostBookieRecoveryDelay zNode to the conif value: {}",
+                LOG.info("Initializing lostBookieRecoveryDelay zNode to the conf value: {}",
                         conf.getLostBookieRecoveryDelay());
             } else {
                 LOG.info("Valid lostBookieRecoveryDelay zNode is available, so not creating "


### PR DESCRIPTION

### Motivation

'conif' seems to be a typo of `conf`.

### Changes

Fixed the typo.