### PR TITLE
state store: getStream: log stream info

### DIFF
--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/metadata/RootRangeStoreImpl.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/metadata/RootRangeStoreImpl.java
@@ -449,6 +449,11 @@ public class RootRangeStoreImpl
 
     }
 
+    private static void logStreamOp(String op, long nsId, long streamId, String streamName, StatusCode result) {
+        log.info("stream {} namespace_id={} stream_id={} stream_name={} result={}",
+                op, nsId, streamId, streamName, result);
+    }
+
     private CompletableFuture<CreateStreamResponse> executeCreateStreamTxn(long nsId,
                                                                            String streamName,
                                                                            StreamConfiguration streamConf,
@@ -462,7 +467,6 @@ public class RootRangeStoreImpl
         }
 
         long scId = placementPolicy.placeStreamRange(streamId, 0L);
-
 
         StreamProperties streamProps = StreamProperties.newBuilder()
             .setStreamId(streamId)
@@ -506,6 +510,7 @@ public class RootRangeStoreImpl
                         // TODO: differentiate the error codes
                         respBuilder.setCode(StatusCode.INTERNAL_SERVER_ERROR);
                     }
+                    logStreamOp("create", nsId, streamId, streamName, respBuilder.getCode());
                     return respBuilder.build();
                 } finally {
                     txnResult.close();
@@ -593,6 +598,7 @@ public class RootRangeStoreImpl
                 } else {
                     respBuilder.setCode(StatusCode.INTERNAL_SERVER_ERROR);
                 }
+                logStreamOp("delete", nsId, streamId, streamName, respBuilder.getCode());
                 return respBuilder.build();
             } finally {
                 txnResult.close();

--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/metadata/RootRangeStoreImpl.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/metadata/RootRangeStoreImpl.java
@@ -80,7 +80,7 @@ public class RootRangeStoreImpl
     /**
      * ns name key: [NS_NAME_TAG][ns_name].
      */
-    static final byte[] getNamespaceNameKey(String nsName) {
+    static byte[] getNamespaceNameKey(String nsName) {
         byte[] nsNameBytes = nsName.getBytes(UTF_8);
         byte[] nsNameKey = new byte[nsNameBytes.length + 1];
         System.arraycopy(nsNameBytes, 0, nsNameKey, 1, nsNameBytes.length);
@@ -91,7 +91,7 @@ public class RootRangeStoreImpl
     /**
      * ns id key: [NS_ID_TAG][ns_id].
      */
-    static final byte[] getNamespaceIdKey(long nsId) {
+    static byte[] getNamespaceIdKey(long nsId) {
         byte[] nsIdBytes = new byte[Long.BYTES + 1];
         nsIdBytes[0] = NS_ID_TAG;
         Bytes.toBytes(nsId, nsIdBytes, 1);
@@ -101,7 +101,7 @@ public class RootRangeStoreImpl
     /**
      * ns id end key: [NS_ID_TAG][ns_id][NS_END_SEP].
      */
-    static final byte[] getNamespaceIdEndKey(long nsId) {
+    static byte[] getNamespaceIdEndKey(long nsId) {
         byte[] nsIdBytes = new byte[Long.BYTES + 2];
         nsIdBytes[0] = NS_ID_TAG;
         Bytes.toBytes(nsId, nsIdBytes, 1);
@@ -112,7 +112,7 @@ public class RootRangeStoreImpl
     /**
      * stream name key: [NS_ID_TAG][ns_id][STREAM_NAME_SEP][stream_name].
      */
-    static final byte[] getStreamNameKey(long nsId, String streamName) {
+    static byte[] getStreamNameKey(long nsId, String streamName) {
         byte[] streamNameBytes = streamName.getBytes(UTF_8);
         byte[] streamNameKey = new byte[streamNameBytes.length + Long.BYTES + 2];
         streamNameKey[0] = NS_ID_TAG;
@@ -125,7 +125,7 @@ public class RootRangeStoreImpl
     /**
      * stream name id: [NS_ID_TAG][ns_id][STREAM_ID_SEP][stream_id].
      */
-    static final byte[] getStreamIdKey(long nsId, long streamId) {
+    static byte[] getStreamIdKey(long nsId, long streamId) {
         byte[] streamIdBytes = new byte[2 * Long.BYTES + 2];
         streamIdBytes[0] = NS_ID_TAG;
         Bytes.toBytes(nsId, streamIdBytes, 1);
@@ -137,7 +137,7 @@ public class RootRangeStoreImpl
     /**
      * stream id: [STREAM_ID_TAG][stream_id].
      */
-    static final byte[] getStreamIdKey(long streamId) {
+    static byte[] getStreamIdKey(long streamId) {
         byte[] streamIdBytes = new byte[Long.BYTES + 1];
         streamIdBytes[0] = STREAM_ID_TAG;
         Bytes.toBytes(streamId, streamIdBytes, 1);


### PR DESCRIPTION
log the the tuple (namespace id, stream id, stream name) in RootStorageService getRange request.

### Motivation

Server request metrics are labeled with the stream id, extracted from the routing header.  The stream name
(aka "table name") is not available but more useful.  Rather than making a (cacheable) RPC request to fetch
the id -> name mapping in the metrics, logging the information allows one to find the name without requiring
admin access to the state store service.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
