### PR TITLE
[website] Remove Maven references and remove dead links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <img src="https://pbs.twimg.com/profile_images/545716709311520769/piLLa1iC_400x400.png" alt="logo" style="width: 32px;"/>
 
-[![Coverage Status](https://coveralls.io/repos/github/apache/bookkeeper/badge.svg?branch=master)](https://coveralls.io/github/apache/bookkeeper?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.bookkeeper/bookkeeper/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.bookkeeper/bookkeeper)
 
 # Apache BookKeeper
@@ -29,7 +28,7 @@ Please visit the [Documentation](https://bookkeeper.apache.org/docs/latest/overv
 
 ### Report a Bug
 
-For filing bugs, suggesting improvements, or requesting new features, help us out by [opening a Github issue](https://github.com/apache/bookkeeper/issues) or [opening an Apache jira](https://issues.apache.org/jira/browse/BOOKKEEPER).
+For filing bugs, suggesting improvements, or requesting new features, help us out by [opening a Github issue](https://github.com/apache/bookkeeper/issues).
 
 ### Need Help?
 
@@ -45,15 +44,10 @@ We feel that a welcoming open community is important and welcome contributions.
 
 ### Contributing Code
 
-1. See [Developer Setup](https://cwiki.apache.org/confluence/display/BOOKKEEPER/Developer+Setup) to get your local environment setup.
+1. See our [installation guide](https://bookkeeper.apache.org/docs/latest/getting-started/installation/) to get your local environment setup.
 
-2. Take a look at our open issues: [JIRA Issues](https://issues.apache.org/jira/browse/BOOKKEEPER) [Github Issues](https://github.com/apache/bookkeeper/issues).
+2. Take a look at our open issues: [Github Issues](https://github.com/apache/bookkeeper/issues).
 
-3. Review our [coding style](https://cwiki.apache.org/confluence/display/BOOKKEEPER/Coding+Guide) and follow our [pull requests](https://github.com/apache/bookkeeper/pulls) to learn about our conventions.
+3. Review our [coding style](https://bookkeeper.apache.org/community/coding_guide/) and follow our [pull requests](https://github.com/apache/bookkeeper/pulls) to learn more about our conventions.
 
-4. Make your changes according to our [contribution guide](https://cwiki.apache.org/confluence/display/BOOKKEEPER/Contributing+to+BookKeeper).
-
-### Improving Website and Documentation
-
-1. See [Building the website and documentation](https://cwiki.apache.org/confluence/display/BOOKKEEPER/Building+the+website+and+documentation) on how to build the website and documentation.
-
+4. Make your changes according to our [contributing guide](https://bookkeeper.apache.org/community/contributing/)

--- a/site/community/contributing.md
+++ b/site/community/contributing.md
@@ -102,20 +102,6 @@ Depending on your preferred development environment, you may need to prepare it 
 
 ##### IntelliJ
 
-###### Enable Annotation Processing
-
-To configure annotation processing in IntelliJ:
-
-1. Open Annotation Processors Settings dialog box by going to Settings -> Build, Execution, Deployment -> Compiler -> Annotation Processors.
-1. Select the following buttons:
-    1. "Enable annotation processing"
-    1. "Obtain processors from project classpath"
-    1. "Store generated sources relative to: Module content root"
-1. Set the generated source directories to be equal to the Maven directories:
-    1. Set "Production sources directory:" to "target/generated-sources/annotations".
-    1. Set "Test sources directory:" to "target/generated-test-sources/test-annotations".
-1. Click "OK".
-
 ###### Checkstyle
 IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
 
@@ -153,7 +139,6 @@ Start Eclipse with a fresh workspace in a separate directory from your checkout.
 
 	File
 	-> Import...
-	-> Existing Maven Projects
 	-> Browse to the directory you cloned into and select "bookkeeper"
 	-> make sure all bookkeeper projects are selected
 	-> Finalize

--- a/site/docs/latest/getting-started/installation.md
+++ b/site/docs/latest/getting-started/installation.md
@@ -12,63 +12,32 @@ You can install BookKeeper either by [downloading](#download) a [GZipped](http:/
 
 * [Unix environment](http://www.opengroup.org/unix)
 * [Java Development Kit 1.8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) or later
-* [Maven 3.0](https://maven.apache.org/install.html) or later
 
 ## Download
 
-You can download Apache BookKeeper releases from one of many [Apache mirrors](http://www.apache.org/dyn/closer.cgi/bookkeeper). Here's an example for the [apache.claz.org](http://apache.claz.org/bookkeeper) mirror:
-
-```shell
-$ curl -O {{ download_url }}
-$ tar xvf bookkeeper-{{ site.latest_release }}-src.tar.gz
-$ cd bookkeeper-{{ site.latest_release }}
-```
+You can download Apache BookKeeper releases from one of many [Apache mirrors](https://dlcdn.apache.org/bookkeeper/).
 
 ## Clone
 
-To build BookKeeper from source, clone the repository, either from the [GitHub mirror]({{ site.github_repo }}) or from the [Apache repository](http://git.apache.org/bookkeeper.git/):
+To build BookKeeper from source, clone the repository, either from the [GitHub mirror]({{ site.github_repo }}):
 
 ```shell
-# From the GitHub mirror
 $ git clone {{ site.github_repo}}
-
-# From Apache directly
-$ git clone git://git.apache.org/bookkeeper.git/
 ```
 
-## Build using Maven
+## Build using Gradle
 
-Once you have the BookKeeper on your local machine, either by [downloading](#download) or [cloning](#clone) it, you can then build BookKeeper from source using Maven:
+Once you have the BookKeeper on your local machine, either by [downloading](#download) or [cloning](#clone) it, you can then build BookKeeper from source using Gradle:
 
 ```shell
-$ mvn package
+$ ./gradlew build -x signDistTar -x test
 ```
 
-Since 4.8.0, bookkeeper introduces `table service`. If you would like to build and tryout table service, you can build it with `stream` profile.
+To run all the tests:
 
 ```shell
-$ mvn package -Dstream
+$ ./gradlew test -x signDistTar
 ```
-
-> You can skip tests by adding the `-DskipTests` flag when running `mvn package`.
-
-### Useful Maven commands
-
-Some other useful Maven commands beyond `mvn package`:
-
-Command | Action
-:-------|:------
-`mvn clean` | Removes build artifacts
-`mvn compile` | Compiles JAR files from Java sources
-`mvn compile spotbugs:spotbugs` | Compile using the Maven [SpotBugs](https://github.com/spotbugs/spotbugs-maven-plugin) plugin
-`mvn install` | Install the BookKeeper JAR locally in your local Maven cache (usually in the `~/.m2` directory)
-`mvn deploy` | Deploy the BookKeeper JAR to the Maven repo (if you have the proper credentials)
-`mvn verify` | Performs a wide variety of verification and validation tasks
-`mvn apache-rat:check` | Run Maven using the [Apache Rat](http://creadur.apache.org/rat/apache-rat-plugin/) plugin
-`mvn compile javadoc:aggregate` | Build Javadocs locally
-`mvn -am -pl bookkeeper-dist/server package` | Build a server distribution using the Maven [Assembly](http://maven.apache.org/plugins/maven-assembly-plugin/) plugin
-
-> You can enable `table service` by adding the `-Dstream` flag when running above commands.
 
 ## Package directory
 


### PR DESCRIPTION
### Motivation

Remove Maven from the build guide and remove outdated links and suggestions.

### Changes

#### README
* Removed Coveralls badge (the latest build run in 2020)
* Removed Jira references (all the jira issues have been migrated to GitHub, so there's no need to confuse new contributors)
* Replaced Confluence doc links with official website links

#### Website
* Replaced Maven instructions with Gradle ones
