### PR TITLE
Remove the `request` in the stream python client dependency

### DIFF
--- a/stream/clients/python/setup.py
+++ b/stream/clients/python/setup.py
@@ -27,7 +27,6 @@ version = '4.12.0'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'protobuf>=3.0.0',
-    'requests<3.0.0dev,>=2.18.0',
     'setuptools>=34.0.0',
     'six>=1.10.0',
     'pytz',


### PR DESCRIPTION
---

Master Issue: #2752

*Motivation*

As discussed at length in https://issues.apache.org/jira/browse/LEGAL-572
we found out that the chardet library used by requests library was a
mandatory dependency to requests and since it has LGPL licence, we
should not release any Apache Software with it.
