### PR TITLE
fix(cli): incorrect description for autodiscovery

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -62,7 +62,7 @@ where command is one of:
 [service commands]
 
     bookie              Run a bookie server
-    autorecovery        Run AutoRecovery service daemon
+    autorecovery        Run AutoRecovery service
     zookeeper           Run zookeeper server
 
 [development commands]

--- a/site/_data/cli/bookkeeper.yaml
+++ b/site/_data/cli/bookkeeper.yaml
@@ -7,7 +7,7 @@ commands:
   description: Starts up an ensemble of N bookies in a single JVM process. Typically used for local experimentation and development.
   argument: N
 - name: autorecovery
-  description: Runs the autorecovery service daemon.
+  description: Runs the autorecovery service.
 - name: upgrade
   description: Upgrades the bookie's filesystem.
   options:


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

Descriptions of the changes in this PR:


### Motivation

The description of `bin/bookkeeper autorecovery` is wrong, it won't start in daemon.

### Changes

* Changed the description in bookkeeper shell
* Update the doc

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
