### PR TITLE
BP-44: Ledger storage metrics enhancement

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookKeeperServerStats.java
@@ -187,6 +187,7 @@ public interface BookKeeperServerStats {
     String LD_LEDGER_SCOPE = "ledger";
     String LD_INDEX_SCOPE = "index";
     String LD_WRITABLE_DIRS = "writable_dirs";
+    String LD_NUM_DIRS = "num_dirs";
 
     // EntryLogManagerForEntryLogPerLedger Stats
     String ENTRYLOGGER_SCOPE = "entrylogger";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -20,6 +20,7 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_NUM_DIRS;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_WRITABLE_DIRS;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -102,6 +103,20 @@ public class LedgerDirsManager {
             @Override
             public Number getSample() {
                 return writableLedgerDirectories.size();
+            }
+        });
+
+        final int numDirs = dirs.length;
+        statsLogger.registerGauge(LD_NUM_DIRS, new Gauge<Number>() {
+
+            @Override
+            public Number getDefaultValue() {
+                return numDirs;
+            }
+
+            @Override
+            public Number getSample() {
+                return numDirs;
             }
         });
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -35,7 +35,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.LedgerDirsListener;
 import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
+import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.stats.ThreadRegistry;
 
 /**
  * SyncThread is a background thread which help checkpointing ledger storage
@@ -66,15 +70,20 @@ class SyncThread implements Checkpointer {
     private final Object suspensionLock = new Object();
     private boolean suspended = false;
     private boolean disableCheckpoint = false;
+    private final Counter syncExecutorTime;
+    private static String executorName = "SyncThread";
 
     public SyncThread(ServerConfiguration conf,
                       LedgerDirsListener dirsListener,
                       LedgerStorage ledgerStorage,
-                      CheckpointSource checkpointSource) {
+                      CheckpointSource checkpointSource,
+                      StatsLogger statsLogger) {
         this.dirsListener = dirsListener;
         this.ledgerStorage = ledgerStorage;
         this.checkpointSource = checkpointSource;
-        this.executor = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("SyncThread"));
+        this.executor = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory(executorName));
+        this.syncExecutorTime = statsLogger.getThreadScopedCounter("sync-thread-time");
+        this.executor.submit(() -> ThreadRegistry.register(executorName, 0));
     }
 
     @Override
@@ -84,6 +93,7 @@ class SyncThread implements Checkpointer {
 
     protected void doCheckpoint(Checkpoint checkpoint) {
         executor.submit(() -> {
+            long startTime = System.nanoTime();
             try {
                 synchronized (suspensionLock) {
                     while (suspended) {
@@ -101,16 +111,21 @@ class SyncThread implements Checkpointer {
             } catch (Throwable t) {
                 log.error("Exception in SyncThread", t);
                 dirsListener.fatalError();
+            } finally {
+                syncExecutorTime.add(MathUtils.elapsedNanos(startTime));
             }
         });
     }
 
     public Future requestFlush() {
         return executor.submit(() -> {
+            long startTime = System.nanoTime();
             try {
                 flush();
             } catch (Throwable t) {
                 log.error("Exception flushing ledgers ", t);
+            } finally {
+                syncExecutorTime.add(MathUtils.elapsedNanos(startTime));
             }
         });
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
@@ -32,7 +32,8 @@ import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.annotations.StatsDoc;
 
 /**
- * A umbrella class for db ledger storage stats.
+ * A umbrella class for db ledger storage stats with one instance per
+ * ledger directory.
  */
 @StatsDoc(
     name = BOOKIE_SCOPE,
@@ -44,11 +45,19 @@ class DbLedgerStorageStats {
 
     private static final String ADD_ENTRY = "add-entry";
     private static final String READ_ENTRY = "read-entry";
+    private static final String READ_ENTRY_LOCATIONS_INDEX_TIME = "read-locations-index-time";
+    private static final String READ_ENTRYLOG_TIME = "read-entrylog-time";
+    private static final String WRITE_CACHE_HITS = "write-cache-hits";
+    private static final String WRITE_CACHE_MISSES = "write-cache-misses";
     private static final String READ_CACHE_HITS = "read-cache-hits";
     private static final String READ_CACHE_MISSES = "read-cache-misses";
     private static final String READAHEAD_BATCH_COUNT = "readahead-batch-count";
     private static final String READAHEAD_BATCH_SIZE = "readahead-batch-size";
+    private static final String READAHEAD_TIME = "readahead-time";
     private static final String FLUSH = "flush";
+    private static final String FLUSH_ENTRYLOG = "flush-entrylog";
+    private static final String FLUSH_LOCATIONS_INDEX = "flush-locations-index";
+    private static final String FLUSH_LEDGER_INDEX = "flush-ledger-index";
     private static final String FLUSH_SIZE = "flush-size";
     private static final String THROTTLED_WRITE_REQUESTS = "throttled-write-requests";
     private static final String REJECTED_WRITE_REQUESTS = "rejected-write-requests";
@@ -70,17 +79,41 @@ class DbLedgerStorageStats {
     )
     private final OpStatsLogger readEntryStats;
     @StatsDoc(
+            name = READ_ENTRY_LOCATIONS_INDEX_TIME,
+            help = "time spent reading entries from the locations index of the db ledger storage engine",
+            parent = READ_ENTRY
+    )
+    private final Counter readFromLocationIndexTime;
+    @StatsDoc(
+            name = READ_ENTRYLOG_TIME,
+            help = "time spent reading entries from the entry log files of the db ledger storage engine",
+            parent = READ_ENTRY
+    )
+    private final Counter readFromEntryLogTime;
+    @StatsDoc(
+            name = WRITE_CACHE_HITS,
+            help = "number of write cache hits (on reads)",
+            parent = READ_ENTRY
+    )
+    private final Counter writeCacheHitCounter;
+    @StatsDoc(
+            name = WRITE_CACHE_MISSES,
+            help = "number of write cache misses (on reads)",
+            parent = READ_ENTRY
+    )
+    private final Counter writeCacheMissCounter;
+    @StatsDoc(
         name = READ_CACHE_HITS,
-        help = "operation stats of read cache hits",
+        help = "number of read cache hits",
         parent = READ_ENTRY
     )
-    private final OpStatsLogger readCacheHitStats;
+    private final Counter readCacheHitCounter;
     @StatsDoc(
         name = READ_CACHE_MISSES,
-        help = "operation stats of read cache misses",
+        help = "number of read cache misses",
         parent = READ_ENTRY
     )
-    private final OpStatsLogger readCacheMissStats;
+    private final Counter readCacheMissCounter;
     @StatsDoc(
         name = READAHEAD_BATCH_COUNT,
         help = "the distribution of num of entries to read in one readahead batch"
@@ -92,10 +125,30 @@ class DbLedgerStorageStats {
     )
     private final OpStatsLogger readAheadBatchSizeStats;
     @StatsDoc(
+            name = READAHEAD_TIME,
+            help = "Time spent on readahead operations"
+    )
+    private final Counter readAheadTime;
+    @StatsDoc(
         name = FLUSH,
         help = "operation stats of flushing write cache to entry log files"
     )
     private final OpStatsLogger flushStats;
+    @StatsDoc(
+            name = FLUSH_ENTRYLOG,
+            help = "operation stats of flushing to the current entry log file"
+    )
+    private final OpStatsLogger flushEntryLogStats;
+    @StatsDoc(
+            name = FLUSH_LOCATIONS_INDEX,
+            help = "operation stats of flushing to the locations index"
+    )
+    private final OpStatsLogger flushLocationIndexStats;
+    @StatsDoc(
+            name = FLUSH_LOCATIONS_INDEX,
+            help = "operation stats of flushing to the ledger index"
+    )
+    private final OpStatsLogger flushLedgerIndexStats;
     @StatsDoc(
         name = FLUSH_SIZE,
         help = "the distribution of number of bytes flushed from write cache to entry log files"
@@ -138,17 +191,25 @@ class DbLedgerStorageStats {
                          Supplier<Long> writeCacheCountSupplier,
                          Supplier<Long> readCacheSizeSupplier,
                          Supplier<Long> readCacheCountSupplier) {
-        addEntryStats = stats.getOpStatsLogger(ADD_ENTRY);
-        readEntryStats = stats.getOpStatsLogger(READ_ENTRY);
-        readCacheHitStats = stats.getOpStatsLogger(READ_CACHE_HITS);
-        readCacheMissStats = stats.getOpStatsLogger(READ_CACHE_MISSES);
+        addEntryStats = stats.getThreadScopedOpStatsLogger(ADD_ENTRY);
+        readEntryStats = stats.getThreadScopedOpStatsLogger(READ_ENTRY);
+        readFromLocationIndexTime = stats.getThreadScopedCounter(READ_ENTRY_LOCATIONS_INDEX_TIME);
+        readFromEntryLogTime = stats.getThreadScopedCounter(READ_ENTRYLOG_TIME);
+        readCacheHitCounter = stats.getCounter(READ_CACHE_HITS);
+        readCacheMissCounter = stats.getCounter(READ_CACHE_MISSES);
+        writeCacheHitCounter = stats.getCounter(WRITE_CACHE_HITS);
+        writeCacheMissCounter = stats.getCounter(WRITE_CACHE_MISSES);
         readAheadBatchCountStats = stats.getOpStatsLogger(READAHEAD_BATCH_COUNT);
         readAheadBatchSizeStats = stats.getOpStatsLogger(READAHEAD_BATCH_SIZE);
+        readAheadTime = stats.getThreadScopedCounter(READAHEAD_TIME);
         flushStats = stats.getOpStatsLogger(FLUSH);
+        flushEntryLogStats = stats.getOpStatsLogger(FLUSH_ENTRYLOG);
+        flushLocationIndexStats = stats.getOpStatsLogger(FLUSH_LOCATIONS_INDEX);
+        flushLedgerIndexStats = stats.getOpStatsLogger(FLUSH_LEDGER_INDEX);
         flushSizeStats = stats.getOpStatsLogger(FLUSH_SIZE);
 
-        throttledWriteRequests = stats.getCounter(THROTTLED_WRITE_REQUESTS);
-        rejectedWriteRequests = stats.getCounter(REJECTED_WRITE_REQUESTS);
+        throttledWriteRequests = stats.getThreadScopedCounter(THROTTLED_WRITE_REQUESTS);
+        rejectedWriteRequests = stats.getThreadScopedCounter(REJECTED_WRITE_REQUESTS);
 
         writeCacheSizeGauge = new Gauge<Long>() {
             @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -69,8 +69,10 @@ import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.proto.BookieProtocol;
+import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.stats.ThreadRegistry;
 import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.collections.ConcurrentLongHashMap;
 import org.apache.commons.lang.mutable.MutableLong;
@@ -109,7 +111,9 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     protected final AtomicBoolean hasFlushBeenTriggered = new AtomicBoolean(false);
     private final AtomicBoolean isFlushOngoing = new AtomicBoolean(false);
 
-    private final ExecutorService executor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("db-storage"));
+    private static String dbStoragerExecutor = "db-storage";
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(
+            new DefaultThreadFactory(dbStoragerExecutor));
 
     // Executor used to for db index cleanup
     private final ScheduledExecutorService cleanupExecutor = Executors
@@ -129,30 +133,31 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
     private final DbLedgerStorageStats dbLedgerStorageStats;
 
-    static final String READ_AHEAD_CACHE_BATCH_SIZE = "dbStorage_readAheadCacheBatchSize";
-    private static final int DEFAULT_READ_AHEAD_CACHE_BATCH_SIZE = 100;
-
     private static final long DEFAULT_MAX_THROTTLE_TIME_MILLIS = TimeUnit.SECONDS.toMillis(10);
 
     private final long maxReadAheadBytesSize;
 
+    private final Counter flushExecutorTime;
+
     public SingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
             LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager, StatsLogger statsLogger,
-            ByteBufAllocator allocator, ScheduledExecutorService gcExecutor, long writeCacheSize, long readCacheSize)
-            throws IOException {
-
+            ByteBufAllocator allocator, ScheduledExecutorService gcExecutor, long writeCacheSize, long readCacheSize,
+            int readAheadCacheBatchSize) throws IOException {
         checkArgument(ledgerDirsManager.getAllLedgerDirs().size() == 1,
                 "Db implementation only allows for one storage dir");
 
         String baseDir = ledgerDirsManager.getAllLedgerDirs().get(0).toString();
         log.info("Creating single directory db ledger storage on {}", baseDir);
 
+        StatsLogger ledgerDirStatsLogger = statsLogger.scopeLabel("ledgerDir",
+                ledgerDirsManager.getAllLedgerDirs().get(0).getPath());
+
         this.writeCacheMaxSize = writeCacheSize;
         this.writeCache = new WriteCache(allocator, writeCacheMaxSize / 2);
         this.writeCacheBeingFlushed = new WriteCache(allocator, writeCacheMaxSize / 2);
 
         readCacheMaxSize = readCacheSize;
-        readAheadCacheBatchSize = conf.getInt(READ_AHEAD_CACHE_BATCH_SIZE, DEFAULT_READ_AHEAD_CACHE_BATCH_SIZE);
+        this.readAheadCacheBatchSize = readAheadCacheBatchSize;
 
         // Do not attempt to perform read-ahead more than half the total size of the cache
         maxReadAheadBytesSize = readCacheMaxSize / 2;
@@ -163,8 +168,9 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
         readCache = new ReadCache(allocator, readCacheMaxSize);
 
-        ledgerIndex = new LedgerMetadataIndex(conf, KeyValueStorageRocksDB.factory, baseDir, statsLogger);
-        entryLocationIndex = new EntryLocationIndex(conf, KeyValueStorageRocksDB.factory, baseDir, statsLogger);
+        ledgerIndex = new LedgerMetadataIndex(conf, KeyValueStorageRocksDB.factory, baseDir, ledgerDirStatsLogger);
+        entryLocationIndex = new EntryLocationIndex(conf,
+                KeyValueStorageRocksDB.factory, baseDir, ledgerDirStatsLogger);
 
         transientLedgerInfoCache = new ConcurrentLongHashMap<>(16 * 1024,
                 Runtime.getRuntime().availableProcessors() * 2);
@@ -176,12 +182,22 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         gcThread = new GarbageCollectorThread(conf, ledgerManager, this, statsLogger);
 
         dbLedgerStorageStats = new DbLedgerStorageStats(
-            statsLogger,
+                ledgerDirStatsLogger,
             () -> writeCache.size() + writeCacheBeingFlushed.size(),
             () -> writeCache.count() + writeCacheBeingFlushed.count(),
             () -> readCache.size(),
             () -> readCache.count()
         );
+
+        flushExecutorTime = ledgerDirStatsLogger.getThreadScopedCounter("db-storage-thread-time");
+
+        executor.submit(() -> {
+            ThreadRegistry.register(dbStoragerExecutor, 0);
+            // ensure the metric gets registered on start-up as this thread only executes
+            // when the write cache is full which may not happen or not for a long time
+            flushExecutorTime.add(0);
+        });
+
         ledgerDirsManager.addLedgerDirsListener(getLedgerDirsListener());
     }
 
@@ -364,10 +380,13 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 // Trigger an early flush in background
                 log.info("Write cache is full, triggering flush");
                 executor.execute(() -> {
+                        long startTime = System.nanoTime();
                         try {
                             flush();
                         } catch (IOException e) {
                             log.error("Error during flush", e);
+                        } finally {
+                            flushExecutorTime.add(MathUtils.elapsedNanos(startTime));
                         }
                     });
             }
@@ -399,6 +418,17 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     @Override
     public ByteBuf getEntry(long ledgerId, long entryId) throws IOException {
         long startTime = MathUtils.nowInNano();
+        try {
+            ByteBuf entry = doGetEntry(ledgerId, entryId);
+            recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
+            return entry;
+        } catch (IOException e) {
+            recordFailedEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
+            throw e;
+        }
+    }
+
+    private ByteBuf doGetEntry(long ledgerId, long entryId) throws IOException {
         if (log.isDebugEnabled()) {
             log.debug("Get Entry: {}@{}", ledgerId, entryId);
         }
@@ -427,38 +457,45 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         // First try to read from the write cache of recent entries
         ByteBuf entry = localWriteCache.get(ledgerId, entryId);
         if (entry != null) {
-            recordSuccessfulEvent(dbLedgerStorageStats.getReadCacheHitStats(), startTime);
-            recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
+            dbLedgerStorageStats.getWriteCacheHitCounter().inc();
             return entry;
         }
 
         // If there's a flush going on, the entry might be in the flush buffer
         entry = localWriteCacheBeingFlushed.get(ledgerId, entryId);
         if (entry != null) {
-            recordSuccessfulEvent(dbLedgerStorageStats.getReadCacheHitStats(), startTime);
-            recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
+            dbLedgerStorageStats.getWriteCacheHitCounter().inc();
             return entry;
         }
+
+        dbLedgerStorageStats.getWriteCacheMissCounter().inc();
 
         // Try reading from read-ahead cache
         entry = readCache.get(ledgerId, entryId);
         if (entry != null) {
-            recordSuccessfulEvent(dbLedgerStorageStats.getReadCacheHitStats(), startTime);
-            recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
+            dbLedgerStorageStats.getReadCacheHitCounter().inc();
             return entry;
         }
 
+        dbLedgerStorageStats.getReadCacheMissCounter().inc();
+
         // Read from main storage
         long entryLocation;
+        long locationIndexStartNano = MathUtils.nowInNano();
         try {
             entryLocation = entryLocationIndex.getLocation(ledgerId, entryId);
             if (entryLocation == 0) {
                 throw new NoEntryException(ledgerId, entryId);
             }
+        } finally {
+            dbLedgerStorageStats.getReadFromLocationIndexTime().add(MathUtils.elapsedNanos(locationIndexStartNano));
+        }
+
+        long readEntryStartNano = MathUtils.nowInNano();
+        try {
             entry = entryLogger.readEntry(ledgerId, entryId, entryLocation);
-        } catch (NoEntryException e) {
-            recordFailedEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
-            throw e;
+        } finally {
+            dbLedgerStorageStats.getReadFromEntryLogTime().add(MathUtils.elapsedNanos(readEntryStartNano));
         }
 
         readCache.put(ledgerId, entryId, entry);
@@ -467,18 +504,18 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         long nextEntryLocation = entryLocation + 4 /* size header */ + entry.readableBytes();
         fillReadAheadCache(ledgerId, entryId + 1, nextEntryLocation);
 
-        recordSuccessfulEvent(dbLedgerStorageStats.getReadCacheMissStats(), startTime);
-        recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
         return entry;
     }
 
     private void fillReadAheadCache(long orginalLedgerId, long firstEntryId, long firstEntryLocation) {
+        long readAheadStartNano = MathUtils.nowInNano();
+        int count = 0;
+        long size = 0;
+
         try {
             long firstEntryLogId = (firstEntryLocation >> 32);
             long currentEntryLogId = firstEntryLogId;
             long currentEntryLocation = firstEntryLocation;
-            int count = 0;
-            long size = 0;
 
             while (count < readAheadCacheBatchSize
                     && size < maxReadAheadBytesSize
@@ -508,19 +545,18 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                     entry.release();
                 }
             }
-
-            dbLedgerStorageStats.getReadAheadBatchCountStats().registerSuccessfulValue(count);
-            dbLedgerStorageStats.getReadAheadBatchSizeStats().registerSuccessfulValue(size);
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
                 log.debug("Exception during read ahead for ledger: {}: e", orginalLedgerId, e);
             }
+        } finally {
+            dbLedgerStorageStats.getReadAheadBatchCountStats().registerSuccessfulValue(count);
+            dbLedgerStorageStats.getReadAheadBatchSizeStats().registerSuccessfulValue(size);
+            dbLedgerStorageStats.getReadAheadTime().add(MathUtils.elapsedNanos(readAheadStartNano));
         }
     }
 
     public ByteBuf getLastEntry(long ledgerId) throws IOException {
-        long startTime = MathUtils.nowInNano();
-
         long stamp = writeCacheRotationLock.readLock();
         try {
             // First try to read from the write cache of recent entries
@@ -536,8 +572,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                     }
                 }
 
-                recordSuccessfulEvent(dbLedgerStorageStats.getReadCacheHitStats(), startTime);
-                recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
+                dbLedgerStorageStats.getWriteCacheHitCounter().inc();
                 return entry;
             }
 
