### PR TITLE
There should only be a single BookieImpl constructor

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -30,7 +30,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import java.io.File;
@@ -83,7 +82,6 @@ import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.net.DNS;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
-import org.apache.bookkeeper.proto.SimpleBookieServiceInfoProvider;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -598,11 +596,6 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
             currentDirs[i] = getCurrentDirectory(dirs[i]);
         }
         return currentDirs;
-    }
-
-    public BookieImpl(ServerConfiguration conf)
-            throws IOException, InterruptedException, BookieException {
-        this(conf, NullStatsLogger.INSTANCE, PooledByteBufAllocator.DEFAULT, new SimpleBookieServiceInfoProvider(conf));
     }
 
     private static LedgerStorage buildLedgerStorage(ServerConfiguration conf) throws IOException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/AdvertisedAddressTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/AdvertisedAddressTest.java
@@ -71,7 +71,7 @@ public class AdvertisedAddressTest extends BookKeeperClusterTestCase {
         assertEquals(bkAddress, BookieImpl.getBookieAddress(conf));
         assertEquals(bkAddress.toBookieId(), BookieImpl.getBookieId(conf));
 
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
         b.start();
 
         BookKeeperAdmin bka = new BookKeeperAdmin(baseClientConf);
@@ -123,7 +123,7 @@ public class AdvertisedAddressTest extends BookKeeperClusterTestCase {
         assertEquals(bkAddress, BookieImpl.getBookieAddress(conf));
         assertEquals(uuid, BookieImpl.getBookieId(conf).getId());
 
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
         b.start();
 
         BookKeeperAdmin bka = new BookKeeperAdmin(baseClientConf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -307,7 +307,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
                      Supplier<BookieServiceInfo> bookieServiceInfoProvider)
                     throws IOException, KeeperException, InterruptedException,
                     BookieException {
-                Bookie bookie = new BookieImpl(conf);
+                Bookie bookie = new TestBookieImpl(conf);
                 MetadataBookieDriver driver = Whitebox.getInternalState(bookie, "metadataDriver");
                 ((ZKMetadataBookieDriver) driver).setRegManager(rm);
                 return bookie;
@@ -814,7 +814,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
 
         Bookie b = null;
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             b.start();
             assertFalse("Bookie should shutdown normally after catching IOException"
                     + " due to corrupt entry with negative length", b.isRunning());
@@ -890,7 +890,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri()).setZkTimeout(5000);
 
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("Should throw ConnectionLossException as ZKServer is not running!");
         } catch (BookieException.MetadataStoreException e) {
             // expected behaviour
@@ -912,7 +912,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri(zkRoot))
             .setZkTimeout(5000);
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("Should throw NoNodeException");
         } catch (Exception e) {
             // shouldn't be able to start
@@ -921,7 +921,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         adminConf.setMetadataServiceUri(zkUtil.getMetadataServiceUri(zkRoot));
         BookKeeperAdmin.format(adminConf, false, false);
 
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
         b.shutdown();
     }
 
