### PR TITLE
Issue 2482: Added TCP_USER_TIMEOUT to Epoll channel config

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -532,12 +532,13 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     }
 
     /**
-     * Get client netty TCP user timeout in millis (only for Epoll channels).
+     * Get client netty TCP user timeout in millis (only for Epoll channels). The
+     * negative default value represents that the value has not been set.
      *
      * @return client netty Epoll user tcp timeout in millis.
      */
     public int getTcpUserTimeoutMillis() {
-        return getInt(CLIENT_TCP_USER_TIMEOUT_MILLIS, 10000);
+        return getInt(CLIENT_TCP_USER_TIMEOUT_MILLIS, Integer.MIN_VALUE);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -96,6 +96,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     protected static final String CLIENT_WRITEBUFFER_LOW_WATER_MARK = "clientWriteBufferLowWaterMark";
     protected static final String CLIENT_WRITEBUFFER_HIGH_WATER_MARK = "clientWriteBufferHighWaterMark";
     protected static final String CLIENT_CONNECT_TIMEOUT_MILLIS = "clientConnectTimeoutMillis";
+    protected static final String CLIENT_TCP_USER_TIMEOUT_MILLIS = "clientTcpUserTimeoutMillis";
     protected static final String NUM_CHANNELS_PER_BOOKIE = "numChannelsPerBookie";
     protected static final String USE_V2_WIRE_PROTOCOL = "useV2WireProtocol";
     protected static final String NETTY_USE_POOLED_BUFFERS = "nettyUsePooledBuffers";
@@ -527,6 +528,27 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
      */
     public ClientConfiguration setClientConnectTimeoutMillis(int connectTimeoutMillis) {
         setProperty(CLIENT_CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis);
+        return this;
+    }
+
+    /**
+     * Get client netty TCP user timeout in millis (only for Epoll channels).
+     *
+     * @return client netty Epoll user tcp timeout in millis.
+     */
+    public int getTcpUserTimeoutMillis() {
+        return getInt(CLIENT_TCP_USER_TIMEOUT_MILLIS, 10000);
+    }
+
+    /**
+     * Set client netty TCP user timeout in millis (only for Epoll channels).
+     *
+     * @param tcpUserTimeoutMillis
+     *          client netty TCP user timeout in millis.
+     * @return client configuration.
+     */
+    public ClientConfiguration setTcpUserTimeoutMillis(int tcpUserTimeoutMillis) {
+        setProperty(CLIENT_TCP_USER_TIMEOUT_MILLIS, tcpUserTimeoutMillis);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -22,6 +22,7 @@ import static org.apache.bookkeeper.util.BookKeeperConstants.FEATURE_DISABLE_ENS
 
 import io.netty.buffer.ByteBuf;
 
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -532,13 +533,13 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     }
 
     /**
-     * Get client netty TCP user timeout in millis (only for Epoll channels). The
-     * negative default value represents that the value has not been set.
+     * Get client netty TCP user timeout in millis (only for Epoll channels).
      *
      * @return client netty Epoll user tcp timeout in millis.
+     * @throws NoSuchElementException if the property is not set.
      */
     public int getTcpUserTimeoutMillis() {
-        return getInt(CLIENT_TCP_USER_TIMEOUT_MILLIS, Integer.MIN_VALUE);
+        return getInt(CLIENT_TCP_USER_TIMEOUT_MILLIS);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -42,6 +42,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.local.LocalAddress;
@@ -540,6 +541,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         bootstrap.group(eventLoopGroup);
         if (eventLoopGroup instanceof EpollEventLoopGroup) {
             bootstrap.channel(EpollSocketChannel.class);
+            // For Epoll, also set the connection timeout via TCP_USER_TIMEOUT.
+            bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, conf.getClientConnectTimeoutMillis());
         } else if (eventLoopGroup instanceof DefaultEventLoopGroup) {
             bootstrap.channel(LocalChannel.class);
         } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -71,6 +71,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -541,9 +542,11 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         bootstrap.group(eventLoopGroup);
         if (eventLoopGroup instanceof EpollEventLoopGroup) {
             bootstrap.channel(EpollSocketChannel.class);
-            // For Epoll channels, configure the TCP user timeout only if it is set.
-            if (conf.getTcpUserTimeoutMillis() > 0) {
+            try {
+                // For Epoll channels, configure the TCP user timeout.
                 bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, conf.getTcpUserTimeoutMillis());
+            } catch (NoSuchElementException e) {
+                // Property not set, so keeping default value.
             }
         } else if (eventLoopGroup instanceof DefaultEventLoopGroup) {
             bootstrap.channel(LocalChannel.class);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -541,8 +541,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         bootstrap.group(eventLoopGroup);
         if (eventLoopGroup instanceof EpollEventLoopGroup) {
             bootstrap.channel(EpollSocketChannel.class);
-            // For Epoll, also set the connection timeout via TCP_USER_TIMEOUT.
-            bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, conf.getClientConnectTimeoutMillis());
+            // For Epoll channels, we can set the TCP user timeout.
+            bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, conf.getTcpUserTimeoutMillis());
         } else if (eventLoopGroup instanceof DefaultEventLoopGroup) {
             bootstrap.channel(LocalChannel.class);
         } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -541,8 +541,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         bootstrap.group(eventLoopGroup);
         if (eventLoopGroup instanceof EpollEventLoopGroup) {
             bootstrap.channel(EpollSocketChannel.class);
-            // For Epoll channels, we can set the TCP user timeout.
-            bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, conf.getTcpUserTimeoutMillis());
+            // For Epoll channels, configure the TCP user timeout only if it is set.
+            if (conf.getTcpUserTimeoutMillis() > 0) {
+                bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, conf.getTcpUserTimeoutMillis());
+            }
         } else if (eventLoopGroup instanceof DefaultEventLoopGroup) {
             bootstrap.channel(LocalChannel.class);
         } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