@@ -553,25 +588,28 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                     }
                 }
 
-                recordSuccessfulEvent(dbLedgerStorageStats.getReadCacheHitStats(), startTime);
-                recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
+                dbLedgerStorageStats.getWriteCacheHitCounter().inc();
                 return entry;
             }
         } finally {
             writeCacheRotationLock.unlockRead(stamp);
         }
 
+        dbLedgerStorageStats.getWriteCacheMissCounter().inc();
+
         // Search the last entry in storage
+        long locationIndexStartNano = MathUtils.nowInNano();
         long lastEntryId = entryLocationIndex.getLastEntryInLedger(ledgerId);
         if (log.isDebugEnabled()) {
             log.debug("Found last entry for ledger {} in db: {}", ledgerId, lastEntryId);
         }
 
         long entryLocation = entryLocationIndex.getLocation(ledgerId, lastEntryId);
-        ByteBuf content = entryLogger.readEntry(ledgerId, lastEntryId, entryLocation);
+        dbLedgerStorageStats.getReadFromLocationIndexTime().add(MathUtils.elapsedNanos(locationIndexStartNano));
 
-        recordSuccessfulEvent(dbLedgerStorageStats.getReadCacheMissStats(), startTime);
-        recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
+        long readEntryStartNano = MathUtils.nowInNano();
+        ByteBuf content = entryLogger.readEntry(ledgerId, lastEntryId, entryLocation);
+        dbLedgerStorageStats.getReadFromEntryLogTime().add(MathUtils.elapsedNanos(readEntryStartNano));
         return content;
     }
 
