### PR TITLE
Make integration test use standard dist

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,9 +29,6 @@ on:
       - 'site/**'
     workflow_dispatch:
 
-env:
-  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
-
 jobs:
   test:
 
@@ -49,8 +46,6 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Build tar
-        run: ./gradlew stream:server:build -x test
       - name: run cluster integration test
         run: ./gradlew :tests:integration:cluster:test -Dtestlogger.theme=plain
       - name: run smoke test

--- a/bookkeeper-dist/server/build.gradle
+++ b/bookkeeper-dist/server/build.gradle
@@ -31,6 +31,7 @@ releaseArtifacts {
 dependencies {
     implementation project(':bookkeeper-server')
     implementation project(':bookkeeper-stats-providers:prometheus-metrics-provider')
+    implementation project(':bookkeeper-http:vertx-http-server')
     implementation project(':bookkeeper-stats')
     implementation project(':stream:distributedlog:core')
     implementation project(':stream:server')

--- a/tests/docker-images/statestore-image/Dockerfile
+++ b/tests/docker-images/statestore-image/Dockerfile
@@ -46,8 +46,8 @@ RUN mkdir /opt/bookkeeper/conf
 RUN mkdir /opt/bookkeeper/scripts
 
 ### -----Copy Jars------###
-ADD ./dist/server.tar.gz /opt/
-RUN mv /opt/server/lib/*.jar /opt/bookkeeper/lib/
+ADD ./dist/bookkeeper-server-*.*SNAPSHOT.tar.gz /opt/
+RUN mv /opt/bookkeeper-server-*.*SNAPSHOT/lib/*.jar /opt/bookkeeper/lib/
 ### --------------------###
 
 ### ----Copy scripts----------###

--- a/tests/docker-images/statestore-image/image_builder.sh
+++ b/tests/docker-images/statestore-image/image_builder.sh
@@ -27,7 +27,7 @@ mkdir "${BASE_DIR}"/tests/docker-images/statestore-image/scripts
 mkdir "${BASE_DIR}"/tests/docker-images/statestore-image/temp_conf
 mkdir "${BASE_DIR}"/tests/docker-images/statestore-image/temp_bin
 
-cp "${BASE_DIR}"/stream/server/build/distributions/server.tar.gz "${BASE_DIR}"/tests/docker-images/statestore-image/dist
+cp "${BASE_DIR}"/bookkeeper-dist/server/build/distributions/bookkeeper-server-*.*SNAPSHOT.tar.gz "${BASE_DIR}"/tests/docker-images/statestore-image/dist
 cp "${BASE_DIR}"/docker/scripts/* "${BASE_DIR}"/tests/docker-images/statestore-image/scripts
 cp "${BASE_DIR}"/conf/* "${BASE_DIR}"/tests/docker-images/statestore-image/temp_conf
 cp "${BASE_DIR}"/bin/* "${BASE_DIR}"/tests/docker-images/statestore-image/temp_bin

--- a/tests/integration/cluster/build.gradle
+++ b/tests/integration/cluster/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 }
 
 task buildImage(type:Exec) {
+    dependsOn ':bookkeeper-dist-server:distTar'
     workingDir '../../..'
     commandLine './tests/docker-images/statestore-image/image_builder.sh'
 }

--- a/tests/integration/standalone/build.gradle
+++ b/tests/integration/standalone/build.gradle
@@ -22,6 +22,7 @@ plugins {
 }
 
 dependencies {
+    implementation project(':bookkeeper-dist-server')
     testImplementation project(path: ':bookkeeper-common', configuration: 'testArtifacts')
     testImplementation project(':bookkeeper-server')
     testImplementation project(':tests:integration-tests-utils')
@@ -35,6 +36,7 @@ dependencies {
 }
 
 task buildImage(type:Exec) {
+    dependsOn ':bookkeeper-dist-server:distTar'
     workingDir '../../..'
     commandLine './tests/docker-images/statestore-image/image_builder.sh'
 }


### PR DESCRIPTION
### Motivation

- Current integration tests do not run against docker image being built from distribution tarball. Rather it was building its own tarball and then builds docker image from the tar ball. The tar ball current being generated for running integration test is "similar" but not same compared to distribution tar ball. What integration tests should do is, it should actually run against the exact distribution tar.

- Current integration tests was not self contained. That means  bookkeeper has to be built before running tests. This PR takes care of that.  

### Changes

- Build docker image for running tests from distribution jar.
- Make integration test trigger distribution tar ball generation.

Master Issue: #
