### PR TITLE
Add auditor get ledger throttle to avoid auto recovery zk session expire

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -204,7 +204,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String UNDERREPLICATED_LEDGER_RECOVERY_GRACE_PERIOD =
             "underreplicatedLedgerRecoveryGracePeriod";
     protected static final String AUDITOR_REPLICAS_CHECK_INTERVAL = "auditorReplicasCheckInterval";
-    protected static final String AUDITOR_GET_LEDGER_SEMAPHORE = "auditorGetLedgerSemaphore";
+    protected static final String AUDITOR_MAX_NUMBER_OF_CONCURRENT_OPEN_LEDGER_OPERATIONS =
+        "auditorMaxNumberOfConcurrentOpenLedgerOperations";
+    protected static final String AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_SEC =
+        "auditorAcquireConcurrentOpenLedgerOperationsTimeOutSec";
 
     // Worker Thread parameters.
     protected static final String NUM_ADD_WORKER_THREADS = "numAddWorkerThreads";
@@ -2530,16 +2533,33 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      *
      * @return The semaphore value. By default it is 500.
      */
-    public int getAuditorGetLedgerSemaphore() {
-        return getInt(AUDITOR_GET_LEDGER_SEMAPHORE, 500);
+    public int getAuditorMaxNumberOfConcurrentOpenLedgerOperations() {
+        return getInt(AUDITOR_MAX_NUMBER_OF_CONCURRENT_OPEN_LEDGER_OPERATIONS, 500);
     }
 
     /**
      * Set the semaphore limit value for getting ledger from zookeeper in auto recovery.
      * @param semaphore
      */
-    public void setAuditorGetLedgerSemaphore(int semaphore) {
-        setProperty(AUDITOR_GET_LEDGER_SEMAPHORE, semaphore);
+    public void setAuditorMaxNumberOfConcurrentOpenLedgerOperations(int semaphore) {
+        setProperty(AUDITOR_MAX_NUMBER_OF_CONCURRENT_OPEN_LEDGER_OPERATIONS, semaphore);
+    }
+
+    /**
+     * Get the acquire concurrent open ledger operations timeout.
+     *
+     * @return The timeout values. By default it is 30s
+     */
+    public int getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutSec() {
+        return getInt(AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_SEC, 120);
+    }
+
+    /**
+     * Set the acquire concurrent open ledger operations timeout.
+     * @param timeoutMs
+     */
+    public void setAuditorAcquireConcurrentOpenLedgerOperationsTimeoutSec(int timeoutMs) {
+        setProperty(AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_SEC, timeoutMs);
     }
 
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -206,8 +206,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String AUDITOR_REPLICAS_CHECK_INTERVAL = "auditorReplicasCheckInterval";
     protected static final String AUDITOR_MAX_NUMBER_OF_CONCURRENT_OPEN_LEDGER_OPERATIONS =
         "auditorMaxNumberOfConcurrentOpenLedgerOperations";
-    protected static final String AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_SEC =
-        "auditorAcquireConcurrentOpenLedgerOperationsTimeOutSec";
+    protected static final String AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_MSEC =
+        "auditorAcquireConcurrentOpenLedgerOperationsTimeOutMSec";
 
     // Worker Thread parameters.
     protected static final String NUM_ADD_WORKER_THREADS = "numAddWorkerThreads";
@@ -2548,18 +2548,18 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     /**
      * Get the acquire concurrent open ledger operations timeout.
      *
-     * @return The timeout values. By default it is 30s
+     * @return The timeout values. By default it is 120000ms
      */
-    public int getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutSec() {
-        return getInt(AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_SEC, 120);
+    public int getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec() {
+        return getInt(AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_MSEC, 120000);
     }
 
     /**
      * Set the acquire concurrent open ledger operations timeout.
      * @param timeoutMs
      */
-    public void setAuditorAcquireConcurrentOpenLedgerOperationsTimeoutSec(int timeoutMs) {
-        setProperty(AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_SEC, timeoutMs);
+    public void setAuditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec(int timeoutMs) {
+        setProperty(AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_MSEC, timeoutMs);
     }
 
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -204,6 +204,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String UNDERREPLICATED_LEDGER_RECOVERY_GRACE_PERIOD =
             "underreplicatedLedgerRecoveryGracePeriod";
     protected static final String AUDITOR_REPLICAS_CHECK_INTERVAL = "auditorReplicasCheckInterval";
+    protected static final String AUDITOR_GET_LEDGER_SEMAPHORE = "auditorGetLedgerSemaphore";
 
     // Worker Thread parameters.
     protected static final String NUM_ADD_WORKER_THREADS = "numAddWorkerThreads";
@@ -2523,6 +2524,24 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     public long getAuditorPeriodicReplicasCheckInterval() {
         return getLong(AUDITOR_REPLICAS_CHECK_INTERVAL, 0);
     }
+
+    /**
+     * Get the semaphore limit value of getting ledger from zookeeper in auto recovery.
+     *
+     * @return The semaphore value. By default it is 500.
+     */
+    public int getAuditorGetLedgerSemaphore() {
+        return getInt(AUDITOR_GET_LEDGER_SEMAPHORE, 500);
+    }
+
+    /**
+     * Set the semaphore limit value for getting ledger from zookeeper in auto recovery.
+     * @param semaphore
+     */
+    public void setAuditorGetLedgerSemaphore(int semaphore) {
+        setProperty(AUDITOR_GET_LEDGER_SEMAPHORE, semaphore);
+    }
+
 
     /**
      * Set what percentage of a ledger (fragment)'s entries will be verified.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -568,9 +568,11 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
                 MultiCallback mcb = new MultiCallback(zkActiveLedgers.size(), finalCb, ctx,
                                                       successRc, failureRc);
                 // start loop over all ledgers
-                for (Long ledger : zkActiveLedgers) {
-                    processor.process(ledger, mcb);
-                }
+                scheduler.submit(() -> {
+                    for (Long ledger : zkActiveLedgers) {
+                        processor.process(ledger, mcb);
+                    }
+                });
             }
         });
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -166,7 +166,7 @@ public class Auditor implements AutoCloseable {
     private final long underreplicatedLedgerRecoveryGracePeriod;
     private final int zkOpTimeoutMs;
     private final Semaphore openLedgerNoRecoverySemaphore;
-    private final int openLedgerNoRecoverySemaphoreWaitTimeoutSec;
+    private final int openLedgerNoRecoverySemaphoreWaitTimeoutMSec;
 
     private final StatsLogger statsLogger;
     @StatsDoc(
@@ -356,13 +356,13 @@ public class Auditor implements AutoCloseable {
         }
         this.openLedgerNoRecoverySemaphore = new Semaphore(conf.getAuditorMaxNumberOfConcurrentOpenLedgerOperations());
 
-        if (conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutSec() < 0) {
-            LOG.error("auditorAcquireConcurrentOpenLedgerOperationsTimeoutSec should be greater than or equal to 0");
-            throw new UnavailableException("auditorAcquireConcurrentOpenLedgerOperationsTimeoutSec "
+        if (conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec() < 0) {
+            LOG.error("auditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec should be greater than or equal to 0");
+            throw new UnavailableException("auditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec "
                 + "should be greater than or equal to 0");
         }
-        this.openLedgerNoRecoverySemaphoreWaitTimeoutSec =
-            conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutSec();
+        this.openLedgerNoRecoverySemaphoreWaitTimeoutMSec =
+            conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec();
 
         numUnderReplicatedLedger = this.statsLogger.getOpStatsLogger(ReplicationStats.NUM_UNDER_REPLICATED_LEDGERS);
         underReplicatedLedgerTotalSize = this.statsLogger.getOpStatsLogger(UNDER_REPLICATED_LEDGERS_TOTAL_SIZE);
@@ -1267,10 +1267,10 @@ public class Auditor implements AutoCloseable {
                 }
 
                 try {
-                    if (!openLedgerNoRecoverySemaphore.tryAcquire(openLedgerNoRecoverySemaphoreWaitTimeoutSec,
-                        TimeUnit.SECONDS)) {
-                        LOG.warn("Failed to acquire semaphore for {} s, ledgerId: {}",
-                            openLedgerNoRecoverySemaphoreWaitTimeoutSec, ledgerId);
+                    if (!openLedgerNoRecoverySemaphore.tryAcquire(openLedgerNoRecoverySemaphoreWaitTimeoutMSec,
+                        TimeUnit.MILLISECONDS)) {
+                        LOG.warn("Failed to acquire semaphore for {} ms, ledgerId: {}",
+                            openLedgerNoRecoverySemaphoreWaitTimeoutMSec, ledgerId);
                         throw new BKAuditException("Timeout while waiting for acquiring semaphore");
                     }
                 } catch (InterruptedException | BKAuditException e) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -358,8 +358,8 @@ public class Auditor implements AutoCloseable {
 
         if (conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutSec() < 0) {
             LOG.error("auditorAcquireConcurrentOpenLedgerOperationsTimeoutSec should be greater than or equal to 0");
-            throw new UnavailableException("auditorAcquireConcurrentOpenLedgerOperationsTimeoutSec " +
-                "should be greater than or equal to 0");
+            throw new UnavailableException("auditorAcquireConcurrentOpenLedgerOperationsTimeoutSec "
+                + "should be greater than or equal to 0");
         }
         this.openLedgerNoRecoverySemaphoreWaitTimeoutSec =
             conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutSec();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -1271,9 +1271,10 @@ public class Auditor implements AutoCloseable {
                         TimeUnit.MILLISECONDS)) {
                         LOG.warn("Failed to acquire semaphore for {} ms, ledgerId: {}",
                             openLedgerNoRecoverySemaphoreWaitTimeoutMSec, ledgerId);
-                        throw new BKAuditException("Timeout while waiting for acquiring semaphore");
+                        FutureUtils.complete(processFuture, null);
+                        return;
                     }
-                } catch (InterruptedException | BKAuditException e) {
+                } catch (InterruptedException e) {
                     LOG.error("Unable to acquire open ledger operation semaphore ", e);
                     Thread.currentThread().interrupt();
                     FutureUtils.complete(processFuture, null);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.netty.buffer.ByteBuf;
 
@@ -35,7 +36,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -75,10 +75,8 @@ import org.apache.bookkeeper.test.TestStatsProvider.TestOpStatsLogger;
 import org.apache.bookkeeper.test.TestStatsProvider.TestStatsLogger;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.internal.matchers.Null;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -393,7 +391,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
             auditor.checkAllLedgers();
         } catch (Exception e) {
             LOG.error("Caught exception while checking all ledgers ", e);
-            Assert.fail();
+            fail();
         }
 
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
@@ -29,12 +29,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import io.netty.buffer.ByteBuf;
 
@@ -68,7 +65,6 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
@@ -89,7 +85,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -877,7 +877,10 @@ zkEnableSecurity=false
 
 # Semaphore limit of getting ledger from zookeeper. Used to throttle the zookeeper client request operation
 # sending to Zookeeper server. Default value is 500
-# auditorGetLedgerSemaphore=500
+# auditorMaxNumberOfConcurrentOpenLedgerOperations=500
+
+# Wait time out of acquiring semaphore of concurrent open ledger operations. Default value is 120s.
+# auditorAcquireConcurrentOpenLedgerOperationsTimeOutSec=120
 
 #############################################################################
 ## Placement settings

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -875,6 +875,10 @@ zkEnableSecurity=false
 # the provided digest type provided at `digestType` and the provided passwd provided at `passwd`.
 # enableDigestTypeAutodetection=true
 
+# Semaphore limit of getting ledger from zookeeper. Used to throttle the zookeeper client request operation
+# sending to Zookeeper server. Default value is 500
+# auditorGetLedgerSemaphore=500
+
 #############################################################################
 ## Placement settings
 #############################################################################

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -879,8 +879,8 @@ zkEnableSecurity=false
 # sending to Zookeeper server. Default value is 500
 # auditorMaxNumberOfConcurrentOpenLedgerOperations=500
 
-# Wait time out of acquiring semaphore of concurrent open ledger operations. Default value is 120s.
-# auditorAcquireConcurrentOpenLedgerOperationsTimeOutSec=120
+# Wait timeout of acquiring semaphore of concurrent open ledger operations. Default value is 120000ms.
+# auditorAcquireConcurrentOpenLedgerOperationsTimeOutMSec=120000
 
 #############################################################################
 ## Placement settings


### PR DESCRIPTION
### Motivation
When we start BookKeeper auditor, it will start checking all ledgers task with given interval(default 7days) compared to last check timestamp,  and the check ledger operation will process all the activeLedgers shown in the follow code.
https://github.com/apache/bookkeeper/blob/c7236adc3cb659e65ae5ce53b7156569d7f50ebd/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java#L571-L573

 In the logic of process ledger, it will call `readLedgerMetadata` , which will call getData using zkClient and parse ZNode data in callback, which is time consuming.
https://github.com/apache/bookkeeper/blob/c7236adc3cb659e65ae5ce53b7156569d7f50ebd/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java#L433-L474

When use use NettySocketChannel for zk client, and the activeLedger number grows more than 1500+, it will send all ledgers'getData  request to zkServer at a time (before starting receive data from zookeeper server), and call `serDe.parseConfig` to parse ZNode data in callback.  However, the parse Znode is time consuming, which will block zk client send heartbeat to zk server, and will cause zk session expire.

When zk session expire, the BookKeeper auto recovery process will shutdown.

### Modification
1. Add throttle semaphore for Auditor to open ledgers, which will call getData using Zookeeper client.
2. Use  individual thread to call `processor.process(ledger, mcb);` for all ledgers instead of Zookeeper client callback thread.