### PR TITLE
remove -Werror  in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -880,7 +880,7 @@
           <source>${javac.target}</source>
           <target>${javac.target}</target>
           <compilerArgs>
-            <compilerArg>-Werror</compilerArg>
+            <!-- <compilerArg>-Werror</compilerArg> -->
             <compilerArg>-Xlint:deprecation</compilerArg>
             <compilerArg>-Xlint:unchecked</compilerArg>
             <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation
When compiling bookkeeper, an error will be reported: a warning is found, but - werror is specified：
![image](https://user-images.githubusercontent.com/19296967/144578289-68f39682-d0de-4737-83ff-b32afad33160.png)
