### PR TITLE
Issue 2974: better thread selection for the Ordered Executor

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/MathUtils.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/MathUtils.java
@@ -26,6 +26,16 @@ public class MathUtils {
 
     private static final long NANOSECONDS_PER_MILLISECOND = 1000000;
 
+    public static int signSafeMod(int dividend, int divisor) {
+        int mod = dividend % divisor;
+
+        if (mod < 0) {
+            mod += divisor;
+        }
+
+        return mod;
+    }
+
     public static int signSafeMod(long dividend, int divisor) {
         int mod = (int) (dividend % divisor);
 

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/MathUtils.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/MathUtils.java
@@ -26,16 +26,6 @@ public class MathUtils {
 
     private static final long NANOSECONDS_PER_MILLISECOND = 1000000;
 
-    public static int signSafeMod(int dividend, int divisor) {
-        int mod = dividend % divisor;
-
-        if (mod < 0) {
-            mod += divisor;
-        }
-
-        return mod;
-    }
-
     public static int signSafeMod(long dividend, int divisor) {
         int mod = (int) (dividend % divisor);
 

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -19,8 +19,6 @@ package org.apache.bookkeeper.common.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.ForwardingExecutorService;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -76,7 +74,6 @@ public class OrderedExecutor implements ExecutorService {
     public static final int NO_TASK_LIMIT = -1;
     private static final int DEFAULT_MAX_ARRAY_QUEUE_SIZE = 10_000;
     protected static final long WARN_TIME_MICRO_SEC_DEFAULT = TimeUnit.SECONDS.toMicros(1);
-    private static final HashFunction hf = Hashing.murmur3_32_fixed();
 
     final String name;
     final ExecutorService[] threads;
@@ -613,7 +610,7 @@ public class OrderedExecutor implements ExecutorService {
     }
 
     protected static int chooseThreadIdx(long orderingKey, int numThreads) {
-        return MathUtils.signSafeMod(hf.hashLong(orderingKey).asInt(), numThreads);
+        return MathUtils.signSafeMod(orderingKey >>> 1, numThreads);
     }
 
     protected Runnable timedRunnable(Runnable r) {

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -19,6 +19,7 @@ package org.apache.bookkeeper.common.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.ForwardingExecutorService;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -570,7 +571,7 @@ public class OrderedExecutor implements ExecutorService {
             return threadIds[0];
         }
 
-        return threadIds[MathUtils.signSafeMod(orderingKey, threadIds.length)];
+        return threadIds[chooseThreadIdx(orderingKey, threads.length)];
     }
 
     public ExecutorService chooseThread() {
@@ -591,7 +592,7 @@ public class OrderedExecutor implements ExecutorService {
         if (null == orderingKey) {
             return threads[rand.nextInt(threads.length)];
         } else {
-            return threads[MathUtils.signSafeMod(orderingKey.hashCode(), threads.length)];
+            return threads[chooseThreadIdx(orderingKey.hashCode(), threads.length)];
         }
     }
 
@@ -606,7 +607,11 @@ public class OrderedExecutor implements ExecutorService {
             return threads[0];
         }
 
-        return threads[MathUtils.signSafeMod(orderingKey, threads.length)];
+        return threads[chooseThreadIdx(orderingKey, threads.length)];
+    }
+
+    protected static int chooseThreadIdx(long orderingKey, int numThreads) {
+        return Hashing.consistentHash(orderingKey, numThreads);
     }
 
     protected Runnable timedRunnable(Runnable r) {

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -19,6 +19,7 @@ package org.apache.bookkeeper.common.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.ForwardingExecutorService;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -75,6 +76,7 @@ public class OrderedExecutor implements ExecutorService {
     public static final int NO_TASK_LIMIT = -1;
     private static final int DEFAULT_MAX_ARRAY_QUEUE_SIZE = 10_000;
     protected static final long WARN_TIME_MICRO_SEC_DEFAULT = TimeUnit.SECONDS.toMicros(1);
+    private static final HashFunction hf = Hashing.murmur3_32_fixed();
 
     final String name;
     final ExecutorService[] threads;
@@ -611,7 +613,7 @@ public class OrderedExecutor implements ExecutorService {
     }
 
     protected static int chooseThreadIdx(long orderingKey, int numThreads) {
-        return Hashing.consistentHash(orderingKey, numThreads);
+        return MathUtils.signSafeMod(hf.hashLong(orderingKey).asInt(), numThreads);
     }
 
     protected Runnable timedRunnable(Runnable r) {

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestThreadSelection.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestThreadSelection.java
@@ -121,7 +121,6 @@ public class TestThreadSelection {
         log.info("got min={}, max={} (disparity: {}) for {} threads with {} ids", min, max, numThreads, MAX_KEY);
         Assert.assertTrue("all threads were used [numThreads: " + numThreads + "]",
                 min > 0);
-        System.out.println(String.format("%,.2f", (double) max / min));
         log.info("disparity = {}", String.format("%,.2f", (double) max / min));
         Assert.assertTrue("no large disparity found [numThreads: " + numThreads + "]",
                 (double) max / min <= MAX_DISPARITY);

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestThreadSelection.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestThreadSelection.java
@@ -122,7 +122,8 @@ public class TestThreadSelection {
         Assert.assertTrue("all threads were used [numThreads: " + numThreads + "]",
                 min > 0);
         log.info("disparity = {}", String.format("%,.2f", (double) max / min));
-        Assert.assertTrue("no large disparity found [numThreads: " + numThreads + "]",
+        Assert.assertTrue("no large disparity found [numThreads: " + numThreads + "], got "
+                        + (double) max / min,
                 (double) max / min <= MAX_DISPARITY);
     }
 

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestThreadSelection.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestThreadSelection.java
@@ -1,0 +1,130 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.common.util;
+
+import com.google.common.primitives.Longs;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test how even is the distribution of ledgers across the threads of OrderedExecutor.
+ */
+@Slf4j
+public class TestThreadSelection {
+
+    public static final long MAX_KEY = 1_000_000L;
+    public static final int MAX_THREADS = 96;
+    public static final double MAX_DISPARITY = 1.25d;
+
+    private final Random rnd = new SecureRandom();
+
+    /**
+     * Only even keys.
+     */
+    @Test
+    public void testThreadSelectionEvenKeys() {
+        runTest(0L, 2L);
+    }
+
+    /**
+     * Only odd keys.
+     */
+    @Test
+    public void testThreadSelectionOddKeys() {
+        runTest(1L, 2L);
+    }
+
+    /**
+     * All keys.
+     */
+    @Test
+    public void testThreadSelectionAllKeys() {
+        runTest(0L, 1L);
+    }
+
+    /**
+     * Random keys.
+     */
+    @Test
+    public void testThreadSelectionRandKeys() {
+        for (int numThreads = 2; numThreads <= MAX_THREADS; numThreads++) {
+            long[] placement = new long[numThreads];
+
+            log.info("testing {} threads", numThreads);
+            for (long key = 0L; key < MAX_KEY; key += 1L) {
+                int threadId = OrderedExecutor.chooseThreadIdx(rnd.nextLong(), numThreads);
+                placement[threadId]++;
+            }
+            validateTest(placement, numThreads);
+        }
+    }
+
+    /**
+     * Confirm the same key assigned to the same thread on consequent calls.
+     */
+    @Test
+    public void testKeyAssignedToTheSameThread() {
+        for (int numThreads = 2; numThreads <= MAX_THREADS; numThreads++) {
+
+            log.info("testing {} threads", numThreads);
+            for (long key = 0L; key < MAX_KEY; key += 1L) {
+                int threadId = OrderedExecutor.chooseThreadIdx(key, numThreads);
+                for (int i = 0; i < 10; i++) {
+                    Assert.assertEquals("must be assigned to the same thread",
+                            threadId, OrderedExecutor.chooseThreadIdx(key, numThreads));
+                }
+            }
+        }
+    }
+
+
+    private void runTest(long start, long step) {
+        for (int numThreads = 2; numThreads <= MAX_THREADS; numThreads++) {
+            long[] placement = new long[numThreads];
+
+            log.info("testing {} threads", numThreads);
+            for (long key = start; key < MAX_KEY; key += step) {
+                int threadId = OrderedExecutor.chooseThreadIdx(key, numThreads);
+                placement[threadId]++;
+            }
+            validateTest(placement, numThreads);
+        }
+    }
+
+    private void validateTest(long[] placement, int numThreads) {
+        long min = Longs.min(placement);
+        long max = Longs.max(placement);
+        log.info("got min={}, max={} (disparity: {}) for {} threads with {} ids", min, max, numThreads, MAX_KEY);
+        Assert.assertTrue("all threads were used [numThreads: " + numThreads + "]",
+                min > 0);
+        System.out.println(String.format("%,.2f", (double) max / min));
+        log.info("disparity = {}", String.format("%,.2f", (double) max / min));
+        Assert.assertTrue("no large disparity found [numThreads: " + numThreads + "]",
+                (double) max / min <= MAX_DISPARITY);
+    }
+
+}


### PR DESCRIPTION
### Motivation

uneven routing of requests to threads caused by uneven distribution of ledger Ids can leave some threads underutilized

### Changes

Experimented with a few approaches and picked the simplest/fastest one that produced good results.
Locally tested with keys (ledger ids) up to 100mil across up to 512 threads.

This does not address the fact that generated ledger ids are skewed towards even numbers.
This does not fix routing of the journals/data dirs. 

Master Issue: #2974

