### PR TITLE
fix executing ReadLogMetadata with file name in bookkeeper shell

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
@@ -79,10 +79,10 @@ public class ReadLogMetadataCommand extends BookieCommand<ReadLogMetadataFlags> 
     public static class ReadLogMetadataFlags extends CliFlags {
 
         @Parameter(names = { "-l", "--logid" }, description = "Entry log id")
-        private long logId;
+        private long logId = DEFAULT_LOGID;
 
         @Parameter(names = { "-f", "--filename" }, description = "Entry log filename")
-        private String logFilename;
+        private String logFilename = DEFAULT_FILENAME;
 
         @Parameter(names = { "-lf", "--ledgeridformatter" }, description = "Set ledger id formatter")
         private String ledgerIdFormatter = DEFAULT;


### PR DESCRIPTION
Fixes #2889 