### PR TITLE
Change log level from error to warn in getReadLacResponse

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
@@ -74,7 +74,7 @@ class ReadLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             }
         } catch (Bookie.NoLedgerException e) {
             status = StatusCode.ENOLEDGER;
-            logger.error("No ledger found while performing readLac from ledger: {}", ledgerId, e);
+            logger.warn("No ledger found while performing readLac from ledger: {}", ledgerId, e);
         } catch (IOException e) {
             status = StatusCode.EIO;
             logger.error("IOException while performing readLac from ledger: {}", ledgerId);
@@ -89,7 +89,10 @@ class ReadLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             }
         } catch (Bookie.NoLedgerException e) {
             status = StatusCode.ENOLEDGER;
-            logger.error("No ledger found while trying to read last entry: {}", ledgerId, e);
+            logger.warn("No ledger found while trying to read last entry: {}", ledgerId, e);
+        } catch (Bookie.NoEntryException e) {
+            status = StatusCode.ENOENTRY;
+            logger.warn("No Entry found while trying to read last entry: {}", ledgerId, e);
         } catch (IOException e) {
             status = StatusCode.EIO;
             logger.error("IOException while trying to read last entry: {}", ledgerId, e);


### PR DESCRIPTION
### Motivation

Two errors do not have an impact on functionality, so change log level from error to warn

### Changes

change log level from error to warn in getReadLacResponse

do not need documentation.