### PR TITLE
Fix the compatibility workflows

### DIFF
--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -46,6 +46,5 @@ jobs:
         with:
           java-version: 1.11
       - name: Build with gradle
-        run: ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -Dtestlogger.theme=plain
-        -PexcludeTests="*.apache.distributedlog.*, *.apache.bookkeeper.statelib.*, *.apache.bookkeeper.clients.*, *.apache.bookkeeper.common.*, *.apache.bookkeeper.stream.*"
-
+        run: |
+          ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -Dtestlogger.theme=plain -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**"

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -46,8 +46,5 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with gradle
-        run: ./gradlew test -x bookkeeper-server:test
-        -x tests:integration:cluster:test
-        -x tests:integration:smoke:test
-        -x tests:integration:standalone:test -Dtestlogger.theme=plain
-        -PexcludeTests="*.apache.distributedlog.*, *.apache.bookkeeper.statelib.*, *.apache.bookkeeper.clients.*, *.apache.bookkeeper.common.*, *.apache.bookkeeper.stream.*"
+        run: |
+          ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -Dtestlogger.theme=plain -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**"

--- a/bookkeeper-benchmark/build.gradle
+++ b/bookkeeper-benchmark/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation depLibs.nettyTransportNativeEpoll
     implementation depLibs.zookeeper
     implementation depLibs.log4j12api
+    implementation depLibs.log4jCore
+    implementation depLibs.log4jSlf4jImpl
 
     testImplementation project(':bookkeeper-server')
     testImplementation project(path: ':bookkeeper-common', configuration: 'testArtifacts')
@@ -63,7 +65,6 @@ test {
         maxFailures = 10
         maxRetries = 3
     }
-
     maxHeapSize = '4G'
     forkEvery = 1
     jvmArgs("-Djunit.timeout.test=600000",

--- a/build.gradle
+++ b/build.gradle
@@ -212,12 +212,13 @@ allprojects {
                     exclude '**/client/*'
                     exclude '**/bookie/*'
                 }
+
                 if (project.hasProperty('excludeTests')) {
                     String excludeTests = project.property('excludeTests');
                     ArrayList<String> tests = excludeTests.split(',');
                     tests.forEach({it
-                        String exclude = it.trim();
-                        excludeTestsMatching exclude;
+                        String excludeStr = it.trim();
+                        exclude excludeStr
                     });
                 }
             }

--- a/shaded/distributedlog-core-shaded/build.gradle
+++ b/shaded/distributedlog-core-shaded/build.gradle
@@ -53,7 +53,7 @@ shadowJar {
     relocate 'org.rocksdb', 'dlshade.org.rocksdb'
     relocate 'com.scurrilous.circe', 'dlshade.com.scurrilous.circe'
     relocate 'org.apache.bookkeeper', 'dlshade.org.apache.bookkeeper'
-    relocate 'org.apache.distributedlog', 'dhshade.org.apache.distributedlog'
+    relocate 'org.apache.distributedlog', 'dlshade.org.apache.distributedlog'
     archiveBaseName.set("distributedlog-core-shaded")
     archiveClassifier.set("")
 }

--- a/shaded/distributedlog-core-shaded/build.gradle
+++ b/shaded/distributedlog-core-shaded/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 shadowJar {
     dependencies {
     }
-    relocate 'com.google', 'org.apache.bookkeeper.shaded.com.google'
     relocate 'org.apache.commons.cli', 'dlshade.org.apache.commons.cli'
     relocate 'org.apache.commons.codec', 'dlshade.org.apache.commons.codec'
     relocate 'org.apache.commons.collections4', 'dlshade.org.apache.commons.collections4'

--- a/stream/bk-grpc-name-resolver/build.gradle
+++ b/stream/bk-grpc-name-resolver/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     testImplementation project(path: ':bookkeeper-server', configuration: 'testArtifacts')
     testImplementation depLibs.junit
     testImplementation depLibs.zookeeper
+    testImplementation depLibs.zookeeperTest
+    testImplementation depLibs.log4jSlf4jImpl
 
     testCompileOnly depLibs.lombok
     testAnnotationProcessor depLibs.lombok

--- a/tests/integration/cluster/build.gradle
+++ b/tests/integration/cluster/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     testCompileOnly depLibs.lombok
     testImplementation depLibs.log4j12api
+    testImplementation depLibs.log4jCore
     testImplementation depLibs.testcontainers
     testImplementation depLibs.commonsConfiguration
     testImplementation depLibs.googleHTTPClient

--- a/tests/shaded/distributedlog-core-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/DistributedLogCoreShadedJarTest.java
+++ b/tests/shaded/distributedlog-core-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/DistributedLogCoreShadedJarTest.java
@@ -59,7 +59,7 @@ public class DistributedLogCoreShadedJarTest {
 
     @Test
     public void testProtobufShadedPath() throws Exception {
-        Class.forName("dlshade.com.google.protobuf.Message");
+        Class.forName("org.apache.bookkeeper.shaded.com.google.protobuf.Message");
     }
 
     @Test(expected = ClassNotFoundException.class)
@@ -69,7 +69,7 @@ public class DistributedLogCoreShadedJarTest {
 
     @Test
     public void testGuavaShadedPath() throws Exception {
-        Class.forName("dlshade.com.google.common.cache.Cache");
+        Class.forName("org.apache.bookkeeper.shaded.com.google.common.cache.Cache");
         assertTrue(true);
     }
 
@@ -119,19 +119,19 @@ public class DistributedLogCoreShadedJarTest {
 
     @Test
     public void testDistributedLogCommon() throws Exception {
-        Class.forName("org.apache.distributedlog.common.concurrent.AsyncSemaphore");
+        Class.forName("dlshade.org.apache.distributedlog.common.concurrent.AsyncSemaphore");
         assertTrue(true);
     }
 
     @Test
     public void testDistributedLogProto() throws Exception {
-        Class.forName("org.apache.distributedlog.DLSN");
+        Class.forName("dlshade.org.apache.distributedlog.DLSN");
         assertTrue(true);
     }
 
     @Test
     public void testDistributedLogCore() throws Exception {
-        Class.forName("org.apache.distributedlog.api.AsyncLogReader");
+        Class.forName("dlshade.org.apache.distributedlog.api.AsyncLogReader");
         assertTrue(true);
     }
 

--- a/tests/shaded/distributedlog-core-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/DistributedLogCoreShadedJarTest.java
+++ b/tests/shaded/distributedlog-core-shaded-test/src/test/java/org/apache/bookkeeper/tests/shaded/DistributedLogCoreShadedJarTest.java
@@ -59,7 +59,7 @@ public class DistributedLogCoreShadedJarTest {
 
     @Test
     public void testProtobufShadedPath() throws Exception {
-        Class.forName("org.apache.bookkeeper.shaded.com.google.protobuf.Message");
+        Class.forName("dlshade.com.google.protobuf.Message");
     }
 
     @Test(expected = ClassNotFoundException.class)
@@ -69,7 +69,7 @@ public class DistributedLogCoreShadedJarTest {
 
     @Test
     public void testGuavaShadedPath() throws Exception {
-        Class.forName("org.apache.bookkeeper.shaded.com.google.common.cache.Cache");
+        Class.forName("dlshade.com.google.common.cache.Cache");
         assertTrue(true);
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:
- Fix the compatibility workflows for java11 and java8
- Fixes the dependencies in the tests


### Motivation

Compatibility checks workflow wasn't working because there the github workflow.yaml had syntax issues. Also, since it was enabled 1st time, there were build issues with the tests.

