### PR TITLE
Issue 2795: Bookkeeper upgrade using Bookie ID may fail due to cookie mismatch

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -286,26 +286,27 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
         // we are checking all possibilities here, so we don't need to fail if we can only get
         // loopback address. it will fail anyway when the bookie attempts to listen on loopback address.
         try {
-            // ip address
-            addresses.add(getBookieAddress(
-                new ServerConfiguration(conf)
-                    .setUseHostNameAsBookieID(false)
-                    .setAdvertisedAddress(null)
-                    .setAllowLoopback(true)
-            ).toBookieId());
-            // host name
-            addresses.add(getBookieAddress(
-                new ServerConfiguration(conf)
-                    .setUseHostNameAsBookieID(true)
-                    .setAdvertisedAddress(null)
-                    .setAllowLoopback(true)
-            ).toBookieId());
-            // advertised address
-            if (null != conf.getAdvertisedAddress()) {
-                addresses.add(getBookieAddress(conf).toBookieId());
-            }
-            if (null != conf.getBookieId()) {
+	     if (null != conf.getBookieId()) {
                 addresses.add(BookieId.parse(conf.getBookieId()));
+            } else {
+                // ip address
+                addresses.add(getBookieAddress(
+                    new ServerConfiguration(conf)
+                        .setUseHostNameAsBookieID(false)
+                        .setAdvertisedAddress(null)
+                        .setAllowLoopback(true)
+                ).toBookieId());
+                // host name
+                addresses.add(getBookieAddress(
+                    new ServerConfiguration(conf)
+                        .setUseHostNameAsBookieID(true)
+                        .setAdvertisedAddress(null)
+                        .setAllowLoopback(true)
+                ).toBookieId());
+                // advertised address
+                if (null != conf.getAdvertisedAddress()) {
+                    addresses.add(getBookieAddress(conf).toBookieId());
+                }
             }
         } catch (UnknownHostException e) {
             throw new UnknownBookieIdException(e);


### PR DESCRIPTION
### Motivation

If a Bookie uses the new Bookie ID scheme explicitly (set via configuration), it should prevail over default network information to identify the Bookie and lookup for cookies in Zookeeper. Otherwise, the Bookie may fetch legacy cookies related to the same hostname but are invalid because the id differs. Essentially, this PR tries to choose between a configuration-based Bookie ID or a default network info ID when looking for cookies in Zookeeper (considering both is problematic in some cases).

### Changes

The change is simple: when collecting the Bookie IDs that will be used to fetch cookies from Zookeeper (`BookieImpl.possibleBookieIds()`), the code now checks if there is a Bookie ID passed by configuration. If so, we just used that one for lookup cookies in Zookeeper. Otherwise, we keep the existing behavior of using network information to fetch cookies from Zookeeper.

Master Issue: #2795 
