### PR TITLE
[doc] Fix typo in bookkeeper config `tslProvider`

### DIFF
--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -150,7 +150,7 @@ groups:
 
 - name: TLS settings
   params:
-  - param: tslProvider
+  - param: tlsProvider
     description: TLS Provider (JDK or OpenSSL)
     default: OpenSSL
   - param: tlsProviderFactoryClass


### PR DESCRIPTION
It looks like an obvious typo that `tslProvider` should be `tlsProvider`, and the configuration item in the source code is also `tlsProvider`: https://github.com/apache/bookkeeper/blob/31e8d1b44ffafd867d0eb2774085e4b1141a7acb/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java#L102
