### PR TITLE
Optimize memory：Support shrinking in ConcurrentLongLongPairHashMap

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
@@ -77,7 +77,11 @@ public class ReadCache implements Closeable {
 
         for (int i = 0; i < segmentsCount; i++) {
             cacheSegments.add(Unpooled.directBuffer(segmentSize, segmentSize));
-            cacheIndexes.add(new ConcurrentLongLongPairHashMap(4096, 2 * Runtime.getRuntime().availableProcessors()));
+            ConcurrentLongLongPairHashMap concurrentLongLongPairHashMap = ConcurrentLongLongPairHashMap.newBuilder()
+                    .expectedItems(4096)
+                    .concurrencyLevel(2 * Runtime.getRuntime().availableProcessors())
+                    .build();
+            cacheIndexes.add(concurrentLongLongPairHashMap);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
@@ -60,8 +60,10 @@ public class WriteCache implements Closeable {
         void accept(long ledgerId, long entryId, ByteBuf entry);
     }
 
-    private final ConcurrentLongLongPairHashMap index =
-            new ConcurrentLongLongPairHashMap(4096, 2 * Runtime.getRuntime().availableProcessors());
+    private final ConcurrentLongLongPairHashMap index = ConcurrentLongLongPairHashMap.newBuilder()
+            .expectedItems(4096)
+            .concurrencyLevel(2 * Runtime.getRuntime().availableProcessors())
+            .build();
 
     private final ConcurrentLongLongHashMap lastEntryMap =
             new ConcurrentLongLongHashMap(4096, 2 * Runtime.getRuntime().availableProcessors());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -90,11 +90,13 @@ public class ConcurrentLongLongPairHashMap {
         }
 
         public Builder expandFactor(float expandFactor) {
+            checkBiggerN(expandFactor, 1);
             this.expandFactor = expandFactor;
             return this;
         }
 
         public Builder shrinkFactor(float shrinkFactor) {
+            checkBiggerN(shrinkFactor, 1);
             this.shrinkFactor = shrinkFactor;
             return this;
         }
@@ -403,7 +405,7 @@ public class ConcurrentLongLongPairHashMap {
                 if (usedBuckets > resizeThresholdUp) {
                     try {
                         // Expand the hashmap
-                        rehash((int) (capacity * (1 + expandFactor)));
+                        rehash((int) (capacity * expandFactor)));
                     } finally {
                         unlockWrite(stamp);
                     }
@@ -444,7 +446,7 @@ public class ConcurrentLongLongPairHashMap {
                 if (autoShrink && size < resizeThresholdBelow) {
                     try {
                         // shrink the hashmap
-                        rehash((int) (capacity * (1 - shrinkFactor)));
+                        rehash((int) (capacity / shrinkFactor));
                     } finally {
                         unlockWrite(stamp);
                     }
@@ -608,6 +610,12 @@ public class ConcurrentLongLongPairHashMap {
     private static void checkBiggerEqualZero(long n) {
         if (n < 0L) {
             throw new IllegalArgumentException("Keys and values must be >= 0");
+        }
+    }
+
+    private static void checkBiggerN(float m, long n) {
+        if (m <= n) {
+            throw new IllegalArgumentException(String.format("Keys and values must be > %s", n));
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -410,6 +410,8 @@ public class ConcurrentLongLongPairHashMap {
                     table[bucket + 2] = ValueNotFound;
                     table[bucket + 3] = ValueNotFound;
                     --usedBuckets;
+
+                    bucket = (bucket - 4) & (table.length - 1);
                 }
             } else {
                 table[bucket] = DeletedKey;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -474,7 +474,8 @@ public class ConcurrentLongLongPairHashMap {
                 if (autoShrink && size < resizeThresholdBelow) {
                     try {
                         int newCapacity = alignToPowerOfTwo((int) (capacity / shrinkFactor));
-                        if (newCapacity < capacity && newCapacity * mapFillFactor > size) {
+                        int newResizeThresholdUp = (int) (newCapacity * mapFillFactor);
+                        if (newCapacity < capacity && newResizeThresholdUp > size) {
                             // shrink the hashmap
                             rehash(newCapacity);
                         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -320,7 +320,7 @@ public class ConcurrentLongLongPairHashMap {
         Section(int capacity, float mapFillFactor, float mapIdleFactor, boolean autoShrink,
                 float expandFactor, float shrinkFactor) {
             this.capacity = alignToPowerOfTwo(capacity);
-            this.initCapacity = capacity;
+            this.initCapacity = this.capacity;
             this.table = new long[4 * this.capacity];
             this.size = 0;
             this.usedBuckets = 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -405,7 +405,7 @@ public class ConcurrentLongLongPairHashMap {
                 if (usedBuckets > resizeThresholdUp) {
                     try {
                         // Expand the hashmap
-                        rehash((int) (capacity * expandFactor)));
+                        rehash((int) (capacity * expandFactor));
                     } finally {
                         unlockWrite(stamp);
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -306,6 +306,7 @@ public class ConcurrentLongLongPairHashMap {
         private volatile long[] table;
 
         private volatile int capacity;
+        private final int initCapacity;
         private volatile int size;
         private int usedBuckets;
         private int resizeThresholdUp;
@@ -319,6 +320,7 @@ public class ConcurrentLongLongPairHashMap {
         Section(int capacity, float mapFillFactor, float mapIdleFactor, boolean autoShrink,
                 float expandFactor, float shrinkFactor) {
             this.capacity = alignToPowerOfTwo(capacity);
+            this.initCapacity = capacity;
             this.table = new long[4 * this.capacity];
             this.size = 0;
             this.usedBuckets = 0;
@@ -523,6 +525,9 @@ public class ConcurrentLongLongPairHashMap {
                 Arrays.fill(table, EmptyKey);
                 this.size = 0;
                 this.usedBuckets = 0;
+                if (autoShrink) {
+                    rehash(initCapacity);
+                }
             } finally {
                 unlockWrite(stamp);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -432,7 +432,8 @@ public class ConcurrentLongLongPairHashMap {
                 if (usedBuckets > resizeThresholdUp) {
                     try {
                         // Expand the hashmap
-                        rehash((int) (capacity * expandFactor));
+                        int newCapacity = alignToPowerOfTwo((int) (capacity * expandFactor));
+                        rehash(newCapacity);
                     } finally {
                         unlockWrite(stamp);
                     }
@@ -472,8 +473,11 @@ public class ConcurrentLongLongPairHashMap {
             } finally {
                 if (autoShrink && size < resizeThresholdBelow) {
                     try {
-                        // shrink the hashmap
-                        rehash((int) Math.max(size / mapFillFactor, capacity / shrinkFactor));
+                        int newCapacity = alignToPowerOfTwo((int) (capacity / shrinkFactor));
+                        if (newCapacity < capacity && newCapacity * mapFillFactor > size) {
+                            // shrink the hashmap
+                            rehash(newCapacity);
+                        }
                     } finally {
                         unlockWrite(stamp);
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -178,36 +178,6 @@ public class ConcurrentLongLongPairHashMap {
         }
     }
 
-    public void setMapFillFactor(float mapFillFactor) {
-        for (int i = 0; i < sections.length; i++) {
-            sections[i].setMapFillFactor(mapFillFactor);
-        }
-    }
-
-    public void setMapIdleFactor(float mapIdleFactor) {
-        for (int i = 0; i < sections.length; i++) {
-            sections[i].setMapIdleFactor(mapIdleFactor);
-        }
-    }
-
-    public void setExpandFactor(float expandFactor) {
-        for (int i = 0; i < sections.length; i++) {
-            sections[i].setExpandFactor(expandFactor);
-        }
-    }
-
-    public void setShrinkFactor(float shrinkFactor) {
-        for (int i = 0; i < sections.length; i++) {
-            sections[i].setShrinkFactor(shrinkFactor);
-        }
-    }
-
-    public void setAutoShrink(boolean autoShrink) {
-        for (int i = 0; i < sections.length; i++) {
-            sections[i].setAutoShrink(autoShrink);
-        }
-    }
-
     public long size() {
         long size = 0;
         for (Section s : sections) {
@@ -234,7 +204,7 @@ public class ConcurrentLongLongPairHashMap {
         return true;
     }
 
-    public long getUsedBucketCount() {
+    long getUsedBucketCount() {
         long usedBucketCount = 0;
         for (Section s : sections) {
             usedBucketCount += s.usedBuckets;
@@ -337,14 +307,14 @@ public class ConcurrentLongLongPairHashMap {
 
         private volatile int capacity;
         private volatile int size;
-        private volatile int usedBuckets;
+        private int usedBuckets;
         private int resizeThresholdUp;
         private int resizeThresholdBelow;
-        private volatile float mapFillFactor;
-        private volatile float mapIdleFactor;
-        private volatile float expandFactor;
-        private volatile float shrinkFactor;
-        private volatile boolean autoShrink;
+        private final float mapFillFactor;
+        private final float mapIdleFactor;
+        private final float expandFactor;
+        private final float shrinkFactor;
+        private final boolean autoShrink;
 
         Section(int capacity, float mapFillFactor, float mapIdleFactor, boolean autoShrink,
                 float expandFactor, float shrinkFactor) {
@@ -360,36 +330,6 @@ public class ConcurrentLongLongPairHashMap {
             this.resizeThresholdUp = (int) (this.capacity * mapFillFactor);
             this.resizeThresholdBelow = (int) (this.capacity * mapIdleFactor);
             Arrays.fill(table, EmptyKey);
-        }
-
-        public void setMapFillFactor(float mapFillFactor) {
-            checkArgument(mapFillFactor > 0 && mapFillFactor < 1);
-            checkArgument(mapFillFactor > mapIdleFactor);
-
-            this.mapFillFactor = mapFillFactor;
-            this.resizeThresholdUp = (int) (this.capacity * mapFillFactor);
-        }
-
-        public void setMapIdleFactor(float mapIdleFactor) {
-            checkArgument(mapIdleFactor > 0 && mapIdleFactor < 1);
-            checkArgument(mapFillFactor > mapIdleFactor);
-
-            this.mapIdleFactor = mapIdleFactor;
-            this.resizeThresholdBelow = (int) (this.capacity * mapIdleFactor);
-        }
-
-        public void setExpandFactor(float expandFactor) {
-            checkArgument(mapIdleFactor > 1);
-            this.expandFactor = expandFactor;
-        }
-
-        public void setShrinkFactor(float shrinkFactor) {
-            checkArgument(shrinkFactor > 1);
-            this.shrinkFactor = shrinkFactor;
-        }
-
-        public void setAutoShrink(boolean autoShrink) {
-            this.autoShrink = autoShrink;
         }
 
         LongPair get(long key1, long key2, int keyHash) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -359,26 +359,23 @@ public class ConcurrentLongLongPairHashMap {
             this.shrinkFactor = shrinkFactor;
             this.resizeThresholdUp = (int) (this.capacity * mapFillFactor);
             this.resizeThresholdBelow = (int) (this.capacity * mapIdleFactor);
-            checkArgument(resizeThresholdBelow > 0 && resizeThresholdUp > resizeThresholdBelow);
             Arrays.fill(table, EmptyKey);
         }
 
         public void setMapFillFactor(float mapFillFactor) {
             checkArgument(mapFillFactor > 0 && mapFillFactor < 1);
-            int resizeThresholdUpTmp = (int) (this.capacity * mapFillFactor);
-            checkArgument(resizeThresholdUpTmp > 0 && resizeThresholdUpTmp > this.resizeThresholdBelow);
+            checkArgument(mapFillFactor > mapIdleFactor);
 
             this.mapFillFactor = mapFillFactor;
-            this.resizeThresholdUp = resizeThresholdUpTmp;
+            this.resizeThresholdUp = (int) (this.capacity * mapFillFactor);
         }
 
         public void setMapIdleFactor(float mapIdleFactor) {
             checkArgument(mapIdleFactor > 0 && mapIdleFactor < 1);
-            int resizeThresholdBelowTmp = (int) (this.capacity * mapIdleFactor);
-            checkArgument(resizeThresholdBelowTmp > 0 && resizeThresholdBelowTmp < this.resizeThresholdUp);
+            checkArgument(mapFillFactor > mapIdleFactor);
 
             this.mapIdleFactor = mapIdleFactor;
-            this.resizeThresholdBelow = resizeThresholdBelowTmp;
+            this.resizeThresholdBelow = (int) (this.capacity * mapIdleFactor);
         }
 
         public void setExpandFactor(float expandFactor) {
@@ -533,11 +530,10 @@ public class ConcurrentLongLongPairHashMap {
                 }
 
             } finally {
-                if (autoShrink && size < resizeThresholdBelow
-                        && resizeThresholdUp > resizeThresholdBelow) {
+                if (autoShrink && size < resizeThresholdBelow) {
                     try {
                         // shrink the hashmap
-                        rehash((int) Math.max(resizeThresholdUp, capacity / shrinkFactor));
+                        rehash((int) Math.max(size / mapFillFactor, capacity / shrinkFactor));
                     } finally {
                         unlockWrite(stamp);
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -233,7 +233,7 @@ public class ConcurrentLongLongPairHashMap {
         return true;
     }
 
-    long getUsedBucketCount() {
+    public long getUsedBucketCount() {
         long usedBucketCount = 0;
         for (Section s : sections) {
             usedBucketCount += s.usedBuckets;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -404,7 +404,7 @@ public class ConcurrentLongLongPairHashMap {
 
                 // Reduce unnecessary rehash
                 bucket = (bucket - 4) & (table.length - 1);
-                while(table[bucket] == DeletedKey){
+                while (table[bucket] == DeletedKey) {
                     table[bucket] = EmptyKey;
                     table[bucket + 1] = EmptyKey;
                     table[bucket + 2] = ValueNotFound;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.StampedLock;
 
+import lombok.Data;
+
 /**
  * Concurrent hash map where both keys and values are composed of pairs of longs.
  *
@@ -175,6 +177,36 @@ public class ConcurrentLongLongPairHashMap {
         }
     }
 
+    public void setMapFillFactor(float mapFillFactor) {
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].setMapFillFactor(mapFillFactor);
+        }
+    }
+
+    public void setMapIdleFactor(float mapIdleFactor) {
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].setMapIdleFactor(mapIdleFactor);
+        }
+    }
+
+    public void setExpandFactor(float expandFactor) {
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].setExpandFactor(expandFactor);
+        }
+    }
+
+    public void setShrinkFactor(float shrinkFactor) {
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].setShrinkFactor(shrinkFactor);
+        }
+    }
+
+    public void setAutoShrink(boolean autoShrink) {
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].setAutoShrink(autoShrink);
+        }
+    }
+
     public long size() {
         long size = 0;
         for (Section s : sections) {
@@ -297,6 +329,7 @@ public class ConcurrentLongLongPairHashMap {
     }
 
     // A section is a portion of the hash map that is covered by a single
+    @Data
     @SuppressWarnings("serial")
     private static final class Section extends StampedLock {
         // Keys and values are stored interleaved in the table array
@@ -304,14 +337,14 @@ public class ConcurrentLongLongPairHashMap {
 
         private volatile int capacity;
         private volatile int size;
-        private int usedBuckets;
+        private volatile int usedBuckets;
         private int resizeThresholdUp;
         private int resizeThresholdBelow;
-        private final float mapFillFactor;
-        private final float mapIdleFactor;
-        private final float expandFactor;
-        private final float shrinkFactor;
-        private final boolean autoShrink;
+        private volatile float mapFillFactor;
+        private volatile float mapIdleFactor;
+        private volatile float expandFactor;
+        private volatile float shrinkFactor;
+        private volatile boolean autoShrink;
 
         Section(int capacity, float mapFillFactor, float mapIdleFactor, boolean autoShrink,
                 float expandFactor, float shrinkFactor) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.StampedLock;
 
-import lombok.Data;
+import lombok.Setter;
 
 /**
  * Concurrent hash map where both keys and values are composed of pairs of longs.
@@ -329,7 +329,7 @@ public class ConcurrentLongLongPairHashMap {
     }
 
     // A section is a portion of the hash map that is covered by a single
-    @Data
+    @Setter
     @SuppressWarnings("serial")
     private static final class Section extends StampedLock {
         // Keys and values are stored interleaved in the table array

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -311,7 +311,7 @@ public class ConcurrentLongLongPairHashMap {
         private final float mapIdleFactor;
         private final float expandFactor;
         private final float shrinkFactor;
-        private boolean autoShrink;
+        private final boolean autoShrink;
 
         Section(int capacity, float mapFillFactor, float mapIdleFactor, boolean autoShrink,
                 float expandFactor, float shrinkFactor) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -131,7 +131,8 @@ public class ConcurrentLongLongPairHashMap {
         boolean test(long key1, long key2, long value1, long value2);
     }
 
-    private ConcurrentLongLongPairHashMap(int expectedItems, int concurrencyLevel, float mapFillFactor, float mapIdleFactor,
+    private ConcurrentLongLongPairHashMap(int expectedItems, int concurrencyLevel,
+                                          float mapFillFactor, float mapIdleFactor,
                                          boolean autoShrink, float expandFactor, float shrinkFactor) {
         checkArgument(expectedItems > 0);
         checkArgument(concurrencyLevel > 0);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -401,6 +401,16 @@ public class ConcurrentLongLongPairHashMap {
                 table[bucket + 2] = ValueNotFound;
                 table[bucket + 3] = ValueNotFound;
                 --usedBuckets;
+
+                // Reduce unnecessary rehash
+                bucket = (bucket - 4) & (table.length - 1);
+                while(table[bucket] == DeletedKey){
+                    table[bucket] = EmptyKey;
+                    table[bucket + 1] = EmptyKey;
+                    table[bucket + 2] = ValueNotFound;
+                    table[bucket + 3] = ValueNotFound;
+                    --usedBuckets;
+                }
             } else {
                 table[bucket] = DeletedKey;
                 table[bucket + 1] = DeletedKey;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -51,6 +51,14 @@ public class ConcurrentLongLongPairHashMap {
     private static final int DefaultExpectedItems = 256;
     private static final int DefaultConcurrencyLevel = 16;
 
+    private static final float DefaultMapFillFactor = 0.66f;
+    private static final float DefaultMapIdleFactor = 0.15f;
+
+    private static final float DefaultExpandFactor = 2;
+    private static final float DefaultShrinkFactor = 2;
+
+    private static final boolean DefaultAutoShrink = false;
+
     private final Section[] sections;
 
     public static Builder newBuilder() {
@@ -63,11 +71,11 @@ public class ConcurrentLongLongPairHashMap {
     public static class Builder {
         int expectedItems = DefaultExpectedItems;
         int concurrencyLevel = DefaultConcurrencyLevel;
-        float mapFillFactor = 0.66f;
-        float mapIdleFactor = 0.15f;
-        float expandFactor = 2;
-        float shrinkFactor = 2;
-        boolean autoShrink = false;
+        float mapFillFactor = DefaultMapFillFactor;
+        float mapIdleFactor = DefaultMapIdleFactor;
+        float expandFactor = DefaultExpandFactor;
+        float shrinkFactor = DefaultShrinkFactor;
+        boolean autoShrink = DefaultAutoShrink;
 
         public Builder expectedItems(int expectedItems) {
             this.expectedItems = expectedItems;
@@ -131,6 +139,22 @@ public class ConcurrentLongLongPairHashMap {
      */
     public interface LongLongPairPredicate {
         boolean test(long key1, long key2, long value1, long value2);
+    }
+
+    @Deprecated
+    public ConcurrentLongLongPairHashMap() {
+        this(DefaultExpectedItems);
+    }
+
+    @Deprecated
+    public ConcurrentLongLongPairHashMap(int expectedItems) {
+        this(expectedItems, DefaultConcurrencyLevel);
+    }
+
+    @Deprecated
+    public ConcurrentLongLongPairHashMap(int expectedItems, int concurrencyLevel) {
+        this(expectedItems, concurrencyLevel, DefaultMapFillFactor, DefaultMapIdleFactor,
+                DefaultAutoShrink, DefaultExpandFactor, DefaultShrinkFactor);
     }
 
     private ConcurrentLongLongPairHashMap(int expectedItems, int concurrencyLevel,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -176,7 +176,7 @@ public class ConcurrentLongLongPairHashMapTest {
     public void testRehashing() {
         int n = 16;
         ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
-                .expectedItems(n/2)
+                .expectedItems(n / 2)
                 .concurrencyLevel(1)
                 .build();
         assertEquals(map.capacity(), n);
@@ -194,7 +194,7 @@ public class ConcurrentLongLongPairHashMapTest {
     public void testRehashingWithDeletes() {
         int n = 16;
         ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
-                .expectedItems(n/2)
+                .expectedItems(n / 2)
                 .concurrencyLevel(1)
                 .build();
         assertEquals(map.capacity(), n);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -48,21 +48,29 @@ public class ConcurrentLongLongPairHashMapTest {
     @Test
     public void testConstructor() {
         try {
-            new ConcurrentLongLongPairHashMap(0);
+             ConcurrentLongLongPairHashMap.newBuilder()
+                    .expectedItems(0)
+                    .build();
             fail("should have thrown exception");
         } catch (IllegalArgumentException e) {
             // ok
         }
 
         try {
-            new ConcurrentLongLongPairHashMap(16, 0);
+            ConcurrentLongLongPairHashMap.newBuilder()
+                    .expectedItems(16)
+                    .concurrencyLevel(0)
+                    .build();
             fail("should have thrown exception");
         } catch (IllegalArgumentException e) {
             // ok
         }
 
         try {
-            new ConcurrentLongLongPairHashMap(4, 8);
+            ConcurrentLongLongPairHashMap.newBuilder()
+                    .expectedItems(4)
+                    .concurrencyLevel(8)
+                    .build();
             fail("should have thrown exception");
         } catch (IllegalArgumentException e) {
             // ok
@@ -71,8 +79,9 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void simpleInsertions() {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap(16);
-
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .expectedItems(16)
+                .build();
         assertTrue(map.isEmpty());
         assertTrue(map.put(1, 1, 11, 11));
         assertFalse(map.isEmpty());
@@ -99,7 +108,9 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void testRemove() {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap();
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap
+                .newBuilder()
+                .build();
 
         assertTrue(map.isEmpty());
         assertTrue(map.put(1, 1, 11, 11));
@@ -115,7 +126,10 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void testExpandAndShrink() {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap(2, 1);
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .expectedItems(2)
+                .concurrencyLevel(1)
+                .build();
         assertTrue(map.put(1, 1, 11, 11));
         assertTrue(map.put(2, 2, 22, 22));
         assertTrue(map.put(3, 3, 33, 33));
@@ -143,7 +157,10 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void testNegativeUsedBucketCount() {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap(16, 1);
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .expectedItems(16)
+                .concurrencyLevel(1)
+                .build();
 
         map.put(0, 0, 0, 0);
         assertEquals(1, map.getUsedBucketCount());
@@ -158,7 +175,10 @@ public class ConcurrentLongLongPairHashMapTest {
     @Test
     public void testRehashing() {
         int n = 16;
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap(n / 2, 1);
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .expectedItems(n/2)
+                .concurrencyLevel(1)
+                .build();
         assertEquals(map.capacity(), n);
         assertEquals(map.size(), 0);
 
@@ -173,7 +193,10 @@ public class ConcurrentLongLongPairHashMapTest {
     @Test
     public void testRehashingWithDeletes() {
         int n = 16;
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap(n / 2, 1);
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .expectedItems(n/2)
+                .concurrencyLevel(1)
+                .build();
         assertEquals(map.capacity(), n);
         assertEquals(map.size(), 0);
 
@@ -195,7 +218,8 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void concurrentInsertions() throws Throwable {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap();
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .build();
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -234,7 +258,8 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void concurrentInsertionsAndReads() throws Throwable {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap();
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .build();
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -273,7 +298,8 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void testIteration() {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap();
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .build();
 
         assertEquals(map.keys(), Collections.emptyList());
         assertEquals(map.values(), Collections.emptyList());
@@ -316,7 +342,9 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void testPutIfAbsent() {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap();
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .build();
+
         assertTrue(map.putIfAbsent(1, 1, 11, 11));
         assertEquals(map.get(1, 1), new LongPair(11, 11));
 
@@ -326,7 +354,11 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void testIvalidKeys() {
-        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap(16, 1);
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .expectedItems(16)
+                .concurrencyLevel(1)
+                .build();
+
 
         try {
             map.put(-5, 3, 4, 4);
@@ -359,7 +391,10 @@ public class ConcurrentLongLongPairHashMapTest {
 
     @Test
     public void testAsMap() {
-        ConcurrentLongLongPairHashMap lmap = new ConcurrentLongLongPairHashMap(16, 1);
+        ConcurrentLongLongPairHashMap lmap = ConcurrentLongLongPairHashMap.newBuilder()
+                .expectedItems(16)
+                .concurrencyLevel(1)
+                .build();
         lmap.put(1, 1, 11, 11);
         lmap.put(2, 2, 22, 22);
         lmap.put(3, 3, 33, 33);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -114,6 +114,22 @@ public class ConcurrentLongLongPairHashMapTest {
     }
 
     @Test
+    public void testExpandAndShrink() {
+        ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap(2, 1);
+        assertTrue(map.put(1, 1, 11, 11));
+        assertTrue(map.put(2, 2, 22, 22));
+        assertTrue(map.put(3, 3, 33, 33));
+
+        // expand hashmap
+        assertTrue(map.capacity() == 8);
+
+        assertTrue(map.remove(1, 1, 11, 11));
+        assertFalse(map.remove(2, 2, 22, 22));
+        // shrink hashmap
+        assertTrue(map.capacity() == 4);
+    }
+
+    @Test
     public void testNegativeUsedBucketCount() {
         ConcurrentLongLongPairHashMap map = new ConcurrentLongLongPairHashMap(16, 1);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -129,6 +129,8 @@ public class ConcurrentLongLongPairHashMapTest {
         ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
                 .expectedItems(2)
                 .concurrencyLevel(1)
+                .autoShrink(true)
+                .mapIdleFactor(0.25f)
                 .build();
         assertTrue(map.put(1, 1, 11, 11));
         assertTrue(map.put(2, 2, 22, 22));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -125,6 +125,25 @@ public class ConcurrentLongLongPairHashMapTest {
     }
 
     @Test
+    public void testClear() {
+        ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
+                .expectedItems(2)
+                .concurrencyLevel(1)
+                .autoShrink(true)
+                .mapIdleFactor(0.25f)
+                .build();
+        assertTrue(map.capacity() == 4);
+
+        assertTrue(map.put(1, 1, 11, 11));
+        assertTrue(map.put(2, 2, 22, 22));
+        assertTrue(map.put(3, 3, 33, 33));
+
+        assertTrue(map.capacity() == 8);
+        map.clear();
+        assertTrue(map.capacity() == 4);
+    }
+
+    @Test
     public void testExpandAndShrink() {
         ConcurrentLongLongPairHashMap map = ConcurrentLongLongPairHashMap.newBuilder()
                 .expectedItems(2)

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -124,9 +124,21 @@ public class ConcurrentLongLongPairHashMapTest {
         assertTrue(map.capacity() == 8);
 
         assertTrue(map.remove(1, 1, 11, 11));
+        // not shrink
+        assertTrue(map.capacity() == 8);
         assertTrue(map.remove(2, 2, 22, 22));
         // shrink hashmap
         assertTrue(map.capacity() == 4);
+
+        // expand hashmap
+        assertTrue(map.put(4, 4, 44, 44));
+        assertTrue(map.put(5, 5, 55, 55));
+        assertTrue(map.capacity() == 8);
+
+        //verify that the map does not keep shrinking at every remove() operation
+        assertTrue(map.put(6, 6, 66, 66));
+        assertTrue(map.remove(6, 6, 66, 66));
+        assertTrue(map.capacity() == 8);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -124,7 +124,7 @@ public class ConcurrentLongLongPairHashMapTest {
         assertTrue(map.capacity() == 8);
 
         assertTrue(map.remove(1, 1, 11, 11));
-        assertFalse(map.remove(2, 2, 22, 22));
+        assertTrue(map.remove(2, 2, 22, 22));
         // shrink hashmap
         assertTrue(map.capacity() == 4);
     }


### PR DESCRIPTION
### Motivation
We found that the pulsar broker frequently appeared Full Gc, and found by dumping the heap memory: org.apache.pulsar.broker.service.Consumer#pendingAcks occupies 9.9G of memory. The pendingAcks variable is defined as follows:
![image](https://user-images.githubusercontent.com/19296967/154415440-79c221fd-41cb-4e9c-b847-d20fdfc5a6ae.png)

The heap memory usage is as follows：
![image](https://user-images.githubusercontent.com/19296967/154651860-604ca0b2-c103-4042-9926-26a08ab9edbe.png)


**The old age continues to rise until the FULL GC is triggered, which causes the connection between the broker and the zookeeper to time out, and finally causes the pulsar broker process to exit:**
![image](https://user-images.githubusercontent.com/19296967/154651524-99fa1d3b-90c3-4b0b-bc02-1abb579027c1.png)

Full GC:
![image](https://user-images.githubusercontent.com/19296967/154419489-f3d9f77b-206a-4916-80e5-e41f83b46ba3.png)

zookkepeer session timeout:
![image](https://user-images.githubusercontent.com/19296967/154648138-d1a160d4-bfb2-4d1f-af58-284a48855b33.png)


I found that ConcurrentLongLongPairHashMap only supports expansion, not shrinkage, and most of the memory is not used and wasted.

Of course, this structure is used not only in pulsar, but also in the read and write cache of bookkeeper, which will also lead to a lot of memory waste：
![image](https://user-images.githubusercontent.com/19296967/154415958-fdd8adb3-a4fb-47a7-948d-069a3f02593a.png)



### Changes

When removing, judge whether to shrink. If the current use size is less than resizeThresholdBelow, then shrinking is required.
 if (size < resizeThresholdBelow) {
                    try {
                        // shrink the hashmap
                        rehash(capacity / 2);
                    } finally {
                        unlockWrite(stamp);
                    }
                } else {
                    unlockWrite(stamp);
                }