### PR TITLE
Upgrade RocksDB

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -260,7 +260,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-servlet-9.4.43.v20210629.jar [22]
 - lib/org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar [22]
 - lib/org.eclipse.jetty-jetty-util-ajax-9.4.43.v20210629.jar [22]
-- lib/org.rocksdb-rocksdbjni-6.22.1.1.jar [23]
+- lib/org.rocksdb-rocksdbjni-6.27.3.jar [23]
 - lib/com.beust-jcommander-1.78.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
@@ -586,7 +586,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-6.22.1.1.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-6.27.3.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -260,7 +260,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-servlet-9.4.43.v20210629.jar [22]
 - lib/org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar [22]
 - lib/org.eclipse.jetty-jetty-util-ajax-9.4.43.v20210629.jar [22]
-- lib/org.rocksdb-rocksdbjni-6.22.1.1.jar [23]
+- lib/org.rocksdb-rocksdbjni-6.27.3.jar [23]
 - lib/com.beust-jcommander-1.78.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
@@ -584,7 +584,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-6.22.1.1.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-6.27.3.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -72,7 +72,7 @@ depVersions = [
     prometheus: "0.8.1",
     protobuf: "3.16.1",
     reflections: "0.9.11",
-    rocksDb: "6.22.1.1",
+    rocksDb: "6.27.3",
     rxjava: "3.0.1",
     slf4j: "1.7.32",
     snakeyaml: "1.30",


### PR DESCRIPTION
Descriptions of the changes in this PR:

Dependency change

### Motivation

I encountered https://github.com/apache/bookkeeper/issues/3024 and noticed that newer version of RocksDB includes multiple fixes for concurrency issues with various side-effects and fixes for a few crashes.
I upgraded, ran `org.apache.bookkeeper.bookie.BookieJournalTest` test in a loop and didn't repro the crash so far.
It is hard to say 100% if it is fixed given it was not happening all the time. 

### Changes

Upgraded RocksDB
Master Issue: #3024

