### PR TITLE
Added OWASP dependency-check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ allprojects {
                 // for configuration properties
                 suppressionFile = "$rootDir/src/owasp-dependency-check-suppressions.xml"
                 skipProjects = skipDepCheck
+                skipConfigurations = ["checkstyle"]
                 analyzers {
                     msbuildEnabled = false
                     rubygemsEnabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,13 @@ releaseParams { // ReleaseExtension
     }
 }
 
+def skipDepCheck = []
+allprojects {
+    if (it.path.startsWith(':tests')) {
+        skipDepCheck << it.path
+    }
+}
+
 allprojects {
     apply from: "$rootDir/dependencies.gradle"
     if (it.path != ':circe-checksum:src:main:circe'
@@ -71,33 +78,37 @@ allprojects {
         apply plugin: 'org.nosphere.apache.rat'
         apply plugin: "checkstyle"
         apply plugin: 'com.github.spotbugs'
-        apply plugin: 'org.owasp.dependencycheck'
+        
+        if (!it.path.startsWith(':tests')) {
+            apply plugin: 'org.owasp.dependencycheck'
 
-        dependencyCheck {
-            // see https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
-            // for configuration properties
-            suppressionFile = "src/owasp-dependency-check-suppressions.xml"
-            analyzers {
-                msbuildEnabled = false
-                rubygemsEnabled = false
-                pyDistributionEnabled = false
-                pyPackageEnabled = false
-                nuspecEnabled = false
-                nugetconfEnabled = false
-                assemblyEnabled = false
-                cmakeEnabled = false
-                composerEnabled = false
-                cpanEnabled  =false
-                nodeEnabled = false
-                cocoapodsEnabled = false
-                swiftEnabled = false
-                swiftPackageResolvedEnabled = false
-                bundleAuditEnabled = false
-                golangDepEnabled = false
-                golangModEnabled = false
+            dependencyCheck {
+                // see https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
+                // for configuration properties
+                suppressionFile = "$rootDir/src/owasp-dependency-check-suppressions.xml"
+                skipProjects = skipDepCheck
+                analyzers {
+                    msbuildEnabled = false
+                    rubygemsEnabled = false
+                    pyDistributionEnabled = false
+                    pyPackageEnabled = false
+                    nuspecEnabled = false
+                    nugetconfEnabled = false
+                    assemblyEnabled = false
+                    cmakeEnabled = false
+                    composerEnabled = false
+                    cpanEnabled = false
+                    nodeEnabled = false
+                    cocoapodsEnabled = false
+                    swiftEnabled = false
+                    swiftPackageResolvedEnabled = false
+                    bundleAuditEnabled = false
+                    golangDepEnabled = false
+                    golangModEnabled = false
 
-                nodeAudit.enabled = false
-                retirejs.enabled = false
+                    nodeAudit.enabled = false
+                    retirejs.enabled = false
+                }
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ plugins {
     id 'checkstyle'
     id 'org.nosphere.apache.rat'
     id 'com.github.spotbugs'
+    id 'org.owasp.dependencycheck'
 }
 
 subprojects {
@@ -70,6 +71,36 @@ allprojects {
         apply plugin: 'org.nosphere.apache.rat'
         apply plugin: "checkstyle"
         apply plugin: 'com.github.spotbugs'
+        apply plugin: 'org.owasp.dependencycheck'
+
+        dependencyCheck {
+            // see https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
+            // for configuration properties
+            suppressionFile = "src/owasp-dependency-check-suppressions.xml"
+            analyzers {
+                msbuildEnabled = false
+                rubygemsEnabled = false
+                pyDistributionEnabled = false
+                pyPackageEnabled = false
+                nuspecEnabled = false
+                nugetconfEnabled = false
+                assemblyEnabled = false
+                cmakeEnabled = false
+                composerEnabled = false
+                cpanEnabled  =false
+                nodeEnabled = false
+                cocoapodsEnabled = false
+                swiftEnabled = false
+                swiftPackageResolvedEnabled = false
+                bundleAuditEnabled = false
+                golangDepEnabled = false
+                golangModEnabled = false
+
+                nodeAudit.enabled = false
+                retirejs.enabled = false
+            }
+        }
+
         checkstyle {
             toolVersion "${checkStyleVersion}"
             configFile file("$rootDir/buildtools/src/main/resources/bookkeeper/checkstyle.xml")

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ allprojects {
                 // for configuration properties
                 suppressionFile = "$rootDir/src/owasp-dependency-check-suppressions.xml"
                 skipProjects = skipDepCheck
-                skipConfigurations = ["checkstyle"]
+                skipConfigurations = ["checkstyle", "spotbugs"]
                 analyzers {
                     msbuildEnabled = false
                     rubygemsEnabled = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,4 @@ checkStyleVersion=6.19
 spotbugsPlugin=4.7.0
 testLogger=2.0.0
 testRetry=1.0.0
+owaspPlugin=6.5.3

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,7 @@ pluginManagement {
         id "com.github.spotbugs" version "${spotbugsPlugin}"
         id "com.adarshr.test-logger" version  "${testLogger}"
         id "org.gradle.test-retry" version "${testRetry}"
+        id "org.owasp.dependencycheck" version "${owaspPlugin}"
     }
 }
 

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <!-- add supressions for known vulnerabilities detected by OWASP Dependency Check -->
+
+</suppressions>
+

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -22,5 +22,50 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <!-- add supressions for known vulnerabilities detected by OWASP Dependency Check -->
 
+    <!-- jetcd matched against ETCD server CVEs-->
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-core-0.5.11.jar
+       ]]></notes>
+        <sha1>c85851ca3ea8128d480d3f75c568a37e64e8a77b</sha1>
+        <cve>CVE-2020-15106</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-core-0.5.11.jar
+       ]]></notes>
+        <sha1>c85851ca3ea8128d480d3f75c568a37e64e8a77b</sha1>
+        <cve>CVE-2020-15112</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-core-0.5.11.jar
+       ]]></notes>
+        <sha1>c85851ca3ea8128d480d3f75c568a37e64e8a77b</sha1>
+        <cve>CVE-2020-15113</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-common-0.5.11.jar
+       ]]></notes>
+        <sha1>6dac6efe035a2be9ba299fbf31be5f903401869f</sha1>
+        <cve>CVE-2020-15106</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-common-0.5.11.jar
+       ]]></notes>
+        <sha1>6dac6efe035a2be9ba299fbf31be5f903401869f</sha1>
+        <cve>CVE-2020-15112</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-common-0.5.11.jar
+       ]]></notes>
+        <sha1>6dac6efe035a2be9ba299fbf31be5f903401869f</sha1>
+        <cve>CVE-2020-15113</cve>
+    </suppress>
+
 </suppressions>
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Added OWASP dependency-check plugin to gradle build (maven is due for removal so I ignored it)

### Motivation

Run dependency check to detect CVEs/dependencies that need upgrade.

### Changes

Updated gradle build files.

To run:

```sh
./gradlew clean build -x microbenchmarks:checkstyleMain -x spotbugsTest -x signDistTar -x test dependencyCheckAggregate
```
See `build/reports/dependency-check-report.html` for results.

Current summary:
```
Dependencies Scanned: 360 (359 unique)
Vulnerable Dependencies: 65
Vulnerabilities Found: 174
Vulnerabilities Suppressed: 0
```