### PR TITLE
Adjust checkpoint timing adaptively according to throughput

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -83,6 +83,20 @@ class SyncThread implements Checkpointer {
     }
 
     protected void doCheckpoint(Checkpoint checkpoint) {
+	// Clear stacked checkpoint tasks
+        try {
+            Field filed = executor.getClass().getDeclaredField("e");
+            filed.setAccessible(true);
+            ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = (ScheduledThreadPoolExecutor) filed.get(executor);
+            BlockingQueue<Runnable> workQueue = scheduledThreadPoolExecutor.getQueue();
+            int workQueueSize = workQueue.size();
+            if (workQueueSize > 1) {
+                workQueue.clear();
+            }
+        } catch (Exception e) {
+            log.error("Clear SyncThread thread pool wrokQueue failed exception:{}", e.getMessage());
+            e.printStackTrace();
+        }
         executor.submit(() -> {
             try {
                 synchronized (suspensionLock) {


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

When using the singleentrylog mode, depending on the throughput, for example, under the throughput of 200m / s, The default value of the configuration parameter logsizelimit is 1.2g. At this time, due to the large throughput, the generation of checkpoint tasks is fast, but the execution time of checkpoint tasks is long. The speed of the two is inconsistent. A large number of tasks accumulate in the checkpoint thread, resulting in the checkpoint bits recorded in the lastmark file greatly lagging behind the real-time data. Restarting bookie will be abnormally slow. Unnecessary checkpoint tasks can be eliminated according to the execution time of checkpoint tasks. The next effective checkpoint task is generated only after one checkpoint task is executed. 



### Changes
The specific way is to clear the accumulated tasks in the checkpoint thread pool every time a newly generated checkpoint task is added. In this way, no matter how large the throughput is, the time to generate the checkpoint task and the time to execute the checkpoint task can match.

Master Issue: #2896
