### PR TITLE
Allow to easily override `zkServers` with `metadataServiceUri`

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -265,7 +265,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      */
     public String getMetadataServiceUri() throws ConfigurationException {
         String serviceUri = getString(METADATA_SERVICE_URI);
-        if (null == serviceUri) {
+        if (StringUtils.isBlank(serviceUri)) {
             // no service uri is defined, fallback to old settings
             String ledgerManagerType;
             ledgerManagerType = getLedgerManagerLayoutStringFromFactoryClass();


### PR DESCRIPTION
### Motivation

If `metadataServiceUri` is present (uncommented) in the `bookie.conf`, the bookie will try to use it, even if it is empty, instead of just falling back to `zkServers`, as it happens when the `metadataServiceUri` is not present at all. 

### Modification

Check for blank, instead of `null`, to make it easier to have both keys and override them as needed.