### PR TITLE
ISSUE #2846 Allow to run on java 17

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
@@ -83,7 +83,7 @@ class DirectMemoryCRC32Digest implements CRC32Digest {
             updateBytesMethod = CRC32.class.getDeclaredMethod("updateBytes", int.class, byte[].class, int.class,
                     int.class);
             updateBytesMethod.setAccessible(true);
-        } catch (NoSuchMethodException | SecurityException e) {
+        } catch (Exception e) {
             updateByteBufferMethod = null;
             updateBytesMethod = null;
         }


### PR DESCRIPTION
### Motivation
Fix #2846 

Allow bookkeeper to run on java 17.


### Changes
The problem is java17 doesn't allow `setAccessible(true)` unless config `--add-opens`
```java
// DirectMemoryCRC32Digest.class
 updateByteBufferMethod = CRC32.class.getDeclaredMethod("updateByteBuffer", int.class, long.class, int.class,
                    int.class);
            updateByteBufferMethod.setAccessible(true);

            updateBytesMethod = CRC32.class.getDeclaredMethod("updateBytes", int.class, byte[].class, int.class,
                    int.class);
            updateBytesMethod.setAccessible(true);
```

If run on java17, config the `--add-opens`
