### PR TITLE
bug fix for EntryLocationIndex.getLastEntryInLedger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -93,7 +93,10 @@ public class EntryLocationIndex implements Closeable {
     public long getLastEntryInLedger(long ledgerId) throws IOException {
         if (deletedLedgers.contains(ledgerId)) {
             // Ledger already deleted
-            return -1;
+            if (log.isDebugEnabled()) {
+                log.debug("Ledger {} already deleted in db", ledgerId);
+            }
+            throw new Bookie.NoEntryException(ledgerId, -1);
         }
 
         return getLastEntryInLedgerInternal(ledgerId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -99,7 +99,7 @@ public class EntryLocationIndex implements Closeable {
             /**
              * when Ledger already deleted,
              * throw Bookie.NoEntryException same like  the method
-             * {@link EntryLocationIndex.getLastEntryInLedgerInternal} solving ledgerId is not found
+             * {@link EntryLocationIndex.getLastEntryInLedgerInternal} solving ledgerId is not found.
              * */
             throw new Bookie.NoEntryException(ledgerId, -1);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -96,9 +96,12 @@ public class EntryLocationIndex implements Closeable {
             if (log.isDebugEnabled()) {
                 log.debug("Ledger {} already deleted in db", ledgerId);
             }
+            /**
+             * when Ledger already deleted,
+             * throw Bookie.NoEntryException same like  the method {@link EntryLocationIndex.getLastEntryInLedgerInternal} solving ledgerId is not found
+             * */
             throw new Bookie.NoEntryException(ledgerId, -1);
         }
-
         return getLastEntryInLedgerInternal(ledgerId);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -98,7 +98,8 @@ public class EntryLocationIndex implements Closeable {
             }
             /**
              * when Ledger already deleted,
-             * throw Bookie.NoEntryException same like  the method {@link EntryLocationIndex.getLastEntryInLedgerInternal} solving ledgerId is not found
+             * throw Bookie.NoEntryException same like  the method
+             * {@link EntryLocationIndex.getLastEntryInLedgerInternal} solving ledgerId is not found
              * */
             throw new Bookie.NoEntryException(ledgerId, -1);
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

bug fix for EntryLocationIndex.getLastEntryInLedger
when the ledger is deleted, then get last entry in this ledger, two case in method(name is EntryLocationIndex.getLastEntryInLedger)

case return -1:
    1)  when the ledger is deleted,return -1
    2)  then the method(name is SingleDirectoryDbLedgerStorage.getLastEntry) should read entry's location index,  but entryID's value is -1, the code will throw a unexcepted error( error information is "IOException: org.apache.bookkeeper.bookie.EntryLogger$EntryLookupException$MissingLogFileException: Missing entryLog 0 for ledgerId ***, entry -1 at offset 0", if you want to get more details,you can read the Issue: #2927 

case throw NoEntryException:
    1)  when the ledger is deleted,throw NoEntryException like the method( name is  **getLastEntryInLedgerInternal** )  solving ledgerId is not found
    2)  then the method(name is SingleDirectoryDbLedgerStorage.getLastEntry) just throw NoEntryException , don't need to read entry's location index and entry's log


From what has been discussed above
When ledger is deleted, it is more correct to return NoEntryException when get last entry

### Changes

1.if the ledger has been deleted,run default path for NoEntryException

Master Issue: #2927 
