### PR TITLE
Backward compatibility tests: add retries

### DIFF
--- a/tests/backward-compat/build.gradle
+++ b/tests/backward-compat/build.gradle
@@ -20,6 +20,7 @@
 plugins {
     id 'groovy'
     id 'com.adarshr.test-logger'
+    id 'org.gradle.test-retry'
 }
 
 subprojects {
@@ -29,6 +30,8 @@ subprojects {
 
     apply plugin: 'groovy'
     apply plugin: 'com.adarshr.test-logger'
+    apply plugin: 'org.gradle.test-retry'
+
 
     dependencies {
         testImplementation 'org.codehaus.groovy:groovy-all:2.4.15'
@@ -43,6 +46,10 @@ subprojects {
 
     test {
         dependsOn(":tests:docker-images:buildImages")
+        retry {
+            maxFailures = 10
+            maxRetries = 5
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation

Backward compatibility tests are [flaky](https://github.com/apache/bookkeeper/actions/workflows/backward-compat-tests.yml?query=is%3Afailure++). When they fail, they always fail due to
```
Not enough non-faulty bookies available
```

I spent a lot of time trying to tune connection parameters, split tests and so on, my understanding is that at certain points the machine starts suffering (he restart many times the bookies of different versions - 3 bookies and 1 zk in the same machine) and the bookie is unable to send ZK ping and then it's cut off from the ensemble.

### Changes

I added the retry options to the tests with max 5 retries per test, it should be enough. (I don't have numbers to demonstrate that, we'll see it )
