### PR TITLE
set Mod initial Delay time to simply avoid GarbageCollectorThread working at the same time

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -121,6 +121,7 @@ public class GarbageCollectorThread extends SafeRunnable {
 
     final ServerConfiguration conf;
 
+    final static AtomicLong threadNum = new AtomicLong(0);
     /**
      * Create a garbage collector thread.
      *
@@ -339,7 +340,22 @@ public class GarbageCollectorThread extends SafeRunnable {
         if (scheduledFuture != null) {
             scheduledFuture.cancel(false);
         }
-        scheduledFuture = gcExecutor.scheduleAtFixedRate(this, gcWaitTime, gcWaitTime, TimeUnit.MILLISECONDS);
+        long initialDelay = getModInitialDelay();
+        scheduledFuture = gcExecutor.scheduleAtFixedRate(this, initialDelay, gcWaitTime, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * when number of ledger's Dir are more than 1,the same of GarbageCollectorThread will do the same thing,
+     * Especially
+     * 1) deleting ledger, then SyncThread will be timed to do rocksDB compact
+     * 2) compact: entry, cost cpu.
+     * then get Mod initial Delay time to simply avoid GarbageCollectorThread working at the same time
+     */
+    public long getModInitialDelay() {
+        int ledgerDirsNum = conf.getLedgerDirs().length;
+        long splitTime = gcWaitTime / ledgerDirsNum;
+        long currentThreadNum = threadNum.incrementAndGet();
+        return gcWaitTime + currentThreadNum * splitTime;
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -121,7 +121,7 @@ public class GarbageCollectorThread extends SafeRunnable {
 
     final ServerConfiguration conf;
 
-    private final static AtomicLong threadNum = new AtomicLong(0);
+    private static final AtomicLong threadNum = new AtomicLong(0);
     /**
      * Create a garbage collector thread.
      *

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -121,7 +121,7 @@ public class GarbageCollectorThread extends SafeRunnable {
 
     final ServerConfiguration conf;
 
-    final static AtomicLong threadNum = new AtomicLong(0);
+    private final static AtomicLong threadNum = new AtomicLong(0);
     /**
      * Create a garbage collector thread.
      *

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerDeleteTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerDeleteTest.java
@@ -129,7 +129,7 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
             bkc.deleteLedger(lh.getId());
         }
         LOG.info("Finished deleting all ledgers so waiting for the GC thread to clean up the entryLogs");
-        Thread.sleep(2000);
+        Thread.sleep(5000);
 
         // Verify that the first entry log (0.log) has been deleted from all of the Bookie Servers.
         for (File ledgerDirectory : ledgerDirectories) {
@@ -163,7 +163,7 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
             bkc.deleteLedger(lh.getId());
         }
         LOG.info("Finished deleting all ledgers so waiting for the GC thread to clean up the entryLogs");
-        Thread.sleep(2 * baseConf.getGcWaitTime());
+        Thread.sleep(5000);
 
         /*
          * Verify that the first two entry logs ([0,1].log) have been deleted


### PR DESCRIPTION

Descriptions of the changes in this PR:

### Motivation

when number of ledger's Dir are more than 1,the same of GarbageCollectorThread will do the same thing,
Especially:
  1) deleting ledger, then SyncThread will be timed to do rocksDB compact
  2) compact: entry, cost cpu.

### Changes

set a Mod initial Delay time to simply avoid GarbageCollectorThread working at the same time
