### PR TITLE
Fix semaphore leak when EntryMemTable#addEntry accepts the same entries

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTable.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTable.java
@@ -320,6 +320,9 @@ public class EntryMemTable implements AutoCloseable{
             try {
                 EntryKeyValue toAdd = cloneWithAllocator(ledgerId, entryId, entry);
                 size = internalAdd(toAdd);
+                if (size == 0) {
+                    skipListSemaphore.release(len);
+                }
             } finally {
                 this.lock.readLock().unlock();
             }


### PR DESCRIPTION
### Motivation

If `EntryMemTable#addEntry` accepts the same entries (assuming size is `N`), which means they have the same ledger id and entry id, the semaphore will be acquired multiple times (assuming `M` times) but only one entry will be added to `kvmap`. When the `EntryMemTable` is flushed, only `N` permits will be released, while `M * N` permits are acquired.  Then the semaphore leak happens.

### Changes

In `EntryMemTable#addEntry`, release the acquired permits if `internalAdd` returns 0. Because it means the entry size is zero or the entry has already existed in `kvmap`. `testAddSameEntries` is added to verify when the same entries are added, `flush` can still release all acquired permits.