### PR TITLE
ISSUE 3044: ETCD tests hang.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,7 @@ allprojects {
         }
         dependencies {
             implementation(enforcedPlatform(depLibs.nettyBom))
+            testImplementation depLibs.log4jSlf4jImpl
         }
         tasks.register('writeClasspath') {
             doLast {

--- a/metadata-drivers/etcd/build.gradle
+++ b/metadata-drivers/etcd/build.gradle
@@ -54,3 +54,6 @@ publishing {
     }
 }
 
+test {
+    forkEvery = 1
+}

--- a/metadata-drivers/etcd/src/test/java/org/apache/bookkeeper/metadata/etcd/testing/EtcdTestBase.java
+++ b/metadata-drivers/etcd/src/test/java/org/apache/bookkeeper/metadata/etcd/testing/EtcdTestBase.java
@@ -31,12 +31,17 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 
 /**
  * A test base that setup etcd cluster for testing.
  */
 @Slf4j
 public abstract class EtcdTestBase {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(120);
 
     protected static EtcdContainer etcdContainer;
 


### PR DESCRIPTION

Descriptions of the changes in this PR:

### Motivation

ETCD test flake / hang occasionally causing CI job timeout.

### Changes

Added global timeout - kill test early if hanged
fork tests jvm - I think it helped locally (no repro) but possibly just reduced frequency of hangs 
fixed noop slf4j warning, also to see log in case of hang 

Master Issue: #3044

