### PR TITLE
Avoiding call fileChannelProvider init multiple times

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -618,8 +618,8 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
     final File journalDirectory;
     final ServerConfiguration conf;
     final ForceWriteThread forceWriteThread;
+    final FileChannelProvider fileChannelProvider;
 
-    private FileChannelProvider fileChannelProvider;
     // Time after which we will stop grouping and issue the flush
     private final long maxGroupWaitInNanos;
     // Threshold after which we flush any buffered journal entries
@@ -736,9 +736,8 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         try {
             this.fileChannelProvider = FileChannelProvider.newProvider(conf.getJournalChannelProvider());
         } catch (IOException e) {
-            LOG.warn("Failed to initiate {}, use default fileSystem provider instead.",
-                conf.getJournalChannelProvider());
-            this.fileChannelProvider = new DefaultFileChannelProvider();
+            LOG.error("Failed to initiate file channel provider: {}", conf.getJournalChannelProvider());
+            throw new RuntimeException(e);
         }
 
         // Expose Stats

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -47,7 +47,6 @@ class JournalChannel implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(JournalChannel.class);
 
     static final long MB = 1024 * 1024L;
-    final FileChannelProvider fileChannelProvider;
     final BookieFileChannel channel;
     final int fd;
     final FileChannel fc;
@@ -92,37 +91,42 @@ class JournalChannel implements Closeable {
 
     // Mostly used by tests
     JournalChannel(File journalDirectory, long logId) throws IOException {
-        this(journalDirectory, logId, 4 * MB, 65536, START_OF_FILE, new ServerConfiguration());
+        this(journalDirectory, logId, 4 * MB, 65536, START_OF_FILE, new ServerConfiguration(),
+            new DefaultFileChannelProvider());
     }
 
     // Open journal for scanning starting from the first record in journal.
     JournalChannel(File journalDirectory, long logId,
-                   long preAllocSize, int writeBufferSize, ServerConfiguration conf) throws IOException {
-        this(journalDirectory, logId, preAllocSize, writeBufferSize, START_OF_FILE, conf);
+                   long preAllocSize, int writeBufferSize, ServerConfiguration conf,
+                   FileChannelProvider provider) throws IOException {
+        this(journalDirectory, logId, preAllocSize, writeBufferSize, START_OF_FILE, conf, provider);
     }
 
     // Open journal for scanning starting from given position.
     JournalChannel(File journalDirectory, long logId,
-                   long preAllocSize, int writeBufferSize, long position, ServerConfiguration conf) throws IOException {
+                   long preAllocSize, int writeBufferSize, long position, ServerConfiguration conf,
+                   FileChannelProvider provider) throws IOException {
          this(journalDirectory, logId, preAllocSize, writeBufferSize, SECTOR_SIZE,
-                 position, false, V5, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER, conf);
+                 position, false, V5, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER,
+             conf, provider);
     }
 
     // Open journal to write
     JournalChannel(File journalDirectory, long logId,
                    long preAllocSize, int writeBufferSize, int journalAlignSize,
                    boolean fRemoveFromPageCache, int formatVersionToWrite,
-                   ServerConfiguration configuration) throws IOException {
+                   ServerConfiguration conf, FileChannelProvider provider) throws IOException {
         this(journalDirectory, logId, preAllocSize, writeBufferSize, journalAlignSize, fRemoveFromPageCache,
-                formatVersionToWrite, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER, configuration);
+                formatVersionToWrite, Journal.BufferedChannelBuilder.DEFAULT_BCBUILDER, conf, provider);
     }
 
     JournalChannel(File journalDirectory, long logId,
                    long preAllocSize, int writeBufferSize, int journalAlignSize,
                    boolean fRemoveFromPageCache, int formatVersionToWrite,
-                   Journal.BufferedChannelBuilder bcBuilder, ServerConfiguration configuration) throws IOException {
+                   Journal.BufferedChannelBuilder bcBuilder, ServerConfiguration conf,
+                   FileChannelProvider provider) throws IOException {
         this(journalDirectory, logId, preAllocSize, writeBufferSize, journalAlignSize,
-                START_OF_FILE, fRemoveFromPageCache, formatVersionToWrite, bcBuilder, configuration);
+                START_OF_FILE, fRemoveFromPageCache, formatVersionToWrite, bcBuilder, conf, provider);
     }
 
     /**
@@ -151,16 +155,16 @@ class JournalChannel implements Closeable {
                            long preAllocSize, int writeBufferSize, int journalAlignSize,
                            long position, boolean fRemoveFromPageCache,
                            int formatVersionToWrite, Journal.BufferedChannelBuilder bcBuilder,
-                           ServerConfiguration configuration) throws IOException {
+                           ServerConfiguration conf,
+                           FileChannelProvider provider) throws IOException {
         this.journalAlignSize = journalAlignSize;
         this.zeros = ByteBuffer.allocate(journalAlignSize);
         this.preAllocSize = preAllocSize - preAllocSize % journalAlignSize;
         this.fRemoveFromPageCache = fRemoveFromPageCache;
-        this.configuration = configuration;
+        this.configuration = conf;
 
         File fn = new File(journalDirectory, Long.toHexString(logId) + ".txn");
-        fileChannelProvider = FileChannelProvider.newProvider(configuration.getJournalChannelProvider());
-        channel = fileChannelProvider.open(fn, configuration);
+        channel = provider.open(fn, configuration);
 
         if (formatVersionToWrite < V4) {
             throw new IOException("Invalid journal format to write : version = " + formatVersionToWrite);
@@ -275,9 +279,6 @@ class JournalChannel implements Closeable {
     public void close() throws IOException {
         if (bc != null) {
             bc.close();
-        }
-        if (fileChannelProvider != null) {
-            fileChannelProvider.close();
         }
     }
 


### PR DESCRIPTION
### Motivation
In current JournalChannel implementation, it create fileChannelProvider instance every time, which is unnecessary.
https://github.com/apache/bookkeeper/blob/4debbbf84db09f80ffeb4154e8e6feed134be0c0/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java#L162

### Changes
Create fileChannelProvider in Journal creation, avoiding call fileChannelProvider init multiple times.
