### PR TITLE
Fix checkstyle on "microbenchmarks"

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -47,6 +47,6 @@ jobs:
         with:
           java-version: 1.8
       - name: Validate pull request
-        run: ./gradlew build -x microbenchmarks:checkstyleMain -x spotbugsTest -x signDistTar -x test
+        run: ./gradlew build -x spotbugsTest -x signDistTar -x test
       - name: Check license files
         run: dev/check-all-licenses-gradle

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/common/OrderedExecutorBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/common/OrderedExecutorBenchmark.java
@@ -51,14 +51,17 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
 public class OrderedExecutorBenchmark {
 
-    private static Map<String, Supplier<ExecutorService>> providers = ImmutableMap.of( //
+    private static Map<String, Supplier<ExecutorService>> providers = ImmutableMap.of(
             "JDK-ThreadPool", () -> Executors.newFixedThreadPool(1),
-            "OrderedExecutor", () -> OrderedExecutor.newBuilder().numThreads(1).build(), //
+            "OrderedExecutor", () -> OrderedExecutor.newBuilder().numThreads(1).build(),
             "OrderedScheduler", () -> OrderedScheduler.newSchedulerBuilder().numThreads(1).build());
 
+    /**
+     * State holder of the test.
+    */
     @State(Scope.Benchmark)
     public static class TestState {
-        @Param({ "JDK-ThreadPool", "OrderedExecutor", "OrderedScheduler" })
+        @Param({"JDK-ThreadPool", "OrderedExecutor", "OrderedScheduler"})
         private String executorName;
 
         private ExecutorService executor;

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/common/package-info.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/common/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Generic benchmarks.
+ */
+package org.apache.bookkeeper.common;

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/ProtocolBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/ProtocolBenchmark.java
@@ -27,6 +27,7 @@ import io.netty.util.ReferenceCountUtil;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.bookkeeper.proto.BookieProtoEncoding.EnDecoder;
 import org.apache.bookkeeper.proto.BookieProtoEncoding.RequestEnDeCoderPreV3;
 import org.apache.bookkeeper.proto.BookieProtoEncoding.RequestEnDecoderV3;
@@ -49,12 +50,12 @@ import org.slf4j.MDC;
 /**
  * Benchmarking serialization and deserialization.
  */
-@BenchmarkMode({ Mode.Throughput })
+@BenchmarkMode({Mode.Throughput})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
 public class ProtocolBenchmark {
 
-    @Param({ "10", "100", "1000", "10000" })
+    @Param({"10", "100", "1000", "10000"})
     int size;
 
     byte[] masterKey;

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestTypeBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestTypeBenchmark.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestTypeBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestTypeBenchmark.java
@@ -1,5 +1,4 @@
 /**
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
 package org.apache.bookkeeper.proto.checksum;
@@ -30,6 +28,7 @@ import io.netty.buffer.Unpooled;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -140,27 +139,27 @@ public class DigestTypeBenchmark {
 
         public ByteBuf getByteBuff(BufferType bType) {
             switch (bType) {
-            case ARRAY_BACKED:
-                return arrayBackedBuffer;
-            case NOT_ARRAY_BACKED:
-                return notArrayBackedBuffer;
-            case BYTE_BUF_DEFAULT_ALLOC:
-                return byteBufDefaultAlloc;
-            default:
-                throw new IllegalArgumentException("unknown buffer type " + bType);
+                case ARRAY_BACKED:
+                    return arrayBackedBuffer;
+                case NOT_ARRAY_BACKED:
+                    return notArrayBackedBuffer;
+                case BYTE_BUF_DEFAULT_ALLOC:
+                    return byteBufDefaultAlloc;
+                default:
+                    throw new IllegalArgumentException("unknown buffer type " + bType);
             }
         }
 
         public DigestManager getDigestManager(Digest digest) {
             switch (digest) {
-            case CRC32:
-                return crc32;
-            case CRC32_C:
-                return crc32c;
-            case MAC:
-                return mac;
-            default:
-                throw new IllegalArgumentException("unknown digest " + digest);
+                case CRC32:
+                    return crc32;
+                case CRC32_C:
+                    return crc32c;
+                case MAC:
+                    return mac;
+                default:
+                    throw new IllegalArgumentException("unknown digest " + digest);
             }
         }
     }

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestTypeBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestTypeBenchmark.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/package-info.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for checksum functions.
+ */
+package org.apache.bookkeeper.proto.checksum;

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/package-info.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Protocol implementations benchmarks.
+ */
+package org.apache.bookkeeper.proto;

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/StatsLoggerBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/StatsLoggerBenchmark.java
@@ -56,9 +56,12 @@ public class StatsLoggerBenchmark {
         providers.put("FastCodahale", FastCodahaleMetricsProvider::new);
     }
 
+    /**
+     * State holder of the logger.
+     */
     @State(Scope.Benchmark)
     public static class LoggerState {
-        @Param({ "Prometheus", "Codahale", "FastCodahale", "Twitter", "Ostrich" })
+        @Param({"Prometheus", "Codahale", "FastCodahale", "Twitter", "Ostrich"})
         private String statsProvider;
 
         private Counter counter;
@@ -75,7 +78,7 @@ public class StatsLoggerBenchmark {
         }
     }
 
-     @Benchmark
+    @Benchmark
     public void counterIncrement(LoggerState s) {
         s.counter.inc();
     }

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/TimerBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/TimerBenchmark.java
@@ -5,9 +5,9 @@
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/TimerBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/TimerBenchmark.java
@@ -5,9 +5,9 @@
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/TimerBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/TimerBenchmark.java
@@ -5,9 +5,9 @@
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -74,12 +74,12 @@ public class TimerBenchmark {
         public void doSetup() throws Exception {
             StatsLogger logger = null;
             switch (timerType) {
-            case CodahaleTimer:
-                logger = new CodahaleMetricsProvider().getStatsLogger("test");
-                break;
-            case FastTimer:
-                logger = new FastCodahaleMetricsProvider().getStatsLogger("test");
-                break;
+                case CodahaleTimer:
+                    logger = new CodahaleMetricsProvider().getStatsLogger("test");
+                    break;
+                case FastTimer:
+                    logger = new FastCodahaleMetricsProvider().getStatsLogger("test");
+                    break;
             }
 
             synchronized (MyState.class) {
@@ -168,12 +168,16 @@ public class TimerBenchmark {
     /**
      * Test routing for manual testing of memory footprint of default Codahale Timer vs. improved FastTimer.
      * JMH can't do that, so we have a small stand-alone test routine here.
-     * Run with: java -Xmx1g -cp target/benchmarks.jar org.apache.bookkeeper.stats.codahale.TimerBenchmark <codahale|fast>
+     * Run with:
+     * <code>
+     *  java -Xmx1g -cp target/benchmarks.jar \
+     *     org.apache.bookkeeper.stats.codahale.TimerBenchmark &lt;codahale|fast&gt;
+     * </code>
      * @param args
      */
     public static void main(String[] args) {
-        if (args.length != 1 ||
-                (!args[0].equalsIgnoreCase("codahale") && !args[0].equalsIgnoreCase("fast"))) {
+        if (args.length != 1
+                || (!args[0].equalsIgnoreCase("codahale") && !args[0].equalsIgnoreCase("fast"))) {
             System.out.println("usage: " + TimerBenchmark.class.getCanonicalName() + " <codahale|fast>");
             System.exit(1);
         }
@@ -186,24 +190,24 @@ public class TimerBenchmark {
         System.out.println("Using " + logger.getClass().getCanonicalName());
         System.out.println("Creating 1000 OpStatsLoggers (2000 Timers) and updating each of them 1000 times ...");
         OpStatsLogger[] timers = new OpStatsLogger[1000];
-        for (int i=0; i<timers.length; i++) {
+        for (int i = 0; i < timers.length; i++) {
             timers[i] = logger.getOpStatsLogger("test-timer-" + i);
         }
         long[] times = new long[199]; // 199 is prime, so each timer will get each time
         for (int i = 0; i < times.length; i++) {
             times[i] = Math.abs(ThreadLocalRandom.current().nextLong() % 1000);
         }
-        for (int i=0; i<1000 * timers.length; i++) {
+        for (int i = 0; i < 1000 * timers.length; i++) {
             timers[i % timers.length].registerSuccessfulEvent(times[i % times.length], TimeUnit.MILLISECONDS);
             timers[i % timers.length].registerFailedEvent(times[i % times.length], TimeUnit.MILLISECONDS);
         }
         times = null; // let it become garbage
         System.out.println("Done.");
         System.out.println("Now run 'jmap -histo:live <pid>' on this JVM to get a heap histogram, then kill this JVM.");
-        while(true) {
+        while (true) {
             try {
                 TimeUnit.MILLISECONDS.sleep(1000);
-            } catch(Exception e) {
+            } catch (Exception e) {
                 // ignore
             }
         }

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/package-info.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Stats implementations benchmarks.
+ */
+/**
+ * Stats benchmark runner.
+ */
+package org.apache.bookkeeper.stats.codahale;

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/package-info.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/codahale/package-info.java
@@ -15,9 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Stats implementations benchmarks.
- */
+
 /**
  * Stats benchmark runner.
  */

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/package-info.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/package-info.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Stats implementations benchmarks.
  */

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/package-info.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/stats/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Stats implementations benchmarks.
+ */
+package org.apache.bookkeeper.stats;


### PR DESCRIPTION
### Motivation

Currently we are forced to skip `microbenchmarks` checkstyle task because it fails. 
In fact, the "pr-validation" check skips that task.

### Changes

- fixed checkstyle
- removed the skip in the "pr-validation" check