### PR TITLE
rxjava: add maven dependency

### DIFF
--- a/bookkeeper-common/pom.xml
+++ b/bookkeeper-common/pom.xml
@@ -69,6 +69,11 @@
       <artifactId>error_prone_annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- import for rxjava3 in maven -->
+    <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -130,6 +130,11 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
+    <!-- import for rxjava3 in maven -->
+    <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
     <!-- testing dependencies -->
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
     <forkCount.variable>1</forkCount.variable>
     <servlet-api.version>4.0.0</servlet-api.version>
+    <rxjava.version>3.0.1</rxjava.version>
   </properties>
 
   <!-- dependency definitions -->
@@ -757,6 +758,13 @@
         <artifactId>jmh-generator-annprocess</artifactId>
         <version>${jmh.version}</version>
       </dependency>
+
+      <!-- import for rxjava3 in maven -->
+      <dependency>
+        <groupId>io.reactivex.rxjava3</groupId>
+        <artifactId>rxjava</artifactId>
+        <version>${rxjava.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -783,7 +791,6 @@
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
     </dependency>
-
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

1. pr: #2936   miss rxjava maven dependency 
2. the default workflow check just build with gradle,miss the maven build,so the problem of maven compilation is easy to be ignored, do we need to open maven compilation in default workflow?

<img width="600" alt="image" src="https://user-images.githubusercontent.com/42990025/149494732-6d1aab71-7d8b-4319-8ec8-ce17789f5763.png">

### Changes

rxjava: add maven dependency 

### PS
Bookkeeper committer I can't be missing......Ha Ha Ha
