### PR TITLE
Cleanup code in RackawareEnsemblePlacementPolicyImpl

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -90,7 +90,6 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
     protected boolean enforceMinNumRacksPerWriteQuorum;
     protected boolean ignoreLocalNodeInPlacementPolicy;
 
-    public static final String REPP_DNS_RESOLVER_CLASS = "reppDnsResolverClass";
     public static final String REPP_RANDOM_READ_REORDERING = "ensembleRandomReadReordering";
 
     static final int RACKNAME_DISTANCE_FROM_LEAVES = 1;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
@@ -27,9 +27,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Network Utilities.
  */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetUtils.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
  * Network Utilities.
  */
 public class NetUtils {
-    private static final Logger logger = LoggerFactory.getLogger(NetUtils.class);
 
     /**
      * Given a string representation of a host, return its ip address


### PR DESCRIPTION

Descriptions of the changes in this PR:

### Motivation

Simple code cleanup

### Changes

1.RackawareEnsemblePlacementPolicyImpl.REPP_DNS_RESOLVER_CLASS has be existed in his parent class,so clean in the child class

2.NetUtils.logger is no use
