### PR TITLE
Update version to 4.15.0-SNAPSHOT (Gradle)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -16,4 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-ext.buildVersion = "4.14.0-SNAPSHOT"
+ext.buildVersion = "4.15.0-SNAPSHOT"


### PR DESCRIPTION
### Motivation

Currently the version of the project used for Gradle builds is `4.14.0-SNAPSHOT` which is a already released version.

### Changes

Upgrade version to be the same of Maven in `version.gradle`