### PR TITLE
ISSUE #2640: BP-43 Migrate bookkeepr-server org.apache.bookkeeper.bookie.* tests to gradle

### DIFF
--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -29,10 +29,6 @@ on:
       - 'site/**'
     workflow_dispatch:
 
-
-env:
-  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
-
 jobs:
   test:
 
@@ -50,14 +46,5 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Maven build bookkeeper-server
-        run: mvn -B -nsu -am -pl bookkeeper-server clean install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
-
-      - name: Run EntryLogTests
-        run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.TestEntryLog" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
-
-      - name: Run InterleavedLedgerStorageTest
-        run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.TestInterleavedLederStorage" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
-
-      - name: Run bookie tests
-        run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.*Test" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+      - name: Run bookie test
+        run: ./gradlew bookkeeper-server:test --tests="org.apache.bookkeeper.bookie.*" -Dtestlogger.theme=plain

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -77,8 +77,8 @@ import org.slf4j.LoggerFactory;
  * Tests for EntryLog.
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class TestEntryLog {
-    private static final Logger LOG = LoggerFactory.getLogger(TestEntryLog.class);
+public class EntryLogTest {
+    private static final Logger LOG = LoggerFactory.getLogger(EntryLogTest.class);
 
     final List<File> tempDirs = new ArrayList<File>();
     final Random rand = new Random();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorageTest.java
@@ -68,15 +68,15 @@ import org.slf4j.LoggerFactory;
  * Test for InterleavedLedgerStorage.
  */
 @RunWith(Parameterized.class)
-public class TestInterleavedLedgerStorage {
-    private static final Logger LOG = LoggerFactory.getLogger(TestInterleavedLedgerStorage.class);
+public class InterleavedLedgerStorageTest {
+    private static final Logger LOG = LoggerFactory.getLogger(InterleavedLedgerStorageTest.class);
 
     @Parameterized.Parameters
     public static Iterable<Boolean> elplSetting() {
         return Arrays.asList(true, false);
     }
 
-    public TestInterleavedLedgerStorage(boolean elplSetting) {
+    public InterleavedLedgerStorageTest(boolean elplSetting) {
         conf.setEntryLogSizeLimit(2048);
         conf.setEntryLogPerLedgerEnabled(elplSetting);
     }


### PR DESCRIPTION
### Motivation
 Migrating bookkeeper-server bookie tests to gradle.

### Changes

1. As per the naming convention name of test class/file Should be {FooFeature}Test as opposed to Test{FooFeature}
2. Migrating tests to gradle

Master Issue: #2640

