### PR TITLE
The descriptions of methods getTotalDiskSpace and getTotalFreeSpace are wrong

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DiskChecker.java
@@ -177,7 +177,7 @@ public class DiskChecker {
      * Calculate the total amount of free space available
      * in all of the ledger directories put together.
      *
-     * @return totalDiskSpace in bytes
+     * @return freeDiskSpace in bytes
      * @throws IOException
      */
     public long getTotalFreeSpace(List<File> dirs) throws IOException {
@@ -193,10 +193,10 @@ public class DiskChecker {
     }
 
     /**
-     * Calculate the total amount of free space available
+     * Calculate the total amount of disk space
      * in all of the ledger directories put together.
      *
-     * @return freeDiskSpace in bytes
+     * @return totalDiskSpace in bytes
      * @throws IOException
      */
     public long getTotalDiskSpace(List<File> dirs) throws IOException {


### PR DESCRIPTION
### Motivation
The descriptions of methods getTotalDiskSpace and getTotalFreeSpace are wrong in org.apache.bookkeeper.util.DiskChecker.
