### PR TITLE
[build] do not run spotbugsTest by default

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -47,6 +47,6 @@ jobs:
         with:
           java-version: 1.8
       - name: Validate pull request
-        run: ./gradlew build -x spotbugsTest -x signDistTar -x test
+        run: ./gradlew build -x signDistTar -x test
       - name: Check license files
         run: dev/check-all-licenses

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
     id "com.github.vlsi.stage-vote-release" version "1.77"
     id 'checkstyle'
     id 'org.nosphere.apache.rat'
-    id 'com.github.spotbugs'
+    id 'com.github.spotbugs' apply false
 }
 
 subprojects {
@@ -87,6 +87,7 @@ allprojects {
             toolVersion = '3.1.8'
             excludeFilter = file("$rootDir/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml")
             reportLevel = 'high'
+            spotbugsTest.enabled = false
         }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
     id "com.github.vlsi.stage-vote-release" version "1.77"
     id 'checkstyle'
     id 'org.nosphere.apache.rat'
-    id 'com.github.spotbugs' apply false
+    id 'com.github.spotbugs'
 }
 
 subprojects {


### PR DESCRIPTION
### Motivation

`spotbugsTest` fails on a few submodules.
Run spotbugs against test files is useless and slow down development.

We can just skip it by default without having to specify `-x spotbugsTest`

### Changes

Skip `spotbugsTest` by default
