### PR TITLE
Bump log4j2 to 2.15.0

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -241,10 +241,10 @@ Apache Software License, Version 2.
 - lib/io.vertx-vertx-core-3.9.8.jar [15]
 - lib/io.vertx-vertx-web-3.9.8.jar [16]
 - lib/io.vertx-vertx-web-common-3.9.8.jar [16]
-- lib/org.apache.logging.log4j-log4j-1.2-api-2.14.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-api-2.14.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-core-2.14.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.14.1.jar [17]
+- lib/org.apache.logging.log4j-log4j-1.2-api-2.15.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-api-2.15.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-core-2.15.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.15.0.jar [17]
 - lib/net.java.dev.jna-jna-3.2.7.jar [18]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-lang3-3.6.jar [20]
@@ -321,7 +321,7 @@ Apache Software License, Version 2.
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
 [15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8
 [16] Source available at https://github.com/vert-x3/vertx-web/tree/3.9.8
-[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.14.1
+[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.15.0
 [18] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -230,10 +230,10 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-4.1.68.Final.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.68.Final-linux-x86_64.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.68.Final.jar [11]
-- lib/org.apache.logging.log4j-log4j-1.2-api-2.14.1.jar [16]
-- lib/org.apache.logging.log4j-log4j-api-2.14.1.jar [16]
-- lib/org.apache.logging.log4j-log4j-core-2.14.1.jar [16]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.14.1.jar [16]
+- lib/org.apache.logging.log4j-log4j-1.2-api-2.15.0.jar [16]
+- lib/org.apache.logging.log4j-log4j-api-2.15.0.jar [16]
+- lib/org.apache.logging.log4j-log4j-core-2.15.0.jar [16]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.15.0.jar [16]
 - lib/net.java.dev.jna-jna-3.2.7.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [18]
 - lib/org.apache.commons-commons-lang3-3.6.jar [19]
@@ -293,7 +293,7 @@ Apache Software License, Version 2.
 [9] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=tag;h=375459
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.68.Final
-[16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.14.1
+[16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.15.0
 [17] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -241,10 +241,10 @@ Apache Software License, Version 2.
 - lib/io.vertx-vertx-core-3.9.8.jar [15]
 - lib/io.vertx-vertx-web-3.9.8.jar [16]
 - lib/io.vertx-vertx-web-common-3.9.8.jar [16]
-- lib/org.apache.logging.log4j-log4j-1.2-api-2.14.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-api-2.14.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-core-2.14.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.14.1.jar [17]
+- lib/org.apache.logging.log4j-log4j-1.2-api-2.15.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-api-2.15.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-core-2.15.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.15.0.jar [17]
 - lib/net.java.dev.jna-jna-3.2.7.jar [18]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-lang3-3.6.jar [20]
@@ -319,7 +319,7 @@ Apache Software License, Version 2.
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
 [15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8
 [16] Source available at https://github.com/vert-x3/vertx-web/tree/3.9.8
-[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.14.1
+[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.15.0
 [18] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -62,7 +62,7 @@ depVersions = [
     junit: "4.12",
     junitFoundation: "11.0.0",
     kerby: "1.1.1",
-    log4j: "2.14.1",
+    log4j: "2.15.0",
     lombok: "1.18.20",
     lz4: "1.3.0",
     mockito: "3.0.0",

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <junit.version>4.12</junit.version>
     <libthrift.version>0.14.2</libthrift.version>
     <lombok.version>1.18.20</lombok.version>
-    <log4j.version>2.14.1</log4j.version>
+    <log4j.version>2.15.0</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.0.0</mockito.version>
     <netty.version>4.1.68.Final</netty.version>


### PR DESCRIPTION
### Motivation

Bump log4j2 to 2.15.0 to solve https://www.lunasec.io/docs/blog/log4j-zero-day/
