### PR TITLE
Changing the routing of ledgers to journal directories

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -43,6 +44,7 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1259,7 +1261,17 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
     }
 
     private Journal getJournal(long ledgerId) {
-        return journals.get(MathUtils.signSafeMod(ledgerId, journals.size()));
+        String dividendString = Double.toString(ledgerId);
+        byte[] secretBytes = null;
+        int index = 0;
+        try {
+            secretBytes = MessageDigest.getInstance("md5").digest(dividendString.getBytes());
+            BigInteger md5Code = new BigInteger(1, secretBytes);
+            index = md5Code.mod(new BigInteger(Integer.toString(journals.size()))).intValue();
+        } catch (Exception e) {
+            LOG.error("get journal directory failed exception:{}", e.getMessage());
+        }
+        return journals.get(index);
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:
issue : #2974

**BUG REPORT**

***Describe the bug***

When the journal directory is configured to be even, the ledger allocated to each journal will be uneven. The root cause is that almost all the ledger IDs generated by the LedgerIdGenerator class are even. The number of ZK temporary order nodes is determined by the cversion of the parent node. Whenever a child node is added or deleted, it will increase by 1. The LedgerIdGenerator class uses ZK's temporary order node to generate the ledgerid, and deletes the node immediately after generation. This way of use causes almost all cversions to be even, resulting in all ledgerids to be even.

***To Reproduce***

Steps to reproduce the behavior:
1. Configure in bk_server.conf: jouranlDirectorie=/tmp/bk-txn1,/tmp/bk-txn2
2. production data to bookie

***Expected behavior***

Almost all ledgerids are assigned to directory 1

***Screenshots***


ledgerIdGenerator class :  ZKledgerIdGenerator

<img width="702" alt="journal" src="https://user-images.githubusercontent.com/35036009/141671860-bd2eaa8b-9b01-41d3-a159-688ceea08554.png">

<img width="503" alt="mathutil" src="https://user-images.githubusercontent.com/35036009/141671870-fca81d57-9d97-49ed-8669-b77cdb3176c5.png">

Changing the routing of ledgers to journal directories can fix this bug
<img width="942" alt="mathutilnew" src="https://user-images.githubusercontent.com/35036009/141671914-469286b1-b07d-423f-9fef-664286bc2122.png">


