### PR TITLE
ISSUE #2640: BP-43 Migrate bookkeeper client tests to gradle

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -29,10 +29,6 @@ on:
       - 'site/**'
     workflow_dispatch:
 
-
-env:
-  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
-
 jobs:
   test:
 
@@ -50,4 +46,4 @@ jobs:
         with:
           java-version: 1.8
       - name: Run client tests
-        run: mvn -B -am -nsu -pl bookkeeper-server clean install test -Dtest="org.apache.bookkeeper.client.**" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        run: ./gradlew bookkeeper-server:test --tests="org.apache.bookkeeper.client.*" -Dtestlogger.theme=plain

--- a/bookkeeper-server/build.gradle
+++ b/bookkeeper-server/build.gradle
@@ -18,6 +18,7 @@
  */
 plugins {
     id 'java'
+    id 'com.adarshr.test-logger'
 }
 
 dependencies {

--- a/bookkeeper-server/build.gradle
+++ b/bookkeeper-server/build.gradle
@@ -19,6 +19,7 @@
 plugins {
     id 'java'
     id 'com.adarshr.test-logger'
+    id 'org.gradle.test-retry'
 }
 
 dependencies {
@@ -75,6 +76,11 @@ dependencies {
 }
 
 test {
+    retry {
+        maxFailures = 200
+        maxRetries = 5
+    }
+
     maxHeapSize = '2G'
     forkEvery = 1
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,5 @@ shadowPluginVersion=6.1.0
 licenseGradlePluginVersion=0.15.0
 checkStyleVersion=6.19
 spotbugsPlugin=4.7.0
+testLogger=2.0.0
+testRetry=1.0.0testReadLACLongPollWhenSomeBookiesDown

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ licenseGradlePluginVersion=0.15.0
 checkStyleVersion=6.19
 spotbugsPlugin=4.7.0
 testLogger=2.0.0
-testRetry=1.0.0testReadLACLongPollWhenSomeBookiesDown
+testRetry=1.0.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,8 @@ pluginManagement {
         id "com.github.johnrengelman.shadow" version "${shadowPluginVersion}"
         id "com.github.hierynomus.license" version "${licenseGradlePluginVersion}"
         id "com.github.spotbugs" version "${spotbugsPlugin}"
+        id "com.adarshr.test-logger" version  "${testLogger}"
+        id "org.gradle.test-retry" version "${testRetry}"
     }
 }
 


### PR DESCRIPTION
### Motivation
Sometimes ago gradle was introduced to Bookkeeper, 
and with that build and release capabilities were built in Bookkeeper with gradle. But we never migrated bookkeeper to gradle.

Taking a first step towards gradle migration; This PR migrate all client unit tests of bookkeepr-server module to gradle 
### Changes
Replace maven test target with gradle

Master Issue: #2640

This is copy of the approved PR https://github.com/apache/bookkeeper/pull/2800

As github somehow is giving 404 with https://github.com/apache/bookkeeper/pull/2800 while merging it.