### PR TITLE
Unit test run with gradle failing

### DIFF
--- a/bookkeeper-benchmark/build.gradle
+++ b/bookkeeper-benchmark/build.gradle
@@ -51,10 +51,18 @@ dependencies {
     testImplementation depLibs.hamcrest
     testImplementation depLibs.snappy
     testImplementation depLibs.zookeeperTest
-
-
+    testImplementation depLibs. metricsCore
     annotationProcessor depLibs.lombok
     testAnnotationProcessor depLibs.lombok
+}
+
+test {
+    maxHeapSize = '4G'
+    forkEvery = 1
+    jvmArgs("-Djunit.timeout.test=600000",
+            "-Djunit.max.retry=3",
+            "-Djava.net.preferIPv4Stack=true",
+            "-Dio.netty.leakDetection.level=paranoid")
 }
 
 jar {


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation
Benchmark tests were failing due to 

- Missing runtime test dependency of MetricsCore
- Lack of enough JVM memory.

### Changes

- Include metricsCore as testDependency
- Increase heap size of 4 GB.


Master Issue: #2640