@@ -592,10 +630,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             return;
         }
 
-        long startTime = MathUtils.nowInNano();
-
         // Only a single flush operation can happen at a time
         flushMutex.lock();
+
+        long startTime = MathUtils.nowInNano();
 
         try {
             // Swap the write cache so that writes can continue to happen while the flush is
@@ -621,17 +659,22 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 }
             });
 
+            long entryLoggerStart = MathUtils.nowInNano();
             entryLogger.flush();
+            recordSuccessfulEvent(dbLedgerStorageStats.getFlushEntryLogStats(), entryLoggerStart);
 
-            long batchFlushStarTime = System.nanoTime();
+            long batchFlushStartTime = MathUtils.nowInNano();
             batch.flush();
             batch.close();
+            recordSuccessfulEvent(dbLedgerStorageStats.getFlushLocationIndexStats(), batchFlushStartTime);
             if (log.isDebugEnabled()) {
                 log.debug("DB batch flushed time : {} s",
-                        MathUtils.elapsedNanos(batchFlushStarTime) / (double) TimeUnit.SECONDS.toNanos(1));
+                        MathUtils.elapsedNanos(batchFlushStartTime) / (double) TimeUnit.SECONDS.toNanos(1));
             }
 
+            long ledgerIndexStartTime = MathUtils.nowInNano();
             ledgerIndex.flush();
