### PR TITLE
Auditor should get the LegdgerManagerFactory from the client instance

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -89,7 +89,6 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.meta.AbstractZkLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRange;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -480,10 +480,7 @@ public class Auditor implements AutoCloseable {
     private void initialize(ServerConfiguration conf, BookKeeper bkc)
             throws UnavailableException {
         try {
-            LedgerManagerFactory ledgerManagerFactory = AbstractZkLedgerManagerFactory
-                    .newLedgerManagerFactory(
-                        conf,
-                        bkc.getMetadataClientDriver().getLayoutManager());
+            LedgerManagerFactory ledgerManagerFactory = bkc.getLedgerManagerFactory();
             ledgerManager = ledgerManagerFactory.newLedgerManager();
             this.bookieLedgerIndexer = new BookieLedgerIndexer(ledgerManager);
 
@@ -503,7 +500,7 @@ public class Auditor implements AutoCloseable {
         } catch (CompatibilityException ce) {
             throw new UnavailableException(
                     "CompatibilityException while initializing Auditor", ce);
-        } catch (IOException | KeeperException ioe) {
+        } catch (KeeperException ioe) {
             throw new UnavailableException(
                     "Exception while initializing Auditor", ioe);
         } catch (InterruptedException ie) {


### PR DESCRIPTION
### Motivation

The auditor cannot assume to have a Zookeeper based `LedgerManagerFactory`. Instead, the BK client already has a instance of the factory that we can reuse.

Additionally, the code was leaking the factory instance which was supposed to get closed.