### PR TITLE
The pattern variable is proposed as a public constant

### DIFF
--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/DockerUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/DockerUtils.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DockerUtils {
     private static final Logger LOG = LoggerFactory.getLogger(DockerUtils.class);
+    private static final Pattern pattern = Pattern.compile("^arq.cube.docker.([^.]*).ip$");
 
     private static File getTargetDirectory(String containerId) {
         String base = System.getProperty("maven.buildDirectory");
@@ -223,7 +224,6 @@ public class DockerUtils {
     }
 
     public static Set<String> cubeIdsMatching(String needle) {
-        Pattern pattern = Pattern.compile("^arq.cube.docker.([^.]*).ip$");
         return System.getProperties().keySet().stream()
             .map(k -> pattern.matcher(k.toString()))
             .filter(m -> m.matches())


### PR DESCRIPTION
### Motivation

When using regular expressions, make good use of its pre-compilation function, which can effectively speed up the regular table matching speed.

### Changes
The pattern variable is proposed as a public constant