@@ -949,7 +949,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         conf.setMinUsableSizeForEntryLogCreation(Long.MAX_VALUE)
             .setReadOnlyModeEnabled(false);
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("NoWritableLedgerDirException expected");
         } catch (NoWritableLedgerDirException e) {
             // expected
@@ -958,7 +958,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         conf.setMinUsableSizeForEntryLogCreation(Long.MIN_VALUE)
             .setReadOnlyModeEnabled(false);
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("NoWritableLedgerDirException expected");
         } catch (NoWritableLedgerDirException e) {
             // expected
@@ -970,7 +970,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         try {
             // bookie is okay to start up when readonly mode is enabled because entry log file creation
             // is deferred.
-            bookie = new BookieImpl(conf);
+            bookie = new TestBookieImpl(conf);
         } catch (NoWritableLedgerDirException e) {
             fail("NoWritableLedgerDirException unexpected");
         } finally {
@@ -1002,7 +1002,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // while replaying the journal)
         conf.setReadOnlyModeEnabled(true)
             .setIsForceGCAllowWhenNoSpace(true);
-        final Bookie bk = new BookieImpl(conf);
+        final Bookie bk = new TestBookieImpl(conf);
         bk.start();
         Thread.sleep((conf.getDiskCheckInterval() * 2) + 100);
 
@@ -1555,7 +1555,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         conf.setJournalDirsName(journalDirs);
         conf.setLedgerDirNames(new String[] { tmpLedgerDir.getPath() });
 
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
 
         final BookieId bookieAddress = BookieImpl.getBookieId(conf);
 
@@ -1569,7 +1569,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         rmCookie.getValue().deleteFromRegistrationManager(rm, conf, rmCookie.getVersion());
 
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             Assert.fail("Bookie should not have come up. Cookie no present in metadata store.");
         } catch (Exception e) {
             LOG.info("As expected Bookie fails to come up without a cookie in metadata store.");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -464,7 +464,7 @@ public class BookieJournalTest {
 
         Bookie b = null;
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start without admin");
         } catch (Throwable t) {
             // correct behaviour
@@ -497,7 +497,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
     }
 
     /**
@@ -519,7 +519,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
     }
 
     /**
@@ -547,7 +547,7 @@ public class BookieJournalTest {
 
         Bookie b = null;
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
         } catch (Throwable t) {
             // correct behaviour
         }
@@ -655,7 +655,7 @@ public class BookieJournalTest {
     }
 
     private BookieImpl createBookieAndReadJournal(ServerConfiguration conf) throws Exception {
-        BookieImpl b = new BookieImpl(conf);
+        BookieImpl b = new TestBookieImpl(conf);
         for (Journal journal : b.journals) {
             LastLogMark lastLogMark = journal.getLastLogMark().markLog();
             b.readJournal();
@@ -690,7 +690,7 @@ public class BookieJournalTest {
         conf.setJournalDirName(journalDir.getPath())
                 .setLedgerDirNames(new String[] { ledgerDir.getPath() });
 
-        BookieImpl b = new BookieImpl(conf);
+        BookieImpl b = new TestBookieImpl(conf);
         b.readJournal();
         b.ledgerStorage.flush();
         b.readEntry(1, 80);
@@ -735,13 +735,13 @@ public class BookieJournalTest {
 
         if (truncateMasterKey) {
             try {
-                BookieImpl b = new BookieImpl(conf);
+                BookieImpl b = new TestBookieImpl(conf);
                 b.readJournal();
                 fail("Should not reach here!");
             } catch (IOException ie) {
             }
         } else {
-            BookieImpl b = new BookieImpl(conf);
+            BookieImpl b = new TestBookieImpl(conf);
             b.readJournal();
             b.readEntry(1, 100);
             try {
@@ -791,7 +791,7 @@ public class BookieJournalTest {
             .setLedgerDirNames(new String[] { ledgerDir.getPath() })
             .setMetadataServiceUri(null);
 
-        BookieImpl b = new BookieImpl(conf);
+        BookieImpl b = new TestBookieImpl(conf);
         b.readJournal();
         b.readEntry(1, 100);
         try {
@@ -829,7 +829,7 @@ public class BookieJournalTest {
         PowerMockito.mockStatic(JournalChannel.class);
         PowerMockito.when(JournalChannel.openFileChannel(Mockito.any(RandomAccessFile.class))).thenReturn(fileChannel);
 
-        BookieImpl b = new BookieImpl(conf);
+        BookieImpl b = new TestBookieImpl(conf);
 
         for (Journal journal : b.journals) {
             List<Long> journalIds = journal.listJournalIds(journal.getJournalDirectory(), null);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShutdownTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShutdownTest.java
@@ -120,7 +120,7 @@ public class BookieShutdownTest extends BookKeeperClusterTestCase {
         killBookie(0);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch shutdownComplete = new CountDownLatch(1);
-        Bookie bookie = new BookieImpl(conf) {
+        Bookie bookie = new TestBookieImpl(conf) {
             @Override
             public void run() {
                 try {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieWriteToJournalTest.java
@@ -63,7 +63,7 @@ public class BookieWriteToJournalTest {
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
 
-    class NoOpJournalReplayBookie extends BookieImpl {
+    class NoOpJournalReplayBookie extends TestBookieImpl {
 
         public NoOpJournalReplayBookie(ServerConfiguration conf)
                 throws IOException, InterruptedException, BookieException {
@@ -158,7 +158,7 @@ public class BookieWriteToJournalTest {
         conf.setJournalDirName(journalDir.getPath())
                 .setLedgerDirNames(new String[]{ledgerDir.getPath()});
 
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
         b.start();
 
         long ledgerId = 1;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CheckpointOnNewLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CheckpointOnNewLedgersTest.java
@@ -69,7 +69,7 @@ public class CheckpointOnNewLedgersTest {
         conf.setLedgerDirNames(new String[] { bkDir.toString() });
         conf.setEntryLogSizeLimit(10 * 1024);
 
-        bookie = spy(new BookieImpl(conf));
+        bookie = spy(new TestBookieImpl(conf));
         bookie.start();
 
         getLedgerDescCalledLatch = new CountDownLatch(1);
@@ -175,7 +175,7 @@ public class CheckpointOnNewLedgersTest {
         t1.join();
 
         // construct a new bookie to simulate "bookie restart from crash"
-        Bookie newBookie = new BookieImpl(conf);
+        Bookie newBookie = new TestBookieImpl(conf);
         newBookie.start();
 
         for (int i = 0; i < numEntries; i++) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -924,7 +924,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
          * purpose.
          */
         newBookieConf.setMetadataServiceUri(null);
-        Bookie newbookie = new BookieImpl(newBookieConf);
+        Bookie newbookie = new TestBookieImpl(newBookieConf);
 
         DigestManager digestManager = DigestManager.instantiate(ledgerId, passwdBytes,
                 BookKeeper.DigestType.toProtoDigestType(digestType), UnpooledByteBufAllocator.DEFAULT,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CookieTest.java
@@ -106,7 +106,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
-            Bookie b = new BookieImpl(conf);
+            Bookie b = new TestBookieImpl(conf);
         } catch (Exception e) {
             fail("Should not reach here.");
         }
@@ -140,7 +140,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         c2.writeToDirectory(new File(ledgerDir, "current"));
 
         try {
-            Bookie b = new BookieImpl(conf2);
+            Bookie b = new TestBookieImpl(conf2);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -163,13 +163,13 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
         conf.setLedgerDirNames(new String[] { ledgerDirs[0], ledgerDirs[1] });
         try {
-            Bookie b2 = new BookieImpl(conf);
+            Bookie b2 = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -177,14 +177,14 @@ public class CookieTest extends BookKeeperClusterTestCase {
 
         conf.setJournalDirName(newDirectory()).setLedgerDirNames(ledgerDirs);
         try {
-            Bookie b2 = new BookieImpl(conf);
+            Bookie b2 = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
         }
 
         conf.setJournalDirName(journalDir);
-        b = new BookieImpl(conf);
+        b = new TestBookieImpl(conf);
         b.start();
         b.shutdown();
     }
@@ -204,7 +204,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
@@ -212,7 +212,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             new File(BookieImpl.getCurrentDirectory(new File(journalDir)), BookKeeperConstants.VERSION_FILENAME);
         assertTrue(cookieFile.delete());
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -234,7 +234,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
@@ -242,7 +242,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             new File(BookieImpl.getCurrentDirectory(new File(ledgerDirs[0])), BookKeeperConstants.VERSION_FILENAME);
         assertTrue(cookieFile.delete());
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -264,20 +264,20 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
         conf.setLedgerDirNames(new String[] { ledgerDir0, newDirectory() });
         try {
-            Bookie b2 = new BookieImpl(conf);
+            Bookie b2 = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
         }
 
         conf.setLedgerDirNames(new String[] { ledgerDir0 });
-        b = new BookieImpl(conf);
+        b = new TestBookieImpl(conf);
         b.start();
         b.shutdown();
     }
@@ -299,7 +299,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setAllowStorageExpansion(true)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
-        BookieImpl b = new BookieImpl(conf); // should work fine
+        BookieImpl b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
         b = null;
@@ -315,7 +315,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         conf.setIndexDirName(iPaths);
 
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
         } catch (BookieException.InvalidCookieException ice) {
             fail("Should have been able to start the bookie");
         }
@@ -347,7 +347,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         String[] lPaths2 = new String[] { lPaths[0], lPaths[1], newDirectory() };
         conf.setLedgerDirNames(lPaths2);
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Should not have been able to start the bookie");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behavior
@@ -358,7 +358,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         lPaths2 = new String[] { lPaths[0], lPaths[1] };
         conf.setLedgerDirNames(lPaths2);
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Should not have been able to start the bookie");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behavior
@@ -382,7 +382,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setAllowStorageExpansion(true)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
         b = null;
@@ -397,7 +397,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         assertTrue(currentDir.list().length == 1);
 
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behavior
@@ -413,7 +413,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         assertTrue(currentDir.list().length == 1);
 
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behavior
@@ -434,13 +434,13 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
 
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
         FileUtils.deleteDirectory(new File(ledgerDir0));
         try {
-            Bookie b2 = new BookieImpl(conf);
+            Bookie b2 = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -458,13 +458,13 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setLedgerDirNames(new String[] { newDirectory() , newDirectory() })
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
         conf.setBookiePort(3182);
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -484,7 +484,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setLedgerDirNames(new String[] { newDirectory() , newDirectory() })
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
@@ -494,7 +494,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -519,12 +519,12 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         // Bookie should start successfully for fresh env.
-        new BookieImpl(bookieConf);
+        new TestBookieImpl(bookieConf);
 
         // Format metadata one more time.
         BookKeeperAdmin.format(adminConf, false, true);
         try {
-            new BookieImpl(bookieConf);
+            new TestBookieImpl(bookieConf);
             fail("Bookie should not start with previous instance id.");
         } catch (BookieException.InvalidCookieException e) {
             assertTrue(
@@ -535,7 +535,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
         // Now format the Bookie and restart.
         BookieImpl.format(bookieConf, false, true);
         // After bookie format bookie should be able to start again.
-        new BookieImpl(bookieConf);
+        new TestBookieImpl(bookieConf);
     }
 
     /**
@@ -553,7 +553,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
-            Bookie b = new BookieImpl(conf);
+            Bookie b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -576,7 +576,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
-            Bookie b = new BookieImpl(conf);
+            Bookie b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -598,13 +598,13 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
         conf.setUseHostNameAsBookieID(true);
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("Should not start a bookie with hostname if the bookie has been started with an ip");
         } catch (InvalidCookieException e) {
             // expected
@@ -625,13 +625,13 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         conf.setUseHostNameAsBookieID(false);
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
         conf.setAdvertisedAddress("unknown");
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("Should not start a bookie with ip if the bookie has been started with an ip");
         } catch (InvalidCookieException e) {
             // expected
@@ -652,13 +652,13 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         conf.setUseHostNameAsBookieID(true);
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
 
         conf.setUseHostNameAsBookieID(false);
         try {
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("Should not start a bookie with ip if the bookie has been started with an ip");
         } catch (InvalidCookieException e) {
             // expected
@@ -681,7 +681,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         try {
             conf.setUseHostNameAsBookieID(true);
-            new BookieImpl(conf);
+            new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException ice) {
             // correct behaviour
@@ -702,7 +702,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
         Versioned<Cookie> zkCookie = Cookie.readFromRegistrationManager(rm, conf);
@@ -734,7 +734,7 @@ public class CookieTest extends BookKeeperClusterTestCase {
             .setLedgerDirNames(ledgerDirs)
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
-        Bookie b = new BookieImpl(conf); // should work fine
+        Bookie b = new TestBookieImpl(conf); // should work fine
         b.start();
         b.shutdown();
         Versioned<Cookie> zkCookie = Cookie.readFromRegistrationManager(rm, conf);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/EntryLogTest.java
@@ -307,7 +307,7 @@ public class EntryLogTest {
         conf.setJournalDirName(ledgerDir1.toString());
         conf.setLedgerDirNames(new String[] { ledgerDir1.getAbsolutePath(),
                 ledgerDir2.getAbsolutePath() });
-        BookieImpl bookie = new BookieImpl(conf);
+        BookieImpl bookie = new TestBookieImpl(conf);
         EntryLogger entryLogger = new EntryLogger(conf,
                 bookie.getLedgerDirsManager());
         InterleavedLedgerStorage ledgerStorage =
@@ -687,7 +687,7 @@ public class EntryLogTest {
         conf.setLedgerDirNames(new String[] { ledgerDir.getAbsolutePath()});
         conf.setLedgerStorageClass(ledgerStorageClass);
         conf.setEntryLogPerLedgerEnabled(entryLogPerLedgerEnabled);
-        BookieImpl bookie = new BookieImpl(conf);
+        BookieImpl bookie = new TestBookieImpl(conf);
         CompactableLedgerStorage ledgerStorage = (CompactableLedgerStorage) bookie.ledgerStorage;
         Random rand = new Random(0);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -87,7 +87,7 @@ public class LedgerCacheTest {
         conf.setMetadataServiceUri(null);
         conf.setJournalDirName(txnDir.getPath());
         conf.setLedgerDirNames(new String[] { ledgerDir.getPath() });
-        bookie = new BookieImpl(conf);
+        bookie = new TestBookieImpl(conf);
 
         activeLedgers = new SnapshotMap<Long, Boolean>();
         ledgerCache = ((InterleavedLedgerStorage) bookie.getLedgerStorage().getUnderlyingLedgerStorage()).ledgerCache;
@@ -275,7 +275,7 @@ public class LedgerCacheTest {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setLedgerDirNames(new String[] { ledgerDir1.getAbsolutePath(), ledgerDir2.getAbsolutePath() });
 
-        BookieImpl bookie = new BookieImpl(conf);
+        BookieImpl bookie = new TestBookieImpl(conf);
         InterleavedLedgerStorage ledgerStorage =
             ((InterleavedLedgerStorage) bookie.getLedgerStorage().getUnderlyingLedgerStorage());
         LedgerCacheImpl ledgerCache = (LedgerCacheImpl) ledgerStorage.ledgerCache;
@@ -328,7 +328,7 @@ public class LedgerCacheTest {
             .setPageLimit(1)
             .setLedgerStorageClass(InterleavedLedgerStorage.class.getName());
 
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
         b.start();
         for (int i = 1; i <= numLedgers; i++) {
             ByteBuf packet = generateEntry(i, 1);
@@ -340,7 +340,7 @@ public class LedgerCacheTest {
         conf.setJournalDirName(journalDir.getPath())
             .setLedgerDirNames(new String[] { ledgerDir.getPath() });
 
-        b = new BookieImpl(conf);
+        b = new TestBookieImpl(conf);
         for (int i = 1; i <= numLedgers; i++) {
             try {
                 b.readEntry(i, 1);
@@ -723,9 +723,9 @@ public class LedgerCacheTest {
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
         conf.setLedgerStorageClass(FlushTestSortedLedgerStorage.class.getName());
 
-        Bookie bookie = new BookieImpl(conf);
-        FlushTestSortedLedgerStorage flushTestSortedLedgerStorage = (FlushTestSortedLedgerStorage) bookie.
-                getLedgerStorage();
+        Bookie bookie = new TestBookieImpl(conf);
+        FlushTestSortedLedgerStorage flushTestSortedLedgerStorage =
+            (FlushTestSortedLedgerStorage) bookie.getLedgerStorage();
         EntryMemTable memTable = flushTestSortedLedgerStorage.memTable;
 
         // this bookie.addEntry call is required. FileInfo for Ledger 1 would be created with this call.
@@ -770,7 +770,7 @@ public class LedgerCacheTest {
             .setJournalDirName(tmpDir.toString())
             .setLedgerStorageClass(FlushTestSortedLedgerStorage.class.getName());
 
-        Bookie bookie = new BookieImpl(conf);
+        Bookie bookie = new TestBookieImpl(conf);
         bookie.start();
         FlushTestSortedLedgerStorage flushTestSortedLedgerStorage = (FlushTestSortedLedgerStorage) bookie.
                 getLedgerStorage();
@@ -821,9 +821,9 @@ public class LedgerCacheTest {
         // enable entrylog per ledger
         conf.setEntryLogPerLedgerEnabled(true);
 
-        Bookie bookie = new BookieImpl(conf);
-        FlushTestSortedLedgerStorage flushTestSortedLedgerStorage = (FlushTestSortedLedgerStorage) bookie.
-                getLedgerStorage();
+        Bookie bookie = new TestBookieImpl(conf);
+        FlushTestSortedLedgerStorage flushTestSortedLedgerStorage =
+            (FlushTestSortedLedgerStorage) bookie.getLedgerStorage();
         EntryMemTable memTable = flushTestSortedLedgerStorage.memTable;
 
         /*
@@ -862,9 +862,9 @@ public class LedgerCacheTest {
         // enable entrylog per ledger
         conf.setEntryLogPerLedgerEnabled(true);
 
-        Bookie bookie = new BookieImpl(conf);
-        FlushTestSortedLedgerStorage flushTestSortedLedgerStorage = (FlushTestSortedLedgerStorage) bookie.
-                getLedgerStorage();
+        Bookie bookie = new TestBookieImpl(conf);
+        FlushTestSortedLedgerStorage flushTestSortedLedgerStorage =
+            (FlushTestSortedLedgerStorage) bookie.getLedgerStorage();
         EntryMemTable memTable = flushTestSortedLedgerStorage.memTable;
 
         /*

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageTest.java
@@ -142,7 +142,7 @@ public class LedgerStorageTest extends BookKeeperClusterTestCase {
          * purpose.
          */
         newBookieConf.setMetadataServiceUri(null);
-        BookieImpl newbookie = new BookieImpl(newBookieConf);
+        BookieImpl newbookie = new TestBookieImpl(newBookieConf);
         /*
          * since 'newbookie' uses the same data as original Bookie, it should be
          * able to read journal of the original bookie and hence explicitLac buf
@@ -307,7 +307,7 @@ public class LedgerStorageTest extends BookKeeperClusterTestCase {
          * purpose.
          */
         newBookieConf.setMetadataServiceUri(null);
-        BookieImpl newbookie = new BookieImpl(newBookieConf);
+        BookieImpl newbookie = new TestBookieImpl(newBookieConf);
         /*
          * since 'newbookie' uses the same data as original Bookie, it should be
          * able to read journal of the original bookie.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SingleBookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SingleBookieInitializationTest.java
@@ -89,7 +89,7 @@ public class SingleBookieInitializationTest {
         conf.setMinUsableSizeForEntryLogCreation(Long.MIN_VALUE);
         conf.setLedgerStorageClass(InterleavedLedgerStorage.class.getName());
 
-        bookie = new BookieImpl(conf);
+        bookie = new TestBookieImpl(conf);
         bookie.start();
 
         CompletableFuture<Integer> writeFuture = new CompletableFuture<>();
@@ -111,7 +111,7 @@ public class SingleBookieInitializationTest {
         conf.setMinUsableSizeForEntryLogCreation(Long.MAX_VALUE);
         conf.setLedgerStorageClass(InterleavedLedgerStorage.class.getName());
 
-        bookie = new BookieImpl(conf);
+        bookie = new TestBookieImpl(conf);
         bookie.start();
 
         try {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestBookieImpl.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestBookieImpl.java
@@ -1,0 +1,37 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie;
+
+import io.netty.buffer.PooledByteBufAllocator;
+import java.io.IOException;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.proto.SimpleBookieServiceInfoProvider;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+
+/**
+ * Test wrapper for BookieImpl that chooses defaults for dependencies.
+ */
+public class TestBookieImpl extends BookieImpl {
+    public TestBookieImpl(ServerConfiguration conf) throws IOException, InterruptedException, BookieException {
+        super(conf, NullStatsLogger.INSTANCE, PooledByteBufAllocator.DEFAULT,
+                new SimpleBookieServiceInfoProvider(conf));
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
@@ -154,7 +154,7 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort);
         Bookie b = null;
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException e) {
             // correct behaviour
@@ -162,14 +162,14 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
         }
 
         FileSystemUpgrade.upgrade(conf); // should work fine
-        b = new BookieImpl(conf);
+        b = new TestBookieImpl(conf);
         b.start();
         b.shutdown();
         b = null;
 
         FileSystemUpgrade.rollback(conf);
         try {
-            b = new BookieImpl(conf);
+            b = new TestBookieImpl(conf);
             fail("Shouldn't have been able to start");
         } catch (BookieException.InvalidCookieException e) {
             // correct behaviour
@@ -178,7 +178,7 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
 
         FileSystemUpgrade.upgrade(conf);
         FileSystemUpgrade.finalizeUpgrade(conf);
-        b = new BookieImpl(conf);
+        b = new TestBookieImpl(conf);
         b.start();
         b.shutdown();
         b = null;
@@ -211,7 +211,7 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
             .setBookiePort(bookiePort)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         FileSystemUpgrade.upgrade(conf); // should work fine with current directory
-        Bookie b = new BookieImpl(conf);
+        Bookie b = new TestBookieImpl(conf);
         b.start();
         b.shutdown();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.bookie.BookieImpl;
 import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.EntryLogger;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.proto.BookieProtocol;
@@ -66,7 +67,7 @@ public class DbLedgerStorageTest {
         conf.setGcWaitTime(gcWaitTime);
         conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
-        BookieImpl bookie = new BookieImpl(conf);
+        BookieImpl bookie = new TestBookieImpl(conf);
 
         ledgerDirsManager = bookie.getLedgerDirsManager();
         storage = (DbLedgerStorage) bookie.getLedgerStorage();
@@ -251,7 +252,7 @@ public class DbLedgerStorageTest {
         conf.setLedgerDirNames(new String[] { firstDir.getCanonicalPath(), secondDir.getCanonicalPath() });
 
         // Should not fail
-        Bookie bookie = new BookieImpl(conf);
+        Bookie bookie = new TestBookieImpl(conf);
         assertEquals(2, ((DbLedgerStorage) bookie.getLedgerStorage()).getLedgerStorageList().size());
 
         bookie.shutdown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
@@ -35,6 +35,7 @@ import org.apache.bookkeeper.bookie.CheckpointSource;
 import org.apache.bookkeeper.bookie.Checkpointer;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
 import org.apache.bookkeeper.bookie.StateManager;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
@@ -116,7 +117,7 @@ public class DbLedgerStorageWriteCacheTest {
         conf.setProperty(DbLedgerStorage.WRITE_CACHE_MAX_SIZE_MB, 1);
         conf.setProperty(DbLedgerStorage.MAX_THROTTLE_TIME_MILLIS, 1000);
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
-        Bookie bookie = new BookieImpl(conf);
+        Bookie bookie = new TestBookieImpl(conf);
 
         storage = (DbLedgerStorage) bookie.getLedgerStorage();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperCloseTest.java
@@ -38,7 +38,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.BookieImpl;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CreateCallback;
@@ -76,7 +76,7 @@ public class BookKeeperCloseTest extends BookKeeperClusterTestCase {
     private void restartBookieSlow() throws Exception{
         ServerConfiguration conf = killBookie(0);
 
-        Bookie delayBookie = new BookieImpl(conf) {
+        Bookie delayBookie = new TestBookieImpl(conf) {
                 @Override
                 public void recoveryAddEntry(ByteBuf entry, WriteCallback cb,
                                              Object ctx, byte[] masterKey)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.bookkeeper.bookie.Bookie;
-import org.apache.bookkeeper.bookie.BookieImpl;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.common.testing.annotations.FlakyTest;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -78,7 +78,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
             BookKeeperCheckInfoReader client, ServerConfiguration conf, final long initialFreeDiskSpace,
             final long finalFreeDiskSpace, final AtomicBoolean useFinal) throws Exception {
         final AtomicBoolean ready = useFinal == null ? new AtomicBoolean(false) : useFinal;
-        Bookie bookieWithCustomFreeDiskSpace = new BookieImpl(conf) {
+        Bookie bookieWithCustomFreeDiskSpace = new TestBookieImpl(conf) {
             long startTime = System.currentTimeMillis();
             @Override
             public long getTotalFreeSpace() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.BookieImpl;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BKException.BKLedgerClosedException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -1495,7 +1495,7 @@ public class BookieWriteLedgerTest extends
         }
     }
 
-    static class CorruptReadBookie extends BookieImpl {
+    static class CorruptReadBookie extends TestBookieImpl {
 
         static final Logger LOG = LoggerFactory.getLogger(CorruptReadBookie.class);
         ByteBuf localBuf;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCloseTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.BookieImpl;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -197,7 +197,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
 
     private void startUnauthorizedBookie(ServerConfiguration conf, final CountDownLatch latch)
             throws Exception {
-        Bookie sBookie = new BookieImpl(conf) {
+        Bookie sBookie = new TestBookieImpl(conf) {
             @Override
             public void addEntry(ByteBuf entry, boolean ackBeforeSync, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
@@ -221,7 +221,7 @@ public class LedgerCloseTest extends BookKeeperClusterTestCase {
     // simulate slow adds, then become normal when recover,
     // so no ensemble change when recovering ledger on this bookie.
     private void startDeadBookie(ServerConfiguration conf, final CountDownLatch latch) throws Exception {
-        Bookie dBookie = new BookieImpl(conf) {
+        Bookie dBookie = new TestBookieImpl(conf) {
             @Override
             public void addEntry(ByteBuf entry, boolean ackBeforeSync, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerRecoveryTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.BookieImpl;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -188,7 +188,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
         BookieId host = beforelh.getCurrentEnsemble().get(slowBookieIdx);
         ServerConfiguration conf = killBookie(host);
 
-        Bookie fakeBookie = new BookieImpl(conf) {
+        Bookie fakeBookie = new TestBookieImpl(conf) {
             @Override
             public void addEntry(ByteBuf entry, boolean ackBeforeSync, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
@@ -245,7 +245,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
 
         // Add a dead bookie to the cluster
         ServerConfiguration conf = newServerConfiguration();
-        Bookie deadBookie1 = new BookieImpl(conf) {
+        Bookie deadBookie1 = new TestBookieImpl(conf) {
             @Override
             public void recoveryAddEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
@@ -323,7 +323,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
 
         // Add a dead bookie to the cluster
         ServerConfiguration conf = newServerConfiguration();
-        Bookie deadBookie1 = new BookieImpl(conf) {
+        Bookie deadBookie1 = new TestBookieImpl(conf) {
             @Override
             public void recoveryAddEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {
@@ -405,7 +405,7 @@ public class LedgerRecoveryTest extends BookKeeperClusterTestCase {
     }
 
     private void startDeadBookie(ServerConfiguration conf) throws Exception {
-        Bookie rBookie = new BookieImpl(conf) {
+        Bookie rBookie = new TestBookieImpl(conf) {
             @Override
             public void recoveryAddEntry(ByteBuf entry, WriteCallback cb, Object ctx, byte[] masterKey)
                     throws IOException, BookieException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ParallelLedgerRecoveryTest.java
@@ -37,8 +37,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.BookieImpl;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.WriteFlag;
@@ -483,7 +483,7 @@ public class ParallelLedgerRecoveryTest extends BookKeeperClusterTestCase {
         assertEquals("recovery callback should be triggered only once", 0, numFailureCalls.get());
     }
 
-    static class DelayResponseBookie extends BookieImpl {
+    static class DelayResponseBookie extends TestBookieImpl {
 
         static final class WriteCallbackEntry {
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedAndEntry.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestReadLastConfirmedAndEntry.java
@@ -34,10 +34,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.BookieImpl;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.bookie.SortedLedgerStorage;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -76,7 +76,7 @@ public class TestReadLastConfirmedAndEntry extends BookKeeperClusterTestCase {
         });
     }
 
-    static class FakeBookie extends BookieImpl {
+    static class FakeBookie extends TestBookieImpl {
 
         final long expectedEntryToFail;
         final boolean stallOrRespondNull;
@@ -173,7 +173,7 @@ public class TestReadLastConfirmedAndEntry extends BookKeeperClusterTestCase {
         assertEquals(BKException.Code.OK, rcHolder.get());
     }
 
-    static class SlowReadLacBookie extends BookieImpl {
+    static class SlowReadLacBookie extends TestBookieImpl {
 
         private final long lacToSlowRead;
         private final CountDownLatch readLatch;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureTest.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.bookie.Journal;
 import org.apache.bookkeeper.bookie.SlowBufferedChannel;
 import org.apache.bookkeeper.bookie.SlowInterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.SlowSortedLedgerStorage;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadLastConfirmedCallback;
@@ -122,7 +123,7 @@ public class BookieBackpressureTest extends BookKeeperClusterTestCase
 
     private Bookie bookieWithMockedJournal(ServerConfiguration conf,
                                            long getDelay, long addDelay, long flushDelay) throws Exception {
-        Bookie bookie = new BookieImpl(conf);
+        Bookie bookie = new TestBookieImpl(conf);
         if (getDelay <= 0 && addDelay <= 0 && flushDelay <= 0) {
             return bookie;
         }
@@ -145,7 +146,7 @@ public class BookieBackpressureTest extends BookKeeperClusterTestCase
 
     @SuppressWarnings("unchecked")
     private List<Journal> getJournals(Bookie bookie) throws NoSuchFieldException, IllegalAccessException {
-        Field f = bookie.getClass().getDeclaredField("journals");
+        Field f = BookieImpl.class.getDeclaredField("journals");
         f.setAccessible(true);
 
         return (List<Journal>) f.get(bookie);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.bookkeeper.auth.AuthProviderFactoryFactory;
 import org.apache.bookkeeper.auth.ClientAuthProvider;
 import org.apache.bookkeeper.bookie.Bookie;
-import org.apache.bookkeeper.bookie.BookieImpl;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -244,7 +244,7 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
     public void testRequestCompletesAfterDisconnectRace() throws Exception {
         ServerConfiguration conf = killBookie(0);
 
-        Bookie delayBookie = new BookieImpl(conf) {
+        Bookie delayBookie = new TestBookieImpl(conf) {
             @Override
             public ByteBuf readEntry(long ledgerId, long entryId)
                     throws IOException, NoLedgerException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
@@ -58,6 +58,7 @@ import org.apache.bookkeeper.bookie.BookieAccessor;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.BookieImpl;
 import org.apache.bookkeeper.bookie.IndexPersistenceMgr;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.BKException;
@@ -283,7 +284,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
         final AtomicInteger numReads = new AtomicInteger(0);
         ServerConfiguration conf = killBookie(0);
 
-        Bookie deadBookie = new BookieImpl(conf) {
+        Bookie deadBookie = new TestBookieImpl(conf) {
             @Override
             public ByteBuf readEntry(long ledgerId, long entryId)
                     throws IOException, NoLedgerException {
@@ -772,7 +773,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
 
         LOG.info("Killing bookie " + addressByIndex(bookieIdx));
         ServerConfiguration conf = killBookie(bookieIdx);
-        Bookie writeFailingBookie = new BookieImpl(conf) {
+        Bookie writeFailingBookie = new TestBookieImpl(conf) {
             @Override
             public void addEntry(ByteBuf entry, boolean ackBeforeSync, WriteCallback cb,
                              Object ctx, byte[] masterKey)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ConcurrentLedgerTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.BookieImpl;
+import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.net.BookieId;
@@ -85,7 +85,7 @@ public class ConcurrentLedgerTest {
         conf.setMetadataServiceUri(null);
         conf.setJournalDirName(txnDir.getPath());
         conf.setLedgerDirNames(new String[] { ledgerDir.getPath() });
-        bookie = new BookieImpl(conf);
+        bookie = new TestBookieImpl(conf);
         bookie.start();
     }
 


### PR DESCRIPTION
### Motivation

To have DI on the bookie, it's better to have a single constructor
that takes all the injected implementations. With a single
constructor, there's only one place modify in production code when we
want to inject something, rather than having the bookie need to know
how to create a "default" version (which often breaks encapsulation).

If we need convenience constructors for tests, they should live in the
tests.

### Changes

The principle changes are:
- remove the BookieImpl constructor which takes only a ServerConfiguration and chooses default values for the other ijectable dependencies.
- add a TestBookieImpl for use in tests which has a constructor that matches the one removed from BookieImpl.

This is one of many preliminary PRs with refactorings required for the "BP-46 Running without journal" work.
