### PR TITLE
improve the throttle function

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -402,9 +402,7 @@ public class LedgerFragmentReplicator {
                                 lh.getLastAddConfirmed(), entry.getLength(),
                                 Unpooled.wrappedBuffer(data, 0, data.length));
                 if (replicationThrottle != null) {
-                    int toSendSize = toSend.readableBytes();
-                    averageEntrySize = (int) (averageEntrySize * AVERAGE_ENTRY_SIZE_RATIO
-                            + (1 - AVERAGE_ENTRY_SIZE_RATIO) * toSendSize);
+                    updateAverageEntrySize(toSend.readableBytes());
                 }
                 for (BookieId newBookie : newBookies) {
                     long startWriteEntryTime = MathUtils.nowInNano();
@@ -418,6 +416,16 @@ public class LedgerFragmentReplicator {
                 toSend.release();
             }
         }, null);
+    }
+
+    /**
+     *   make sure this update safety when different callback run this updating
+     *   why use synchronized not AtomicInteger.compareAndSet?
+     *   for expect value may be update all the time,so waste more cpu to compareAndSet
+     * */
+    private synchronized void updateAverageEntrySize(int toSendSize) {
+        averageEntrySize = (int) (averageEntrySize * AVERAGE_ENTRY_SIZE_RATIO
+                + (1 - AVERAGE_ENTRY_SIZE_RATIO) * toSendSize);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -418,9 +418,7 @@ public class LedgerFragmentReplicator {
         }, null);
     }
 
-    /**
-     * make sure this update safety when different callback run this updating
-     */
+    /* make sure this update safety when different callback run this updating */
     private synchronized void updateAverageEntrySize(int toSendSize) {
         averageEntrySize = (int) (averageEntrySize * AVERAGE_ENTRY_SIZE_RATIO
                 + (1 - AVERAGE_ENTRY_SIZE_RATIO) * toSendSize);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -419,7 +419,7 @@ public class LedgerFragmentReplicator {
     }
 
     /**
-     * Make sure this update safety when different callback run this updating
+     * make sure this update safety when different callback run this updating
      */
     private synchronized void updateAverageEntrySize(int toSendSize) {
         averageEntrySize = (int) (averageEntrySize * AVERAGE_ENTRY_SIZE_RATIO

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -419,8 +419,8 @@ public class LedgerFragmentReplicator {
     }
 
     /**
-     *   Make sure this update safety when different callback run this updating
-     * */
+     * Make sure this update safety when different callback run this updating
+     */
     private synchronized void updateAverageEntrySize(int toSendSize) {
         averageEntrySize = (int) (averageEntrySize * AVERAGE_ENTRY_SIZE_RATIO
                 + (1 - AVERAGE_ENTRY_SIZE_RATIO) * toSendSize);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -419,9 +419,7 @@ public class LedgerFragmentReplicator {
     }
 
     /**
-     *   make sure this update safety when different callback run this updating
-     *   why use synchronized not AtomicInteger.compareAndSet?
-     *   for expect value may be update all the time,so waste more cpu to compareAndSet
+     *   Make sure this update safety when different callback run this updating
      * */
     private synchronized void updateAverageEntrySize(int toSendSize) {
         averageEntrySize = (int) (averageEntrySize * AVERAGE_ENTRY_SIZE_RATIO

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -188,6 +188,8 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
     // option to limit stats logging
     public static final String LIMIT_STATS_LOGGING = "limitStatsLogging";
 
+    protected static final String REPLICATION_RATE_BY_BYTES = "replicationRateByBytes";
+
     protected AbstractConfiguration() {
         super();
         if (READ_SYSTEM_PROPERTIES) {
@@ -1201,6 +1203,28 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      */
     public T setLimitStatsLogging(boolean limitStatsLogging) {
         setProperty(LIMIT_STATS_LOGGING, limitStatsLogging);
+        return getThis();
+    }
+
+    /**
+     * Get the bytes rate of re-replication.
+     * Default value is -1 which it means entries will replicated without any throttling activity.
+     *
+     * @return bytes rate of re-replication.
+     */
+    public int getReplicationRateByBytes() {
+        return getInt(REPLICATION_RATE_BY_BYTES, -1);
+    }
+
+    /**
+     * Set the bytes rate of re-replication.
+     *
+     * @param rate bytes rate of re-replication.
+     *
+     * @return ClientConfiguration
+     */
+    public T setReplicationRateByBytes(int rate) {
+        this.setProperty(REPLICATION_RATE_BY_BYTES, rate);
         return getThis();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -200,30 +200,6 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     protected static final String CLIENT_CONNECT_BOOKIE_UNAVAILABLE_LOG_THROTTLING =
             "clientConnectBookieUnavailableLogThrottling";
 
-    protected static final String REPLICATION_RATE_BY_BYTES = "replicationRateByBytes";
-
-    /**
-     * Get the bytes rate of re-replication.
-     * Default value is -1 which it means entries will replicated without any throttling activity.
-     *
-     * @return bytes rate of re-replication.
-     */
-    public int getReplicationRateByBytes() {
-        return getInt(REPLICATION_RATE_BY_BYTES, -1);
-    }
-
-    /**
-     * Set the bytes rate of re-replication.
-     *
-     * @param rate bytes rate of re-replication.
-     *
-     * @return ClientConfiguration
-     */
-    public ClientConfiguration setReplicationRateByBytes(int rate) {
-        this.setProperty(REPLICATION_RATE_BY_BYTES, rate);
-        return this;
-    }
-
     /**
      * Construct a default client-side configuration.
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -213,7 +213,6 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
         "auditorMaxNumberOfConcurrentOpenLedgerOperations";
     protected static final String AUDITOR_ACQUIRE_CONCURRENT_OPEN_LEDGER_OPERATIONS_TIMEOUT_MSEC =
         "auditorAcquireConcurrentOpenLedgerOperationsTimeOutMSec";
-    protected static final String REPLICATION_RATE_BY_BYTES = "replicationRateByBytes";
     protected static final String IN_FLIGHT_READ_ENTRY_NUM_IN_LEDGER_CHECKER = "inFlightReadEntryNumInLedgerChecker";
 
 
@@ -3719,16 +3718,6 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get the bytes rate of re-replication.
-     * Default value is -1 which it means entries will replicated without any throttling activity.
-     *
-     * @return bytes rate of re-replication.
-     */
-    public int getReplicationRateByBytes() {
-        return getInt(REPLICATION_RATE_BY_BYTES, -1);
-    }
-
-    /**
      * Get in flight read entry number when ledger checker.
      * Default value is -1 which it is unlimited  when ledger checker.
      *
@@ -3736,18 +3725,6 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public int getInFlightReadEntryNumInLedgerChecker(){
         return getInt(IN_FLIGHT_READ_ENTRY_NUM_IN_LEDGER_CHECKER, -1);
-    }
-
-    /**
-     * Set the rate of re-replication.
-     *
-     * @param rate bytes rate of re-replication.
-     *
-     * @return ServerConfiguration
-     */
-    public ServerConfiguration setReplicationRateByBytes(int rate) {
-        setProperty(REPLICATION_RATE_BY_BYTES, rate);
-        return this;
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

improve the throttle function : old pr: #2778 
1. duplicate definition for replicationRateByBytes
2.make sure this update safety when different callback run averageEntrySize updating

### Changes

1.clean code for duplicate definition for replicationRateByBytes
2.add a lock to make sure data safety for updateAverageEntrySize
