### PR TITLE
Skip update entryLogMetaMap if not modified

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -45,6 +45,7 @@ import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.SafeRunnable;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -464,13 +465,13 @@ public class GarbageCollectorThread extends SafeRunnable {
     }
 
     private boolean removeIfLedgerNotExists(EntryLogMetadata meta) throws EntryLogMetadataMapException {
-        AtomicBoolean modified = new AtomicBoolean(false);
+        MutableBoolean modified = new MutableBoolean(false);
         meta.removeLedgerIf((entryLogLedger) -> {
             // Remove the entry log ledger from the set if it isn't active.
             try {
                 boolean exist = ledgerStorage.ledgerExists(entryLogLedger);
                 if (!exist) {
-                    modified.set(true);
+                    modified.setTrue();
                 }
                 return !exist;
             } catch (IOException e) {
@@ -479,7 +480,7 @@ public class GarbageCollectorThread extends SafeRunnable {
             }
         });
 
-        return modified.get();
+        return modified.getValue();
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -438,9 +438,7 @@ public class GarbageCollectorThread extends SafeRunnable {
         // Loop through all of the entry logs and remove the non-active ledgers.
         entryLogMetaMap.forEach((entryLogId, meta) -> {
             try {
-                removeIfLedgerNotExists(meta);
-                // update entryMetadta to persistent-map
-                entryLogMetaMap.put(meta.getEntryLogId(), meta);
+                boolean modified = removeIfLedgerNotExists(meta);
                 if (meta.isEmpty()) {
                     // This means the entry log is not associated with any active
                     // ledgers anymore.
@@ -448,6 +446,9 @@ public class GarbageCollectorThread extends SafeRunnable {
                     LOG.info("Deleting entryLogId {} as it has no active ledgers!", entryLogId);
                     removeEntryLog(entryLogId);
                     gcStats.getReclaimedSpaceViaDeletes().add(meta.getTotalSize());
+                } else if (modified) {
+                    // update entryLogMetaMap only when the meta modified.
+                    entryLogMetaMap.put(meta.getEntryLogId(), meta);
                 }
             } catch (EntryLogMetadataMapException e) {
                 // Ignore and continue because ledger will not be cleaned up
@@ -462,16 +463,23 @@ public class GarbageCollectorThread extends SafeRunnable {
         this.numActiveEntryLogs = entryLogMetaMap.size();
     }
 
-    private void removeIfLedgerNotExists(EntryLogMetadata meta) throws EntryLogMetadataMapException {
+    private boolean removeIfLedgerNotExists(EntryLogMetadata meta) throws EntryLogMetadataMapException {
+        AtomicBoolean modified = new AtomicBoolean(false);
         meta.removeLedgerIf((entryLogLedger) -> {
             // Remove the entry log ledger from the set if it isn't active.
             try {
-                return !ledgerStorage.ledgerExists(entryLogLedger);
+                boolean exist = ledgerStorage.ledgerExists(entryLogLedger);
+                if (!exist) {
+                    modified.set(true);
+                }
+                return !exist;
             } catch (IOException e) {
                 LOG.error("Error reading from ledger storage", e);
                 return false;
             }
         });
+
+        return modified.get();
     }
 
     /**


### PR DESCRIPTION
### Motivation
After we support RocksDB backend entryMetaMap, we should avoid updating the entryMetaMap if unnecessary.

In `doGcEntryLogs` method, it iterate through the entryLogMetaMap and update the meta if ledgerNotExists. We should check whether the meta has been modified in `removeIfLedgerNotExists`. If not modified, we can avoid update the  entryLogMetaMap.

### Modification
 1. Add a flag to represent whether the meta has been modified in `removeIfLedgerNotExists` method. If not, skip update the entryLogMetaMap.