### PR TITLE
Forget to close preAllocator log on shutdown

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
@@ -192,8 +192,11 @@ class EntryLoggerAllocator {
                 if (bufferedLogChannel != null) {
                     bufferedLogChannel.close();
                 }
-            } catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {
-                log.warn("release preAllocator log failed, ignore error");
+            } catch (InterruptedException e) {
+                log.warn("interrupted while release preAllocate log");
+                Thread.currentThread().interrupt();
+            } catch (IOException | ExecutionException | TimeoutException e) {
+                log.warn("release preAllocate log failed, ignore error");
             }
         }
     }


### PR DESCRIPTION
### Motivation
Release the filehandler which preAllocator acquired.
It will cause a file handler leak on shutdown. Typically useful on windows unit test
### Changes
If preAllocator success, close the bufferchannel on stop.