### PR TITLE
auto metaformat

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -2328,7 +2328,7 @@ public class BookieShell implements Tool {
         }
     }
 
-    public static void main(String[] argv) throws Exception {
+    public static int doMain(String[] argv) throws Exception {
         BookieShell shell = new BookieShell();
 
         // handle some common options for multiple cmds
@@ -2366,7 +2366,11 @@ public class BookieShell implements Tool {
         }
         LOG.debug("Using entry formatter {}", shell.entryFormatter.getClass());
 
-        int res = shell.run(cmdLine.getArgs());
+        return shell.run(cmdLine.getArgs());
+    }
+
+    public static void main(String[] argv) throws Exception {
+        int res = doMain(argv);
         System.exit(res);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -300,6 +300,7 @@ public class Main {
                     Thread.sleep(50);
                     timeCost = System.currentTimeMillis() - start;
                 }
+                throw new RuntimeException("Failed to metaformat,timeout: " +INSTANCEID_TIMEOUT+ " ms");
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/BookKeeperConstants.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/BookKeeperConstants.java
@@ -48,6 +48,7 @@ public class BookKeeperConstants {
     public static final String DEFAULT_ZK_LEDGERS_ROOT_PATH = "/ledgers";
     public static final String LAYOUT_ZNODE = "LAYOUT";
     public static final String INSTANCEID = "INSTANCEID";
+    public static final String INSTANCEID_LOCK = "INSTANCEID_LOCK";
 
     /**
      * Set the max log size limit to 1GB. It makes extra room for entry log file before


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

Make it possible to automatically check zookeeper and create bookkeeper metadata when starting bookkeeper.

### Changes

1. automatically check zookeeper,
2. add a distributed lock to avoid consistency problems,
3. automatically  create bookkeeper metadata. 

Master Issue: [#2904](https://github.com/apache/bookkeeper/issues/2904)
