### PR TITLE
Log which java field cannot be accessed with --illegal-access=deny (NativeIO)

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/NativeIO.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/NativeIO.java
@@ -65,8 +65,8 @@ public final class NativeIO {
         } catch (Exception e) {
             // We don't really expect this so throw an assertion to
             // catch this during development
-            assert false;
             LOG.warn("Unable to read {} field from {}", fieldName, cls.getName());
+            assert false;
         }
 
         return field;


### PR DESCRIPTION
### Motivation

I was running BK with jdk16 where --illegal-access property is set on "deny" and there was an illegal access done by `NativeIO#getFieldByReflection`; the application crashes due to java `assert` without logging which module/package you have to explicit open with --add-opens option

Plus: I'm not sure if it is correct to keep `assert` in this case, maybe throwing the IllegalAccessException is safer 

### Changes

Log which field cannot be accessed before application crashes

