### PR TITLE
Cleanup unused Journal#EMPTY_ARRAY_LIST

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -75,7 +75,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
     private static final RecyclableArrayList.Recycler<QueueEntry> entryListRecycler =
         new RecyclableArrayList.Recycler<QueueEntry>();
-    private static final RecyclableArrayList<QueueEntry> EMPTY_ARRAY_LIST = new RecyclableArrayList<>();
 
     /**
      * Filter to pickup journals.


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

Simple code cleanup.

### Changes

Remove EMPTY_ARRAY_LIST in org.apache.bookkeeper.bookie.Journal. It's not used anymore.

