### PR TITLE
Make sure the LedgerHandle close callback can be completed when encounter exception

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -573,8 +573,9 @@ public class LedgerHandle implements WriteHandle {
                 // running under any bk locks.
                 try {
                     errorOutPendingAdds(rc, pendingAdds);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     closePromise.completeExceptionally(e);
+                    return;
                 }
 
                 if (prevHandleState != HandleState.CLOSED) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -571,7 +571,11 @@ public class LedgerHandle implements WriteHandle {
 
                 // error out all pending adds during closing, the callbacks shouldn't be
                 // running under any bk locks.
-                errorOutPendingAdds(rc, pendingAdds);
+                try {
+                    errorOutPendingAdds(rc, pendingAdds);
+                } catch (Exception e) {
+                    closePromise.completeExceptionally(e);
+                }
 
                 if (prevHandleState != HandleState.CLOSED) {
                     if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
Related to https://github.com/apache/pulsar/pull/12993