### PR TITLE
Gradle compileJava: enable -Xlint options

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -146,7 +146,6 @@ public class LocalBookKeeper implements AutoCloseable {
         return server;
     }
 
-    @SuppressWarnings("deprecation")
     private void initializeZookeeper() throws IOException {
         LOG.info("Instantiate ZK Client");
         //initialize the zk client with values
@@ -183,7 +182,6 @@ public class LocalBookKeeper implements AutoCloseable {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private void runBookies()
             throws Exception {
         LOG.info("Starting Bookie(s)");
@@ -221,6 +219,7 @@ public class LocalBookKeeper implements AutoCloseable {
         serializeLocalBookieConfig(baseConfWithCorrectZKServers, "baseconf.conf");
     }
 
+    @SuppressWarnings("deprecation")
     private void runBookie(int bookieIndex) throws Exception {
         File journalDirs;
         if (null == baseConf.getJournalDirNameWithoutDefault()) {
@@ -295,6 +294,7 @@ public class LocalBookKeeper implements AutoCloseable {
                 true, "test", null, defaultLocalBookiesConfigDir);
     }
 
+    @SuppressWarnings("deprecation")
     private static LocalBookKeeper getLocalBookiesInternal(ServerConfiguration conf,
                                                              String zkHost,
                                                              int zkPort,

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,11 @@ allprojects {
                 archiveExtension = 'tar.gz'
             }
         }
+        compileJava {
+            sourceCompatibility = 1.8
+            targetCompatibility = 1.8
+            options.compilerArgs = ["-Xlint:unchecked", "-Xlint:deprecation", "-Werror"]
+        }
 
         javadoc {
             options.addBooleanOption('Xdoclint:none', true)
@@ -231,6 +236,4 @@ allprojects {
 
 }
 
-pluginManager.withPlugin('java') {
-    sourceCompatibility = targetCompatibility = 8
-}
+

--- a/circe-checksum/build.gradle
+++ b/circe-checksum/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 
 compileJava {
     options.headerOutputDirectory = file("${buildDir}/javahGenerated")
+    // override args and remove -Werror
+    // Object.finalize() is deprecated at java 9
+    options.compilerArgs = ["-Xlint:unchecked", "-Xlint:deprecation"]
 }
 
 jar {


### PR DESCRIPTION
### Motivation

In the `maven-compiler-plugin` configuration there are `lint:deprecation` and `lint:unchecked` options enabled by default (also -`Werror` in order to make the build fails in case of warnings)

The Maven configuration is 
https://github.com/apache/bookkeeper/blob/a522fa33b31e2405830a33cd2120be60d3174cd5/pom.xml#L880-L888

### Changes
* Enable -Xlint:unchecked -Xlint:deprecation -Werror on all projects