### PR TITLE
Upgrade to Grpc 1.42.1

### DIFF
--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -47,4 +47,4 @@ jobs:
           java-version: 1.8
       - name: Build with gradle
         run: |
-          ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -Dtestlogger.theme=plain -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**"
+          ./gradlew -i test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -Dtestlogger.theme=plain -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**"

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -47,4 +47,4 @@ jobs:
           java-version: 1.8
       - name: Build with gradle
         run: |
-          ./gradlew -i test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -Dtestlogger.theme=plain -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**"
+          ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -Dtestlogger.theme=plain -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**"

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -623,13 +623,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.14.0.jar
-Source available at https://github.com/google/protobuf/tree/v3.14.0
+  - lib/com.google.protobuf-protobuf-java-3.17.2.jar
+Source available at https://github.com/google/protobuf/tree/v3.17.2
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.12.0.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.12.0
+  - lib/com.google.protobuf-protobuf-java-util-3.17.2.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.17.2
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -206,7 +206,7 @@ The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.11.0.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
 - lib/com.google.guava-guava-30.0-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
@@ -263,9 +263,9 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/com.google.api.grpc-proto-google-common-protos-1.17.0.jar [28]
+- lib/com.google.api.grpc-proto-google-common-protos-2.0.1.jar [28]
 - lib/com.google.code.gson-gson-2.8.6.jar [29]
-- lib/io.opencensus-opencensus-api-0.24.0.jar [30]
+- lib/io.opencensus-opencensus-api-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
 - lib/io.grpc-grpc-all-1.42.1.jar [33]
@@ -282,11 +282,12 @@ Apache Software License, Version 2.
 - lib/io.grpc-grpc-stub-1.42.1.jar [33]
 - lib/io.grpc-grpc-testing-1.42.1.jar [33]
 - lib/io.grpc-grpc-xds-1.42.1.jar [33]
+- lib/io.grpc-grpc-rls-1.42.1.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
 - lib/org.inferred-freebuilder-2.7.0.jar [35]
-- lib/com.google.errorprone-error_prone_annotations-2.4.0.jar [36]
+- lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [36]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [37]
 - lib/org.jctools-jctools-core-2.1.2.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [39]
@@ -294,19 +295,19 @@ Apache Software License, Version 2.
 - lib/org.apache.thrift-libthrift-0.14.2.jar [41]
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
 - lib/com.google.http-client-google-http-client-1.34.0.jar [43]
-- lib/com.google.http-client-google-http-client-jackson2-1.34.0.jar [43]
-- lib/com.google.auto.value-auto-value-annotations-1.7.jar [44]
+- lib/com.google.http-client-google-http-client-jackson2-1.38.0.jar [43]
+- lib/com.google.auto.value-auto-value-annotations-1.7.4.jar [44]
 - lib/com.google.j2objc-j2objc-annotations-1.3.jar [45]
-- lib/com.google.re2j-re2j-1.2.jar [46]
+- lib/com.google.re2j-re2j-1.5.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-3.2.5.jar [47]
 - lib/io.dropwizard.metrics-metrics-graphite-3.2.5.jar [47]
 - lib/io.dropwizard.metrics-metrics-jvm-3.2.5.jar [47]
-- lib/io.perfmark-perfmark-api-0.19.0.jar [48]
+- lib/io.perfmark-perfmark-api-0.23.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.jar [50]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.0
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
 [4] Source available at https://github.com/google/guava/tree/v30.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
