### PR TITLE
Fix wrong ledger id parse radix for index relocation file in IndexPersistenceMgr

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/IndexPersistenceMgr.java
@@ -274,8 +274,9 @@ public class IndexPersistenceMgr {
                                 // name is the HexString representation of the
                                 // ledgerId.
                                 String ledgerIdInHex = index.getName().replace(RLOC, "").replace(IDX, "");
+                                long ledgerId = Long.parseLong(ledgerIdInHex, 16);
                                 if (index.getName().endsWith(RLOC)) {
-                                    if (findIndexFile(Long.parseLong(ledgerIdInHex)) != null) {
+                                    if (findIndexFile(ledgerId) != null) {
                                         if (!index.delete()) {
                                             LOG.warn("Deleting the rloc file " + index + " failed");
                                         }
@@ -288,7 +289,7 @@ public class IndexPersistenceMgr {
                                         }
                                     }
                                 }
-                                activeLedgers.put(Long.parseLong(ledgerIdInHex, 16), true);
+                                activeLedgers.put(ledgerId, true);
                             }
                         }
                     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation
1. `IndexPersistenceMgr` fails to start after crashing index file movement.

### Changes
1. Add test to assert index file relocation
2. Fix wrong ledger id parse radix for index relocation file in IndexPersistenceMgr

Master Issue: None
