### PR TITLE
Restart the upgrade in rotation, should not quarantine the bookie node

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -593,6 +593,10 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         this.upgrading = upgrading;
     }
 
+    public boolean isUpgrading() {
+        return upgrading != null && upgrading.get();
+    }
+
     int getReturnRc(int rc) {
         return getReturnRc(bookieClient, rc);
     }
@@ -625,7 +629,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     void checkForFaultyBookies() {
         List<BookieId> faultyBookies = bookieClient.getFaultyBookies();
         for (BookieId faultyBookie : faultyBookies) {
-            if (!upgrading.get() && Math.random() <= bookieQuarantineRatio) {
+            if (!isUpgrading() && Math.random() <= bookieQuarantineRatio) {
                 bookieWatcher.quarantineBookie(faultyBookie);
                 statsLogger.getCounter(BookKeeperServerStats.BOOKIE_QUARANTINE).inc();
             } else {


### PR DESCRIPTION
### Motivation

When I restarted and upgraded pulsar and bookkeeper in rotation, I found that all bookie nodes were quarantine, which caused the client to be abnormal for a long time：
![image](https://user-images.githubusercontent.com/19296967/140854567-284ce8cb-dd7b-4494-bc45-7c5c1ac12844.png)



### Changes
Therefore, bookkeeper needs to provide an interface to mark whether the cluster is restarting and upgrading in rotation.  should not  quarantine bookie at this time.

When the bookkeeper cluster needs to be restarted and upgraded in turn, we mark the upgrade through dynamic configuration. At this time, the bookie node that fails to write due to the restart will not be quarantined.
Corresponding Pulsar's PR：https://github.com/apache/pulsar/pull/12683
