### PR TITLE
Add ensemble relocation command which adheres to placement policy

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -696,8 +696,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         return scheduler;
     }
 
-    @VisibleForTesting
-    EnsemblePlacementPolicy getPlacementPolicy() {
+    public EnsemblePlacementPolicy getPlacementPolicy() {
         return placementPolicy;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1137,7 +1137,7 @@ public class BookKeeperAdmin implements AutoCloseable {
         replicateLedgerFragment(lh, ledgerFragment, targetBookieAddresses, onReadEntryFailureCallback);
     }
 
-    private void replicateLedgerFragment(LedgerHandle lh,
+    public void replicateLedgerFragment(LedgerHandle lh,
             final LedgerFragment ledgerFragment,
             final Map<Integer, BookieId> targetBookieAddresses,
             final BiConsumer<Long, Long> onReadEntryFailureCallback)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
@@ -442,6 +442,31 @@ public interface EnsemblePlacementPolicy {
     }
 
     /**
+     * Returns placement result. If the currentEnsemble is not adhering placement policy, returns new ensemble that
+     * adheres placement policy. It should be implemented so as to minify the number of bookies replaced.
+     *
+     * @param ensembleSize
+     *            ensemble size
+     * @param writeQuorumSize
+ *                writeQuorumSize of the ensemble
+     * @param ackQuorumSize
+     *            ackQuorumSize of the ensemble
+     * @param excludeBookies
+     *            bookies that should not be considered as targets
+     * @param currentEnsemble
+     *            current ensemble
+     * @return a placement result
+     */
+    default PlacementResult<List<BookieId>> replaceToAdherePlacementPolicy(
+            int ensembleSize,
+            int writeQuorumSize,
+            int ackQuorumSize,
+            Set<BookieId> excludeBookies,
+            List<BookieId> currentEnsemble) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * enum for PlacementPolicyAdherence. Currently we are supporting tri-value
      * enum for PlacementPolicyAdherence. If placement policy is met strictly
      * then it is MEETS_STRICT, if it doesn't adhere to placement policy then it

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
@@ -40,7 +40,7 @@ public class LedgerFragment {
     private final DistributionSchedule schedule;
     private final boolean isLedgerClosed;
 
-    LedgerFragment(LedgerHandle lh,
+    public LedgerFragment(LedgerHandle lh,
                    long firstEntryId,
                    long lastKnownEntryId,
                    Set<Integer> bookieIndexes) {
@@ -56,7 +56,7 @@ public class LedgerFragment {
                 || !ensemble.equals(ensembles.get(ensembles.lastKey()));
     }
 
-    LedgerFragment(LedgerFragment lf, Set<Integer> subset) {
+    public LedgerFragment(LedgerFragment lf, Set<Integer> subset) {
         this.ledgerId = lf.ledgerId;
         this.firstEntryId = lf.firstEntryId;
         this.lastKnownEntryId = lf.lastKnownEntryId;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
@@ -237,6 +237,28 @@ public class RackawareEnsemblePlacementPolicy extends RackawareEnsemblePlacement
     }
 
     @Override
+    public PlacementResult<List<BookieId>> replaceToAdherePlacementPolicy(
+            int ensembleSize,
+            int writeQuorumSize,
+            int ackQuorumSize,
+            Set<BookieId> excludeBookies,
+            List<BookieId> currentEnsemble) {
+        final PlacementResult<List<BookieId>> placementResult =
+                super.replaceToAdherePlacementPolicy(ensembleSize, writeQuorumSize, ackQuorumSize,
+                        excludeBookies, currentEnsemble);
+        if (placementResult.isAdheringToPolicy() != PlacementPolicyAdherence.FAIL) {
+            return placementResult;
+        } else {
+            if (slave == null) {
+                return placementResult;
+            } else {
+                return slave.replaceToAdherePlacementPolicy(ensembleSize, writeQuorumSize, ackQuorumSize,
+                        excludeBookies, currentEnsemble);
+            }
+        }
+    }
+
+    @Override
     public void handleBookiesThatLeft(Set<BookieId> leftBookies) {
         super.handleBookiesThatLeft(leftBookies);
         if (null != slave) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -1131,6 +1131,13 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                     prevNode = replaceToAdherePlacementPolicyInternal(
                             curRack, excludeNodes, ensemble, ensemble,
                             provisionalEnsembleNodes, i, ensembleSize, minNumRacksPerWriteQuorumForThisEnsemble);
+                    // got a good candidate
+                    if (ensemble.addNode(prevNode)) {
+                        // add the candidate to exclude set
+                        excludeNodes.add(prevNode);
+                    } else {
+                        throw new BKNotEnoughBookiesException();
+                    }
                     // replace to newer node
                     provisionalEnsembleNodes.set(i, prevNode);
                 } catch (BKNotEnoughBookiesException e) {
@@ -1159,10 +1166,6 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
         final BookieNode currentNode = provisionalEnsembleNodes.get(ensembleIndex);
         // if the current bookie could be applied to the ensemble, apply it to minify the number of bookies replaced
         if (!excludeBookies.contains(currentNode) && predicate.apply(currentNode, ensemble)) {
-            if (ensemble.addNode(currentNode)) {
-                // add the candidate to exclude set
-                excludeBookies.add(currentNode);
-            }
             return currentNode;
         }
 
@@ -1234,11 +1237,6 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                     continue;
                 }
                 BookieNode bn = (BookieNode) n;
-                // got a good candidate
-                if (ensemble.addNode(bn)) {
-                    // add the candidate to exclude set
-                    excludeBookies.add(bn);
-                }
                 return bn;
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -802,12 +802,16 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements
     protected Set<Node> convertBookiesToNodes(Collection<BookieId> excludeBookies) {
         Set<Node> nodes = new HashSet<Node>();
         for (BookieId addr : excludeBookies) {
-            BookieNode bn = knownBookies.get(addr);
-            if (null == bn) {
-                bn = createBookieNode(addr);
-            }
-            nodes.add(bn);
+            nodes.add(convertBookieToNode(addr));
         }
         return nodes;
+    }
+
+    protected BookieNode convertBookieToNode(BookieId addr) {
+        BookieNode bn = knownBookies.get(addr);
+        if (null == bn) {
+            bn = createBookieNode(addr);
+        }
+        return bn;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/CorrectEnsemblePlacementCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/CorrectEnsemblePlacementCommand.java
@@ -20,20 +20,15 @@ package org.apache.bookkeeper.tools.cli.commands.bookies;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.converters.CommaParameterSplitter;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Functions;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.Cleanup;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -41,9 +36,6 @@ import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
-import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
-import org.apache.bookkeeper.client.LedgerFragment;
-import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
@@ -51,7 +43,6 @@ import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
 import org.apache.bookkeeper.meta.MetadataBookieDriver;
 import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.meta.exceptions.MetadataException;
-import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
@@ -133,7 +124,7 @@ public class CorrectEnsemblePlacementCommand extends
 
             final ClientConfiguration clientConf = new ClientConfiguration(conf);
             final BookKeeper bookKeeper = new BookKeeper(clientConf);
-            final BookKeeperAdmin admin = new BookKeeperAdmin(clientConf);
+            final BookKeeperAdmin admin = new BookKeeperAdmin(bookKeeper);
             return relocate(conf, flags, bookKeeper, admin);
         } catch (Exception e) {
             throw new UncheckedExecutionException(e.getMessage(), e);
@@ -143,8 +134,6 @@ public class CorrectEnsemblePlacementCommand extends
     @VisibleForTesting
     public boolean relocate(ServerConfiguration conf, CorrectEnsemblePlacementFlags flags,
                             BookKeeper bookKeeper, BookKeeperAdmin admin) throws Exception {
-        final EnsemblePlacementPolicy placementPolicy = bookKeeper.getPlacementPolicy();
-
         @Cleanup
         final MetadataBookieDriver metadataDriver = instantiateMetadataDriver(conf);
         @Cleanup
@@ -153,7 +142,7 @@ public class CorrectEnsemblePlacementCommand extends
         final LedgerUnderreplicationManager lum = lmf.newLedgerUnderreplicationManager();
 
         final List<Long> targetLedgers =
-                flags.ledgerIds.stream().parallel().distinct().filter(ledgerId -> {
+                flags.ledgerIds.stream().distinct().filter(ledgerId -> {
                     try {
                         return (!flags.skipOpenLedgers || bookKeeper.isClosed(ledgerId))
                                 && !lum.isLedgerBeingReplicated(ledgerId);
@@ -172,6 +161,9 @@ public class CorrectEnsemblePlacementCommand extends
         final NavigableSet<Pair<Long, Long>> failedTargets = new ConcurrentSkipListSet<>();
         final CountDownLatch latch = new CountDownLatch(targetLedgers.size());
         for (long ledgerId : targetLedgers) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Start relocation of the ledger {}.", ledgerId);
+            }
             if (!flags.dryRun) {
                 try {
                     lum.acquireUnderreplicatedLedger(ledgerId);
@@ -188,103 +180,18 @@ public class CorrectEnsemblePlacementCommand extends
                         LOG.warn("Failed to open ledger {}", ledgerId);
                         return;
                     }
-
-                    final LedgerMetadata ledgerMeta = lh.getLedgerMetadata();
-                    final Map<Long, Long> ledgerFragmentsRange = new HashMap<>();
-                    Long curEntryId = null;
-                    for (Map.Entry<Long, ? extends List<BookieId>> entry :
-                            ledgerMeta.getAllEnsembles().entrySet()) {
-                        if (curEntryId != null) {
-                            ledgerFragmentsRange.put(curEntryId, entry.getKey() - 1);
-                        }
-                        curEntryId = entry.getKey();
-                    }
-                    if (curEntryId != null) {
-                        ledgerFragmentsRange.put(curEntryId, lh.getLastAddConfirmed());
-                    }
-
-                    for (Map.Entry<Long, ? extends List<BookieId>> entry : ledgerMeta.getAllEnsembles().entrySet()) {
-                        if (placementPolicy.isEnsembleAdheringToPlacementPolicy(entry.getValue(),
-                                ledgerMeta.getWriteQuorumSize(), ledgerMeta.getAckQuorumSize())
-                                == EnsemblePlacementPolicy.PlacementPolicyAdherence.FAIL) {
-                            try {
-                                final List<BookieId> currentEnsemble =  entry.getValue();
-                                // Currently, don't consider quarantinedBookies
-                                final EnsemblePlacementPolicy.PlacementResult<List<BookieId>> placementResult =
-                                        placementPolicy.replaceToAdherePlacementPolicy(
-                                                ledgerMeta.getEnsembleSize(),
-                                                ledgerMeta.getWriteQuorumSize(),
-                                                ledgerMeta.getAckQuorumSize(),
-                                                Collections.emptySet(),
-                                                currentEnsemble);
-
-                                if (placementResult.isAdheringToPolicy()
-                                        == EnsemblePlacementPolicy.PlacementPolicyAdherence.FAIL) {
-                                    LOG.warn("Failed to relocate the ensemble. So, skip the operation."
-                                                    + " ledgerId: {}, fragmentIndex: {}",
-                                            ledgerId, entry.getKey());
-                                    failedTargets.add(Pair.of(ledgerId, entry.getKey()));
-                                } else {
-                                    final List<BookieId> newEnsemble = placementResult.getResult();
-                                    final Map<Integer, BookieId> replaceBookiesMap = IntStream
-                                            .range(0, ledgerMeta.getEnsembleSize()).boxed()
-                                            .filter(i -> !newEnsemble.get(i).equals(currentEnsemble.get(i)))
-                                            .collect(Collectors.toMap(Functions.identity(), newEnsemble::get));
-                                    if (replaceBookiesMap.isEmpty()) {
-                                        LOG.warn("Failed to get bookies to replace. So, skip the operation."
-                                                        + " ledgerId: {}, fragmentIndex: {}",
-                                                ledgerId, entry.getKey());
-                                        failedTargets.add(Pair.of(ledgerId, entry.getKey()));
-                                    } else if (flags.dryRun) {
-                                        LOG.info("Would replace the ensemble. ledgerId: {}, fragmentIndex: {},"
-                                                        + " currentEnsemble: {} replaceBookiesMap {}",
-                                                ledgerId, entry.getKey(),
-                                                currentEnsemble, replaceBookiesMap);
-                                    } else {
-                                        if (LOG.isDebugEnabled()) {
-                                            LOG.debug("Try to replace the ensemble. ledgerId: {}, fragmentIndex: {},"
-                                                            + " replaceBookiesMap {}",
-                                                    ledgerId, entry.getKey(), replaceBookiesMap);
-                                        }
-                                        final LedgerFragment fragment = new LedgerFragment(lh, entry.getKey(),
-                                                ledgerFragmentsRange.get(entry.getKey()), replaceBookiesMap.keySet());
-
-                                        try {
-                                            admin.replicateLedgerFragment(lh, fragment, replaceBookiesMap,
-                                                    (lId, eId) -> {
-                                                        // This consumer is already accepted before the method returns
-                                                        // void. Therefore, use failedTargets in this consumer.
-                                                        LOG.warn("Failed to read entry {}:{}", lId, eId);
-                                                        failedTargets.add(Pair.of(ledgerId, entry.getKey()));
-                                                    });
-                                            LOG.info("Operation finished in the ensemble. ledgerId: {},"
-                                                            + " fragmentIndex: {}, replaceBookiesMap {}",
-                                                    ledgerId, entry.getKey(), replaceBookiesMap);
-                                        } catch (BKException | InterruptedException e) {
-                                            LOG.warn("Failed to replicate ledger fragment.", e);
-                                            failedTargets.add(Pair.of(ledgerId, entry.getKey()));
-                                        }
-                                    }
-                                }
-                            } catch (UnsupportedOperationException e) {
-                                LOG.warn("UnsupportedOperationException caught. The placement policy might not support"
-                                        + " replaceToAdherePlacementPolicy method.", e);
-                                failedTargets.add(Pair.of(ledgerId, entry.getKey()));
-                            }
-                        } else {
-                            if (LOG.isDebugEnabled()) {
-                                LOG.debug("The fragment is adhering to placement policy. So, skip the operation."
-                                        + " ledgerId: {}, fragmentIndex: {}", ledgerId, entry.getKey());
-                            }
-                        }
-                    }
+                    admin.relocateLedgerToAdherePlacementPolicy(lh, flags.dryRun)
+                            .forEach(e -> failedTargets.add(Pair.of(ledgerId, e)));
+                } catch (UnsupportedOperationException e) {
+                    LOG.warn("UnsupportedOperationException caught. The placement policy might not support"
+                            + " replaceToAdherePlacementPolicy method.", e);
                 } finally {
                     try {
                         if (!flags.dryRun) {
                             lum.releaseUnderreplicatedLedger(ledgerId);
                         }
                     } catch (ReplicationException e) {
-                        LOG.warn("Failed to release under replicated ledger {}.", ledgerId, e);
+                        LOG.error("Failed to release under replicated ledger {}.", ledgerId, e);
                     } finally {
                         ((CountDownLatch) ctx).countDown();
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/CorrectEnsemblePlacementCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/CorrectEnsemblePlacementCommand.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookies;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.converters.CommaParameterSplitter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Functions;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.Cleanup;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
+import org.apache.bookkeeper.client.LedgerFragment;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.MetadataBookieDriver;
+import org.apache.bookkeeper.meta.MetadataDrivers;
+import org.apache.bookkeeper.meta.exceptions.MetadataException;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.replication.ReplicationException;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
+import org.apache.bookkeeper.tools.framework.CliFlags;
+import org.apache.bookkeeper.tools.framework.CliSpec;
+import org.apache.bookkeeper.util.IOUtils;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Command to relocate ledgers to adhere ensemble placement policy.
+ */
+public class CorrectEnsemblePlacementCommand extends
+        BookieCommand<CorrectEnsemblePlacementCommand.CorrectEnsemblePlacementFlags> {
+    private static final Logger LOG = LoggerFactory.getLogger(CorrectEnsemblePlacementCommand.class);
+
+    private static final String NAME = "correct-ensemble-placement";
+    private static final String DESC = "Relocate ledgers to adhere ensemble placement policy.";
+
+    public CorrectEnsemblePlacementCommand() {
+        this(new CorrectEnsemblePlacementFlags());
+    }
+
+    private CorrectEnsemblePlacementCommand(CorrectEnsemblePlacementFlags flags) {
+        super(CliSpec.<CorrectEnsemblePlacementFlags>newBuilder()
+                .withName(NAME)
+                .withDescription(DESC)
+                .withFlags(flags)
+                .build());
+    }
+
+    /**
+     * Flags for correct-ensemble-placement command.
+     */
+    @Accessors(fluent = true)
+    @Setter
+    public static class CorrectEnsemblePlacementFlags extends CliFlags {
+        @Parameter(names = { "-l", "--ledgerids" },
+                description = "Target ledger IDs to relocate. Multiple can be specified, comma separated.",
+                splitter = CommaParameterSplitter.class, required = true)
+        private List<Long> ledgerIds;
+
+        @Parameter(names = { "-dr", "--dryrun" },
+                description = "Printing the relocation plan w/o doing actual relocation")
+        private boolean dryRun;
+
+        @Parameter(names = { "-f", "--force" }, description = "Force relocation without confirmation")
+        private boolean force;
+
+        @Parameter(names = {"-sk", "--skipOpenLedgers"}, description = "Skip relocating open ledgers")
+        private boolean skipOpenLedgers;
+    }
+
+    @Override
+    public boolean apply(ServerConfiguration conf, CorrectEnsemblePlacementFlags flags) {
+        try {
+            if (flags.dryRun) {
+                LOG.info("The dry-run output could change every time you run"
+                        + " since the selection of bookies replaced includes some randomness.");
+            }
+            if (!flags.skipOpenLedgers) {
+                LOG.warn("Try to relocate also open ledgers. It is not recommended.");
+            }
+            try {
+                if (!flags.force) {
+                    final boolean confirm =
+                            IOUtils.confirmPrompt("Are you sure to relocate target ledgers?");
+                    if (!confirm) {
+                        LOG.error("Relocation is aborted.");
+                        return false;
+                    }
+                }
+            } catch (IOException e) {
+                LOG.error("Error during relocation", e);
+                return false;
+            }
+
+            final ClientConfiguration clientConf = new ClientConfiguration(conf);
+            final BookKeeper bookKeeper = new BookKeeper(clientConf);
+            final BookKeeperAdmin admin = new BookKeeperAdmin(clientConf);
+            return relocate(conf, flags, bookKeeper, admin);
+        } catch (Exception e) {
+            throw new UncheckedExecutionException(e.getMessage(), e);
+        }
+    }
+
+    @VisibleForTesting
+    public boolean relocate(ServerConfiguration conf, CorrectEnsemblePlacementFlags flags,
+                            BookKeeper bookKeeper, BookKeeperAdmin admin) throws Exception {
+        final EnsemblePlacementPolicy placementPolicy = bookKeeper.getPlacementPolicy();
+
+        @Cleanup
+        final MetadataBookieDriver metadataDriver = instantiateMetadataDriver(conf);
+        @Cleanup
+        final LedgerManagerFactory lmf = metadataDriver.getLedgerManagerFactory();
+        @Cleanup
+        final LedgerUnderreplicationManager lum = lmf.newLedgerUnderreplicationManager();
+
+        final List<Long> targetLedgers =
+                flags.ledgerIds.stream().parallel().distinct().filter(ledgerId -> {
+                    try {
+                        return (!flags.skipOpenLedgers || bookKeeper.isClosed(ledgerId))
+                                && !lum.isLedgerBeingReplicated(ledgerId);
+                    } catch (BKException | InterruptedException | ReplicationException e) {
+                        LOG.warn("Failed to add the ledger {} to target.", ledgerId, e);
+                        return false;
+                    }
+                }).collect(Collectors.toList());
+
+        if (targetLedgers.isEmpty()) {
+            LOG.info("None of ledgers are relocated.");
+            return true;
+        }
+
+        final NavigableSet<Long> unAcquirableLedgers = new TreeSet<>();
+        final NavigableSet<Pair<Long, Long>> failedTargets = new ConcurrentSkipListSet<>();
+        final CountDownLatch latch = new CountDownLatch(targetLedgers.size());
+        for (long ledgerId : targetLedgers) {
+            if (!flags.dryRun) {
+                try {
+                    lum.acquireUnderreplicatedLedger(ledgerId);
+                } catch (ReplicationException e) {
+                    LOG.warn("Failed to acquire ledger to under replicated {}.", ledgerId);
+                    unAcquirableLedgers.add(ledgerId);
+                    latch.countDown();
+                    continue;
+                }
+            }
+            admin.asyncOpenLedger(ledgerId, (rc, lh, ctx) -> {
+                try {
+                    if (rc != BKException.Code.OK) {
+                        LOG.warn("Failed to open ledger {}", ledgerId);
+                        return;
+                    }
+
+                    final LedgerMetadata ledgerMeta = lh.getLedgerMetadata();
+                    final Map<Long, Long> ledgerFragmentsRange = new HashMap<>();
+                    Long curEntryId = null;
+                    for (Map.Entry<Long, ? extends List<BookieId>> entry :
+                            ledgerMeta.getAllEnsembles().entrySet()) {
+                        if (curEntryId != null) {
+                            ledgerFragmentsRange.put(curEntryId, entry.getKey() - 1);
+                        }
+                        curEntryId = entry.getKey();
+                    }
+                    if (curEntryId != null) {
+                        ledgerFragmentsRange.put(curEntryId, lh.getLastAddConfirmed());
+                    }
+
+                    for (Map.Entry<Long, ? extends List<BookieId>> entry : ledgerMeta.getAllEnsembles().entrySet()) {
+                        if (placementPolicy.isEnsembleAdheringToPlacementPolicy(entry.getValue(),
+                                ledgerMeta.getWriteQuorumSize(), ledgerMeta.getAckQuorumSize())
+                                == EnsemblePlacementPolicy.PlacementPolicyAdherence.FAIL) {
+                            try {
+                                final List<BookieId> currentEnsemble =  entry.getValue();
+                                // Currently, don't consider quarantinedBookies
+                                final EnsemblePlacementPolicy.PlacementResult<List<BookieId>> placementResult =
+                                        placementPolicy.replaceToAdherePlacementPolicy(
+                                                ledgerMeta.getEnsembleSize(),
+                                                ledgerMeta.getWriteQuorumSize(),
+                                                ledgerMeta.getAckQuorumSize(),
+                                                Collections.emptySet(),
+                                                currentEnsemble);
+
+                                if (placementResult.isAdheringToPolicy()
+                                        == EnsemblePlacementPolicy.PlacementPolicyAdherence.FAIL) {
+                                    LOG.warn("Failed to relocate the ensemble. So, skip the operation."
+                                                    + " ledgerId: {}, fragmentIndex: {}",
+                                            ledgerId, entry.getKey());
+                                    failedTargets.add(Pair.of(ledgerId, entry.getKey()));
+                                } else {
+                                    final List<BookieId> newEnsemble = placementResult.getResult();
+                                    final Map<Integer, BookieId> replaceBookiesMap = IntStream
+                                            .range(0, ledgerMeta.getEnsembleSize()).boxed()
+                                            .filter(i -> !newEnsemble.get(i).equals(currentEnsemble.get(i)))
+                                            .collect(Collectors.toMap(Functions.identity(), newEnsemble::get));
+                                    if (replaceBookiesMap.isEmpty()) {
+                                        LOG.warn("Failed to get bookies to replace. So, skip the operation."
+                                                        + " ledgerId: {}, fragmentIndex: {}",
+                                                ledgerId, entry.getKey());
+                                        failedTargets.add(Pair.of(ledgerId, entry.getKey()));
+                                    } else if (flags.dryRun) {
+                                        LOG.info("Would replace the ensemble. ledgerId: {}, fragmentIndex: {},"
+                                                        + " currentEnsemble: {} replaceBookiesMap {}",
+                                                ledgerId, entry.getKey(),
+                                                currentEnsemble, replaceBookiesMap);
+                                    } else {
+                                        if (LOG.isDebugEnabled()) {
+                                            LOG.debug("Try to replace the ensemble. ledgerId: {}, fragmentIndex: {},"
+                                                            + " replaceBookiesMap {}",
+                                                    ledgerId, entry.getKey(), replaceBookiesMap);
+                                        }
+                                        final LedgerFragment fragment = new LedgerFragment(lh, entry.getKey(),
+                                                ledgerFragmentsRange.get(entry.getKey()), replaceBookiesMap.keySet());
+
+                                        try {
+                                            admin.replicateLedgerFragment(lh, fragment, replaceBookiesMap,
+                                                    (lId, eId) -> {
+                                                        // This consumer is already accepted before the method returns
+                                                        // void. Therefore, use failedTargets in this consumer.
+                                                        LOG.warn("Failed to read entry {}:{}", lId, eId);
+                                                        failedTargets.add(Pair.of(ledgerId, entry.getKey()));
+                                                    });
+                                            LOG.info("Operation finished in the ensemble. ledgerId: {},"
+                                                            + " fragmentIndex: {}, replaceBookiesMap {}",
+                                                    ledgerId, entry.getKey(), replaceBookiesMap);
+                                        } catch (BKException | InterruptedException e) {
+                                            LOG.warn("Failed to replicate ledger fragment.", e);
+                                            failedTargets.add(Pair.of(ledgerId, entry.getKey()));
+                                        }
+                                    }
+                                }
+                            } catch (UnsupportedOperationException e) {
+                                LOG.warn("UnsupportedOperationException caught. The placement policy might not support"
+                                        + " replaceToAdherePlacementPolicy method.", e);
+                                failedTargets.add(Pair.of(ledgerId, entry.getKey()));
+                            }
+                        } else {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("The fragment is adhering to placement policy. So, skip the operation."
+                                        + " ledgerId: {}, fragmentIndex: {}", ledgerId, entry.getKey());
+                            }
+                        }
+                    }
+                } finally {
+                    try {
+                        if (!flags.dryRun) {
+                            lum.releaseUnderreplicatedLedger(ledgerId);
+                        }
+                    } catch (ReplicationException e) {
+                        LOG.warn("Failed to release under replicated ledger {}.", ledgerId, e);
+                    } finally {
+                        ((CountDownLatch) ctx).countDown();
+                    }
+                }
+            }, latch);
+        }
+
+        // Currently, don't add timeout
+        latch.await();
+
+        if (unAcquirableLedgers.isEmpty() && failedTargets.isEmpty()) {
+            return true;
+        } else {
+            LOG.warn("Some ensembles couldn't be relocated to adhere placement policy."
+                    + " Un-acquirable ledgers: {}"
+                    + ", Failed targets [(ledgerId, fragmentIndex), ...]: {}", unAcquirableLedgers, failedTargets);
+            return false;
+        }
+    }
+
+    private static MetadataBookieDriver instantiateMetadataDriver(ServerConfiguration conf)
+            throws BookieException {
+        try {
+            final String metadataServiceUriStr = conf.getMetadataServiceUri();
+            final MetadataBookieDriver driver = MetadataDrivers.getBookieDriver(URI.create(metadataServiceUriStr));
+            driver.initialize(conf, NullStatsLogger.INSTANCE);
+            return driver;
+        } catch (MetadataException me) {
+            throw new BookieException.MetadataStoreException("Failed to initialize metadata bookie driver", me);
+        } catch (ConfigurationException e) {
+            throw new BookieException.BookieIllegalOpException(e);
+        }
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/CorrectEnsemblePlacementCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/CorrectEnsemblePlacementCmdTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.client;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl.REPP_DNS_RESOLVER_CLASS;
+import static org.mockito.ArgumentMatchers.eq;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Cleanup;
+import org.apache.bookkeeper.bookie.BookieShell;
+import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.net.NetworkTopology;
+import org.apache.bookkeeper.proto.BookieAddressResolver;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.tools.cli.commands.bookies.CorrectEnsemblePlacementCommand;
+import org.apache.bookkeeper.util.EntryFormatter;
+import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.apache.bookkeeper.util.StaticDNSResolver;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests of correct-ensemble-placement command.
+ */
+public class CorrectEnsemblePlacementCmdTest extends BookKeeperClusterTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CorrectEnsemblePlacementCmdTest.class);
+    private BookKeeper.DigestType digestType = BookKeeper.DigestType.CRC32;
+    private static final String PASSWORD = "testPasswd";
+
+    public CorrectEnsemblePlacementCmdTest() throws Exception {
+        super(0);
+        baseConf.setLedgerStorageClass(DbLedgerStorage.class.getName());
+        baseConf.setGcWaitTime(60000);
+        baseConf.setFlushInterval(1);
+    }
+
+    /**
+     * list of entry logger files that contains given ledgerId.
+     */
+    @Test
+    public void testArgument() throws Exception {
+        startNewBookie();
+
+        @Cleanup
+        final BookKeeper bk = new BookKeeper(baseClientConf, zkc);
+        @Cleanup
+        final LedgerHandle lh = createLedgerWithEntries(bk, 10, 1, 1);
+
+        final String[] argv1 = { "correct-ensemble-placement", "--ledgerids", String.valueOf(lh.getId()),
+                "--skipOpenLedgers", "--force"};
+        final String[] argv2 = { "correct-ensemble-placement", "--ledgerids", String.valueOf(lh.getId()),
+                "--skipOpenLedgers", "--force", "--dryrun"};
+        final BookieShell bkShell =
+                new BookieShell(LedgerIdFormatter.LONG_LEDGERID_FORMATTER, EntryFormatter.STRING_FORMATTER);
+        bkShell.setConf(baseClientConf);
+
+        assertEquals("Failed to return exit code!", 0, bkShell.run(argv1));
+        assertEquals("Failed to return exit code!", 0, bkShell.run(argv2));
+    }
+
+    @Test
+    public void testCorrectEnsemblePlacementByRackaware() throws Exception {
+        final int ensembleSize = 7;
+        final int quorumSize = 2;
+
+        final BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.1", 3181);
+        final BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.2", 3181);
+        final BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.3", 3181);
+        final BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.4", 3181);
+        final BookieSocketAddress addr5 = new BookieSocketAddress("127.0.0.5", 3181);
+        final BookieSocketAddress addr6 = new BookieSocketAddress("127.0.0.6", 3181);
+        final BookieSocketAddress addr7 = new BookieSocketAddress("127.0.0.7", 3181);
+        final BookieSocketAddress addr8 = new BookieSocketAddress("127.0.0.8", 3181);
+        final BookieSocketAddress addr9 = new BookieSocketAddress("127.0.0.9", 3181);
+
+        final Set<BookieId> writableBookies = new HashSet<>();
+        writableBookies.add(addr1.toBookieId());
+        writableBookies.add(addr2.toBookieId());
+        writableBookies.add(addr3.toBookieId());
+        writableBookies.add(addr4.toBookieId());
+        writableBookies.add(addr5.toBookieId());
+        writableBookies.add(addr6.toBookieId());
+        writableBookies.add(addr7.toBookieId());
+        writableBookies.add(addr8.toBookieId());
+        writableBookies.add(addr9.toBookieId());
+
+        // add bookie node to resolver
+        StaticDNSResolver.reset();
+
+        final String rackName1 = NetworkTopology.DEFAULT_REGION + "/r1";
+        final String rackName2 = NetworkTopology.DEFAULT_REGION + "/r2";
+        final String rackName3 = NetworkTopology.DEFAULT_REGION + "/r3";
+
+        // update dns mapping
+        // add port for testing
+        StaticDNSResolver.addNodeToRack(addr1.getSocketAddress().getAddress().getHostAddress(), rackName1);
+        StaticDNSResolver.addNodeToRack(addr2.getSocketAddress().getAddress().getHostAddress(), rackName1);
+        StaticDNSResolver.addNodeToRack(addr3.getSocketAddress().getAddress().getHostAddress(), rackName1);
+        StaticDNSResolver.addNodeToRack(addr4.getSocketAddress().getAddress().getHostAddress(), rackName2);
+        StaticDNSResolver.addNodeToRack(addr5.getSocketAddress().getAddress().getHostAddress(), rackName2);
+        StaticDNSResolver.addNodeToRack(addr6.getSocketAddress().getAddress().getHostAddress(), rackName2);
+        StaticDNSResolver.addNodeToRack(addr7.getSocketAddress().getAddress().getHostAddress(), rackName3);
+        StaticDNSResolver.addNodeToRack(addr8.getSocketAddress().getAddress().getHostAddress(), rackName3);
+        StaticDNSResolver.addNodeToRack(addr9.getSocketAddress().getAddress().getHostAddress(), rackName3);
+        LOG.info("Set up static DNS Resolver.");
+        baseClientConf.setEnsemblePlacementPolicy(RackawareEnsemblePlacementPolicy.class);
+        baseClientConf.setProperty(REPP_DNS_RESOLVER_CLASS, StaticDNSResolver.class.getName());
+
+        startNewBookie();
+
+        final NavigableMap<Long, List<BookieId>> ensemble = new TreeMap<>();
+        // create failed ensemble
+        // expect that the ensemble will be replaced to
+        // [addr1, addr4, addr7, addr2, addr5, addr8, *addr6 (in /default-region/r2 bookies)*]
+        ensemble.put(0L, Arrays.asList(
+                addr1.toBookieId(), addr4.toBookieId(),
+                addr7.toBookieId(), addr2.toBookieId(),
+                addr5.toBookieId(), addr8.toBookieId(),
+                addr3.toBookieId()));
+        final LedgerMetadata lm1 = Mockito.mock(LedgerMetadata.class);
+        Mockito.doReturn(ensemble).when(lm1).getAllEnsembles();
+        Mockito.doReturn(ensembleSize).when(lm1).getEnsembleSize();
+        Mockito.doReturn(quorumSize).when(lm1).getWriteQuorumSize();
+        Mockito.doReturn(quorumSize).when(lm1).getAckQuorumSize();
+        final LedgerHandle lh1 = Mockito.mock(LedgerHandle.class);
+        Mockito.when(lh1.getLedgerMetadata()).thenReturn(lm1);
+
+        @Cleanup
+        final BookKeeper bookKeeper = Mockito.spy(new BookKeeper(baseClientConf));
+        Mockito.doReturn(true).when(bookKeeper).isClosed(Mockito.anyLong());
+
+        @Cleanup
+        final BookKeeperAdmin admin = Mockito.spy(new BookKeeperAdmin(baseClientConf));
+        Mockito.doAnswer(invocationOnMock -> {
+            final AsyncCallback.OpenCallback op = invocationOnMock.getArgument(1);
+            final CountDownLatch ctx = invocationOnMock.getArgument(2);
+            op.openComplete(BKException.Code.OK, lh1, ctx);
+            return null;
+        }).when(admin).asyncOpenLedger(Mockito.anyLong(), Mockito.any(), Mockito.any());
+        // expected return
+        final Map<Integer, BookieId> expectedMap = new HashMap<>();
+        expectedMap.put(6, addr6.toBookieId());
+        Mockito.doNothing().when(admin)
+                .replicateLedgerFragment(Mockito.any(), Mockito.any(), eq(expectedMap), Mockito.any());
+
+        final EnsemblePlacementPolicy policy = bookKeeper.getPlacementPolicy();
+        final Field topologyField = TopologyAwareEnsemblePlacementPolicy.class
+                .getDeclaredField("topology");
+        topologyField.setAccessible(true);
+        final NetworkTopology topology = Mockito.spy((NetworkTopology) topologyField.get(policy));
+        Mockito.doReturn(2).when(topology).getNumOfRacks();
+        topologyField.set(policy, topology);
+        final Field bookieAddressResolverField = TopologyAwareEnsemblePlacementPolicy.class
+                .getDeclaredField("bookieAddressResolver");
+        bookieAddressResolverField.setAccessible(true);
+        final BookieAddressResolver bookieAddressResolver =
+                Mockito.spy((BookieAddressResolver) bookieAddressResolverField.get(policy));
+        Mockito.doAnswer(invocationOnMock -> {
+            final BookieId bookieId = invocationOnMock.getArgument(0);
+            return new BookieSocketAddress(bookieId.getId());
+        }).when(bookieAddressResolver).resolve(Mockito.any());
+        bookieAddressResolverField.set(policy, bookieAddressResolver);
+
+        // add mock bookies to knownBookies
+        policy.onClusterChanged(writableBookies, Collections.emptySet());
+
+        // make sure that the ensemble is FAIL state
+        assertEquals(EnsemblePlacementPolicy.PlacementPolicyAdherence.FAIL,
+                policy.isEnsembleAdheringToPlacementPolicy(ensemble.get(0L), quorumSize, quorumSize));
+
+        final CorrectEnsemblePlacementCommand.CorrectEnsemblePlacementFlags flag =
+                new CorrectEnsemblePlacementCommand.CorrectEnsemblePlacementFlags();
+        flag.ledgerIds(Collections.singletonList(1L));
+        final CorrectEnsemblePlacementCommand cmd = new CorrectEnsemblePlacementCommand();
+        cmd.relocate(baseConf, flag, bookKeeper, admin);
+
+        Mockito.verify(admin, Mockito.times(1))
+                .replicateLedgerFragment(Mockito.any(), Mockito.any(), eq(expectedMap), Mockito.any());
+    }
+
+    private LedgerHandle createLedgerWithEntries(BookKeeper bk, int numOfEntries,
+                                                 int ensembleSize, int quorumSize) throws Exception {
+        LedgerHandle lh = bk.createLedger(ensembleSize, quorumSize, digestType, PASSWORD.getBytes());
+        final AtomicInteger rc = new AtomicInteger(BKException.Code.OK);
+        final CountDownLatch latch = new CountDownLatch(numOfEntries);
+
+        final AsyncCallback.AddCallback cb = (rccb, lh1, entryId, ctx) -> {
+            rc.compareAndSet(BKException.Code.OK, rccb);
+            latch.countDown();
+        };
+        for (int i = 0; i < numOfEntries; i++) {
+            lh.asyncAddEntry(("foobar" + i).getBytes(), cb, null);
+        }
+        if (!latch.await(30, TimeUnit.SECONDS)) {
+            throw new Exception("Entries took too long to add");
+        }
+        if (rc.get() != BKException.Code.OK) {
+            throw BKException.create(rc.get());
+        }
+        return lh;
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/CorrectEnsemblePlacementCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/CorrectEnsemblePlacementCmdTest.java
@@ -18,37 +18,16 @@
 package org.apache.bookkeeper.client;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl.REPP_DNS_RESOLVER_CLASS;
-import static org.mockito.ArgumentMatchers.eq;
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import org.apache.bookkeeper.bookie.BookieShell;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
-import org.apache.bookkeeper.client.api.LedgerMetadata;
-import org.apache.bookkeeper.net.BookieId;
-import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.net.NetworkTopology;
-import org.apache.bookkeeper.proto.BookieAddressResolver;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.bookkeeper.tools.cli.commands.bookies.CorrectEnsemblePlacementCommand;
 import org.apache.bookkeeper.util.EntryFormatter;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
-import org.apache.bookkeeper.util.StaticDNSResolver;
-import org.junit.After;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,16 +41,10 @@ public class CorrectEnsemblePlacementCmdTest extends BookKeeperClusterTestCase {
     private static final String PASSWORD = "testPasswd";
 
     public CorrectEnsemblePlacementCmdTest() throws Exception {
-        super(0);
+        super(1);
         baseConf.setLedgerStorageClass(DbLedgerStorage.class.getName());
         baseConf.setGcWaitTime(60000);
         baseConf.setFlushInterval(1);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        super.tearDown();
-        StaticDNSResolver.reset();
     }
 
     /**
@@ -79,16 +52,12 @@ public class CorrectEnsemblePlacementCmdTest extends BookKeeperClusterTestCase {
      */
     @Test
     public void testArgument() throws Exception {
-        startNewBookie();
+        @Cleanup final BookKeeper bk = new BookKeeper(baseClientConf, zkc);
+        @Cleanup final LedgerHandle lh = createLedgerWithEntries(bk, 10, 1, 1);
 
-        @Cleanup
-        final BookKeeper bk = new BookKeeper(baseClientConf, zkc);
-        @Cleanup
-        final LedgerHandle lh = createLedgerWithEntries(bk, 10, 1, 1);
-
-        final String[] argv1 = { "correct-ensemble-placement", "--ledgerids", String.valueOf(lh.getId()),
+        final String[] argv1 = {"correct-ensemble-placement", "--ledgerids", String.valueOf(lh.getId()),
                 "--skipOpenLedgers", "--force"};
-        final String[] argv2 = { "correct-ensemble-placement", "--ledgerids", String.valueOf(lh.getId()),
+        final String[] argv2 = {"correct-ensemble-placement", "--ledgerids", String.valueOf(lh.getId()),
                 "--skipOpenLedgers", "--force", "--dryrun"};
         final BookieShell bkShell =
                 new BookieShell(LedgerIdFormatter.LONG_LEDGERID_FORMATTER, EntryFormatter.STRING_FORMATTER);
@@ -96,126 +65,6 @@ public class CorrectEnsemblePlacementCmdTest extends BookKeeperClusterTestCase {
 
         assertEquals("Failed to return exit code!", 0, bkShell.run(argv1));
         assertEquals("Failed to return exit code!", 0, bkShell.run(argv2));
-    }
-
-    @Test
-    public void testCorrectEnsemblePlacementByRackaware() throws Exception {
-        final int ensembleSize = 7;
-        final int quorumSize = 2;
-
-        final BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.1", 3181);
-        final BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.2", 3181);
-        final BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.3", 3181);
-        final BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.4", 3181);
-        final BookieSocketAddress addr5 = new BookieSocketAddress("127.0.0.5", 3181);
-        final BookieSocketAddress addr6 = new BookieSocketAddress("127.0.0.6", 3181);
-        final BookieSocketAddress addr7 = new BookieSocketAddress("127.0.0.7", 3181);
-        final BookieSocketAddress addr8 = new BookieSocketAddress("127.0.0.8", 3181);
-        final BookieSocketAddress addr9 = new BookieSocketAddress("127.0.0.9", 3181);
-
-        final Set<BookieId> writableBookies = new HashSet<>();
-        writableBookies.add(addr1.toBookieId());
-        writableBookies.add(addr2.toBookieId());
-        writableBookies.add(addr3.toBookieId());
-        writableBookies.add(addr4.toBookieId());
-        writableBookies.add(addr5.toBookieId());
-        writableBookies.add(addr6.toBookieId());
-        writableBookies.add(addr7.toBookieId());
-        writableBookies.add(addr8.toBookieId());
-        writableBookies.add(addr9.toBookieId());
-
-        // add bookie node to resolver
-        StaticDNSResolver.reset();
-
-        final String rackName1 = NetworkTopology.DEFAULT_REGION + "/r1";
-        final String rackName2 = NetworkTopology.DEFAULT_REGION + "/r2";
-        final String rackName3 = NetworkTopology.DEFAULT_REGION + "/r3";
-
-        // update dns mapping
-        // add port for testing
-        StaticDNSResolver.addNodeToRack(addr1.getSocketAddress().getAddress().getHostAddress(), rackName1);
-        StaticDNSResolver.addNodeToRack(addr2.getSocketAddress().getAddress().getHostAddress(), rackName1);
-        StaticDNSResolver.addNodeToRack(addr3.getSocketAddress().getAddress().getHostAddress(), rackName1);
-        StaticDNSResolver.addNodeToRack(addr4.getSocketAddress().getAddress().getHostAddress(), rackName2);
-        StaticDNSResolver.addNodeToRack(addr5.getSocketAddress().getAddress().getHostAddress(), rackName2);
-        StaticDNSResolver.addNodeToRack(addr6.getSocketAddress().getAddress().getHostAddress(), rackName2);
-        StaticDNSResolver.addNodeToRack(addr7.getSocketAddress().getAddress().getHostAddress(), rackName3);
-        StaticDNSResolver.addNodeToRack(addr8.getSocketAddress().getAddress().getHostAddress(), rackName3);
-        StaticDNSResolver.addNodeToRack(addr9.getSocketAddress().getAddress().getHostAddress(), rackName3);
-        LOG.info("Set up static DNS Resolver.");
-        baseClientConf.setEnsemblePlacementPolicy(RackawareEnsemblePlacementPolicy.class);
-        baseClientConf.setProperty(REPP_DNS_RESOLVER_CLASS, StaticDNSResolver.class.getName());
-
-        startNewBookie();
-
-        final NavigableMap<Long, List<BookieId>> ensemble = new TreeMap<>();
-        // create failed ensemble
-        // expect that the ensemble will be replaced to
-        // [addr1, addr4, addr7, addr2, addr5, addr8, *addr6 (in /default-region/r2 bookies)*]
-        ensemble.put(0L, Arrays.asList(
-                addr1.toBookieId(), addr4.toBookieId(),
-                addr7.toBookieId(), addr2.toBookieId(),
-                addr5.toBookieId(), addr8.toBookieId(),
-                addr3.toBookieId()));
-        final LedgerMetadata lm1 = Mockito.mock(LedgerMetadata.class);
-        Mockito.doReturn(ensemble).when(lm1).getAllEnsembles();
-        Mockito.doReturn(ensembleSize).when(lm1).getEnsembleSize();
-        Mockito.doReturn(quorumSize).when(lm1).getWriteQuorumSize();
-        Mockito.doReturn(quorumSize).when(lm1).getAckQuorumSize();
-        final LedgerHandle lh1 = Mockito.mock(LedgerHandle.class);
-        Mockito.when(lh1.getLedgerMetadata()).thenReturn(lm1);
-
-        @Cleanup
-        final BookKeeper bookKeeper = Mockito.spy(new BookKeeper(baseClientConf));
-        Mockito.doReturn(true).when(bookKeeper).isClosed(Mockito.anyLong());
-
-        @Cleanup
-        final BookKeeperAdmin admin = Mockito.spy(new BookKeeperAdmin(baseClientConf));
-        Mockito.doAnswer(invocationOnMock -> {
-            final AsyncCallback.OpenCallback op = invocationOnMock.getArgument(1);
-            final CountDownLatch ctx = invocationOnMock.getArgument(2);
-            op.openComplete(BKException.Code.OK, lh1, ctx);
-            return null;
-        }).when(admin).asyncOpenLedger(Mockito.anyLong(), Mockito.any(), Mockito.any());
-        // expected return
-        final Map<Integer, BookieId> expectedMap = new HashMap<>();
-        expectedMap.put(6, addr6.toBookieId());
-        Mockito.doNothing().when(admin)
-                .replicateLedgerFragment(Mockito.any(), Mockito.any(), eq(expectedMap), Mockito.any());
-
-        final EnsemblePlacementPolicy policy = bookKeeper.getPlacementPolicy();
-        final Field topologyField = TopologyAwareEnsemblePlacementPolicy.class
-                .getDeclaredField("topology");
-        topologyField.setAccessible(true);
-        final NetworkTopology topology = Mockito.spy((NetworkTopology) topologyField.get(policy));
-        Mockito.doReturn(2).when(topology).getNumOfRacks();
-        topologyField.set(policy, topology);
-        final Field bookieAddressResolverField = TopologyAwareEnsemblePlacementPolicy.class
-                .getDeclaredField("bookieAddressResolver");
-        bookieAddressResolverField.setAccessible(true);
-        final BookieAddressResolver bookieAddressResolver =
-                Mockito.spy((BookieAddressResolver) bookieAddressResolverField.get(policy));
-        Mockito.doAnswer(invocationOnMock -> {
-            final BookieId bookieId = invocationOnMock.getArgument(0);
-            return new BookieSocketAddress(bookieId.getId());
-        }).when(bookieAddressResolver).resolve(Mockito.any());
-        bookieAddressResolverField.set(policy, bookieAddressResolver);
-
-        // add mock bookies to knownBookies
-        policy.onClusterChanged(writableBookies, Collections.emptySet());
-
-        // make sure that the ensemble is FAIL state
-        assertEquals(EnsemblePlacementPolicy.PlacementPolicyAdherence.FAIL,
-                policy.isEnsembleAdheringToPlacementPolicy(ensemble.get(0L), quorumSize, quorumSize));
-
-        final CorrectEnsemblePlacementCommand.CorrectEnsemblePlacementFlags flag =
-                new CorrectEnsemblePlacementCommand.CorrectEnsemblePlacementFlags();
-        flag.ledgerIds(Collections.singletonList(1L));
-        final CorrectEnsemblePlacementCommand cmd = new CorrectEnsemblePlacementCommand();
-        cmd.relocate(baseConf, flag, bookKeeper, admin);
-
-        Mockito.verify(admin, Mockito.times(1))
-                .replicateLedgerFragment(Mockito.any(), Mockito.any(), eq(expectedMap), Mockito.any());
     }
 
     private LedgerHandle createLedgerWithEntries(BookKeeper bk, int numOfEntries,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/CorrectEnsemblePlacementCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/CorrectEnsemblePlacementCmdTest.java
@@ -46,6 +46,7 @@ import org.apache.bookkeeper.tools.cli.commands.bookies.CorrectEnsemblePlacement
 import org.apache.bookkeeper.util.EntryFormatter;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
 import org.apache.bookkeeper.util.StaticDNSResolver;
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -65,6 +66,12 @@ public class CorrectEnsemblePlacementCmdTest extends BookKeeperClusterTestCase {
         baseConf.setLedgerStorageClass(DbLedgerStorage.class.getName());
         baseConf.setGcWaitTime(60000);
         baseConf.setFlushInterval(1);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        StaticDNSResolver.reset();
     }
 
     /**


### PR DESCRIPTION
### Motivation

Currently, we can't recover the ensemble which isn't adhering to placement policy directly.
The `recover` command or autorecovery process is one of the alternative approaches. Unfortunately, however, we can't.

For example, suppose
* the bookie cluster has two racks( `/region/rack1` , `/region/rack2` )
* target ledger has the ensemble ( `[bookie1(/region/rack1), bookie2(/region/rack1)]` )
* the replicator uses RackawareEnsemblePlacementPolicy

When `bookie1` or `bookie2` goes down, then run autorecovery process.
If the bookie cluster has remained bookies which place to `/region/rack1`, the ledger recovers to the `/region/rack1` bookie again.
https://github.com/apache/bookkeeper/blob/release-4.14.4/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java#L225-L246
https://github.com/apache/bookkeeper/blob/release-4.14.4/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java#L1055-L1103
https://github.com/apache/bookkeeper/blob/release-4.14.4/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java#L474-L481

Therefore, we can't recover the ensemble which isn't adhering to placement policy directly.
The `recover` command is similar to this behavior.

I want to add a relocation feature to adhere placement policy.

### Changes

Add relocation feature to shell command.
So, we can use it synchronously instead of executing asynchronously like the autorecovery process.

In this specification, optimize the new ensemble arrangement to minify the number of bookies replaced.
Therefore, we should implement the new method that returns the new ensemble by policies.
First, I introduce this feature to RackawareEnsemblePlacementPolicy in this PR.