@@ -32,11 +32,13 @@ public class NoSystemPropertiesConfigurationTest {
         // this property is read when AbstractConfiguration class is loaded.
         // this test will work as expected only using a new JVM (or classloader) for the test
         System.setProperty(ClientConfiguration.THROTTLE, "10");
+        System.setProperty(ClientConfiguration.CLIENT_TCP_USER_TIMEOUT_MILLIS, "20000");
     }
 
     @Test
     public void testUseSystemProperty() {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         assertEquals(5000, clientConfiguration.getThrottleValue());
+        assertEquals(10000, clientConfiguration.getTcpUserTimeoutMillis());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.util.NoSuchElementException;
+
 /**
  * Test Configuration API.
  *
@@ -35,10 +37,11 @@ public class NoSystemPropertiesConfigurationTest {
         System.setProperty(ClientConfiguration.CLIENT_TCP_USER_TIMEOUT_MILLIS, "20000");
     }
 
-    @Test
+    @Test(expected = NoSuchElementException.class)
     public void testUseSystemProperty() {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         assertEquals(5000, clientConfiguration.getThrottleValue());
-        assertEquals(Integer.MIN_VALUE, clientConfiguration.getTcpUserTimeoutMillis());
+        // This should throw NoSuchElementException if the property has not been set.
+        clientConfiguration.getTcpUserTimeoutMillis();
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
@@ -19,9 +19,8 @@ package org.apache.bookkeeper.conf;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import java.util.NoSuchElementException;
+import org.junit.Test;
 
 /**
  * Test Configuration API.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/NoSystemPropertiesConfigurationTest.java
@@ -39,6 +39,6 @@ public class NoSystemPropertiesConfigurationTest {
     public void testUseSystemProperty() {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         assertEquals(5000, clientConfiguration.getThrottleValue());
-        assertEquals(10000, clientConfiguration.getTcpUserTimeoutMillis());
+        assertEquals(Integer.MIN_VALUE, clientConfiguration.getTcpUserTimeoutMillis());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/SystemPropertiesConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/SystemPropertiesConfigurationTest.java
@@ -33,11 +33,13 @@ public class SystemPropertiesConfigurationTest {
         // this test will work as expected only using a new JVM (or classloader) for the test
         System.setProperty(AbstractConfiguration.READ_SYSTEM_PROPERTIES_PROPERTY, "true");
         System.setProperty(ClientConfiguration.THROTTLE, "10");
+        System.setProperty(ClientConfiguration.CLIENT_TCP_USER_TIMEOUT_MILLIS, "20000");
     }
 
     @Test
     public void testUseSystemProperty() {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         assertEquals(10, clientConfiguration.getThrottleValue());
+        assertEquals(20000, clientConfiguration.getTcpUserTimeoutMillis());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -326,7 +326,8 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
                 Mockito.mock(PerChannelBookieClientPool.class), BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
 
         // Verify that the configured value has not been set in the channel if does not exist in config.
-        assertEquals(channelDefault.connect().channel().config().getOption(EpollChannelOption.TCP_USER_TIMEOUT).intValue(), 0);
+        assertEquals(channelDefault.connect().channel().config()
+                .getOption(EpollChannelOption.TCP_USER_TIMEOUT).intValue(), 0);
 
         // Create a new channel with new TCP user timeout set.
         conf.setTcpUserTimeoutMillis(tcpUserTimeout);
@@ -335,8 +336,8 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
                 Mockito.mock(PerChannelBookieClientPool.class), BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
 
         // Verify that the configured value has been set.
-        assertEquals(channelConfigured.connect().channel().config().getOption(EpollChannelOption.TCP_USER_TIMEOUT).intValue(),
-                tcpUserTimeout);
+        assertEquals(channelConfigured.connect().channel().config()
+                        .getOption(EpollChannelOption.TCP_USER_TIMEOUT).intValue(), tcpUserTimeout);
 
         channelDefault.close();
         channelConfigured.close();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -20,6 +20,10 @@
  */
 package org.apache.bookkeeper.proto;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.google.protobuf.ExtensionRegistry;
 
 import io.netty.buffer.ByteBuf;
@@ -54,10 +58,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for PerChannelBookieClient. Historically, this class has
@@ -313,10 +313,14 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
         conf.setTcpUserTimeoutMillis(tcpUserTimeout);
         BookieId addr = getBookie(0);
 
-        PerChannelBookieClient channel = new PerChannelBookieClient(conf, executor, eventLoopGroup, addr, Mockito.mock(StatsLogger.class),
-                authProvider, extRegistry, Mockito.mock(PerChannelBookieClientPool.class), BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        // Pass to the PerChannelBookieClient object the client configuration with TCP user timeout.
+        PerChannelBookieClient channel = new PerChannelBookieClient(conf, executor, eventLoopGroup,
+                addr, Mockito.mock(StatsLogger.class), authProvider, extRegistry,
+                Mockito.mock(PerChannelBookieClientPool.class), BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
 
-        assertEquals(channel.connect().channel().config().getOption(EpollChannelOption.TCP_USER_TIMEOUT).intValue(), tcpUserTimeout);
+        // Verify that the configured value has been set.
+        assertEquals(channel.connect().channel().config().getOption(EpollChannelOption.TCP_USER_TIMEOUT).intValue(),
+                tcpUserTimeout);
 
         channel.close();
         eventLoopGroup.shutdownGracefully();


### PR DESCRIPTION
### Motivation

Added `TCP_USER_TIMEOUT` in Epoll channel config to limit the time a connection is left sending keepalives to a non-responding Bookie.

### Changes

The original issue reported that in scenarios where Bookies may go down unexpectedly and change their IP (e.g., Kubernetes), the Bookkeeper client may be left for some time attempting to connect with the old IP of the restarted Bookie (see #2482 for details). To prevent this problem from happening (in Epoll channels), we introduce the following changes:
- Epoll channels are now configured with `TCP_USER_TIMEOUT`. This parameter rules over the underlying TCP keepalive configuration (see https://datatracker.ietf.org/doc/html/rfc5482), which may be defaulted to retry for too long depending on the environment (e.g., 10-15 minutes in our experience).
- To prevent adding more configuration parameters, the existing `clientConnectTimeoutMillis` value in `ClientConfiguration` is the one used to set `TCP_USER_TIMEOUT` due to its similarity.

### Validation

We have reproduced the original testing environment in which this problem appears consistently:
- Cluster with 4 Bookies and 3 Kubernetes nodes, in addition to https://pravega.io which uses the Bookkeeper client.
- Deployed an application to do IO to Pravega (and therefore, to Bookkeeper).
- Periodically shut down a Kubernetes node, so Bookkeeper pods on it are restarted as well.

Considering this test procedure, without the proposed PR we consistently observe Bookkeeper clients getting stuck trying to contact with old IPs from Bookies. With this change, we confirmed via logs that the configuration change takes place and we have not been able to reproduce the original problem so far after performing multiple node reboots.

Master Issue: #2482
