### PR TITLE
Correct the comment of caching index & filter block with additional options to improve performance

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -149,8 +149,12 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
                     tableOptions.setFilterPolicy(new BloomFilter(bloomFilterBitsPerKey, false));
                 }
 
-                // Options best suited for HDDs
+                // Cache index & filter in block cache to limit the memory usage
                 tableOptions.setCacheIndexAndFilterBlocks(true);
+                // Options below are tune to mitigate the performance regression when limiting the memory usage
+                tableOptions.setCacheIndexAndFilterBlocksWithHighPriority(true);
+                tableOptions.setPinL0FilterAndIndexBlocksInCache(true);
+
                 options.setLevelCompactionDynamicLevelBytes(true);
 
                 options.setTableFormatConfig(tableOptions);


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

The previous comment of `tableOptions.setCacheIndexAndFilterBlocks(true)` is `Options best suited for HDDs`. If the comment thought that we could cache index&filter blocks when using HDD for better performance, however, this is not correct as this option actually helps on limit the memory usage of index & filter blocks. More internal details could refer to https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks

Apart from correcting the comment, this PR also add additional options to help improve performance.

### Changes

Correct the comment of caching index & filter block with additional options to improve performance.

