### PR TITLE
Explicit error message if an exception other than BKNoSuchLedgerExistsOnMetadataServerException occurs in over-replicated ledger GC

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -269,8 +269,8 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
                                         overReplicatedLedgers.add(ledgerId);
                                         garbageCleaner.clean(ledgerId);
                                     }
-                                } else if (!(exception instanceof
-                                        BKException.BKNoSuchLedgerExistsOnMetadataServerException)) {
+                                } else if (!(exception
+                                        instanceof BKException.BKNoSuchLedgerExistsOnMetadataServerException)) {
                                     LOG.warn("Failed to get metadata for ledger {}. {}: {}",
                                             ledgerId, exception.getClass().getName(), exception.getMessage());
                                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -240,6 +240,10 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
                     continue;
                 }
             } catch (Throwable t) {
+                if (!(t.getCause() instanceof BKException.BKNoSuchLedgerExistsOnMetadataServerException)) {
+                    LOG.warn("Failed to get metadata for ledger {}. {}: {}",
+                            ledgerId, t.getClass().getName(), t.getMessage());
+                }
                 latch.countDown();
                 continue;
             }
@@ -265,6 +269,10 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
                                         overReplicatedLedgers.add(ledgerId);
                                         garbageCleaner.clean(ledgerId);
                                     }
+                                } else if (!(exception instanceof
+                                        BKException.BKNoSuchLedgerExistsOnMetadataServerException)) {
+                                    LOG.warn("Failed to get metadata for ledger {}. {}: {}",
+                                            ledgerId, exception.getClass().getName(), exception.getMessage());
                                 }
                             } finally {
                                 semaphore.release();


### PR DESCRIPTION
### Motivation
- Even if an exception other than BKNoSuchLedgerExistsOnMetadataServerException occurs of readLedgerMetadata in over-replicated ledger GC, nothing will be output to the log.
(https://github.com/apache/bookkeeper/pull/2844#discussion_r735219876)

### Changes
- If an exception other than BKNoSuchLedgerExistsOnMetadataServerException occurs in readLedgerMetadata, output information to the log.
