### PR TITLE
Forced the same version of guava (plus upgraded it); fixed deprecations etc.

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -208,7 +208,7 @@ Apache Software License, Version 2.
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
 - lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
-- lib/com.google.guava-guava-30.0-jre.jar [4]
+- lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
 - lib/commons-cli-commons-cli-1.2.jar [5]
@@ -312,7 +312,7 @@ Apache Software License, Version 2.
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
-[4] Source available at https://github.com/google/guava/tree/v30.0
+[4] Source available at https://github.com/google/guava/tree/v31.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
 [6] Source available at http://svn.apache.org/viewvc/commons/proper/codec/tags/1_6/
 [7] Source available at http://svn.apache.org/viewvc/commons/proper/configuration/tags/CONFIGURATION_1_10/
@@ -667,7 +667,7 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-qual-3.5.0.jar
+  - lib/org.checkerframework-checker-qual-3.12.0.jar
 ------------------------------------------------------------------------------------
 This product bundles the Reactive Streams library, which is licensed under
 Public Domain (CC0). For details, see deps/reactivestreams-1.0.3/LICENSE

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -208,7 +208,7 @@ Apache Software License, Version 2.
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
 - lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
-- lib/com.google.guava-guava-30.0-jre.jar [4]
+- lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
 - lib/commons-cli-commons-cli-1.2.jar [5]
@@ -289,7 +289,7 @@ Apache Software License, Version 2.
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
-[4] Source available at https://github.com/google/guava/tree/v30.0
+[4] Source available at https://github.com/google/guava/tree/v31.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
 [6] Source available at http://svn.apache.org/viewvc/commons/proper/codec/tags/1_6/
 [7] Source available at http://svn.apache.org/viewvc/commons/proper/configuration/tags/CONFIGURATION_1_10/
@@ -594,7 +594,7 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-qual-3.5.0.jar
+  - lib/org.checkerframework-checker-qual-3.12.0.jar
 ------------------------------------------------------------------------------------
 This product bundles the Reactive Streams library, which is licensed under
 Public Domain (CC0). For details, see deps/reactivestreams-1.0.3/LICENSE

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -208,7 +208,7 @@ Apache Software License, Version 2.
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
 - lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
-- lib/com.google.guava-guava-30.0-jre.jar [4]
+- lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
 - lib/commons-cli-commons-cli-1.2.jar [5]
@@ -310,7 +310,7 @@ Apache Software License, Version 2.
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
-[4] Source available at https://github.com/google/guava/tree/v30.0
+[4] Source available at https://github.com/google/guava/tree/v31.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
 [6] Source available at http://svn.apache.org/viewvc/commons/proper/codec/tags/1_6/
 [7] Source available at http://svn.apache.org/viewvc/commons/proper/configuration/tags/CONFIGURATION_1_10/
@@ -659,7 +659,7 @@ This product uses the annotations from The Checker Framework, which are licensed
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE
 
 Bundles as
-  - lib/org.checkerframework-checker-qual-3.5.0.jar
+  - lib/org.checkerframework-checker-qual-3.12.0.jar
 ------------------------------------------------------------------------------------
 This product bundles the Reactive Streams library, which is licensed under
 Public Domain (CC0). For details, see deps/reactivestreams-1.0.3/LICENSE

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/Value.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/metastore/Value.java
@@ -92,7 +92,7 @@ public class Value {
 
     @Override
     public int hashCode() {
-        HashFunction hf = Hashing.murmur3_32();
+        HashFunction hf = Hashing.murmur3_32_fixed();
         Hasher hc = hf.newHasher();
         for (String key : fields.keySet()) {
             hc.putString(key, Charset.defaultCharset());

--- a/build.gradle
+++ b/build.gradle
@@ -286,6 +286,11 @@ allprojects {
                 new File(buildDir, "classpath.txt").text = sourceSets.main.runtimeClasspath.collect { it.absolutePath }.join(':') + "\n"
             }
         }
+
+        dependencies {
+            implementation(enforcedPlatform(depLibs.guavaBom))
+        }
+
     }
 
     repositories {

--- a/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
+++ b/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
@@ -20,8 +20,6 @@
  */
 package org.apache.bookkeeper.common.util.affinity.impl;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.File;
@@ -50,7 +48,7 @@ public class NativeUtils {
             value = "OBL_UNSATISFIED_OBLIGATION",
             justification = "work around for java 9: https://github.com/spotbugs/spotbugs/issues/493")
     public static void loadLibraryFromJar(String path) throws Exception {
-        checkArgument(path.startsWith("/"), "absolute path must start with /");
+        com.google.common.base.Preconditions.checkArgument(path.startsWith("/"), "absolute path must start with /");
 
         String[] parts = path.split("/");
         String filename = (parts.length > 0) ? parts[parts.length - 1] : null;

--- a/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/ProcessorsInfo.java
+++ b/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/ProcessorsInfo.java
@@ -20,8 +20,6 @@
  */
 package org.apache.bookkeeper.common.util.affinity.impl;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -80,8 +78,8 @@ class ProcessorsInfo {
                 }
             }
 
-            checkArgument(cpuId >= 0);
-            checkArgument(coreId >= 0);
+            com.google.common.base.Preconditions.checkArgument(cpuId >= 0);
+            com.google.common.base.Preconditions.checkArgument(coreId >= 0);
             pi.cpus.put(cpuId, coreId);
         }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -45,7 +45,7 @@ depVersions = [
     gradleTooling: "4.0.1",
     grpc: "1.42.1",
     groovy: "2.5.8",
-    guava: "30.0-jre",
+    guava: "31.0.1-jre",
     hamcrest: "1.3",
     hdrhistogram: "2.1.10",
     httpclient: "4.5.13",
@@ -139,6 +139,7 @@ depLibs = [
         exclude group: 'com.google.guava', module: 'guava'
     },
     groovy: "org.codehaus.groovy:groovy-all:${depVersions.groovy}",
+    guavaBom: "com.google.guava:guava-bom:${depVersions.guava}",
     guava: dependencies.create("com.google.guava:guava:${depVersions.guava}"){
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     },

--- a/stream/common/src/test/java/org/apache/bookkeeper/common/router/HashRouterTest.java
+++ b/stream/common/src/test/java/org/apache/bookkeeper/common/router/HashRouterTest.java
@@ -40,7 +40,7 @@ public class HashRouterTest {
         int hash32 = Murmur3.hash32(
             key, key.readerIndex(), key.readableBytes(), (int) AbstractHashRouter.HASH_SEED);
         int bytesHash32 = Murmur3.hash32(keyBytes, 0, keyBytes.length, (int) AbstractHashRouter.HASH_SEED);
-        int guavaHash32 = Hashing.murmur3_32((int) AbstractHashRouter.HASH_SEED)
+        int guavaHash32 = Hashing.murmur3_32_fixed((int) AbstractHashRouter.HASH_SEED)
             .newHasher()
             .putString("foo", UTF_8)
             .hash()


### PR DESCRIPTION
### Motivation

Older versions of guava (w/CVEs) used in some subprojects

### Changes

Forced the same version of guava; fixed deprecation problems (murmur3_32) and compilation problems (checkArgument).
checkArgument cannot be statically imported because there are now overrides of it; checkstyle was not very cooperative so I had to remove the import altogether. 
Then updated the guava version to match one in Pulsar.