### PR TITLE
Allow to configure bookie http host

### DIFF
--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
@@ -106,6 +106,11 @@ public interface HttpServer {
     boolean startServer(int port);
 
     /**
+     * Start the HTTP server on given port and host.
+     */
+    boolean startServer(int port, String host);
+
+    /**
      * Stop the HTTP server.
      */
     void stopServer();

--- a/bookkeeper-http/servlet-http-server/src/main/java/org/apache/bookkeeper/http/servlet/BookieServletHttpServer.java
+++ b/bookkeeper-http/servlet-http-server/src/main/java/org/apache/bookkeeper/http/servlet/BookieServletHttpServer.java
@@ -32,6 +32,8 @@ public class BookieServletHttpServer implements HttpServer {
   static final Logger LOG = LoggerFactory.getLogger(BookieServletHttpServer.class);
   private static HttpServiceProvider bookieHttpServiceProvider;
   private static int listenPort = -1;
+  private static String listenHost = "0.0.0.0";
+
 
   public static HttpServiceProvider getBookieHttpServiceProvider(){
     return bookieHttpServiceProvider;
@@ -41,6 +43,10 @@ public class BookieServletHttpServer implements HttpServer {
    **/
   public static int getListenPort(){
     return listenPort;
+  }
+
+  public static String getListenHost() {
+    return listenHost;
   }
 
   @Override
@@ -56,9 +62,21 @@ public class BookieServletHttpServer implements HttpServer {
   public static synchronized void setPort(int port){
     listenPort = port;
   }
+
+  public static void setHost(String host) {
+    listenHost = host;
+  }
+
   @Override
   public boolean startServer(int port) {
     setPort(port);
+    return true;
+  }
+
+  @Override
+  public boolean startServer(int port, String host) {
+    setPort(port);
+    setHost(host);
     return true;
   }
 

--- a/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxHttpServer.java
+++ b/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxHttpServer.java
@@ -44,7 +44,7 @@ public class VertxHttpServer implements HttpServer {
 
     static final Logger LOG = LoggerFactory.getLogger(VertxHttpServer.class);
 
-    private Vertx vertx;
+    private final Vertx vertx;
     private boolean isRunning;
     private HttpServiceProvider httpServiceProvider;
     private int listeningPort = -1;
@@ -64,6 +64,11 @@ public class VertxHttpServer implements HttpServer {
 
     @Override
     public boolean startServer(int port) {
+        return startServer(port, "0.0.0.0");
+    }
+
+    @Override
+    public boolean startServer(int port, String host) {
         CompletableFuture<AsyncResult<io.vertx.core.http.HttpServer>> future = new CompletableFuture<>();
         VertxHttpHandlerFactory handlerFactory = new VertxHttpHandlerFactory(httpServiceProvider);
         Router router = Router.router(vertx);
@@ -82,7 +87,7 @@ public class VertxHttpServer implements HttpServer {
             @Override
             public void start() throws Exception {
                 LOG.info("Starting Vertx HTTP server on port {}", port);
-                vertx.createHttpServer().requestHandler(router).listen(port, future::complete);
+                vertx.createHttpServer().requestHandler(router).listen(port, host, future::complete);
             }
         });
         try {

--- a/bookkeeper-http/vertx-http-server/src/test/java/org/apache/bookkeeper/http/vertx/TestVertxHttpServer.java
+++ b/bookkeeper-http/vertx-http-server/src/test/java/org/apache/bookkeeper/http/vertx/TestVertxHttpServer.java
@@ -56,6 +56,19 @@ public class TestVertxHttpServer {
     }
 
     @Test
+    public void testStartBasicHttpServerConfigHost() throws Exception {
+        VertxHttpServer httpServer = new VertxHttpServer();
+        HttpServiceProvider httpServiceProvider = NullHttpServiceProvider.getInstance();
+        httpServer.initialize(httpServiceProvider);
+        assertTrue(httpServer.startServer(0, "localhost"));
+        int port = httpServer.getListeningPort();
+        HttpResponse httpResponse = send(getUrl(port, HttpRouter.HEARTBEAT), HttpServer.Method.GET);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), httpResponse.responseCode);
+        assertEquals(HeartbeatService.HEARTBEAT.trim(), httpResponse.responseBody.trim());
+        httpServer.stopServer();
+    }
+
+    @Test
     public void testStartMetricsServiceOnRouterPath() throws Exception {
         VertxHttpServer httpServer = new VertxHttpServer();
         HttpServiceProvider httpServiceProvider = NullHttpServiceProvider.getInstance();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -261,6 +261,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     // Http Server parameters
     protected static final String HTTP_SERVER_ENABLED = "httpServerEnabled";
     protected static final String HTTP_SERVER_PORT = "httpServerPort";
+    protected static final String HTTP_SERVER_HOST = "httpServerHost";
 
     // Lifecycle Components
     protected static final String EXTRA_SERVER_COMPONENTS = "extraServerComponents";
@@ -3402,6 +3403,27 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setHttpServerPort(int port) {
         setProperty(HTTP_SERVER_PORT, port);
+        return this;
+    }
+
+    /**
+     * Get the http server host.
+     *
+     * @return http server host
+     */
+    public String getHttpServerHost() {
+        return getString(HTTP_SERVER_HOST, "0.0.0.0");
+    }
+
+    /**
+     * Set Http server host listening on.
+     *
+     * @param host
+     *          host to listen on
+     * @return server configuration
+     */
+    public ServerConfiguration setHttpServerHost(String host) {
+        setProperty(HTTP_SERVER_HOST, host);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/HttpService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/HttpService.java
@@ -54,7 +54,7 @@ public class HttpService extends ServerLifecycleComponent {
 
     @Override
     protected void doStart() {
-        server.startServer(conf.getServerConf().getHttpServerPort());
+        server.startServer(conf.getServerConf().getHttpServerPort(), conf.getServerConf().getHttpServerHost());
     }
 
     @Override

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -219,6 +219,9 @@ httpServerEnabled=false
 # The http server port to listen on. Default value is 8080.
 httpServerPort=8080
 
+# The http server host to listen on. Default value is '0.0.0.0'.
+httpServerHost=0.0.0.0
+
 # The http server class
 httpServerClass=org.apache.bookkeeper.http.vertx.VertxHttpServer
 

--- a/site/_data/config/bk_server.yaml
+++ b/site/_data/config/bk_server.yaml
@@ -135,6 +135,9 @@ groups:
   - param: httpServerPort
     description: The http server port to listen on if `httpServerEnabled` is set to true.
     default: 8080
+  - param: httpServerHost
+    description: The http server host to listen on if `httpServerEnabled` is set to true.
+    default: '0.0.0.0'
 
 - name: Security settings
   params:


### PR DESCRIPTION
Descriptions of the changes in this PR:

Allow to config bookie http host

### Motivation

For security, make bookie bind addr can config.
For compatibility, make default value is 0.0.0.0
