### PR TITLE
Issue 2770 Avoid to call ledgerExists two times

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -144,9 +144,7 @@ public class SortedLedgerStorage
         // the O(1) for the ledgerCache.
         if (!interleavedLedgerStorage.ledgerExists(ledgerId)) {
             EntryKeyValue kv = memTable.getLastEntry(ledgerId);
-            if (null == kv) {
-                return interleavedLedgerStorage.ledgerExists(ledgerId);
-            }
+            return kv != null;
         }
         return true;
     }


### PR DESCRIPTION
The `interleavedLedgerStorage.ledgerExists` can be only call once instead of twice.