### PR TITLE
ISSUE #1514: Clean up javadoc mojos execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -907,7 +907,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>
-          <additionalparam>-notimestamp</additionalparam>
+          <notimestamp>true</notimestamp>
           <!-- Prevent missing javadoc comments from being marked as errors -->
           <doclint>none</doclint>
           <subpackages>org.apache.bookkeeper.client:org.apache.bookkeeper.client.api:org.apache.bookkeeper.common.annotation:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature:org.apache.bookkeeper.stats</subpackages>
@@ -936,6 +936,10 @@
           <overview>site/_site/overview/index.html</overview>
           <show>package</show>
           <detectJavaApiLink>false</detectJavaApiLink>
+          <!-- The javadoc plugin only runs in the javadoc modules. But with the default configuration it tries
+               to run a new maven instance in every dependency, in order to generate the apidocs there as well.
+               {@link https://maven.apache.org/plugins-archives/maven-javadoc-plugin-3.1.1/javadoc-mojo.html#detectOfflineLinks} -->
+          <detectOfflineLinks>false</detectOfflineLinks>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Fixes #1514.

### Changes

1. Configuring maven-javadoc-plugin with `detectOfflineLinks=false` eliminates the Maven invocations (refer to: [https://issues.redhat.com/browse/ISPN-8629](https://issues.redhat.com/browse/ISPN-8629)).
2. Use option `notimestamp` to replace `additionalparam` since the latter is not allowed from version `3.x`.

