### PR TITLE
Issue 2787: TestPerChannelBookieClient.testEpollChannelTcpUserTimeout fails

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -314,7 +314,7 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
         EventLoopGroup eventLoopGroup = new EpollEventLoopGroup();
         OrderedExecutor executor = getOrderedSafeExecutor();
         ClientConfiguration conf = new ClientConfiguration();
-        int tcpUserTimeout = 1234;
+        int tcpUserTimeout = 1236; // this value may be rounded on some Linux implementations
         BookieId addr = getBookie(0);
 
         // Pass to the PerChannelBookieClient object the client configuration with TCP user timeout.


### PR DESCRIPTION
- Fixes #2787
- On some Linux systems the value 1234 is rounded to 1236, this patch simply uses 1236 as value in order to prevent failures