### PR TITLE
Reorder the sequence of the bookkeeper server shutdown so that there are no read/ write ops while shutting down the bookie

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -272,6 +272,7 @@ public class BookieRequestProcessor implements RequestProcessor {
         }
         shutdownExecutor(highPriorityThreadPool);
         requestTimer.stop();
+        LOG.info("Closed RequestProcessor");
     }
 
     private OrderedExecutor createExecutor(

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -264,6 +264,7 @@ public class BookieRequestProcessor implements RequestProcessor {
 
     @Override
     public void close() {
+        LOG.info("Closing RequestProcessor");
         shutdownExecutor(writeThreadPool);
         shutdownExecutor(readThreadPool);
         if (serverCfg.getNumLongPollWorkerThreads() > 0 || readThreadPool == null) {
@@ -294,7 +295,8 @@ public class BookieRequestProcessor implements RequestProcessor {
 
     private void shutdownExecutor(OrderedExecutor service) {
         if (null != service) {
-            service.forceShutdown(1000, TimeUnit.SECONDS);
+            service.shutdown();
+            service.forceShutdown(10, TimeUnit.SECONDS);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -294,7 +294,7 @@ public class BookieRequestProcessor implements RequestProcessor {
 
     private void shutdownExecutor(OrderedExecutor service) {
         if (null != service) {
-            service.shutdown();
+            service.forceShutdown(1000, TimeUnit.SECONDS);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -216,10 +216,10 @@ public class BookieServer {
 
     public synchronized void shutdown() {
         LOG.info("Shutting down BookieServer");
+        this.nettyServer.shutdown();
         if (!running) {
             return;
         }
-        this.nettyServer.shutdown();
         this.requestProcessor.close();
         exitCode = bookie.shutdown();
         running = false;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -216,12 +216,12 @@ public class BookieServer {
 
     public synchronized void shutdown() {
         LOG.info("Shutting down BookieServer");
-        this.nettyServer.shutdown();
         if (!running) {
             return;
         }
-        exitCode = bookie.shutdown();
+        this.nettyServer.shutdown();
         this.requestProcessor.close();
+        exitCode = bookie.shutdown();
         running = false;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -66,7 +66,9 @@ abstract class PacketProcessorBase<T extends Request> extends SafeRunnable {
     }
 
     protected void sendResponse(int rc, Object response, OpStatsLogger statsLogger) {
-        channel.writeAndFlush(response, channel.voidPromise());
+        if (channel.isActive()) {
+            channel.writeAndFlush(response, channel.voidPromise());
+        }
         if (BookieProtocol.EOK == rc) {
             statsLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
         } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -68,6 +68,8 @@ abstract class PacketProcessorBase<T extends Request> extends SafeRunnable {
     protected void sendResponse(int rc, Object response, OpStatsLogger statsLogger) {
         if (channel.isActive()) {
             channel.writeAndFlush(response, channel.voidPromise());
+        } else {
+            LOGGER.info("Netty channel is inactive, hence bypassing netty channel writeAndFlush during sendResponse");
         }
         if (BookieProtocol.EOK == rc) {
             statsLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -69,7 +69,8 @@ abstract class PacketProcessorBase<T extends Request> extends SafeRunnable {
         if (channel.isActive()) {
             channel.writeAndFlush(response, channel.voidPromise());
         } else {
-            LOGGER.info("Netty channel is inactive, hence bypassing netty channel writeAndFlush during sendResponse");
+            LOGGER.debug("Netty channel {} is inactive, "
+                    + "hence bypassing netty channel writeAndFlush during sendResponse", channel);
         }
         if (BookieProtocol.EOK == rc) {
             statsLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
@@ -87,25 +87,26 @@ public abstract class PacketProcessorBaseV3 extends SafeRunnable {
                 requestProcessor.invalidateBlacklist(channel);
             }
         }
-
-        channel.writeAndFlush(response).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                long writeElapsedNanos = MathUtils.elapsedNanos(writeNanos);
-                if (!future.isSuccess()) {
-                    requestProcessor.getRequestStats().getChannelWriteStats()
-                        .registerFailedEvent(writeElapsedNanos, TimeUnit.NANOSECONDS);
-                } else {
-                    requestProcessor.getRequestStats().getChannelWriteStats()
-                        .registerSuccessfulEvent(writeElapsedNanos, TimeUnit.NANOSECONDS);
+        if (channel.isActive()) {
+            channel.writeAndFlush(response).addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    long writeElapsedNanos = MathUtils.elapsedNanos(writeNanos);
+                    if (!future.isSuccess()) {
+                        requestProcessor.getRequestStats().getChannelWriteStats()
+                                .registerFailedEvent(writeElapsedNanos, TimeUnit.NANOSECONDS);
+                    } else {
+                        requestProcessor.getRequestStats().getChannelWriteStats()
+                                .registerSuccessfulEvent(writeElapsedNanos, TimeUnit.NANOSECONDS);
+                    }
+                    if (StatusCode.EOK == code) {
+                        statsLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+                    } else {
+                        statsLogger.registerFailedEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+                    }
                 }
-                if (StatusCode.EOK == code) {
-                    statsLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
-                } else {
-                    statsLogger.registerFailedEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
-                }
-            }
-        });
+            });
+        }
     }
 
     protected boolean isVersionCompatible() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
@@ -107,7 +107,8 @@ public abstract class PacketProcessorBaseV3 extends SafeRunnable {
                 }
             });
         } else {
-            LOGGER.info("Netty channel is inactive, hence bypassing netty channel writeAndFlush during sendResponse");
+            LOGGER.debug("Netty channel {} is inactive, "
+                    + "hence bypassing netty channel writeAndFlush during sendResponse", channel);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
@@ -106,6 +106,8 @@ public abstract class PacketProcessorBaseV3 extends SafeRunnable {
                     }
                 }
             });
+        } else {
+            LOGGER.info("Netty channel is inactive, hence bypassing netty channel writeAndFlush during sendResponse");
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ForceLedgerProcessorV3Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ForceLedgerProcessorV3Test.java
@@ -77,6 +77,7 @@ public class ForceLedgerProcessorV3Test {
         when(requestProcessor.getBookie()).thenReturn(bookie);
         when(requestProcessor.getWaitTimeoutOnBackpressureMillis()).thenReturn(-1L);
         when(requestProcessor.getRequestStats()).thenReturn(new RequestStats(NullStatsLogger.INSTANCE));
+        when(channel.isActive()).thenReturn(true);
         processor = new ForceLedgerProcessorV3(
             request,
             channel,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
@@ -71,6 +71,7 @@ public class WriteEntryProcessorTest {
         requestProcessor = mock(BookieRequestProcessor.class);
         when(requestProcessor.getBookie()).thenReturn(bookie);
         when(requestProcessor.getRequestStats()).thenReturn(new RequestStats(NullStatsLogger.INSTANCE));
+        when(channel.isActive()).thenReturn(true);
         processor = WriteEntryProcessor.create(
             request,
             channel,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3Test.java
@@ -82,6 +82,7 @@ public class WriteEntryProcessorV3Test {
         when(requestProcessor.getBookie()).thenReturn(bookie);
         when(requestProcessor.getWaitTimeoutOnBackpressureMillis()).thenReturn(-1L);
         when(requestProcessor.getRequestStats()).thenReturn(new RequestStats(NullStatsLogger.INSTANCE));
+        when(channel.isActive()).thenReturn(true);
         processor = new WriteEntryProcessorV3(
             request,
             channel,

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -41,7 +41,7 @@ function run_command() {
         chmod -R +x ${BINDIR}
         chmod -R +x ${SCRIPTS_DIR}
         echo "This is root, will use user $BK_USER to run command '$@'"
-        sudo -s -E -u "$BK_USER" /bin/bash "$@"
+        exec sudo -s -E -u "$BK_USER" /bin/bash "$@"
         exit
     else
         echo "Run command '$@'"

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -41,7 +41,7 @@ function run_command() {
         chmod -R +x ${BINDIR}
         chmod -R +x ${SCRIPTS_DIR}
         echo "This is root, will use user $BK_USER to run command '$@'"
-        exec sudo -s -E -u "$BK_USER" /bin/bash "$@"
+        sudo -s -E -u "$BK_USER" /bin/bash "$@"
         exit
     else
         echo "Run command '$@'"


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

After the readcache has been shutdown, all the buffers will be released in memory. In the meantime, if read and write ops are performed on the read cache, then it results in the segmentation fault on invalid memory. So, this PR will shutdown the request processor that does readops and writeops before the bookie shutdown sequence.

### Changes

- Stop all the requestProcessor threads before bookie shutdown sequence to avoid read/write ops during bookie shutdown
- Force shutdown the executors so that it is ensured to stop all executor threads before bookie shutdown.

### How to reproduce
- Apply this diff https://gist.github.com/pradeepbn/a033cae7171f9e6da9a7f92737f843b9 on the master branch to reproduce the issue
- Use this (https://gist.github.com/pradeepbn/65ef387a164953fb3f90057860b12da1) client to pump traffic and initiate reads
- Wait until the console shows `Waiting for reads to be done` and kill the bookie with ctrl+c