### PR TITLE
replication stat num-under-replicated-ledgers changed as with the pro…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
@@ -231,6 +231,15 @@ public interface LedgerUnderreplicationManager extends AutoCloseable {
     long getReplicasCheckCTime() throws ReplicationException.UnavailableException;
 
     /**
+     * Receive notification asynchronously when the num of under-replicated ledgers  Changed.
+     *
+     * @param cb
+     * @throws ReplicationException.UnavailableException
+     */
+    void notifyUnderReplicationLedgerChanged(GenericCallback<Void> cb)
+            throws ReplicationException.UnavailableException;
+
+    /**
      * Receive notification asynchronously when the lostBookieRecoveryDelay value is Changed.
      *
      * @param cb


### PR DESCRIPTION

### Motivation

Now ReplicationStats  numUnderReplicatedLedger  registers  when `publishSuspectedLedgersAsync`, but its value doesn't decrease as with the ledger replicated successfully,  We cannot know the progress of replication from the stat.
### Changes

registers a `notifyUnderReplicationLedgerChanged` when auditor starts. numUnderReplicatedLedger value will decrease when the ledger path under replicate deleted.
