### PR TITLE
Support specifying bookie http port as a command argument

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -76,7 +76,7 @@ public class Main {
         BK_OPTS.addOption("z", "zkserver", true, "Zookeeper Server");
         BK_OPTS.addOption("m", "zkledgerpath", true, "Zookeeper ledgers root path");
         BK_OPTS.addOption("p", "bookieport", true, "bookie port exported");
-        BK_OPTS.addOption("httpport", true, "bookie http port exported");
+        BK_OPTS.addOption("hp", "httpport", true, "bookie http port exported");
         BK_OPTS.addOption("j", "journal", true, "bookie journal directory");
         Option indexDirs = new Option ("i", "indexdirs", true, "bookie index directories");
         indexDirs.setArgs(10);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -76,6 +76,7 @@ public class Main {
         BK_OPTS.addOption("z", "zkserver", true, "Zookeeper Server");
         BK_OPTS.addOption("m", "zkledgerpath", true, "Zookeeper ledgers root path");
         BK_OPTS.addOption("p", "bookieport", true, "bookie port exported");
+        BK_OPTS.addOption("httpport", true, "bookie http port exported");
         BK_OPTS.addOption("j", "journal", true, "bookie journal directory");
         Option indexDirs = new Option ("i", "indexdirs", true, "bookie index directories");
         indexDirs.setArgs(10);
@@ -171,6 +172,13 @@ public class Main {
                 log.info("Get cmdline bookie port: {}", sPort);
                 Integer iPort = Integer.parseInt(sPort);
                 conf.setBookiePort(iPort.intValue());
+            }
+
+            if (cmdLine.hasOption("httpport")) {
+                String sPort = cmdLine.getOptionValue("httpport");
+                log.info("Get cmdline http port: {}", sPort);
+                Integer iPort = Integer.parseInt(sPort);
+                conf.setHttpServerPort(iPort.intValue());
             }
 
             if (cmdLine.hasOption('j')) {


### PR DESCRIPTION
### Motivation

I was trying to start multiple bookies locally and found it's a bit inconvenient to specify different http ports for different bookies.

### Changes

Add a command-line argument `httpport` to the bookie command to support specifying bookie http port from the command line.
