### PR TITLE
CI workflow to check dependencies with OWASP

### DIFF
--- a/.github/workflows/owasp-dep-check.yml
+++ b/.github/workflows/owasp-dep-check.yml
@@ -47,8 +47,8 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: run "clean install verify" to trigger dependency check
-        run: ./gradlew clean build -x microbenchmarks:checkstyleMain -x spotbugsTest -x signDistTar -x test dependencyCheckAggregate
+      - name: run "clean build dependencyCheckAggregate" to trigger dependency check
+        run: ./gradlew clean build -x signDistTar -x test dependencyCheckAggregate
 
       - name: Upload report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/owasp-dep-check.yml
+++ b/.github/workflows/owasp-dep-check.yml
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: OWASP Dependency Check
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - branch-*
+    paths-ignore:
+      - 'site/**'
+    workflow_dispatch:
+
+
+jobs:
+  check:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: run "clean install verify" to trigger dependency check
+        run: ./gradlew clean build -x microbenchmarks:checkstyleMain -x spotbugsTest -x signDistTar -x test dependencyCheckAggregate
+
+      - name: Upload report
+        uses: actions/upload-artifact@v2
+        if: ${{ cancelled() || failure() }}
+        continue-on-error: true
+        with:
+          name: dependency report
+          path: build/reports/dependency-check-report.html

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ allprojects {
                 suppressionFile = "$rootDir/src/owasp-dependency-check-suppressions.xml"
                 skipProjects = skipDepCheck
                 skipConfigurations = ["checkstyle", "spotbugs"]
+                failBuildOnCVSS = 7
                 analyzers {
                     msbuildEnabled = false
                     rubygemsEnabled = false


### PR DESCRIPTION
### Motivation

Detect CVEs early and make them visible to the committers

### Changes

Added GH workflow that will fail if new CVE with level > 7 detected. The plan is to not treat it as blocking merge.
Currently some projects that will not pass the check until other pending PRs are merged.

