### PR TITLE
[ISSUE 3031] fixed test; chooseThread() uses orderingKey as a param, not a thread index

### DIFF
--- a/stream/storage/impl/src/test/java/org/apache/bookkeeper/stream/storage/impl/store/MVCCStoreFactoryImplTest.java
+++ b/stream/storage/impl/src/test/java/org/apache/bookkeeper/stream/storage/impl/store/MVCCStoreFactoryImplTest.java
@@ -147,13 +147,13 @@ public class MVCCStoreFactoryImplTest {
             assertTrue(store.spec().getKeyCoder() instanceof ByteArrayCoder);
             assertTrue(store.spec().getValCoder() instanceof ByteArrayCoder);
             assertSame(
-                factory.writeIOScheduler().chooseThread(streamId % 3),
+                factory.writeIOScheduler().chooseThread(streamId),
                 store.spec().getWriteIOScheduler());
             assertSame(
-                factory.readIOScheduler().chooseThread(streamId % 3),
+                factory.readIOScheduler().chooseThread(streamId),
                 store.spec().getReadIOScheduler());
             assertSame(
-                factory.checkpointScheduler().chooseThread(streamId % 3),
+                factory.checkpointScheduler().chooseThread(streamId),
                 store.spec().getCheckpointIOScheduler());
             assertTrue(store.spec().getCheckpointStore() instanceof FSCheckpointManager);
             assertEquals(Duration.ofMinutes(15), store.spec().getCheckpointDuration());


### PR DESCRIPTION
### Motivation

Test flaked on CI

### Changes

Fixed test

Master Issue: #3031 
