### PR TITLE
BP-44: Removed bookie port number from OrderedExecutor name

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -157,12 +157,12 @@ public class BookieRequestProcessor implements RequestProcessor {
             }
             this.longPollThreadPool = createExecutor(
                 numThreads,
-                "BookieLongPollThread-" + serverCfg.getBookiePort(),
+                "BookieLongPollThread",
                 OrderedExecutor.NO_TASK_LIMIT, statsLogger);
         }
         this.highPriorityThreadPool = createExecutor(
                 this.serverCfg.getNumHighPriorityWorkerThreads(),
-                "BookieHighPriorityThread-" + serverCfg.getBookiePort(),
+                "BookieHighPriorityThread",
                 OrderedExecutor.NO_TASK_LIMIT, statsLogger);
         this.shFactory = shFactory;
         if (shFactory != null) {


### PR DESCRIPTION
### Motivation

Including the port number only complicates things for
admins who rely on OrderedExecutor metrics for alerts
and dashboards. Removing the port number reduces,
the complexity for deployments which use various
non-standard bookie ports.

### Changes

Removed port number from high priority and long poll thread pool names.

Master Issue: #2834