### PR TITLE
fix metric error and format problem in BookieStats

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -1075,7 +1075,6 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
             throws IOException, NoLedgerException, BookieException {
         long requestNanos = MathUtils.nowInNano();
         boolean success = false;
-        int entrySize = 0;
         try {
             LedgerDescriptor handle = handles.getReadOnlyHandle(ledgerId);
             if (LOG.isTraceEnabled()) {
@@ -1089,10 +1088,8 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
             long elapsedNanos = MathUtils.elapsedNanos(requestNanos);
             if (success) {
                 bookieStats.getReadEntryStats().registerSuccessfulEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-                bookieStats.getReadBytesStats().registerSuccessfulValue(entrySize);
             } else {
                 bookieStats.getReadEntryStats().registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-                bookieStats.getReadEntryStats().registerFailedValue(entrySize);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/stats/BookieStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/stats/BookieStats.java
@@ -25,7 +25,6 @@ import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_ADD_ENTR
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_FORCE_LEDGER;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_GET_LIST_OF_ENTRIES_OF_LEDGER;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_READ_ENTRY;
-import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_READ_ENTRY_BYTES;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_RECOVERY_ADD_ENTRY;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_SCOPE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.CATEGORY_SERVER;
@@ -102,11 +101,6 @@ public class BookieStats {
     )
     private final OpStatsLogger addBytesStats;
     @StatsDoc(
-        name = BOOKIE_READ_ENTRY_BYTES,
-        help = "bytes stats of ReadEntry on a bookie"
-    )
-    private final OpStatsLogger readBytesStats;
-    @StatsDoc(
         name = JOURNAL_DIRS,
         help = "number of configured journal directories"
     )
@@ -127,7 +121,6 @@ public class BookieStats {
         readEntryStats = statsLogger.getOpStatsLogger(BOOKIE_READ_ENTRY);
         getListOfEntriesOfLedgerStats = statsLogger.getOpStatsLogger(BOOKIE_GET_LIST_OF_ENTRIES_OF_LEDGER);
         addBytesStats = statsLogger.getOpStatsLogger(BOOKIE_ADD_ENTRY_BYTES);
-        readBytesStats = statsLogger.getOpStatsLogger(BOOKIE_READ_ENTRY_BYTES);
         journalDirsGauge = new Gauge<Integer>() {
             @Override
             public Integer getDefaultValue() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/stats/BookieStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/stats/BookieStats.java
@@ -56,11 +56,20 @@ public class BookieStats {
 
     // Expose Stats
     final StatsLogger statsLogger;
-    @StatsDoc(name = WRITE_BYTES, help = "total bytes written to a bookie")
+    @StatsDoc(
+        name = WRITE_BYTES,
+        help = "total bytes written to a bookie"
+    )
     private final Counter writeBytes;
-    @StatsDoc(name = READ_BYTES, help = "total bytes read from a bookie")
+    @StatsDoc(
+        name = READ_BYTES,
+        help = "total bytes read from a bookie"
+    )
     private final Counter readBytes;
-    @StatsDoc(name = BOOKIE_FORCE_LEDGER, help = "total force operations occurred on a bookie")
+    @StatsDoc(
+        name = BOOKIE_FORCE_LEDGER,
+        help = "total force operations occurred on a bookie"
+    )
     private final Counter forceLedgerOps;
     // Bookie Operation Latency Stats
     @StatsDoc(
@@ -69,7 +78,10 @@ public class BookieStats {
         parent = ADD_ENTRY
     )
     private final OpStatsLogger addEntryStats;
-    @StatsDoc(name = BOOKIE_RECOVERY_ADD_ENTRY, help = "operation stats of RecoveryAddEntry on a bookie")
+    @StatsDoc(
+        name = BOOKIE_RECOVERY_ADD_ENTRY,
+        help = "operation stats of RecoveryAddEntry on a bookie"
+    )
     private final OpStatsLogger recoveryAddEntryStats;
     @StatsDoc(
         name = BOOKIE_READ_ENTRY,
@@ -78,19 +90,31 @@ public class BookieStats {
     )
     private final OpStatsLogger readEntryStats;
     @StatsDoc(
-            name = BOOKIE_GET_LIST_OF_ENTRIES_OF_LEDGER,
-            help = "operation stats of GetListOfEntriesOfLedger on a bookie",
-            parent = GET_LIST_OF_ENTRIES_OF_LEDGER
+        name = BOOKIE_GET_LIST_OF_ENTRIES_OF_LEDGER,
+        help = "operation stats of GetListOfEntriesOfLedger on a bookie",
+        parent = GET_LIST_OF_ENTRIES_OF_LEDGER
     )
     private final OpStatsLogger getListOfEntriesOfLedgerStats;
     // Bookie Operation Bytes Stats
-    @StatsDoc(name = BOOKIE_ADD_ENTRY_BYTES, help = "bytes stats of AddEntry on a bookie")
+    @StatsDoc(
+        name = BOOKIE_ADD_ENTRY_BYTES,
+        help = "bytes stats of AddEntry on a bookie"
+    )
     private final OpStatsLogger addBytesStats;
-    @StatsDoc(name = BOOKIE_READ_ENTRY_BYTES, help = "bytes stats of ReadEntry on a bookie")
+    @StatsDoc(
+        name = BOOKIE_READ_ENTRY_BYTES,
+        help = "bytes stats of ReadEntry on a bookie"
+    )
     private final OpStatsLogger readBytesStats;
-    @StatsDoc(name = JOURNAL_DIRS, help = "number of configured journal directories")
+    @StatsDoc(
+        name = JOURNAL_DIRS,
+        help = "number of configured journal directories"
+    )
     private final Gauge<Integer> journalDirsGauge;
-    @StatsDoc(name = JOURNAL_QUEUE_MAX_SIZE, help = "maximum length of a journal queue")
+    @StatsDoc(
+        name = JOURNAL_QUEUE_MAX_SIZE,
+        help = "maximum length of a journal queue"
+    )
     private final Gauge<Integer> journalQueueMaxQueueSizeGauge;
 
     public BookieStats(StatsLogger statsLogger, int numJournalDirs, int maxJournalQueueSize) {


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

1. the code style in BookieStats is different to other Stats
2. the BOOKIE_READ_ENTRY_BYTES metric in BookieStats is not correct 

### Changes

1. fix the code style problem in BookieStats
2. since the BOOKIE_READ_ENTRY_BYTES and the READ_BYTES metric both collect entry.readableBytes() in BookieImpl#readEntry()，it is better to keep the counter, not OpStatsLogger. OpStatsLogger is relatively expensive.

