### PR TITLE
bugfix for RackawareEnsemblePlacementPolicyImpl.isEnsembleAdheringToPlacementPolicy

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -1035,8 +1035,8 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                     LOG.warn("Received exception while trying to get network location of bookie: {}", bookie, e);
                 }
             }
-            if ((racksInQuorum.size() < minNumRacksPerWriteQuorumForThisEnsemble)
-                    || (enforceMinNumRacksPerWriteQuorum && racksInQuorum.contains(getDefaultRack()))) {
+            if (enforceMinNumRacksPerWriteQuorum && (racksInQuorum.size() < minNumRacksPerWriteQuorumForThisEnsemble
+                    || racksInQuorum.contains(getDefaultRack()))) {
                 return PlacementPolicyAdherence.FAIL;
             }
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicy.java
@@ -79,6 +79,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
     BookieSocketAddress addr2, addr3, addr4;
     io.netty.util.HashedWheelTimer timer;
     final int minNumRacksPerWriteQuorumConfValue = 2;
+    final boolean enforceMinNumRacksPerWriteQuorum = true;
 
     @Override
     protected void setUp() throws Exception {
@@ -746,7 +747,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
 
         ClientConfiguration clientConf = new ClientConfiguration(conf);
         clientConf.setMinNumRacksPerWriteQuorum(2);
-        clientConf.setEnforceMinNumRacksPerWriteQuorum(true);
+        clientConf.setEnforceMinNumRacksPerWriteQuorum(enforceMinNumRacksPerWriteQuorum);
         repp = new RackawareEnsemblePlacementPolicy();
         repp.initialize(clientConf, Optional.<DNSToSwitchMapping> empty(), timer, DISABLE_ALL,
                 NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
@@ -783,7 +784,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         ClientConfiguration clientConf = new ClientConfiguration(conf);
         clientConf.setMinNumRacksPerWriteQuorum(minNumRacksPerWriteQuorum);
         // set enforceMinNumRacksPerWriteQuorum
-        clientConf.setEnforceMinNumRacksPerWriteQuorum(true);
+        clientConf.setEnforceMinNumRacksPerWriteQuorum(enforceMinNumRacksPerWriteQuorum);
         TestStatsProvider statsProvider = new TestStatsProvider();
         TestStatsLogger statsLogger = statsProvider.getStatsLogger("");
         repp = new RackawareEnsemblePlacementPolicy();
@@ -1447,7 +1448,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
             int numCovered = getNumCoveredWriteQuorums(ensemble, writeQuorumSize,
                                                        conf.getMinNumRacksPerWriteQuorum(), repp.bookieAddressResolver);
             assertTrue(numCovered >= 1 && numCovered < 3);
-            assertEquals(PlacementPolicyAdherence.FAIL, isEnsembleAdheringToPlacementPolicy);
+            assertEquals(PlacementPolicyAdherence.MEETS_STRICT, isEnsembleAdheringToPlacementPolicy);
             ensembleSize = 4;
             EnsemblePlacementPolicy.PlacementResult<List<BookieId>> ensembleResponse2 =
                 repp.newEnsemble(ensembleSize, writeQuorumSize,
@@ -1457,7 +1458,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
             numCovered = getNumCoveredWriteQuorums(ensemble2, writeQuorumSize,
                                                    conf.getMinNumRacksPerWriteQuorum(), repp.bookieAddressResolver);
             assertTrue(numCovered >= 1 && numCovered < 3);
-            assertEquals(PlacementPolicyAdherence.FAIL, isEnsembleAdheringToPlacementPolicy2);
+            assertEquals(PlacementPolicyAdherence.MEETS_STRICT, isEnsembleAdheringToPlacementPolicy2);
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
         }
@@ -2026,7 +2027,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
             List<BookieId> ensemble = ensembleResponse.getResult();
             PlacementPolicyAdherence isEnsembleAdheringToPlacementPolicy = ensembleResponse.isAdheringToPolicy();
             assertFalse(ensemble.contains(addr4.toBookieId()));
-            assertEquals(PlacementPolicyAdherence.FAIL, isEnsembleAdheringToPlacementPolicy);
+            assertEquals(PlacementPolicyAdherence.MEETS_STRICT, isEnsembleAdheringToPlacementPolicy);
         }
 
         // we could still use addr4 for urgent allocation if it is just bookie flapping
@@ -2034,7 +2035,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
             repp.newEnsemble(4, 2, 2, null, new HashSet<BookieId>());
         List<BookieId> ensemble = ensembleResponse.getResult();
         PlacementPolicyAdherence isEnsembleAdheringToPlacementPolicy = ensembleResponse.isAdheringToPolicy();
-        assertEquals(PlacementPolicyAdherence.FAIL, isEnsembleAdheringToPlacementPolicy);
+        assertEquals(PlacementPolicyAdherence.MEETS_STRICT, isEnsembleAdheringToPlacementPolicy);
         assertTrue(ensemble.contains(addr4.toBookieId()));
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
@@ -236,6 +236,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int writeQuorumSize = 3;
         int ackQuorumSize = 2;
         int minNumRacksPerWriteQuorumConfValue = 3;
+        boolean enforceMinNumRacksPerWriteQuorum = true;
 
         /*
          * this closed ledger doesn't adhere to placement policy because there are only
@@ -273,6 +274,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
 
         ServerConfiguration servConf = new ServerConfiguration(confByIndex(0));
         servConf.setMinNumRacksPerWriteQuorum(minNumRacksPerWriteQuorumConfValue);
+        servConf.setEnforceMinNumRacksPerWriteQuorum(enforceMinNumRacksPerWriteQuorum);
         setServerConfigPropertiesForRackPlacement(servConf);
         MutableObject<Auditor> auditorRef = new MutableObject<Auditor>();
         try {
@@ -454,6 +456,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int writeQuorumSize = 5;
         int ackQuorumSize = 2;
         int minNumRacksPerWriteQuorumConfValue = 4;
+        boolean enforceMinNumRacksPerWriteQuorum = true;
 
         /*
          * this closed ledger in each writeQuorumSize (5), there would be
@@ -510,6 +513,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
 
         ServerConfiguration servConf = new ServerConfiguration(confByIndex(0));
         servConf.setMinNumRacksPerWriteQuorum(minNumRacksPerWriteQuorumConfValue);
+        servConf.setEnforceMinNumRacksPerWriteQuorum(enforceMinNumRacksPerWriteQuorum);
         setServerConfigPropertiesForRackPlacement(servConf);
         MutableObject<Auditor> auditorRef = new MutableObject<Auditor>();
         try {


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

bugfix:
when enforceMinNumRacksPerWriteQuorum is false, no need to check racks in quorum
when all bookies is in a rack,when the old bookie node is offline for machine is broken,the ReplicationWorker want call method BookKeeperAdmin.getReplacementBookiesByIndexes, but find minNumRacksPerWriteQuorum(default value is 2) is large than racksInQuorum,but enforceMinNumRacksPerWriteQuorum(default value is false) is not open for checking this rack.

So I think we should charge enforceMinNumRacksPerWriteQuorum is closed,no need to check rack's information
 
<img width="668" alt="image" src="https://user-images.githubusercontent.com/42990025/147206534-bf9f3568-4463-4727-89c4-85ef0f3e9924.png">
<img width="808" alt="image" src="https://user-images.githubusercontent.com/42990025/147207554-8290677f-23e1-4077-84f3-ba7b352a8a30.png">

case :
1) minNumRacksPerWriteQuorum(default value is 2)
2) enforceMinNumRacksPerWriteQuorum(default value is false)
3) no rack config(just use default-rack)
isEnsembleAdheringToPlacementPolicy will return false, then it will be unexpected

### Changes

bugfix: when enforceMinNumRacksPerWriteQuorum is false, no need to check racks in quorum