### PR TITLE
Return too many requests error when the write cache flush timeout occurs

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
@@ -186,7 +186,7 @@ public abstract class BookieException extends Exception {
     }
 
     /**
-     * Signals that a ledger's operation has been rejected by an internal component because of the resource saturation
+     * Signals that a ledger's operation has been rejected by an internal component because of the resource saturation.
      */
     public static class OperationRejectedException extends BookieException {
         public OperationRejectedException() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
@@ -186,7 +186,7 @@ public abstract class BookieException extends Exception {
     }
 
     /**
-     * Signals that a ledger has been fenced in a bookie. No more entries can be appended to that ledger.
+     * Signals that a ledger's operation has been rejected by an internal component because of the resource saturation
      */
     public static class OperationRejectedException extends BookieException {
         public OperationRejectedException() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -85,7 +85,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Operation rejected while writing {}", request, e);
             }
-            rc = BookieProtocol.EIO;
+            rc = BookieProtocol.ETOOMANYREQUESTS;
         } catch (IOException e) {
             LOG.error("Error writing {}", request, e);
             rc = BookieProtocol.EIO;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
@@ -131,7 +131,7 @@ class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
             if (logger.isDebugEnabled()) {
                 logger.debug("Operation rejected while writing {}", request, e);
             }
-            status = StatusCode.EIO;
+            status = StatusCode.ETOOMANYREQUESTS;
         } catch (IOException e) {
             logger.error("Error writing entry:{} to ledger:{}",
                     entryId, ledgerId, e);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
@@ -34,10 +34,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.netty.channel.DefaultChannelPromise;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.proto.BookieProtocol.ParsedAddRequest;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
@@ -36,7 +36,10 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.channel.DefaultChannelPromise;
 import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.proto.BookieProtocol.ParsedAddRequest;
 import org.apache.bookkeeper.proto.BookieProtocol.Response;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -218,4 +221,34 @@ public class WriteEntryProcessorTest {
         response.recycle();
     }
 
+    @Test
+    public void testWritesCacheFlushTimeout() throws Exception {
+        when(bookie.isReadOnly()).thenReturn(false);
+        when(channel.voidPromise()).thenReturn(mock(ChannelPromise.class));
+        when(channel.writeAndFlush(any())).thenReturn(mock(ChannelPromise.class));
+        doAnswer(invocationOnMock -> {
+            throw new BookieException.OperationRejectedException();
+        }).when(bookie).addEntry(
+                any(ByteBuf.class), eq(false), same(processor), same(channel), eq(new byte[0]));
+
+        ChannelPromise promise = new DefaultChannelPromise(channel);
+        AtomicReference<Object> writtenObject = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocationOnMock -> {
+            writtenObject.set(invocationOnMock.getArgument(0));
+            latch.countDown();
+            return promise;
+        }).when(channel).writeAndFlush(any(), any(ChannelPromise.class));
+
+        processor.run();
+
+        verify(bookie, times(1))
+                .addEntry(any(ByteBuf.class), eq(false), same(processor), same(channel), eq(new byte[0]));
+        verify(channel, times(1)).writeAndFlush(any(Response.class), any(ChannelPromise.class));
+
+        latch.await();
+        assertTrue(writtenObject.get() instanceof Response);
+        Response response = (Response) writtenObject.get();
+        assertEquals(BookieProtocol.ETOOMANYREQUESTS, response.getErrorCode());
+    }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation
When the write cache flush timeout occurs in SingleDirectoryDbLedgerStorage either because the disk is slow or if there are too many requests and the disk is busy, instead of returning EIO status to the client, ETOOMANYREQUESTS should be returned which is more appropriate for this situation.

### Changes
- Whenever there is a resource constraint by the bookkeeper internal components OperationRejectedException is thrown. Now this exception send status=ETOOMANYREQUESTS
- Changed the Javadoc of OperationRejectedException to reflect the usage of OperationRejectedException appropriately
