### PR TITLE
update default value of allocatorPoolingConcurrency

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.net.ssl.SSLEngine;
 
+import io.netty.buffer.PooledByteBufAllocator;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.bookkeeper.common.allocator.LeakDetectionPolicy;
@@ -1060,7 +1061,7 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      * @return the configured pooling concurrency for the allocator.
      */
     public int getAllocatorPoolingConcurrency() {
-        return this.getInteger(ALLOCATOR_POOLING_CONCURRENCY, 2 * Runtime.getRuntime().availableProcessors());
+        return this.getInteger(ALLOCATOR_POOLING_CONCURRENCY, PooledByteBufAllocator.defaultNumDirectArena());
     }
 
     /**


### PR DESCRIPTION
Set a more reasonable default value to avoid OutOfDirectMemoryError.

Descriptions of the changes in this PR:


### Motivation
The default value of  allocatorPoolingConcurrency is 2 * Runtime.getRuntime().availableProcessors(). It's used to specify the num of Arena in PooledByteBufAllocator. 

Assume:
40 processors
80 arena (processors*2)
2 chunk per arena
16MiB per chunk
JVM's total direct mem should be larger then 80*2*16=2560MiB, otherwise OutOfDirectMemoryError occured.

OutOfDirectMemoryError much more likely to occur in Docker, cause JDK versions earlier than Java SE 8U131 does not support Docker CPU limits.


### Changes
Use Netty default arena num `PooledByteBufAllocator.defaultNumDirectArena()` as default allocatorPoolingConcurrency.


