### PR TITLE
only update topology when bookie rack changed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -749,10 +749,12 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements
                     if (node != null) {
                         // refresh the rack info if its a known bookie
                         BookieNode newNode = createBookieNode(bookieAddress);
-                        topology.remove(node);
-                        topology.add(newNode);
-                        knownBookies.put(bookieAddress, newNode);
-                        historyBookies.put(bookieAddress, newNode);
+                        if (!newNode.getNetworkLocation().equals(node.getNetworkLocation())) {
+                            topology.remove(node);
+                            topology.add(newNode);
+                            knownBookies.put(bookieAddress, newNode);
+                            historyBookies.put(bookieAddress, newNode);
+                        }
                     }
                 } catch (IllegalArgumentException | NetworkTopologyImpl.InvalidTopologyException e) {
                     LOG.error("Failed to update bookie rack info: {} ", bookieAddress, e);


### PR DESCRIPTION
It is unnecessary to update  topology, removing and adding the same bookieNode, if the rack of bookie stay unchanged.