### PR TITLE
Reduce flakiness of TestBKDistributedLogManager

### DIFF
--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKDistributedLogManager.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKDistributedLogManager.java
@@ -72,6 +72,7 @@ import org.apache.distributedlog.metadata.LogSegmentMetadataStoreUpdater;
 import org.apache.distributedlog.metadata.MetadataUpdater;
 import org.apache.distributedlog.util.Utils;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -87,10 +88,22 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
 
     private static final Random RAND = new Random(System.currentTimeMillis());
 
+    protected static int numBookies = 1;
+    static {
+        conf.setEnsembleSize(numBookies)
+            .setAckQuorumSize(numBookies)
+            .setWriteQuorumSize(numBookies);
+    }
+
     @Rule
     public TestName testNames = new TestName();
 
     private static final long DEFAULT_SEGMENT_SIZE = 1000;
+
+    @BeforeClass
+    public static void setupCluster() throws Exception {
+        setupCluster(numBookies);
+    }
 
     private void testNonPartitionedWritesInternal(String name, DistributedLogConfiguration conf) throws Exception {
         BKDistributedLogManager dlm = createNewDLM(conf, name);

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
@@ -73,13 +73,15 @@ public class TestDistributedLogBase {
     static final Logger LOG = LoggerFactory.getLogger(TestDistributedLogBase.class);
 
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(1200);
+    public Timeout globalTimeout = Timeout.seconds(120);
 
     static {
         // org.apache.zookeeper.test.ClientBase uses FourLetterWordMain, from 3.5.3 four letter words
         // are disabled by default due to security reasons
         System.setProperty("zookeeper.4lw.commands.whitelist", "*");
     }
+
+    protected static int numBookies = 1;
 
     // Num worker threads should be one, since the exec service is used for the ordered
     // future pool in test cases, and setting to > 1 will therefore result in unordered
@@ -93,13 +95,17 @@ public class TestDistributedLogBase {
                 .setNumWorkerThreads(1)
                 .setReadAheadNoSuchLedgerExceptionOnReadLACErrorThresholdMillis(20)
                 .setSchedulerShutdownTimeoutMs(0)
+                .setEnsembleSize(numBookies)
+                .setAckQuorumSize(numBookies)
+                .setWriteQuorumSize(numBookies)
+                .setLockTimeout(120)
+                .setZKSessionTimeoutSeconds(60)
                 .setDLLedgerMetadataLayoutVersion(LogSegmentMetadata.LEDGER_METADATA_CURRENT_LAYOUT_VERSION);
     protected ZooKeeper zkc;
     protected static LocalDLMEmulator bkutil;
     protected static ZooKeeperServerShim zks;
     protected static String zkServers;
     protected static int zkPort;
-    protected static int numBookies = 3;
     protected static final List<File> TMP_DIRS = new ArrayList<File>();
 
     @BeforeClass

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
@@ -81,7 +81,7 @@ public class TestDistributedLogBase {
         System.setProperty("zookeeper.4lw.commands.whitelist", "*");
     }
 
-    protected static int numBookies = 1;
+    protected static int numBookies = 3;
 
     // Num worker threads should be one, since the exec service is used for the ordered
     // future pool in test cases, and setting to > 1 will therefore result in unordered
@@ -95,9 +95,6 @@ public class TestDistributedLogBase {
                 .setNumWorkerThreads(1)
                 .setReadAheadNoSuchLedgerExceptionOnReadLACErrorThresholdMillis(20)
                 .setSchedulerShutdownTimeoutMs(0)
-                .setEnsembleSize(numBookies)
-                .setAckQuorumSize(numBookies)
-                .setWriteQuorumSize(numBookies)
                 .setLockTimeout(120)
                 .setZKSessionTimeoutSeconds(60)
                 .setDLLedgerMetadataLayoutVersion(LogSegmentMetadata.LEDGER_METADATA_CURRENT_LAYOUT_VERSION);
@@ -110,13 +107,17 @@ public class TestDistributedLogBase {
 
     @BeforeClass
     public static void setupCluster() throws Exception {
+        setupCluster(numBookies);
+    }
+
+    protected static void setupCluster(int nBookies) throws Exception {
         File zkTmpDir = IOUtils.createTempDir("zookeeper", "distrlog");
         TMP_DIRS.add(zkTmpDir);
         Pair<ZooKeeperServerShim, Integer> serverAndPort = LocalDLMEmulator.runZookeeperOnAnyPort(zkTmpDir);
         zks = serverAndPort.getLeft();
         zkPort = serverAndPort.getRight();
         bkutil = LocalDLMEmulator.newBuilder()
-                .numBookies(numBookies)
+                .numBookies(nBookies)
                 .zkHost("127.0.0.1")
                 .zkPort(zkPort)
                 .serverConf(DLMTestUtil.loadTestBkConf())

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
@@ -73,7 +73,7 @@ public class TestDistributedLogBase {
     static final Logger LOG = LoggerFactory.getLogger(TestDistributedLogBase.class);
 
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(120);
+    public Timeout globalTimeout = Timeout.seconds(1200);
 
     static {
         // org.apache.zookeeper.test.ClientBase uses FourLetterWordMain, from 3.5.3 four letter words

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestNonBlockingReadsMultiReader.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestNonBlockingReadsMultiReader.java
@@ -93,6 +93,7 @@ public class TestNonBlockingReadsMultiReader extends TestDistributedLogBase {
         final RateLimiter limiter = RateLimiter.create(1000);
 
         DistributedLogConfiguration confLocal = new DistributedLogConfiguration();
+        confLocal.loadConf(conf);
         confLocal.setOutputBufferSize(0);
         confLocal.setImmediateFlushEnabled(true);
 


### PR DESCRIPTION
### Motivation

TestBKDistributedLogManager is flaky. 
Sometimes it passes on the CI because of the retries, sometimes it fails.
It passes all tests locally (or in debugger/IDE) if the cases run one by one.
Full suite often fails, typically with random cases failing. 

AFAICT, frequently tests fail because of 
```
[DL-io-0] ERROR org.apache.bookkeeper.common.allocator.impl.ByteBufAllocatorImpl - Unable to allocate memory
java.lang.OutOfMemoryError: Direct buffer memory
```
As result bookies fail, and then test cases fail with something like "BKTransmitException: Failed to write to bookkeeper" 

I don't see anything from netty's leak detection.

It does NOT fix https://github.com/apache/bookkeeper/issues/2898 but it helped to get https://github.com/apache/bookkeeper/issues/2898 reproed without hitting OOME/OODME in the process

### Changes

Reduced number of bookies used for the test.
Closed various resources left open in tests.