### PR TITLE
Memory leak problem when ledger replication

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -196,8 +196,28 @@ class LedgerOpenOp {
                     if (rc == BKException.Code.OK) {
                         openComplete(BKException.Code.OK, lh);
                     } else if (rc == BKException.Code.UnauthorizedAccessException) {
+                        try {
+                            if (lh != null) {
+                                lh.close();
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            LOG.info("InterruptedException while closing ledger {}", ledgerId, e);
+                        } catch (BKException e) {
+                            LOG.warn("BKException while closing ledger {} ", ledgerId, e);
+                        }
                         openComplete(BKException.Code.UnauthorizedAccessException, null);
                     } else {
+                        try {
+                            if (lh != null) {
+                                lh.close();
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            LOG.info("InterruptedException while closing ledger {}", ledgerId, e);
+                        } catch (BKException e) {
+                            LOG.warn("BKException while closing ledger {} ", ledgerId, e);
+                        }
                         openComplete(bk.getReturnRc(BKException.Code.LedgerRecoveryException), null);
                     }
                 }
@@ -212,6 +232,16 @@ class LedgerOpenOp {
                 public void readLastConfirmedComplete(int rc,
                         long lastConfirmed, Object ctx) {
                     if (rc != BKException.Code.OK) {
+                        try {
+                            if (lh != null) {
+                                lh.close();
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            LOG.info("InterruptedException while closing ledger {}", ledgerId, e);
+                        } catch (BKException e) {
+                            LOG.warn("BKException while closing ledger {} ", ledgerId, e);
+                        }
                         openComplete(bk.getReturnRc(BKException.Code.ReadException), null);
                     } else {
                         lh.lastAddConfirmed = lh.lastAddPushed = lastConfirmed;


### PR DESCRIPTION
### Motivation

production environment, memory leak always happened, and there were ledger cannot be replicated successfully.

![image](https://user-images.githubusercontent.com/9278488/133393193-b88f509a-bd9c-49b4-9655-e259fce6d854.png)


This cause by when `openLedgerNoRecovery` with `BKNotEnoughBookiesException`,  the LedgerHandler won't  closed properly, caused memory leak

https://github.com/apache/bookkeeper/blob/c7236adc3cb659e65ae5ce53b7156569d7f50ebd/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java#L364-L424

### Changes

close LedgerHandler when openComplete with exception
