### PR TITLE
zk client config update and bugfix for ZKMetadataClientDriver

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -75,6 +75,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     // Zookeeper Parameters
     protected static final String ZK_TIMEOUT = "zkTimeout";
     protected static final String ZK_SERVERS = "zkServers";
+    protected static final String ZK_RETRY_BACKOFF_MAX_RETRIES = "zkRetryBackoffMaxRetries";
 
     // Ledger Manager
     protected static final String LEDGER_MANAGER_TYPE = "ledgerManagerType";
@@ -342,6 +343,27 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      */
     public T setZkTimeout(int zkTimeout) {
         setProperty(ZK_TIMEOUT, Integer.toString(zkTimeout));
+        return getThis();
+    }
+
+    /**
+     * Get zookeeper client backoff max retry times.
+     *
+     * @return zk backoff max retry times.
+     */
+    public int getZkRetryBackoffMaxRetries() {
+        return getInt(ZK_RETRY_BACKOFF_MAX_RETRIES, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Set zookeeper client backoff max retry times.
+     *
+     * @param maxRetries
+     *          backoff max retry times
+     * @return server configuration.
+     */
+    public T setZkRetryBackoffMaxRetries(int maxRetries) {
+        setProperty(ZK_RETRY_BACKOFF_MAX_RETRIES, Integer.toString(maxRetries));
         return getThis();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataBookieDriver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataBookieDriver.java
@@ -56,7 +56,7 @@ public class ZKMetadataBookieDriver
             conf,
             statsLogger.scope(BOOKIE_SCOPE),
             new BoundExponentialBackoffRetryPolicy(conf.getZkRetryBackoffStartMs(),
-                        conf.getZkRetryBackoffMaxMs(), Integer.MAX_VALUE),
+                        conf.getZkRetryBackoffMaxMs(), conf.getZkRetryBackoffMaxRetries()),
             Optional.empty());
         this.serverConf = conf;
         this.statsLogger = statsLogger;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataClientDriver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataClientDriver.java
@@ -66,7 +66,7 @@ public class ZKMetadataClientDriver
             new BoundExponentialBackoffRetryPolicy(
                 conf.getZkTimeout(),
                 conf.getZkTimeout(),
-                0),
+                conf.getZkRetryBackoffMaxRetries()),
             optionalCtx);
         this.statsLogger = statsLogger;
         this.clientConf = conf;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
@@ -60,6 +60,10 @@ public class TestBKConfiguration {
         confReturn.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
         confReturn.setProperty(DbLedgerStorage.WRITE_CACHE_MAX_SIZE_MB, 4);
         confReturn.setProperty(DbLedgerStorage.READ_AHEAD_CACHE_MAX_SIZE_MB, 4);
+        /**
+         * if testcase has zk error,just try 1 time for fast running
+         */
+        confReturn.setZkRetryBackoffMaxRetries(1);
         setLoopbackInterfaceAndAllowLoopback(confReturn);
         return confReturn;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
@@ -61,9 +61,9 @@ public class TestBKConfiguration {
         confReturn.setProperty(DbLedgerStorage.WRITE_CACHE_MAX_SIZE_MB, 4);
         confReturn.setProperty(DbLedgerStorage.READ_AHEAD_CACHE_MAX_SIZE_MB, 4);
         /**
-         * if testcase has zk error,just try 1 time for fast running
+         * if testcase has zk error,just try 0 time for fast running
          */
-        confReturn.setZkRetryBackoffMaxRetries(1);
+        confReturn.setZkRetryBackoffMaxRetries(0);
         setLoopbackInterfaceAndAllowLoopback(confReturn);
         return confReturn;
     }
@@ -94,9 +94,9 @@ public class TestBKConfiguration {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         clientConfiguration.setTLSEnabledProtocols("TLSv1.2,TLSv1.1");
         /**
-         * if testcase has zk error,just try 1 time for fast running
+         * if testcase has zk error,just try 0 time for fast running
          */
-        clientConfiguration.setZkRetryBackoffMaxRetries(1);
+        clientConfiguration.setZkRetryBackoffMaxRetries(0);
         return clientConfiguration;
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
@@ -93,6 +93,10 @@ public class TestBKConfiguration {
     public static ClientConfiguration newClientConfiguration() {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         clientConfiguration.setTLSEnabledProtocols("TLSv1.2,TLSv1.1");
+        /**
+         * if testcase has zk error,just try 1 time for fast running
+         */
+        clientConfiguration.setZkRetryBackoffMaxRetries(1);
         return clientConfiguration;
     }
 }

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/RegistrationServiceProvider.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/RegistrationServiceProvider.java
@@ -66,7 +66,7 @@ public class RegistrationServiceProvider
         this.bkZkRetryPolicy = new BoundExponentialBackoffRetryPolicy(
             bkServerConf.getZkRetryBackoffStartMs(),
             bkServerConf.getZkRetryBackoffMaxMs(),
-            Integer.MAX_VALUE);
+            bkServerConf.getZkRetryBackoffMaxRetries());
         this.regExecutor = Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder().setNameFormat("registration-service-provider-scheduler").build());
         ClientConfiguration clientConfiguration = new ClientConfiguration(bkServerConf);


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

1. bug fix for error config for BoundExponentialBackoffRetryPolicy in class ZKMetadataClientDriver,if set MaxRetries zero, zk client will throw ConnectionLossException when the zk has some changing,for example: zk leader node changed.

2. In Bookie's ZKClient, different BoundExponentialBackoffRetryPolicy set different MaxRetries,so change zkRetryBackoffMaxRetries to config in Bookie's AbstractConfiguration

### Changes

1. update a error config for BoundExponentialBackoffRetryPolicy in class ZKMetadataClientDriver
2. change zkRetryBackoffMaxRetries to config

Master Issue: #2760 
