### PR TITLE
Add github actions timeout

### DIFF
--- a/.github/workflows/backward-compat-tests.yml
+++ b/.github/workflows/backward-compat-tests.yml
@@ -36,7 +36,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -33,7 +33,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -33,7 +33,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -33,7 +33,7 @@ jobs:
   check:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -33,7 +33,7 @@ jobs:
   check:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -34,7 +34,7 @@ jobs:
   check:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -33,7 +33,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -36,7 +36,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -32,7 +32,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -33,7 +33,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Motivation
Add github actions timeout, default 360m is unreasonable

### Changes
Give them different timeout according to history run time.