+            recordSuccessfulEvent(dbLedgerStorageStats.getFlushLedgerIndexStats(), ledgerIndexStartTime);
 
             cleanupExecutor.execute(() -> {
                 // There can only be one single cleanup task running because the cleanupExecutor
@@ -663,9 +706,11 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             recordSuccessfulEvent(dbLedgerStorageStats.getFlushStats(), startTime);
             dbLedgerStorageStats.getFlushSizeStats().registerSuccessfulValue(sizeToFlush);
         } catch (IOException e) {
+            recordFailedEvent(dbLedgerStorageStats.getFlushStats(), startTime);
             // Leave IOExecption as it is
             throw e;
         } catch (RuntimeException e) {
+            recordFailedEvent(dbLedgerStorageStats.getFlushStats(), startTime);
             // Wrap unchecked exceptions
             throw new IOException(e);
         } finally {
@@ -889,22 +934,6 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
     private void recordFailedEvent(OpStatsLogger logger, long startTimeNanos) {
         logger.registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
-    }
-
-    long getWriteCacheSize() {
-        return writeCache.size() + writeCacheBeingFlushed.size();
-    }
-
-    long getWriteCacheCount() {
-        return writeCache.count() + writeCacheBeingFlushed.count();
-    }
-
-    long getReadCacheSize() {
-        return readCache.size();
-    }
-
-    long getReadCacheCount() {
-        return readCache.count();
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -111,9 +111,9 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     protected final AtomicBoolean hasFlushBeenTriggered = new AtomicBoolean(false);
     private final AtomicBoolean isFlushOngoing = new AtomicBoolean(false);
 
-    private static String dbStoragerExecutor = "db-storage";
+    private static String dbStoragerExecutorName = "db-storage";
     private final ExecutorService executor = Executors.newSingleThreadExecutor(
-            new DefaultThreadFactory(dbStoragerExecutor));
+            new DefaultThreadFactory(dbStoragerExecutorName));
 
     // Executor used to for db index cleanup
     private final ScheduledExecutorService cleanupExecutor = Executors
@@ -192,7 +192,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         flushExecutorTime = ledgerDirStatsLogger.getThreadScopedCounter("db-storage-thread-time");
 
         executor.submit(() -> {
-            ThreadRegistry.register(dbStoragerExecutor, 0);
+            ThreadRegistry.register(dbStoragerExecutorName, 0);
             // ensure the metric gets registered on start-up as this thread only executes
             // when the write cache is full which may not happen or not for a long time
             flushExecutorTime.add(0);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SyncThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SyncThreadTest.java
@@ -44,6 +44,7 @@ import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.junit.After;
 import org.junit.Before;
@@ -118,7 +119,7 @@ public class SyncThreadTest {
                 }
             };
 
-        final SyncThread t = new SyncThread(conf, listener, storage, checkpointSource);
+        final SyncThread t = new SyncThread(conf, listener, storage, checkpointSource, NullStatsLogger.INSTANCE);
         t.startCheckpoint(Checkpoint.MAX);
         assertTrue("Checkpoint should have been called",
                    checkpointCalledLatch.await(10, TimeUnit.SECONDS));
@@ -166,7 +167,7 @@ public class SyncThreadTest {
                     checkpointCount.incrementAndGet();
                 }
             };
-        final SyncThread t = new SyncThread(conf, listener, storage, checkpointSource);
+        final SyncThread t = new SyncThread(conf, listener, storage, checkpointSource, NullStatsLogger.INSTANCE);
         t.startCheckpoint(Checkpoint.MAX);
         while (checkpointCount.get() == 0) {
             Thread.sleep(flushInterval);
@@ -216,7 +217,7 @@ public class SyncThreadTest {
                     throw new RuntimeException("Fatal error in sync thread");
                 }
             };
-        final SyncThread t = new SyncThread(conf, listener, storage, checkpointSource);
+        final SyncThread t = new SyncThread(conf, listener, storage, checkpointSource, NullStatsLogger.INSTANCE);
         t.startCheckpoint(Checkpoint.MAX);
         assertTrue("Should have called fatal error", fatalLatch.await(10, TimeUnit.SECONDS));
         t.shutdown();
@@ -248,7 +249,7 @@ public class SyncThreadTest {
                     throw new NoWritableLedgerDirException("Disk full error in sync thread");
                 }
             };
-        final SyncThread t = new SyncThread(conf, listener, storage, checkpointSource);
+        final SyncThread t = new SyncThread(conf, listener, storage, checkpointSource, NullStatsLogger.INSTANCE);
         t.startCheckpoint(Checkpoint.MAX);
         assertTrue("Should have disk full error", diskFullLatch.await(10, TimeUnit.SECONDS));
         t.shutdown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
@@ -55,20 +55,20 @@ public class DbLedgerStorageWriteCacheTest {
         protected SingleDirectoryDbLedgerStorage newSingleDirectoryDbLedgerStorage(ServerConfiguration conf,
                 LedgerManager ledgerManager, LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
                 StatsLogger statsLogger, ScheduledExecutorService gcExecutor,
-                long writeCacheSize, long readCacheSize)
+                long writeCacheSize, long readCacheSize, int readAheadCacheBatchSize)
                 throws IOException {
             return new MockedSingleDirectoryDbLedgerStorage(conf, ledgerManager, ledgerDirsManager, indexDirsManager,
                                                             statsLogger, allocator, gcExecutor, writeCacheSize,
-                                                            readCacheSize);
+                                                            readCacheSize, readAheadCacheBatchSize);
         }
 
         private static class MockedSingleDirectoryDbLedgerStorage extends SingleDirectoryDbLedgerStorage {
             public MockedSingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
                     LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager, StatsLogger statsLogger,
                     ByteBufAllocator allocator, ScheduledExecutorService gcExecutor, long writeCacheSize,
-                    long readCacheSize) throws IOException {
+                    long readCacheSize, int readAheadCacheBatchSize) throws IOException {
                 super(conf, ledgerManager, ledgerDirsManager, indexDirsManager,
-                      statsLogger, allocator, gcExecutor, writeCacheSize, readCacheSize);
+                      statsLogger, allocator, gcExecutor, writeCacheSize, readCacheSize, readAheadCacheBatchSize);
             }
 
           @Override


### PR DESCRIPTION
### Motivation

See BP-44 for full motivation

### Changes

Various enhancements related to DbLedgerStorage:
- All DbLedgerStorage stats now report their ledgerDir.
- Read cache hit/misses now differentiated from write cache.
- Read/write cache hit/misses now counters, not OpStatsLoggers.
  The OpStatsLoggers are relatively expensive and the counter
  values are most important here.
- Stats where thread info useful are now thread-scoped. In
  general the focus is on time based metrics for operations
  carried out by the read/write thread pools.
- Time spent counters on sub-operations for reads (entry log,
  locations index, readahead).
- Flush time started moved to after lock to avoid 200% time
  utilization calculations. Can reach 200% because one thread
  is busy flushing and another busy waiting on the lock.
- Time spent counters on sub-operations for flushes (entry log,
  locations index, ledgers index).
- DbStorage thread reports time utilization.
- SyncThread reports time utilization.

Some new gauges that report configuration values which are useful
for utilization calculations in dashboards/alerts:
- Write cache max size.
- Number of ledger dirs.
- Readahead batch size.

Master Issue: #2834