### PR TITLE
Make maxConcurrentZkRequests for gc configurable

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -100,13 +100,12 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             this.enableGcOverReplicatedLedger = true;
         }
         this.maxConcurrentRequests = conf.getGcOverreplicatedLedgerMaxConcurrentRequests();
-        LOG.info("Over Replicated Ledger Deletion : enabled={}, interval={}, maxConcurrentRequest={}",
+        LOG.info("Over Replicated Ledger Deletion : enabled={}, interval={}, maxConcurrentRequests={}",
                 enableGcOverReplicatedLedger, gcOverReplicatedLedgerIntervalMillis, maxConcurrentRequests);
 
         verifyMetadataOnGc = conf.getVerifyMetadataOnGC();
 
         this.activeLedgerCounter = 0;
-
     }
 
     public int getNumActiveLedgers() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -84,7 +84,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
     private final boolean verifyMetadataOnGc;
     private int activeLedgerCounter;
     private StatsLogger statsLogger;
-    private final int maxConcurrentZkRequests;
+    private final int maxConcurrentRequests;
 
     public ScanAndCompareGarbageCollector(LedgerManager ledgerManager, CompactableLedgerStorage ledgerStorage,
             ServerConfiguration conf, StatsLogger statsLogger) throws IOException {
@@ -99,9 +99,9 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
         if (gcOverReplicatedLedgerIntervalMillis > 0) {
             this.enableGcOverReplicatedLedger = true;
         }
-        this.maxConcurrentZkRequests = conf.getGcOverreplicatedLedgerMaxConcurrentZkRequests();
-        LOG.info("Over Replicated Ledger Deletion : enabled={}, interval={}, maxConcurrentZkRequest={}",
-                enableGcOverReplicatedLedger, gcOverReplicatedLedgerIntervalMillis, maxConcurrentZkRequests);
+        this.maxConcurrentRequests = conf.getGcOverreplicatedLedgerMaxConcurrentRequests();
+        LOG.info("Over Replicated Ledger Deletion : enabled={}, interval={}, maxConcurrentRequest={}",
+                enableGcOverReplicatedLedger, gcOverReplicatedLedgerIntervalMillis, maxConcurrentRequests);
 
         verifyMetadataOnGc = conf.getVerifyMetadataOnGC();
 
@@ -220,7 +220,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
     private Set<Long> removeOverReplicatedledgers(Set<Long> bkActiveledgers, final GarbageCleaner garbageCleaner)
             throws Exception {
         final Set<Long> overReplicatedLedgers = Sets.newHashSet();
-        final Semaphore semaphore = new Semaphore(this.maxConcurrentZkRequests);
+        final Semaphore semaphore = new Semaphore(this.maxConcurrentRequests);
         final CountDownLatch latch = new CountDownLatch(bkActiveledgers.size());
         // instantiate zookeeper client to initialize ledger manager
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -73,7 +73,6 @@ import org.slf4j.LoggerFactory;
 public class ScanAndCompareGarbageCollector implements GarbageCollector {
 
     static final Logger LOG = LoggerFactory.getLogger(ScanAndCompareGarbageCollector.class);
-    static final int MAX_CONCURRENT_METADATA_REQUESTS = 1000;
 
     private final LedgerManager ledgerManager;
     private final CompactableLedgerStorage ledgerStorage;
@@ -85,6 +84,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
     private final boolean verifyMetadataOnGc;
     private int activeLedgerCounter;
     private StatsLogger statsLogger;
+    private final int maxConcurrentZkRequests;
 
     public ScanAndCompareGarbageCollector(LedgerManager ledgerManager, CompactableLedgerStorage ledgerStorage,
             ServerConfiguration conf, StatsLogger statsLogger) throws IOException {
@@ -99,12 +99,14 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
         if (gcOverReplicatedLedgerIntervalMillis > 0) {
             this.enableGcOverReplicatedLedger = true;
         }
-        LOG.info("Over Replicated Ledger Deletion : enabled=" + enableGcOverReplicatedLedger + ", interval="
-                + gcOverReplicatedLedgerIntervalMillis);
+        this.maxConcurrentZkRequests = conf.getGcOverreplicatedLedgerMaxConcurrentZkRequests();
+        LOG.info("Over Replicated Ledger Deletion : enabled={}, interval={}, maxConcurrentZkRequest={}",
+                enableGcOverReplicatedLedger, gcOverReplicatedLedgerIntervalMillis, maxConcurrentZkRequests);
 
         verifyMetadataOnGc = conf.getVerifyMetadataOnGC();
 
         this.activeLedgerCounter = 0;
+
     }
 
     public int getNumActiveLedgers() {
@@ -129,6 +131,8 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             boolean checkOverreplicatedLedgers = (enableGcOverReplicatedLedger && curTime
                     - lastOverReplicatedLedgerGcTimeMillis > gcOverReplicatedLedgerIntervalMillis);
             if (checkOverreplicatedLedgers) {
+                LOG.info("Start removing over-replicated ledgers. activeLedgerCounter={}", activeLedgerCounter);
+
                 // remove all the overreplicated ledgers from the local bookie
                 Set<Long> overReplicatedLedgers = removeOverReplicatedledgers(bkActiveLedgers, garbageCleaner);
                 if (overReplicatedLedgers.isEmpty()) {
@@ -216,7 +220,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
     private Set<Long> removeOverReplicatedledgers(Set<Long> bkActiveledgers, final GarbageCleaner garbageCleaner)
             throws Exception {
         final Set<Long> overReplicatedLedgers = Sets.newHashSet();
-        final Semaphore semaphore = new Semaphore(MAX_CONCURRENT_METADATA_REQUESTS);
+        final Semaphore semaphore = new Semaphore(this.maxConcurrentZkRequests);
         final CountDownLatch latch = new CountDownLatch(bkActiveledgers.size());
         // instantiate zookeeper client to initialize ledger manager
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -111,7 +111,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String GC_WAIT_TIME = "gcWaitTime";
     protected static final String IS_FORCE_GC_ALLOW_WHEN_NO_SPACE = "isForceGCAllowWhenNoSpace";
     protected static final String GC_OVERREPLICATED_LEDGER_WAIT_TIME = "gcOverreplicatedLedgerWaitTime";
-    protected static final String GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS = "gcOverreplicatedLedgerMaxConcurrentZkRequests";
+    protected static final String GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS =
+            "gcOverreplicatedLedgerMaxConcurrentZkRequests";
     protected static final String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
     protected static final String VERIFY_METADATA_ON_GC = "verifyMetadataOnGC";
     // Scrub Parameters
@@ -434,8 +435,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @param gcOverreplicatedLedgerMaxConcurrentZkRequests
      * @return server configuration
      */
-    public ServerConfiguration setGcOverreplicatedLedgerMaxConcurrentZkRequests(int gcOverreplicatedLedgerMaxConcurrentZkRequests) {
-        this.setProperty(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS, Integer.toString(gcOverreplicatedLedgerMaxConcurrentZkRequests));
+    public ServerConfiguration setGcOverreplicatedLedgerMaxConcurrentZkRequests(
+            int gcOverreplicatedLedgerMaxConcurrentZkRequests) {
+        this.setProperty(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS,
+                Integer.toString(gcOverreplicatedLedgerMaxConcurrentZkRequests));
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -111,8 +111,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String GC_WAIT_TIME = "gcWaitTime";
     protected static final String IS_FORCE_GC_ALLOW_WHEN_NO_SPACE = "isForceGCAllowWhenNoSpace";
     protected static final String GC_OVERREPLICATED_LEDGER_WAIT_TIME = "gcOverreplicatedLedgerWaitTime";
-    protected static final String GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS =
-            "gcOverreplicatedLedgerMaxConcurrentZkRequests";
+    protected static final String GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_REQUESTS =
+            "gcOverreplicatedLedgerMaxConcurrentRequests";
     protected static final String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
     protected static final String VERIFY_METADATA_ON_GC = "verifyMetadataOnGC";
     // Scrub Parameters
@@ -421,24 +421,24 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Max number of concurrent requests to zk in garbage collection of overreplicated ledgers.
+     * Max number of concurrent requests in garbage collection of overreplicated ledgers.
      *
-     * @return max number of concurrent requests to zk
+     * @return max number of concurrent requests
      */
-    public int getGcOverreplicatedLedgerMaxConcurrentZkRequests() {
-        return this.getInt(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS, 1000);
+    public int getGcOverreplicatedLedgerMaxConcurrentRequests() {
+        return this.getInt(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_REQUESTS, 1000);
     }
 
     /**
-     * Max number of concurrent requests to zk in garbage collection of overreplicated ledgers. Default: 1000
+     * Max number of concurrent requests in garbage collection of overreplicated ledgers. Default: 1000
      *
-     * @param gcOverreplicatedLedgerMaxConcurrentZkRequests
+     * @param gcOverreplicatedLedgerMaxConcurrentRequests
      * @return server configuration
      */
-    public ServerConfiguration setGcOverreplicatedLedgerMaxConcurrentZkRequests(
-            int gcOverreplicatedLedgerMaxConcurrentZkRequests) {
-        this.setProperty(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS,
-                Integer.toString(gcOverreplicatedLedgerMaxConcurrentZkRequests));
+    public ServerConfiguration setGcOverreplicatedLedgerMaxConcurrentRequests(
+            int gcOverreplicatedLedgerMaxConcurrentRequests) {
+        this.setProperty(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_REQUESTS,
+                Integer.toString(gcOverreplicatedLedgerMaxConcurrentRequests));
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -111,6 +111,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String GC_WAIT_TIME = "gcWaitTime";
     protected static final String IS_FORCE_GC_ALLOW_WHEN_NO_SPACE = "isForceGCAllowWhenNoSpace";
     protected static final String GC_OVERREPLICATED_LEDGER_WAIT_TIME = "gcOverreplicatedLedgerWaitTime";
+    protected static final String GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS = "gcOverreplicatedLedgerMaxConcurrentZkRequests";
     protected static final String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
     protected static final String VERIFY_METADATA_ON_GC = "verifyMetadataOnGC";
     // Scrub Parameters
@@ -415,6 +416,26 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setGcOverreplicatedLedgerWaitTime(long gcWaitTime, TimeUnit unit) {
         this.setProperty(GC_OVERREPLICATED_LEDGER_WAIT_TIME, Long.toString(unit.toMillis(gcWaitTime)));
+        return this;
+    }
+
+    /**
+     * Max number of concurrent requests to zk in garbage collection of overreplicated ledgers.
+     *
+     * @return max number of concurrent requests to zk
+     */
+    public int getGcOverreplicatedLedgerMaxConcurrentZkRequests() {
+        return this.getInt(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS, 1000);
+    }
+
+    /**
+     * Max number of concurrent requests to zk in garbage collection of overreplicated ledgers. Default: 1000
+     *
+     * @param gcOverreplicatedLedgerMaxConcurrentZkRequests
+     * @return server configuration
+     */
+    public ServerConfiguration setGcOverreplicatedLedgerMaxConcurrentZkRequests(int gcOverreplicatedLedgerMaxConcurrentZkRequests) {
+        this.setProperty(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_ZK_REQUESTS, Integer.toString(gcOverreplicatedLedgerMaxConcurrentZkRequests));
         return this;
     }
 

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -576,8 +576,8 @@ ledgerDirectories=/tmp/bk-data
 # since we read the metadata for all the ledgers on the bookie from zk
 # gcOverreplicatedLedgerWaitTime=86400000
 
-# Max number of concurrent requests to zk in garbage collection of overreplicated ledgers.
-# gcOverreplicatedLedgerMaxConcurrentZkRequests=1000
+# Max number of concurrent requests in garbage collection of overreplicated ledgers.
+# gcOverreplicatedLedgerMaxConcurrentRequests=1000
 
 # Whether force compaction is allowed when the disk is full or almost full.
 # Forcing GC may get some space back, but may also fill up disk space more quickly.

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -576,6 +576,9 @@ ledgerDirectories=/tmp/bk-data
 # since we read the metadata for all the ledgers on the bookie from zk
 # gcOverreplicatedLedgerWaitTime=86400000
 
+# Max number of concurrent requests to zk in garbage collection of overreplicated ledgers.
+# gcOverreplicatedLedgerMaxConcurrentZkRequests=1000
+
 # Whether force compaction is allowed when the disk is full or almost full.
 # Forcing GC may get some space back, but may also fill up disk space more quickly.
 # This is because new log files are created before GC, while old garbage

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -380,6 +380,9 @@ groups:
   - param: gcOverreplicatedLedgerWaitTime
     description: How long the interval to trigger next garbage collection of overreplicated ledgers, in milliseconds. This should not be run very frequently since we read the metadata for all the ledgers on the bookie from zk.
     default: 86400000
+  - param: gcOverreplicatedLedgerMaxConcurrentZkRequests
+    description: Max number of concurrent requests to zk in garbage collection of overreplicated ledgers.
+    default: 1000
   - param: isForceGCAllowWhenNoSpace
     description: Whether force compaction is allowed when the disk is full or almost full. Forcing GC may get some space back, but may also fill up disk space more quickly. This is because new log files are created before GC, while old garbage log files are deleted after GC.
     default: 'false'

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -380,8 +380,8 @@ groups:
   - param: gcOverreplicatedLedgerWaitTime
     description: How long the interval to trigger next garbage collection of overreplicated ledgers, in milliseconds. This should not be run very frequently since we read the metadata for all the ledgers on the bookie from zk.
     default: 86400000
-  - param: gcOverreplicatedLedgerMaxConcurrentZkRequests
-    description: Max number of concurrent requests to zk in garbage collection of overreplicated ledgers.
+  - param: gcOverreplicatedLedgerMaxConcurrentRequests
+    description: Max number of concurrent requests in garbage collection of overreplicated ledgers.
     default: 1000
   - param: isForceGCAllowWhenNoSpace
     description: Whether force compaction is allowed when the disk is full or almost full. Forcing GC may get some space back, but may also fill up disk space more quickly. This is because new log files are created before GC, while old garbage log files are deleted after GC.


### PR DESCRIPTION

### Motivation
In one day, zookeepers became high cpu usage and disk full.
The cause of this is bookie's gc of overreplicated ledgers.
Gc created/deleted zk nodes under `/ledgers/underreplication/locks` very frequently and some bookies ran gc at same time.
As a result, zookeepers created a lot of snapshots and became disk full.

I want to configure max zk concurrent requests lower than 1000(default) to avoid heavy traffic at a specific time.

### Changes

* Make max zk concurrent requests for garbage collection of overreplicated ledgers configurable.
