### PR TITLE
set response body for bookie  is_ready api

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieIsReadyService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieIsReadyService.java
@@ -51,7 +51,7 @@ public class BookieIsReadyService implements HttpEndpointService {
         StateManager sm = bookie.getStateManager();
         if (sm.isRunning() && !sm.isShuttingDown()) {
             response.setCode(HttpServer.StatusCode.OK);
-            response.setBody("");
+            response.setBody("Bookie is fully started.");
         } else {
             response.setCode(HttpServer.StatusCode.SERVICE_UNAVAILABLE);
             response.setBody("Bookie is not fully started yet");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieIsReadyService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieIsReadyService.java
@@ -51,7 +51,7 @@ public class BookieIsReadyService implements HttpEndpointService {
         StateManager sm = bookie.getStateManager();
         if (sm.isRunning() && !sm.isShuttingDown()) {
             response.setCode(HttpServer.StatusCode.OK);
-            response.setBody("Bookie is fully started.");
+            response.setBody("OK");
         } else {
             response.setCode(HttpServer.StatusCode.SERVICE_UNAVAILABLE);
             response.setBody("Bookie is not fully started yet");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -855,6 +855,7 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         HttpServiceRequest request1 = new HttpServiceRequest(null, HttpServer.Method.GET, null);
         HttpServiceResponse response1 = bookieStateServer.handle(request1);
         assertEquals(HttpServer.StatusCode.OK.getValue(), response1.getStatusCode());
+        assertEquals("OK", response1.getBody());
 
         // Try using POST instead of GET
         HttpServiceRequest request2 = new HttpServiceRequest(null, HttpServer.Method.POST, null);


### PR DESCRIPTION
API `/api/v1/bookie/is_ready` should set some response body, when code 200 returned.
Or, this will confuse people, they don't know if this api  return successfully.


![image](https://user-images.githubusercontent.com/9278488/134855390-f8c18ba2-3968-4352-82fd-f59883dcd2cb.png)