### PR TITLE
Add pre-check to over-replicated ledger GC

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -231,11 +231,19 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
 
     private Set<Long> removeOverReplicatedledgers(Set<Long> bkActiveledgers, final GarbageCleaner garbageCleaner)
             throws InterruptedException, KeeperException {
+        // Check ledger ensembles before creating lock nodes.
+        // This is to reduce the number of lock node creations and deletions in ZK.
+        // The ensemble check is done again after the lock node is created.
+        final Set<Long> candidateOverReplicatedLedgers = preCheckOverReplicatedLedgers(bkActiveledgers);
+        if (candidateOverReplicatedLedgers.isEmpty()) {
+            return candidateOverReplicatedLedgers;
+        }
+
         final List<ACL> zkAcls = ZkUtils.getACLs(conf);
         final Set<Long> overReplicatedLedgers = Sets.newHashSet();
         final Semaphore semaphore = new Semaphore(MAX_CONCURRENT_ZK_REQUESTS);
-        final CountDownLatch latch = new CountDownLatch(bkActiveledgers.size());
-        for (final Long ledgerId : bkActiveledgers) {
+        final CountDownLatch latch = new CountDownLatch(candidateOverReplicatedLedgers.size());
+        for (final Long ledgerId : candidateOverReplicatedLedgers) {
             try {
                 // check if the ledger is being replicated already by the replication worker
                 if (ZkLedgerUnderreplicationManager.isLedgerBeingReplicated(zk, zkLedgersRootPath, ledgerId)) {
@@ -252,23 +260,12 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
                     .whenComplete((metadata, exception) -> {
                             try {
                                 if (exception == null) {
-                                    // do not delete a ledger that is not closed, since the ensemble might
-                                    // change again and include the current bookie while we are deleting it
-                                    if (!metadata.getValue().isClosed()) {
-                                        return;
+                                    if (isNotBookieIncludedInLedgerEnsembles(metadata)) {
+                                        // this bookie is not supposed to have this ledger,
+                                        // thus we can delete this ledger now
+                                        overReplicatedLedgers.add(ledgerId);
+                                        garbageCleaner.clean(ledgerId);
                                     }
-                                    SortedMap<Long, ? extends List<BookieId>> ensembles =
-                                        metadata.getValue().getAllEnsembles();
-                                    for (List<BookieId> ensemble : ensembles.values()) {
-                                        // check if this bookie is supposed to have this ledger
-                                        if (ensemble.contains(selfBookieAddress)) {
-                                            return;
-                                        }
-                                    }
-                                    // this bookie is not supposed to have this ledger,
-                                    // thus we can delete this ledger now
-                                    overReplicatedLedgers.add(ledgerId);
-                                    garbageCleaner.clean(ledgerId);
                                 }
                             } finally {
                                 semaphore.release();
@@ -290,5 +287,56 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
         latch.await();
         bkActiveledgers.removeAll(overReplicatedLedgers);
         return overReplicatedLedgers;
+    }
+
+    private Set<Long> preCheckOverReplicatedLedgers(Set<Long> bkActiveLedgers) throws InterruptedException {
+        final Set<Long> candidateOverReplicatedLedgers = Sets.newHashSet();
+        final Semaphore semaphore = new Semaphore(MAX_CONCURRENT_ZK_REQUESTS);
+        final CountDownLatch latch = new CountDownLatch(bkActiveLedgers.size());
+
+        for (final Long ledgerId : bkActiveLedgers) {
+            try {
+                semaphore.acquire();
+                ledgerManager.readLedgerMetadata(ledgerId)
+                        .whenComplete((metadata, exception) -> {
+                            try {
+                                if (exception == null) {
+                                    if (isNotBookieIncludedInLedgerEnsembles(metadata)) {
+                                        candidateOverReplicatedLedgers.add(ledgerId);
+                                    }
+                                }
+                            } finally {
+                                semaphore.release();
+                                latch.countDown();
+                            }
+                        });
+            } catch (Throwable t) {
+                LOG.error("Exception when iterating through the ledgers to pre-check for over-replication", t);
+                latch.countDown();
+            }
+        }
+        latch.await();
+        LOG.info("Finished pre-check over-replicated ledgers. candidateOverReplicatedLedgersSize={}",
+                candidateOverReplicatedLedgers.size());
+        return candidateOverReplicatedLedgers;
+    }
+
+    private boolean isNotBookieIncludedInLedgerEnsembles(Versioned<LedgerMetadata> metadata) {
+        // do not delete a ledger that is not closed, since the ensemble might
+        // change again and include the current bookie while we are deleting it
+        if (!metadata.getValue().isClosed()) {
+            return false;
+        }
+
+        SortedMap<Long, ? extends List<BookieId>> ensembles =
+                metadata.getValue().getAllEnsembles();
+        for (List<BookieId> ensemble : ensembles.values()) {
+            // check if this bookie is supposed to have this ledger
+            if (ensemble.contains(selfBookieAddress)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
### Motivation
- Motivation is as described in [PR#2797](https://github.com/apache/bookkeeper/pull/2797).
> In one day, zookeepers became high cpu usage and disk full.
> The cause of this is bookie's gc of overreplicated ledgers.
> Gc created/deleted zk nodes under /ledgers/underreplication/locks very frequently and some bookies ran gc at same time.
> As a result, zookeepers created a lot of snapshots and became disk full.

- If [PR#2797](https://github.com/apache/bookkeeper/pull/2797) was merged first, this PR needs to be fixed.

### Changes
- Add an ensemble check before creating the lock node.
This is to reduce the number of lock node creations and deletions in ZK.
