### PR TITLE
[ci] Dump stacktrace when a job is cancelled

### DIFF
--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -51,3 +51,7 @@ jobs:
 
       - name: Run bookie test
         run: ./gradlew bookkeeper-server:test --tests="org.apache.bookkeeper.bookie.*" ${GRADLE_ARGS}
+
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -50,3 +50,7 @@ jobs:
           java-version: 1.8
       - name: Run client tests
         run: ./gradlew bookkeeper-server:test --tests="org.apache.bookkeeper.client.*" ${GRADLE_ARGS}
+
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -53,4 +53,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -53,4 +53,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -53,4 +53,4 @@ jobs:
           ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**" ${GRADLE_ARGS} -i
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -50,7 +50,7 @@ jobs:
           java-version: 1.11
       - name: Build with gradle
         run: |
-          ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**" ${GRADLE_ARGS} -i
+          ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**" ${GRADLE_ARGS}
       - name: print JVM thread dumps when cancelled
         if: cancelled()
         run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -53,4 +53,4 @@ jobs:
           ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**" ${GRADLE_ARGS} -i
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -50,7 +50,7 @@ jobs:
           java-version: 1.11
       - name: Build with gradle
         run: |
-          ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**" ${GRADLE_ARGS}
+          ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**" ${GRADLE_ARGS} -i
       - name: print JVM thread dumps when cancelled
         if: cancelled()
         run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -51,3 +51,6 @@ jobs:
       - name: Build with gradle
         run: |
           ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**" ${GRADLE_ARGS}
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -51,3 +51,7 @@ jobs:
       - name: Build with gradle
         run: |
           ./gradlew test -x bookkeeper-server:test -x tests:integration:cluster:test -x tests:integration:smoke:test -x tests:integration:standalone:test -PexcludeTests="**/distributedlog/**, **/statelib/**, **/clients/**, **/*common/**, **/stream/**, **/stream/*bk*/**, **/*backward*/**" ${GRADLE_ARGS}
+
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,3 +57,7 @@ jobs:
         run: ./gradlew tests:integration:smoke:test ${GRADLE_ARGS}
       - name: run standalone test
         run: ./gradlew tests:integration:standalone:test ${GRADLE_ARGS}
+
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,4 +60,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,4 +60,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -51,3 +51,7 @@ jobs:
           java-version: 1.8
       - name: Run remaining tests
         run: ./gradlew bookkeeper-server:test -PexcludeTests="*org.apache.bookkeeper.bookie.*, *org.apache.bookkeeper.client.*, *org.apache.bookkeeper.replication.*, *org.apache.bookkeeper.tls.*" ${GRADLE_ARGS}
+
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -50,3 +50,7 @@ jobs:
           java-version: 1.8
       - name: Run replication tests
         run: ./gradlew bookkeeper-server:test --tests="org.apache.bookkeeper.replication.*" ${GRADLE_ARGS}
+
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -53,4 +53,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -53,4 +53,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run stream:serve tests
         run: ./gradlew stream:server:test ${GRADLE_ARGS}
       - name: Run stream:statelib tests
-        run: ./gradlew stream:statelib:test ${GRADLE_ARGS} -i
+        run: ./gradlew stream:statelib:test ${GRADLE_ARGS}
       - name: Run stream:storage:api:test tests
         run: ./gradlew stream:storage:api:test ${GRADLE_ARGS}
       - name: Run stream:storage:impl tests

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -66,5 +66,5 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps
 

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -66,5 +66,5 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps
 

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -64,3 +64,7 @@ jobs:
       - name: Run stream:storage:impl tests
         run: ./gradlew stream:storage:impl:test ${GRADLE_ARGS}
 
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps
+

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run stream:serve tests
         run: ./gradlew stream:server:test ${GRADLE_ARGS}
       - name: Run stream:statelib tests
-        run: ./gradlew stream:statelib:test ${GRADLE_ARGS}
+        run: ./gradlew stream:statelib:test ${GRADLE_ARGS} -i
       - name: Run stream:storage:api:test tests
         run: ./gradlew stream:storage:api:test ${GRADLE_ARGS}
       - name: Run stream:storage:impl tests

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -50,3 +50,7 @@ jobs:
           java-version: 1.8
       - name: Run tls tests
         run: ./gradlew bookkeeper-server:test --tests="org.apache.bookkeeper.tls.*" ${GRADLE_ARGS}
+
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./dev/ci_tool.sh print_thread_dumps

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -53,4 +53,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool print_thread_dumps
+        run: ./dev/ci-tool print_thread_dumps

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -53,4 +53,4 @@ jobs:
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
-        run: ./dev/ci_tool.sh print_thread_dumps
+        run: ./dev/ci_tool print_thread_dumps

--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,7 @@ allprojects {
         }
         dependencies {
             implementation(enforcedPlatform(depLibs.nettyBom))
+            testImplementation depLibs.log4jSlf4jImpl
         }
         tasks.register('writeClasspath') {
             doLast {

--- a/dev/ci-tool
+++ b/dev/ci-tool
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# shell function library for Bookkeeper CI builds
+
+# lists all available functions in this tool
+function ci_list_functions() {
+  declare -F | awk '{print $NF}' | sort | egrep '^ci_' | sed 's/^ci_//'
+}
+
+# prints thread dumps for all running JVMs
+# used in CI when a job gets cancelled because of a job timeout
+function ci_print_thread_dumps() {
+  for java_pid in $(jps -q -J-XX:+PerfDisableSharedMem); do
+    echo "----------------------- pid $java_pid -----------------------"
+    cat /proc/$java_pid/cmdline | xargs -0 echo
+    jcmd $java_pid Thread.print -l
+    jcmd $java_pid GC.heap_info
+  done
+  return 0
+}
+
+if [ -z "$1" ]; then
+  echo "usage: $0 [ci_tool_function_name]"
+  echo "Available ci tool functions:"
+  ci_list_functions
+  exit 1
+fi
+ci_function_name="ci_$1"
+shift
+
+if [[ "$(LC_ALL=C type -t $ci_function_name)" == "function" ]]; then
+  eval "$ci_function_name" "$@"
+else
+  echo "Invalid ci tool function"
+  echo "Available ci tool functions:"
+  ci_list_functions
+  exit 1
+fi


### PR DESCRIPTION
### Motivation

Sometimes CI jobs fail due to timeout. It would be useful understand what the latest test was doing before being interrupted. 

### Changes

* Added a new script for dumping stacktrace.
* Added in all the jobs the step in case of `cancelled()` is true.
