### PR TITLE
Ensure BookKeeper process receives sigterm in docker container

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -41,11 +41,11 @@ function run_command() {
         chmod -R +x ${BINDIR}
         chmod -R +x ${SCRIPTS_DIR}
         echo "This is root, will use user $BK_USER to run command '$@'"
-        sudo -s -E -u "$BK_USER" /bin/bash "$@"
+        exec sudo -s -E -u "$BK_USER" /bin/bash "$@"
         exit
     else
         echo "Run command '$@'"
-        $@
+        exec $@
     fi
 }
 

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -45,7 +45,7 @@ function run_command() {
         exit
     else
         echo "Run command '$@'"
-        exec $@
+        exec "$@"
     fi
 }
 

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -41,7 +41,7 @@ function run_command() {
         chmod -R +x ${BINDIR}
         chmod -R +x ${SCRIPTS_DIR}
         echo "This is root, will use user $BK_USER to run command '$@'"
-        exec sudo -s -E -u "$BK_USER" /bin/bash "$@"
+        exec sudo -s -E -u "$BK_USER" /bin/bash -c 'exec "$@"' -- "$@"
         exit
     else
         echo "Run command '$@'"


### PR DESCRIPTION
### Motivation

Current official docker images do not handle the SIGTERM sent by the docker runtime and so get killed after the timeout. No graceful shutdown occurs.

The reason is that the entrypoint does not use `exec` when executing the `bin/bookkeeper` shell script and so the BookKeeper process cannot receive signals from the docker runtime.

### Changes

Use `exec` when calling the `bin/bookkeeper` shell script.