### PR TITLE
fix checkAllLedgersDuration compute

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -763,17 +763,20 @@ public class Auditor implements AutoCloseable {
             executor.scheduleAtFixedRate(safeRun(new Runnable() {
                 @Override
                 public void run() {
-                    long checkAllLedgersDuration = 0;
+                    Stopwatch stopwatch = Stopwatch.createStarted();
+                    boolean checkSuccess = false;
                     try {
                         if (!ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {
                             LOG.info("Ledger replication disabled, skipping checkAllLedgers");
                             return;
                         }
 
-                        Stopwatch stopwatch = Stopwatch.createStarted();
                         LOG.info("Starting checkAllLedgers");
                         checkAllLedgers();
-                        checkAllLedgersDuration = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
+                        long checkAllLedgersDuration = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
+                        LOG.info("Completed checkAllLedgers in {} milliSeconds", checkAllLedgersDuration);
+                        checkAllLedgersTime.registerSuccessfulEvent(checkAllLedgersDuration, TimeUnit.MILLISECONDS);
+                        checkSuccess = true;
                     } catch (KeeperException ke) {
                         LOG.error("Exception while running periodic check", ke);
                     } catch (InterruptedException ie) {
@@ -786,8 +789,10 @@ public class Auditor implements AutoCloseable {
                     } catch (ReplicationException.UnavailableException ue) {
                         LOG.error("Underreplication manager unavailable running periodic check", ue);
                     } finally {
-                        LOG.info("Completed checkAllLedgers in {} milliSeconds", checkAllLedgersDuration);
-                        checkAllLedgersTime.registerSuccessfulEvent(checkAllLedgersDuration, TimeUnit.MILLISECONDS);
+                        if (!checkSuccess) {
+                            long checkAllLedgersDuration = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
+                            checkAllLedgersTime.registerFailedEvent(checkAllLedgersDuration, TimeUnit.MILLISECONDS);
+                        }
                     }
                 }
                 }), initialDelay, interval, TimeUnit.SECONDS);


### PR DESCRIPTION
### Motivation

When the checkallledgers method is executed periodically, if an exception is thrown, 
time checkAllLedgers statistics status has not been updated. 
### Changes
So we should update it in finally：

finally {
                        if (!checkSuccess) {
                            long checkAllLedgersDuration = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
                            checkAllLedgersTime.registerFailedEvent(checkAllLedgersDuration, TimeUnit.MILLISECONDS);
                        }
                    }
