### PR TITLE
ISSUE-2806: OOM as 1 million ledgers per entry log

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogMetadata.java
@@ -35,10 +35,13 @@ public class EntryLogMetadata {
     private final ConcurrentLongLongHashMap ledgersMap;
 
     public EntryLogMetadata(long logId) {
+        this(logId, 1);
+    }
+    public EntryLogMetadata(long logId, int concurrencyLevel) {
         this.entryLogId = logId;
 
         totalSize = remainingSize = 0;
-        ledgersMap = new ConcurrentLongLongHashMap(256, 1);
+        ledgersMap = new ConcurrentLongLongHashMap(256, concurrencyLevel);
     }
 
     public void addLedgerSize(long ledgerId, long size) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
@@ -84,6 +84,8 @@ class EntryLoggerAllocator {
         // this header buffer is cleared before writing it into the new logChannel.
         logfileHeader.writeBytes("BKLO".getBytes(UTF_8));
         logfileHeader.writeInt(EntryLogger.HEADER_CURRENT_VERSION);
+        logfileHeader.writerIndex(EntryLogger.CREATE_TIMESTAMP_POSITION);
+        logfileHeader.writeLong(System.currentTimeMillis());
         logfileHeader.writerIndex(EntryLogger.LOGFILE_HEADER_SIZE);
 
     }
@@ -167,7 +169,12 @@ class EntryLoggerAllocator {
         FileChannel channel = new RandomAccessFile(newLogFile, "rw").getChannel();
 
         BufferedLogChannel logChannel = new BufferedLogChannel(byteBufAllocator, channel, conf.getWriteBufferBytes(),
-                conf.getReadBufferBytes(), preallocatedLogId, newLogFile, conf.getFlushIntervalInBytes());
+                conf.getReadBufferBytes(), preallocatedLogId, newLogFile, conf.getFlushIntervalInBytes(),
+                conf.getEntryLogLedgerMapConcurrency());
+        //update create timestamp
+        logfileHeader.writerIndex(EntryLogger.CREATE_TIMESTAMP_POSITION);
+        logfileHeader.writeLong(System.currentTimeMillis());
+        logfileHeader.writerIndex(EntryLogger.LOGFILE_HEADER_SIZE);
         logfileHeader.readerIndex(0);
         logChannel.write(logfileHeader);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -149,8 +149,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         log.info("Creating single directory db ledger storage on {}", baseDir);
 
         this.writeCacheMaxSize = writeCacheSize;
-        this.writeCache = new WriteCache(allocator, writeCacheMaxSize / 2);
-        this.writeCacheBeingFlushed = new WriteCache(allocator, writeCacheMaxSize / 2);
+        this.writeCache = new WriteCache(allocator, writeCacheMaxSize / 2,
+                conf.getFlushEntrySortBufferInitSize());
+        this.writeCacheBeingFlushed = new WriteCache(allocator, writeCacheMaxSize / 2,
+                conf.getFlushEntrySortBufferInitSize());
 
         this.checkpointSource = checkpointSource;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
@@ -84,10 +84,15 @@ public class WriteCache implements Closeable {
 
     public WriteCache(ByteBufAllocator allocator, long maxCacheSize) {
         // Default maxSegmentSize set to 1Gb
-        this(allocator, maxCacheSize, 1 * 1024 * 1024 * 1024);
+        this(allocator, maxCacheSize, 1 * 1024 * 1024 * 1024, 0);
     }
 
-    public WriteCache(ByteBufAllocator allocator, long maxCacheSize, int maxSegmentSize) {
+    public WriteCache(ByteBufAllocator allocator, long maxCacheSize, int entrySortBufferInitSize) {
+        // Default maxSegmentSize set to 1Gb
+        this(allocator, maxCacheSize, 1 * 1024 * 1024 * 1024, entrySortBufferInitSize);
+    }
+
+    public WriteCache(ByteBufAllocator allocator, long maxCacheSize, int maxSegmentSize, int entrySortBufferInitSize) {
         checkArgument(maxSegmentSize > 0);
 
         long alignedMaxSegmentSize = alignToPowerOfTwo(maxSegmentSize);
@@ -110,6 +115,11 @@ public class WriteCache implements Closeable {
 
         int lastSegmentSize = (int) (maxCacheSize % maxSegmentSize);
         cacheSegments[segmentsCount - 1] = Unpooled.directBuffer(lastSegmentSize, lastSegmentSize);
+
+        if (entrySortBufferInitSize > 8) {
+            int bufferSize = entrySortBufferInitSize / 8;
+            sortedEntries = new long[bufferSize];
+        }
     }
 
     public void clear() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -115,12 +115,14 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
             "gcOverreplicatedLedgerMaxConcurrentRequests";
     protected static final String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
     protected static final String VERIFY_METADATA_ON_GC = "verifyMetadataOnGC";
+    protected static final String EXTRACT_META_DELAY_TIME_SECONDS = "extractMetaDelayTimeSeconds";
     // Scrub Parameters
     protected static final String LOCAL_SCRUB_PERIOD = "localScrubInterval";
     protected static final String LOCAL_SCRUB_RATE_LIMIT = "localScrubRateLimit";
     // Sync Parameters
     protected static final String FLUSH_INTERVAL = "flushInterval";
     protected static final String FLUSH_ENTRYLOG_INTERVAL_BYTES = "flushEntrylogBytes";
+    protected static final String FLUSH_ENTRY_SORT_BUFFER_INIT_SIZE = "flushEntrySortBufferInitSize";
     // Bookie death watch interval
     protected static final String DEATH_WATCH_INTERVAL = "bookieDeathWatchInterval";
     // Ledger Cache Parameters
@@ -279,7 +281,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String ENTRY_LOG_PER_LEDGER_ENABLED = "entryLogPerLedgerEnabled";
     // In the case of multipleentrylogs, multiple threads can be used to flush the memtable parallelly.
     protected static final String NUMBER_OF_MEMTABLE_FLUSH_THREADS = "numOfMemtableFlushThreads";
-
+    //ledgers map concurrency of entry log meta data
+    protected static final String ENTRY_LOG_LEDGER_MAP_CONCURRENCY = "entryLogLedgerMapConcurrency";
 
     /*
      * config specifying if the entrylog per ledger is enabled, then the amount
@@ -481,6 +484,27 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
+     * Get extract meta delay time. In delay time, meta data will not load, to reduce memory usage.
+     * If the retention time of all the entry is the same and ledger count is very large, the delay time can
+     * be set to the retention time.
+     * @return meta extracting delay time in second
+     */
+    public long getExtractMetaDelayTimeSeconds(){
+        return this.getLong(EXTRACT_META_DELAY_TIME_SECONDS, 0);
+    }
+
+    /**
+     * Set extract meta delay time.
+     *
+     * @param delayTimeSeconds
+     * @return server configuration
+     */
+    public ServerConfiguration setExtractMetaDelayTimeSeconds(long delayTimeSeconds){
+        this.setProperty(EXTRACT_META_DELAY_TIME_SECONDS, delayTimeSeconds);
+        return this;
+    }
+
+    /**
      * Get whether local scrub is enabled.
      *
      * @return Whether local scrub is enabled.
@@ -573,6 +597,28 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
         return this;
     }
 
+    /**
+     * Get entry sorted buffer init size.
+     *
+     * <p>Default is 0. Greater than 1, will pre-allocated buffer to reduce the probability of allocation failure.
+     *
+     * @return entry sorted buffer init size
+     */
+
+    public int getFlushEntrySortBufferInitSize() {
+        return this.getInt(FLUSH_ENTRY_SORT_BUFFER_INIT_SIZE, 0);
+    }
+
+    /**
+     * Set flush entry sorted buffer init size
+     *
+     * @param initSize
+     * @return server configuration
+     */
+    public ServerConfiguration SetFlushEntrySortBufferInitSize(int initSize) {
+        this.setProperty(FLUSH_ENTRY_SORT_BUFFER_INIT_SIZE, Integer.toString(initSize));
+        return this;
+    }
 
     /**
      * Get bookie death watch interval.
@@ -3558,6 +3604,28 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setNumOfMemtableFlushThreads(int numOfMemtableFlushThreads) {
         this.setProperty(NUMBER_OF_MEMTABLE_FLUSH_THREADS, Integer.toString(numOfMemtableFlushThreads));
+        return this;
+    }
+
+    /**
+     * Get ledger map concurrency of entry log. It should be set greater than 1 to avoid allocating a large contiguous
+     * memory, if there are many ledgers in a entry log.
+     *
+     * @return ledger map concurrency.
+     */
+    public int getEntryLogLedgerMapConcurrency() {
+        return this.getInt(ENTRY_LOG_LEDGER_MAP_CONCURRENCY, 1);
+    }
+
+    /**
+     * Set ledger map concurrency of entry log.
+     *
+     * @param concurrency
+     *          map concurrency level
+     * @return client configuration.
+     */
+    public ServerConfiguration setEntryLogLedgerMapConcurrency(int concurrency) {
+        this.setProperty(ENTRY_LOG_LEDGER_MAP_CONCURRENCY, Integer.toString(concurrency));
         return this;
     }
 

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -470,6 +470,9 @@ ledgerDirectories=/tmp/bk-data
 # I/O. Flushing too frequently may also affect performance negatively.
 # flushEntrylogBytes=0
 
+# Default is 0. Greater than 1, will pre-allocated buffer to reduce the probability of allocation failure
+# flushEntrySortBufferInitSize=0
+
 # The number of bytes we should use as capacity for BufferedReadChannel. Default is 512 bytes.
 # readBufferSizeBytes=512
 
@@ -484,6 +487,10 @@ ledgerDirectories=/tmp/bk-data
 
 # In the case of multipleentrylogs, multiple threads can be used to flush the memtable
 # numOfMemtableFlushThreads=8
+
+# It should be set greater than 1 to avoid allocating a large contiguous memory,
+# if there are a large number of ledgers in a entry log.
+# entryLogLedgerMapConcurrency=1
 
 # in entryLogPerLedger feature, the time duration used for lastaccess eviction policy for cache
 # entrylogMapAccessExpiryTimeInSeconds=300
@@ -587,6 +594,12 @@ ledgerDirectories=/tmp/bk-data
 
 # True if the bookie should double check readMetadata prior to gc
 # verifyMetadataOnGC=false
+
+# If the ledgers count is very lardge, the memory of EntryLogMetadata of all entry log files will also
+# be very large. If the retention time of all the entry is the same, we do not need to extract the entry
+# logs in retention time to load meta to memory. It will reduce memory usage. The delay time can be set
+# to the retention time.
+# extractMetaDelayTimeSeconds=0
 
 #############################################################################
 ## Disk utilization


### PR DESCRIPTION
### Motivation

fix issue [2806](https://github.com/apache/bookkeeper/issues/2806) OOM as 1 million ledgers per entry log


### Changes
1.Add two config entryLogLedgerMapConcurrency and flushEntrySortBufferInitSize, to avoid allocating a large contiguous memory.
2.Reduce memory usage of EntryLogMetadata of entry logs in garbage collector. If the retention time of all the entry is the same, we do not need to extract the entry logs in retention time to load meta to memory. In org.apache.bookkeeper.bookie.GarbageCollectorThread#extractMetaFromEntryLogs, if the entry log in retention time, do not extract the entry log.
