### PR TITLE
Fix check compatibility workflows failing due to regex

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusFormatter.java
@@ -177,9 +177,9 @@ public class TestPrometheusFormatter {
         // or
         // pulsar_subscriptions_count{cluster="standalone", namespace="sample/standalone/ns1",
         // topic="persistent://sample/standalone/ns1/test-2"} 0.0 1517945780897
-        Pattern pattern = Pattern.compile("^(\\w+)(\\{([^\\}]+)\\})?\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
-        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{(\\w+=[\\\"\\.\\w]+(,\\s?\\w+=[\\\"\\.\\w]+)*)\\})?"
-                + "\\s(-?[\\d\\w\\.]+)(\\s(\\d+))?$");
+        Pattern pattern = Pattern.compile("^(\\w+)(\\{([,-=\\'\\\"\\s\\.\\w]*)\\})?\\s(-?[\\d\\w\\.]+)$");
+        Pattern formatPattern = Pattern.compile("^(\\w+)(\\{(\\w+=[-\\'\\\"\\s\\.\\w]+"
+                + "(,\\s?\\w+=[-\\'\\\"\\s\\.\\w]+)*)?\\})?\\s(-?[\\d\\w\\.]+)?$");
         Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
 
         Splitter.on("\n").split(metrics).forEach(line -> {


### PR DESCRIPTION
### Motivation

The java 8 and 11 compatibility workflows are failing because the regex in TestPrometheusFormatter.java does not work correctly, in different ways, for Java 8 and 11 on Ubuntu.

I can reproduce this on Ubuntu 18.04.

### Changes

Changed the regex used for parsing the metrics lines so that it produces the right matches.