@@ -333,23 +334,23 @@ Apache Software License, Version 2.
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [28] Source available at https://github.com/googleapis/googleapis
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
-[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
+[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
 [33] Source available at https://github.com/grpc/grpc-java/tree/v1.42.1
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
-[36] Source available at https://github.com/google/error-prone/tree/v2.4.0
+[36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
 [38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1
 [41] Source available at https://github.com/apache/thrift/tree/0.14.2
 [42] Source available at https://source.android.com/
-[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.34.0
-[44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7
+[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.38.0
+[44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7.4
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
-[46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.2
+[46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.5
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v3.2.5
-[48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.19.0
+[48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.23.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
 [50] Source available at https://github.com/google/snappy/releases/tag/1.1.7
 
@@ -648,9 +649,9 @@ This product bundles the Google Auth Library, which is available under a "3-clau
 license. For details, see deps/google-auth-library-credentials-0.20.0/LICENSE
 
 Bundled as
-  - lib/com.google.auth-google-auth-library-credentials-0.20.0.jar
-  - lib/com.google.auth-google-auth-library-oauth2-http-0.20.0.jar
-Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v0.20.0
+  - lib/com.google.auth-google-auth-library-credentials-0.22.2.jar
+  - lib/com.google.auth-google-auth-library-oauth2-http-0.22.2.jar
+Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v0.22.2
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2/LICENSE.html
@@ -662,4 +663,4 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-qual-3.5.0.jar
+  - lib/org.checkerframework-checker-compat-qual-2.5.5.jar

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -663,4 +663,4 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-compat-qual-2.5.5.jar
+  - lib/org.checkerframework-checker-qual-3.5.0.jar

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -268,20 +268,20 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.33.0.jar [33]
-- lib/io.grpc-grpc-alts-1.33.0.jar [33]
-- lib/io.grpc-grpc-api-1.33.0.jar [33]
-- lib/io.grpc-grpc-auth-1.33.0.jar [33]
-- lib/io.grpc-grpc-context-1.33.0.jar [33]
-- lib/io.grpc-grpc-core-1.33.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.33.0.jar [33]
-- lib/io.grpc-grpc-netty-1.33.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.33.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.33.0.jar [33]
-- lib/io.grpc-grpc-services-1.33.0.jar [33]
-- lib/io.grpc-grpc-stub-1.33.0.jar [33]
-- lib/io.grpc-grpc-testing-1.33.0.jar [33]
-- lib/io.grpc-grpc-xds-1.33.0.jar [33]
+- lib/io.grpc-grpc-all-1.42.1.jar [33]
+- lib/io.grpc-grpc-alts-1.42.1.jar [33]
+- lib/io.grpc-grpc-api-1.42.1.jar [33]
+- lib/io.grpc-grpc-auth-1.42.1.jar [33]
+- lib/io.grpc-grpc-context-1.42.1.jar [33]
+- lib/io.grpc-grpc-core-1.42.1.jar [33]
+- lib/io.grpc-grpc-grpclb-1.42.1.jar [33]
+- lib/io.grpc-grpc-netty-1.42.1.jar [33]
+- lib/io.grpc-grpc-protobuf-1.42.1.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.42.1.jar [33]
+- lib/io.grpc-grpc-services-1.42.1.jar [33]
+- lib/io.grpc-grpc-stub-1.42.1.jar [33]
+- lib/io.grpc-grpc-testing-1.42.1.jar [33]
+- lib/io.grpc-grpc-xds-1.42.1.jar [33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -334,7 +334,7 @@ Apache Software License, Version 2.
 [28] Source available at https://github.com/googleapis/googleapis
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.42.1
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.4.0

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -247,20 +247,20 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.24.0.jar [29]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [29]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [29]
-- lib/io.grpc-grpc-all-1.33.0.jar [32]
-- lib/io.grpc-grpc-alts-1.33.0.jar [32]
-- lib/io.grpc-grpc-api-1.33.0.jar [32]
-- lib/io.grpc-grpc-auth-1.33.0.jar [32]
-- lib/io.grpc-grpc-context-1.33.0.jar [32]
-- lib/io.grpc-grpc-core-1.33.0.jar [32]
-- lib/io.grpc-grpc-grpclb-1.33.0.jar [32]
-- lib/io.grpc-grpc-netty-1.33.0.jar [32]
-- lib/io.grpc-grpc-protobuf-1.33.0.jar [32]
-- lib/io.grpc-grpc-protobuf-lite-1.33.0.jar [32]
-- lib/io.grpc-grpc-services-1.33.0.jar [32]
-- lib/io.grpc-grpc-stub-1.33.0.jar [32]
-- lib/io.grpc-grpc-testing-1.33.0.jar [32]
-- lib/io.grpc-grpc-xds-1.33.0.jar [32]
+- lib/io.grpc-grpc-all-1.42.1.jar [32]
+- lib/io.grpc-grpc-alts-1.42.1.jar [32]
+- lib/io.grpc-grpc-api-1.42.1.jar [32]
+- lib/io.grpc-grpc-auth-1.42.1.jar [32]
+- lib/io.grpc-grpc-context-1.42.1.jar [32]
+- lib/io.grpc-grpc-core-1.42.1.jar [32]
+- lib/io.grpc-grpc-grpclb-1.42.1.jar [32]
+- lib/io.grpc-grpc-netty-1.42.1.jar [32]
+- lib/io.grpc-grpc-protobuf-1.42.1.jar [32]
+- lib/io.grpc-grpc-protobuf-lite-1.42.1.jar [32]
+- lib/io.grpc-grpc-services-1.42.1.jar [32]
+- lib/io.grpc-grpc-stub-1.42.1.jar [32]
+- lib/io.grpc-grpc-testing-1.42.1.jar [32]
+- lib/io.grpc-grpc-xds-1.42.1.jar [32]
 - lib/org.apache.curator-curator-client-5.1.0.jar [33]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [33]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [33]
@@ -303,7 +303,7 @@ Apache Software License, Version 2.
 [27] Source available at https://github.com/googleapis/googleapis
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
 [29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
-[32] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
+[32] Source available at https://github.com/grpc/grpc-java/tree/v1.42.1
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.1.0
 [34] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [35] Source available at https://github.com/google/error-prone/tree/v2.4.0

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -555,13 +555,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.14.0.jar
-Source available at https://github.com/google/protobuf/tree/v3.14.0
+  - lib/com.google.protobuf-protobuf-java-3.17.2.jar
+Source available at https://github.com/google/protobuf/tree/v3.17.2
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.12.0.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.12.0
+  - lib/com.google.protobuf-protobuf-java-util-3.17.2.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.17.2
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles Simple Logging Facade for Java, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -206,7 +206,7 @@ The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.11.0.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
 - lib/com.google.guava-guava-30.0-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
@@ -242,9 +242,9 @@ Apache Software License, Version 2.
 - lib/org.apache.zookeeper-zookeeper-3.6.2-tests.jar [20]
 - lib/com.beust-jcommander-1.78.jar [23]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
-- lib/com.google.api.grpc-proto-google-common-protos-1.17.0.jar [27]
+- lib/com.google.api.grpc-proto-google-common-protos-2.0.1.jar [27]
 - lib/com.google.code.gson-gson-2.8.6.jar [28]
-- lib/io.opencensus-opencensus-api-0.24.0.jar [29]
+- lib/io.opencensus-opencensus-api-0.28.0.jar [29]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [29]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [29]
 - lib/io.grpc-grpc-all-1.42.1.jar [32]
@@ -261,29 +261,30 @@ Apache Software License, Version 2.
 - lib/io.grpc-grpc-stub-1.42.1.jar [32]
 - lib/io.grpc-grpc-testing-1.42.1.jar [32]
 - lib/io.grpc-grpc-xds-1.42.1.jar [32]
+- lib/io.grpc-grpc-rls-1.42.1.jar[32]
 - lib/org.apache.curator-curator-client-5.1.0.jar [33]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [33]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [33]
 - lib/org.inferred-freebuilder-2.7.0.jar [34]
-- lib/com.google.errorprone-error_prone_annotations-2.4.0.jar [35]
+- lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [35]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [36]
 - lib/org.jctools-jctools-core-2.1.2.jar [37]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [38]
 - lib/org.apache.httpcomponents-httpcore-4.4.13.jar [39]
 - lib/org.apache.thrift-libthrift-0.14.2.jar [40]
 - lib/com.google.android-annotations-4.1.1.4.jar [41]
-- lib/com.google.auto.value-auto-value-annotations-1.7.jar [42]
+- lib/com.google.auto.value-auto-value-annotations-1.7.4.jar [42]
 - lib/com.google.http-client-google-http-client-1.34.0.jar [43]
-- lib/com.google.http-client-google-http-client-jackson2-1.34.0.jar [43]
+- lib/com.google.http-client-google-http-client-jackson2-1.38.0.jar [43]
 - lib/com.google.j2objc-j2objc-annotations-1.3.jar [44]
-- lib/com.google.re2j-re2j-1.2.jar [45]
+- lib/com.google.re2j-re2j-1.5.jar [45]
 - lib/io.dropwizard.metrics-metrics-core-3.2.5.jar [46]
-- lib/io.perfmark-perfmark-api-0.19.0.jar [47]
+- lib/io.perfmark-perfmark-api-0.23.0.jar [47]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.jar [50]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.0
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
 [4] Source available at https://github.com/google/guava/tree/v30.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
@@ -302,23 +303,23 @@ Apache Software License, Version 2.
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [27] Source available at https://github.com/googleapis/googleapis
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
-[29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
+[29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
 [32] Source available at https://github.com/grpc/grpc-java/tree/v1.42.1
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.1.0
 [34] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
-[35] Source available at https://github.com/google/error-prone/tree/v2.4.0
+[35] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [36] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
 [37] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [38] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [39] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1
 [40] Source available at https://github.com/apache/thrift/tree/0.14.2
 [41] Source available at https://source.android.com/
-[42] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7
-[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.34.0
+[42] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7.4
+[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.38.0
 [44] Source available at https://github.com/google/j2objc/releases/tag/1.3
-[45] Source available at https://github.com/google/re2j/releases/tag/re2j-1.2
+[45] Source available at https://github.com/google/re2j/releases/tag/re2j-1.5
 [46] Source available at https://github.com/dropwizard/metrics/releases/tag/v3.1.0
-[47] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.19.0
+[47] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.23.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
 [50] Source available at https://github.com/google/snappy/releases/tag/1.1.7
 
@@ -574,9 +575,9 @@ This product bundles the Google Auth Library, which is available under a "3-clau
 license. For details, see deps/google-auth-library-credentials-0.20.0/LICENSE
 
 Bundled as
-  - lib/com.google.auth-google-auth-library-credentials-0.20.0.jar
-  - lib/com.google.auth-google-auth-library-oauth2-http-0.20.0.jar
-Source available at https://github.com/google/google-auth-library-java/tree/0.20.0
+  - lib/com.google.auth-google-auth-library-credentials-0.22.2.jar
+  - lib/com.google.auth-google-auth-library-oauth2-http-0.22.2.jar
+Source available at https://github.com/google/google-auth-library-java/tree/0.22.2
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2/LICENSE.html
@@ -589,4 +590,4 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-qual-3.5.0.jar
+  - lib/org.checkerframework-checker-compat-qual-2.5.5.jar

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -590,4 +590,4 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-compat-qual-2.5.5.jar
+  - lib/org.checkerframework-checker-qual-3.5.0.jar

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -268,20 +268,20 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.33.0.jar [33]
-- lib/io.grpc-grpc-alts-1.33.0.jar [33]
-- lib/io.grpc-grpc-api-1.33.0.jar [33]
-- lib/io.grpc-grpc-auth-1.33.0.jar [33]
-- lib/io.grpc-grpc-context-1.33.0.jar [33]
-- lib/io.grpc-grpc-core-1.33.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.33.0.jar [33]
-- lib/io.grpc-grpc-netty-1.33.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.33.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.33.0.jar [33]
-- lib/io.grpc-grpc-services-1.33.0.jar [33]
-- lib/io.grpc-grpc-stub-1.33.0.jar [33]
-- lib/io.grpc-grpc-testing-1.33.0.jar [33]
-- lib/io.grpc-grpc-xds-1.33.0.jar [33]
+- lib/io.grpc-grpc-all-1.42.1.jar [33]
+- lib/io.grpc-grpc-alts-1.42.1.jar [33]
+- lib/io.grpc-grpc-api-1.42.1.jar [33]
+- lib/io.grpc-grpc-auth-1.42.1.jar [33]
+- lib/io.grpc-grpc-context-1.42.1.jar [33]
+- lib/io.grpc-grpc-core-1.42.1.jar [33]
+- lib/io.grpc-grpc-grpclb-1.42.1.jar [33]
+- lib/io.grpc-grpc-netty-1.42.1.jar [33]
+- lib/io.grpc-grpc-protobuf-1.42.1.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.42.1.jar [33]
+- lib/io.grpc-grpc-services-1.42.1.jar [33]
+- lib/io.grpc-grpc-stub-1.42.1.jar [33]
+- lib/io.grpc-grpc-testing-1.42.1.jar [33]
+- lib/io.grpc-grpc-xds-1.42.1.jar [33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -332,7 +332,7 @@ Apache Software License, Version 2.
 [28] Source available at https://github.com/googleapis/googleapis
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.33.0
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.42.1
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.4.0

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -206,7 +206,7 @@ The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.11.0.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
 - lib/com.google.guava-guava-30.0-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
@@ -263,9 +263,9 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/com.google.api.grpc-proto-google-common-protos-1.17.0.jar [28]
+- lib/com.google.api.grpc-proto-google-common-protos-2.0.1.jar [28]
 - lib/com.google.code.gson-gson-2.8.6.jar [29]
-- lib/io.opencensus-opencensus-api-0.24.0.jar [30]
+- lib/io.opencensus-opencensus-api-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.24.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
 - lib/io.grpc-grpc-all-1.42.1.jar [33]
@@ -282,11 +282,12 @@ Apache Software License, Version 2.
 - lib/io.grpc-grpc-stub-1.42.1.jar [33]
 - lib/io.grpc-grpc-testing-1.42.1.jar [33]
 - lib/io.grpc-grpc-xds-1.42.1.jar [33]
+- lib/io.grpc-grpc-rls-1.42.1.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
 - lib/org.inferred-freebuilder-2.7.0.jar [35]
-- lib/com.google.errorprone-error_prone_annotations-2.4.0.jar [36]
+- lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [36]
 - lib/org.apache.yetus-audience-annotations-0.5.0.jar [37]
 - lib/org.jctools-jctools-core-2.1.2.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [39]
@@ -294,17 +295,17 @@ Apache Software License, Version 2.
 - lib/org.apache.thrift-libthrift-0.14.2.jar [41]
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
 - lib/com.google.http-client-google-http-client-1.34.0.jar [43]
-- lib/com.google.http-client-google-http-client-jackson2-1.34.0.jar [43]
-- lib/com.google.auto.value-auto-value-annotations-1.7.jar [44]
+- lib/com.google.http-client-google-http-client-jackson2-1.38.0.jar [43]
+- lib/com.google.auto.value-auto-value-annotations-1.7.4.jar [44]
 - lib/com.google.j2objc-j2objc-annotations-1.3.jar [45]
-- lib/com.google.re2j-re2j-1.2.jar [46]
+- lib/com.google.re2j-re2j-1.5.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-3.2.5.jar [47]
-- lib/io.perfmark-perfmark-api-0.19.0.jar [48]
+- lib/io.perfmark-perfmark-api-0.23.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.jar [50]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.0
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
 [4] Source available at https://github.com/google/guava/tree/v30.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
@@ -331,23 +332,23 @@ Apache Software License, Version 2.
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [28] Source available at https://github.com/googleapis/googleapis
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.6
-[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.24.0
+[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
 [33] Source available at https://github.com/grpc/grpc-java/tree/v1.42.1
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
-[36] Source available at https://github.com/google/error-prone/tree/v2.4.0
+[36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
 [38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1
 [41] Source available at https://github.com/apache/thrift/tree/0.14.2
 [42] Source available at https://source.android.com/
-[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.34.0
-[44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7
+[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.38.0
+[44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.7.4
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
-[46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.2
+[46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.5
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v3.2.5
-[48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.19.0
+[48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.23.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
 [50] Source available at https://github.com/google/snappy/releases/tag/1.1.7
 
@@ -614,13 +615,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.14.0.jar
-Source available at https://github.com/google/protobuf/tree/v3.14.0
+  - lib/com.google.protobuf-protobuf-java-3.17.2.jar
+Source available at https://github.com/google/protobuf/tree/v3.17.2
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.12.0.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.12.0
+  - lib/com.google.protobuf-protobuf-java-util-3.17.2.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.17.2
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a
@@ -640,9 +641,9 @@ This product bundles the Google Auth Library, which is available under a "3-clau
 license. For details, see deps/google-auth-library-credentials-0.20.0/LICENSE
 
 Bundled as
-  - lib/com.google.auth-google-auth-library-credentials-0.20.0.jar
-  - lib/com.google.auth-google-auth-library-oauth2-http-0.20.0.jar
-Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v0.20.0
+  - lib/com.google.auth-google-auth-library-credentials-0.22.2.jar
+  - lib/com.google.auth-google-auth-library-oauth2-http-0.22.2.jar
+Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v0.22.2
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2/LICENSE.html
@@ -654,4 +655,4 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-qual-3.5.0.jar
+  - lib/org.checkerframework-checker-compat-qual-2.5.5.jar

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -655,4 +655,4 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-compat-qual-2.5.5.jar
+  - lib/org.checkerframework-checker-qual-3.5.0.jar

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -120,15 +120,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.33.0.jar
-- lib/io.grpc-grpc-auth-1.33.0.jar
-- lib/io.grpc-grpc-context-1.33.0.jar
-- lib/io.grpc-grpc-core-1.33.0.jar
-- lib/io.grpc-grpc-netty-1.33.0.jar
-- lib/io.grpc-grpc-protobuf-1.33.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.33.0.jar
-- lib/io.grpc-grpc-stub-1.33.0.jar
-- lib/io.grpc-grpc-testing-1.33.0.jar
+- lib/io.grpc-grpc-all-1.42.1.jar
+- lib/io.grpc-grpc-auth-1.42.1.jar
+- lib/io.grpc-grpc-context-1.42.1.jar
+- lib/io.grpc-grpc-core-1.42.1.jar
+- lib/io.grpc-grpc-netty-1.42.1.jar
+- lib/io.grpc-grpc-protobuf-1.42.1.jar
+- lib/io.grpc-grpc-protobuf-lite-1.42.1.jar
+- lib/io.grpc-grpc-stub-1.42.1.jar
+- lib/io.grpc-grpc-testing-1.42.1.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -47,15 +47,15 @@ under the License.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.33.0.jar
-- lib/io.grpc-grpc-auth-1.33.0.jar
-- lib/io.grpc-grpc-context-1.33.0.jar
-- lib/io.grpc-grpc-core-1.33.0.jar
-- lib/io.grpc-grpc-netty-1.33.0.jar
-- lib/io.grpc-grpc-protobuf-1.33.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.33.0.jar
-- lib/io.grpc-grpc-stub-1.33.0.jar
-- lib/io.grpc-grpc-testing-1.33.0.jar
+- lib/io.grpc-grpc-all-1.42.1.jar
+- lib/io.grpc-grpc-auth-1.42.1.jar
+- lib/io.grpc-grpc-context-1.42.1.jar
+- lib/io.grpc-grpc-core-1.42.1.jar
+- lib/io.grpc-grpc-netty-1.42.1.jar
+- lib/io.grpc-grpc-protobuf-1.42.1.jar
+- lib/io.grpc-grpc-protobuf-lite-1.42.1.jar
+- lib/io.grpc-grpc-stub-1.42.1.jar
+- lib/io.grpc-grpc-testing-1.42.1.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -103,15 +103,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.33.0.jar
-- lib/io.grpc-grpc-auth-1.33.0.jar
-- lib/io.grpc-grpc-context-1.33.0.jar
-- lib/io.grpc-grpc-core-1.33.0.jar
-- lib/io.grpc-grpc-netty-1.33.0.jar
-- lib/io.grpc-grpc-protobuf-1.33.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.33.0.jar
-- lib/io.grpc-grpc-stub-1.33.0.jar
-- lib/io.grpc-grpc-testing-1.33.0.jar
+- lib/io.grpc-grpc-all-1.42.1.jar
+- lib/io.grpc-grpc-auth-1.42.1.jar
+- lib/io.grpc-grpc-context-1.42.1.jar
+- lib/io.grpc-grpc-core-1.42.1.jar
+- lib/io.grpc-grpc-netty-1.42.1.jar
+- lib/io.grpc-grpc-protobuf-1.42.1.jar
+- lib/io.grpc-grpc-protobuf-lite-1.42.1.jar
+- lib/io.grpc-grpc-stub-1.42.1.jar
+- lib/io.grpc-grpc-testing-1.42.1.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
@@ -69,6 +69,7 @@ public class TestPrometheusFormatter {
 
         writer.write("jvm_memory_direct_bytes_max{} 4.77626368E8\n");
         writer.write("jvm_memory_pool_bytes_used{pool=\"Code Cache\"} 3347712.0\n");
+        writer.write("jvm_memory_pool_bytes_used{pool=\"CodeHeap 'non-nmethods'\"} 1207168.0\n");
         System.out.println(writer);
         Multimap<String, Metric> metrics = parseMetrics(writer.toString());
         System.out.println(metrics);
@@ -181,7 +182,7 @@ public class TestPrometheusFormatter {
         // pulsar_subscriptions_count{cluster="standalone", namespace="sample/standalone/ns1",
         // topic="persistent://sample/standalone/ns1/test-2"} 0.0 1517945780897
         Pattern pattern = Pattern.compile("^(\\w+)(\\{([^\\}]*)\\})?\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
-        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{((\\w+=[\\s\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*))?\\})?"
+        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{((\\w+=[-\\s\\\'\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*))?\\})?"
                 + "\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
@@ -193,7 +193,7 @@ public class TestPrometheusFormatter {
             System.err.println("Matches: " + matcher.matches());
             System.err.println(matcher);
             assertTrue(matcher.matches());
-            assertTrue(formatMatcher.matches());
+            assertTrue("failed to validate line: " + line, formatMatcher.matches());
 
             assertEquals(6, matcher.groupCount());
             System.err.println("groups: " + matcher.groupCount());

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
@@ -182,8 +182,9 @@ public class TestPrometheusFormatter {
         // pulsar_subscriptions_count{cluster="standalone", namespace="sample/standalone/ns1",
         // topic="persistent://sample/standalone/ns1/test-2"} 0.0 1517945780897
         Pattern pattern = Pattern.compile("^(\\w+)(\\{([^\\}]*)\\})?\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
-        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{((\\w+=[-\\s\\\'\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*))?\\})?"
-                + "\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
+        Pattern formatPattern =
+                Pattern.compile("^(\\w+)(\\{((\\w+=[-\\s\\\'\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*))?\\})?"
+                        + "\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 
         Splitter.on("\n").split(metrics).forEach(line -> {

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
@@ -68,6 +68,7 @@ public class TestPrometheusFormatter {
         provider.writeAllMetrics(writer);
 
         writer.write("jvm_memory_direct_bytes_max{} 4.77626368E8\n");
+        writer.write("jvm_memory_pool_bytes_used{pool=\"Code Cache\"} 3347712.0\n");
         System.out.println(writer);
         Multimap<String, Metric> metrics = parseMetrics(writer.toString());
         System.out.println(metrics);
@@ -180,7 +181,7 @@ public class TestPrometheusFormatter {
         // pulsar_subscriptions_count{cluster="standalone", namespace="sample/standalone/ns1",
         // topic="persistent://sample/standalone/ns1/test-2"} 0.0 1517945780897
         Pattern pattern = Pattern.compile("^(\\w+)(\\{([^\\}]*)\\})?\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
-        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{((\\w+=[\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*))?\\})?"
+        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{((\\w+=[\\s\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*))?\\})?"
                 + "\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
@@ -66,6 +66,8 @@ public class TestPrometheusFormatter {
 
         StringWriter writer = new StringWriter();
         provider.writeAllMetrics(writer);
+
+        writer.write("jvm_memory_direct_bytes_max{} 4.77626368E8\n");
         System.out.println(writer);
         Multimap<String, Metric> metrics = parseMetrics(writer.toString());
         System.out.println(metrics);
@@ -177,8 +179,8 @@ public class TestPrometheusFormatter {
         // or
         // pulsar_subscriptions_count{cluster="standalone", namespace="sample/standalone/ns1",
         // topic="persistent://sample/standalone/ns1/test-2"} 0.0 1517945780897
-        Pattern pattern = Pattern.compile("^(\\w+)(\\{([^\\}]+)\\})?\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
-        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{(\\w+=[\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*)\\})?"
+        Pattern pattern = Pattern.compile("^(\\w+)(\\{([^\\}]*)\\})?\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
+        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{((\\w+=[\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*))?\\})?"
                 + "\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
@@ -192,7 +192,10 @@ public class TestPrometheusFormatter {
             Matcher formatMatcher = formatPattern.matcher(line);
             System.err.println("Matches: " + matcher.matches());
             System.err.println(matcher);
+            assertTrue(matcher.matches());
+            assertTrue(formatMatcher.matches());
 
+            assertEquals(6, matcher.groupCount());
             System.err.println("groups: " + matcher.groupCount());
             for (int i = 0; i < matcher.groupCount(); i++) {
                 System.err.println("   GROUP " + i + " -- " + matcher.group(i));

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,7 +39,7 @@ depVersions = [
     dockerJava: "3.2.5",
     dropwizard: "3.2.5",
     errorprone: "2.4.0",
-    etcd: "0.5.4",
+    etcd: "0.5.11",
     freebuilder: "2.7.0",
     googleHTTPClient: "1.34.0",
     gradleTooling: "4.0.1",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,7 +43,7 @@ depVersions = [
     freebuilder: "2.7.0",
     googleHTTPClient: "1.34.0",
     gradleTooling: "4.0.1",
-    grpc: "1.33.0",
+    grpc: "1.42.1",
     groovy: "2.5.8",
     guava: "30.0-jre",
     hamcrest: "1.3",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -135,6 +135,7 @@ depLibs = [
         exclude group: 'junit', module: 'junit'
         exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
+        exclude group: 'com.google.guava', module: 'guava'
     },
     groovy: "org.codehaus.groovy:groovy-all:${depVersions.groovy}",
     guava: dependencies.create("com.google.guava:guava:${depVersions.guava}"){

--- a/metadata-drivers/etcd/build.gradle
+++ b/metadata-drivers/etcd/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation project(":bookkeeper-stats")
     implementation depLibs.etcd
     implementation depLibs.commonsConfiguration
+    implementation depLibs.commonsLang3
     implementation depLibs.grpc
     implementation depLibs.zookeeper
 

--- a/metadata-drivers/etcd/src/test/resources/log4j2.xml
+++ b/metadata-drivers/etcd/src/test/resources/log4j2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.}@%L - %msg %X%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="warn">
+            <AppenderRef ref="Console" />
+        </Root>
+        <Logger name="org.eclipse.jetty" level="info"/>
+        <Logger name="org.apache.pulsar" level="info"/>
+        <Logger name="org.apache.bookkeeper" level="info"/>
+        <Logger name="org.apache.kafka" level="info"/>
+        <Logger name="org.testcontainers" level="info"/>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <bouncycastle.version>1.0.2</bouncycastle.version>
     <curator.version>5.1.0</curator.version>
     <dropwizard.version>3.2.5</dropwizard.version>
-    <etcd.version>0.5.4</etcd.version>
+    <etcd.version>0.5.11</etcd.version>
     <freebuilder.version>2.7.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.4.0</google.errorprone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <freebuilder.version>2.7.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.4.0</google.errorprone.version>
-    <grpc.version>1.33.0</grpc.version>
+    <grpc.version>1.42.1</grpc.version>
     <guava.version>30.0-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>2.10.0</hadoop.version>

--- a/stream/bk-grpc-name-resolver/build.gradle
+++ b/stream/bk-grpc-name-resolver/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':bookkeeper-stats')
     implementation project(':stream:common')
     implementation depLibs.grpc
+    implementation depLibs.guava
     implementation depLibs.slf4j
     implementation depLibs.commonsConfiguration
 

--- a/stream/bk-grpc-name-resolver/src/main/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolverProvider.java
+++ b/stream/bk-grpc-name-resolver/src/main/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolverProvider.java
@@ -20,7 +20,6 @@
 package org.apache.bookkeeper.grpc.resolver;
 
 import com.google.common.collect.Lists;
-import io.grpc.Attributes;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 import java.net.URI;
@@ -58,7 +57,7 @@ public class BKRegistrationNameResolverProvider extends NameResolverFactoryProvi
 
     @Nullable
     @Override
-    public NameResolver newNameResolver(URI targetUri, Attributes params) {
+    public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
         ServiceURI serviceURI;
         try {
             serviceURI = ServiceURI.create(targetUri);

--- a/stream/bk-grpc-name-resolver/src/test/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolverTest.java
+++ b/stream/bk-grpc-name-resolver/src/test/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolverTest.java
@@ -27,11 +27,14 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.Listener;
 import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.internal.GrpcUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
@@ -117,7 +120,17 @@ public class BKRegistrationNameResolverTest extends BookKeeperClusterTestCase {
 
         @Cleanup("shutdown")
         NameResolver resolver = resolverProvider.newNameResolver(serviceUri,
-                NameResolver.Args.newBuilder().setDefaultPort(0).build());
+                NameResolver.Args.newBuilder()
+                        .setDefaultPort(0)
+                        .setProxyDetector(GrpcUtil.DEFAULT_PROXY_DETECTOR)
+                        .setSynchronizationContext(new SynchronizationContext((t, ex) -> {}))
+                        .setServiceConfigParser(new NameResolver.ServiceConfigParser() {
+                            @Override
+                            public NameResolver.ConfigOrError parseServiceConfig(Map<String, ?> rawServiceConfig) {
+                                return null;
+                            }
+                        })
+                        .build());
         resolver.start(new Listener() {
             @Override
             public void onAddresses(List<EquivalentAddressGroup> servers, Attributes attributes) {

--- a/stream/bk-grpc-name-resolver/src/test/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolverTest.java
+++ b/stream/bk-grpc-name-resolver/src/test/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolverTest.java
@@ -116,7 +116,8 @@ public class BKRegistrationNameResolverTest extends BookKeeperClusterTestCase {
 
 
         @Cleanup("shutdown")
-        NameResolver resolver = resolverProvider.newNameResolver(serviceUri, Attributes.EMPTY);
+        NameResolver resolver = resolverProvider.newNameResolver(serviceUri,
+                NameResolver.Args.newBuilder().setDefaultPort(0).build());
         resolver.start(new Listener() {
             @Override
             public void onAddresses(List<EquivalentAddressGroup> servers, Attributes attributes) {

--- a/stream/clients/java/all/build.gradle
+++ b/stream/clients/java/all/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(':stream:proto')
 
     implementation depLibs.grpc
+    implementation depLibs.guava
     runtimeOnly depLibs.googleHTTPClient
     compileOnly depLibs.lombok
     implementation depLibs.slf4j

--- a/stream/clients/java/base/build.gradle
+++ b/stream/clients/java/base/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation depLibs.freebuilder
     compileOnly depLibs.jsr305
     implementation depLibs.grpc
+    implementation depLibs.guava
     runtimeOnly depLibs.googleHTTPClient
     compileOnly depLibs.lombok
     implementation depLibs.slf4j

--- a/stream/proto/build.gradle
+++ b/stream/proto/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(':stream:common')
     compileOnly depLibs.lombok
     implementation depLibs.grpc
+    implementation depLibs.guava
     runtimeOnly depLibs.googleHTTPClient
     implementation depLibs.commonsLang3
     compileOnly depLibs.jsr305

--- a/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVAsyncStoreWithCheckpoints.java
+++ b/stream/statelib/src/test/java/org/apache/bookkeeper/statelib/impl/kv/TestRocksdbKVAsyncStoreWithCheckpoints.java
@@ -27,8 +27,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-import com.google.common.io.MoreFiles;
-import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.io.File;
@@ -50,6 +48,7 @@ import org.apache.bookkeeper.statelib.api.exceptions.InvalidStateStoreException;
 import org.apache.bookkeeper.statelib.impl.rocksdb.RocksUtils;
 import org.apache.bookkeeper.statelib.impl.rocksdb.checkpoint.fs.FSCheckpointManager;
 import org.apache.bookkeeper.statelib.testing.executors.MockExecutorController;
+import org.apache.commons.io.FileUtils;
 import org.apache.distributedlog.DLMTestUtil;
 import org.apache.distributedlog.DLSN;
 import org.apache.distributedlog.TestDistributedLogBase;
@@ -239,9 +238,7 @@ public class TestRocksdbKVAsyncStoreWithCheckpoints extends TestDistributedLogBa
         assertTrue(files.isEmpty());
 
         // remove local dir
-        MoreFiles.deleteRecursively(
-            Paths.get(localDir.getAbsolutePath()),
-            RecursiveDeleteOption.ALLOW_INSECURE);
+        FileUtils.deleteDirectory(new File(localDir.getAbsolutePath()));
 
         // reload the store
         store = new RocksdbKVAsyncStore<>(
@@ -276,9 +273,7 @@ public class TestRocksdbKVAsyncStoreWithCheckpoints extends TestDistributedLogBa
         assertEquals(1, files.size());
 
         // remove local dir
-        MoreFiles.deleteRecursively(
-            Paths.get(localDir.getAbsolutePath()),
-            RecursiveDeleteOption.ALLOW_INSECURE);
+        FileUtils.deleteDirectory(new File(localDir.getAbsolutePath()));
 
         // reload the store
         store = new RocksdbKVAsyncStore<>(
@@ -297,9 +292,7 @@ public class TestRocksdbKVAsyncStoreWithCheckpoints extends TestDistributedLogBa
         store.close();
 
         // remove local dir
-        MoreFiles.deleteRecursively(
-            Paths.get(localDir.getAbsolutePath()),
-            RecursiveDeleteOption.ALLOW_INSECURE);
+        FileUtils.deleteDirectory(new File(localDir.getAbsolutePath()));
 
         store = new RocksdbKVAsyncStore<>(
             () -> new RocksdbKVStore<>(),

--- a/stream/tests-common/build.gradle
+++ b/stream/tests-common/build.gradle
@@ -22,6 +22,7 @@ plugins {
 
 dependencies {
     implementation depLibs.grpc
+    implementation depLibs.guava
     testImplementation depLibs.googleHTTPClient
     compileOnly depLibs.lombok
     implementation depLibs.slf4j


### PR DESCRIPTION
### Motivation

`BKRegistrationNameResolverProvider` is relying on an interface from older Grpc version that has changed since then. 

This causes conflicts when trying to use BK with a newer version of Ggrpc, which can be the case when other components are requesting a newer Grpc version.