### PR TITLE
Add gradle task to publish tarball bundle for bk with a dev flag

### DIFF
--- a/bookkeeper-dist/all/build.gradle
+++ b/bookkeeper-dist/all/build.gradle
@@ -126,3 +126,13 @@ distributions {
         }
     }
 }
+
+if (project.hasProperty("dev")) {
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                artifact distTar
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

We don't publish bookkeeper tarballs to maven via gradle

### Changes

We add a property guarged flag to publish the tarball artifacts  to maven.
