### PR TITLE
skip replicating ledger when bookkeeper server is online

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -39,6 +39,7 @@ import com.google.common.util.concurrent.RateLimiter;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,7 +57,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.netty.util.concurrent.DefaultThreadFactory;
 import lombok.Cleanup;
 import lombok.Getter;
 
@@ -295,7 +295,8 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     }
 
     public void markLedgerReplicatedOnStart() {
-        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("MarkLedgerReplicatedOnStartup"));
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(
+                new DefaultThreadFactory("MarkLedgerReplicatedOnStartup"));
         try {
             LedgerManagerFactory mFactory = AbstractZkLedgerManagerFactory
                     .newLedgerManagerFactory(
@@ -317,7 +318,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
             LOG.error("Failed to mark ledger replicated while ledgerStorage startup", e);
 
         } finally {
-            if(!executorService.isShutdown()) {
+            if (!executorService.isShutdown()) {
                 executorService.shutdown();
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -291,7 +291,9 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     @Override
     public void start() {
         gcThread.start();
-        markLedgerReplicatedOnStart();
+        if (conf.getSkipReplicateLedgersOnStartup()) {
+            markLedgerReplicatedOnStart();
+        }
     }
 
     public void markLedgerReplicatedOnStart() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -167,7 +167,9 @@ public class DbLedgerStorage implements LedgerStorage {
     @Override
     public void start() {
         ledgerStorageList.forEach(LedgerStorage::start);
-        markLedgerReplicatedOnStart();
+        if (conf.getSkipReplicateLedgersOnStartup()) {
+            markLedgerReplicatedOnStart();
+        }
     }
 
     public void markLedgerReplicatedOnStart() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -171,7 +171,8 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     public void markLedgerReplicatedOnStart() {
-        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("MarkLedgerReplicatedOnStartup"));
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(
+                new DefaultThreadFactory("MarkLedgerReplicatedOnStartup"));
         try {
             LedgerManagerFactory mFactory = AbstractZkLedgerManagerFactory
                     .newLedgerManagerFactory(
@@ -193,7 +194,7 @@ public class DbLedgerStorage implements LedgerStorage {
             log.error("Failed to mark ledger replicated while ledgerStorage startup", e);
 
         } finally {
-            if(!executorService.isShutdown()) {
+            if (!executorService.isShutdown()) {
                 executorService.shutdown();
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -202,6 +202,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String UNDERREPLICATED_LEDGER_RECOVERY_GRACE_PERIOD =
             "underreplicatedLedgerRecoveryGracePeriod";
     protected static final String AUDITOR_REPLICAS_CHECK_INTERVAL = "auditorReplicasCheckInterval";
+    protected static final String SKIP_REPLICATE_LEDGERS_ON_STARTUP = "skipReplcateLedgersOnStartup";
 
     // Worker Thread parameters.
     protected static final String NUM_ADD_WORKER_THREADS = "numAddWorkerThreads";
@@ -3555,6 +3556,25 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setAuthorizedRoles(String roles) {
         this.setProperty(AUTHORIZED_ROLES, roles);
+        return this;
+    }
+
+    /**
+     * Get whether to skip replicate ledgers when bookie start up.
+     *
+     * @return skip replicate ledgers on startup
+     */
+    public boolean getSkipReplicateLedgersOnStartup() {
+        return this.getBoolean(SKIP_REPLICATE_LEDGERS_ON_STARTUP, false);
+    }
+
+    /**
+     * Set whether to skip replicate ledgers when bookie start up.
+     * @param skipReplicateLedgersOnStartup
+     * @return server configuration
+     */
+    public ServerConfiguration setSkipReplicateLedgersOnStartup(boolean skipReplicateLedgersOnStartup) {
+        this.setProperty(SKIP_REPLICATE_LEDGERS_ON_STARTUP, skipReplicateLedgersOnStartup);
         return this;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -375,6 +375,13 @@ public class ReplicationWorker implements Runnable {
                     foundOpenFragments = true;
                     continue;
                 }
+                List<BookieId> currentEnsemble = ledgerFragment.getEnsemble();
+                Collection<BookieId> available = admin.getAvailableBookies();
+                if (available.containsAll(currentEnsemble)) {
+                    LOG.info("Ignore replicating ledger, cause bookie is online now");
+                    continue;
+                }
+
                 if (!tryReadingFaultyEntries(lh, ledgerFragment)) {
                     LOG.error("Failed to read faulty entries, so giving up replicating ledgerFragment {}",
                             ledgerFragment);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -375,13 +375,6 @@ public class ReplicationWorker implements Runnable {
                     foundOpenFragments = true;
                     continue;
                 }
-                List<BookieId> currentEnsemble = ledgerFragment.getEnsemble();
-                Collection<BookieId> available = admin.getAvailableBookies();
-                if (available.containsAll(currentEnsemble)) {
-                    LOG.info("Ignore replicating ledger, cause bookie is online now");
-                    continue;
-                }
-
                 if (!tryReadingFaultyEntries(lh, ledgerFragment)) {
                     LOG.error("Failed to read faulty entries, so giving up replicating ledgerFragment {}",
                             ledgerFragment);


### PR DESCRIPTION
Fixes #2766 

### Motivation

When 2 or more bookies in the cluster are down, the auto-recovery gets triggered, but as these come back online, the rereplication worker should Ideally skip the rereplication of the ledgers that are marked as underreplicated. But the ledgers are rereplicated instead
### Changes
Add `skipReplcateLedgersOnStartup` config to control whether to skip replicate ledger on startup.
skip replicated ledger when bookkeeper server is online.