### PR TITLE
Support isolate read write thread pool

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
@@ -49,6 +49,7 @@ class ClientInternalConf {
     final boolean enableBookieFailureTracking;
     final boolean useV2WireProtocol;
     final boolean enforceMinNumFaultDomainsForWrite;
+    final boolean isolateReadWriteThreadPool;
 
     static ClientInternalConf defaultValues() {
         return fromConfig(new ClientConfiguration());
@@ -83,6 +84,7 @@ class ClientInternalConf {
         this.useV2WireProtocol = conf.getUseV2WireProtocol();
         this.enableStickyReads = conf.isStickyReadsEnabled();
         this.enforceMinNumFaultDomainsForWrite = conf.getEnforceMinNumFaultDomainsForWrite();
+        this.isolateReadWriteThreadPool = conf.getIsolateReadWriteThreadPool();
 
         if (conf.getFirstSpeculativeReadTimeout() > 0) {
             this.readSpeculativeRequestPolicy =

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -516,6 +516,10 @@ public class LedgerHandle implements WriteHandle {
         return !getLedgerMetadata().isClosed() && handleState == HandleState.OPEN;
     }
 
+    boolean isolateReadWriteThreadPool() {
+        return clientCtx.getConf().isolateReadWriteThreadPool;
+    }
+
     void asyncCloseInternal(final CloseCallback cb, final Object ctx, final int rc) {
         try {
             doAsyncCloseInternal(cb, ctx, rc);
@@ -887,7 +891,7 @@ public class LedgerHandle implements WriteHandle {
                 ws.recycle();
             }
 
-            if (isHandleWritable()) {
+            if (isHandleWritable() && !isolateReadWriteThreadPool()) {
                 // Ledger handle in read/write mode: submit to OSE for ordered execution.
                 clientCtx.getMainWorkerPool().executeOrdered(ledgerId, op);
             } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -155,6 +155,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     // Number of Threads
     protected static final String NUM_WORKER_THREADS = "numWorkerThreads";
     protected static final String NUM_IO_THREADS = "numIOThreads";
+    protected static final String ISOLATE_READ_WRITE_THREAD_POOL = "isolateReadWriteThreadPool";
 
     // Ensemble Placement Policy
     public static final String ENSEMBLE_PLACEMENT_POLICY = "ensemblePlacementPolicy";
@@ -897,6 +898,14 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     }
 
     /**
+     * Get whether allows read and write requests to isolate in separate thread pools.
+     * @return
+     */
+    public boolean getIsolateReadWriteThreadPool() {
+        return getBoolean(ISOLATE_READ_WRITE_THREAD_POOL, false);
+    }
+
+    /**
      * Set the number of IO threads.
      *
      * <p>
@@ -914,6 +923,16 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
      */
     public ClientConfiguration setNumIOThreads(int numThreads) {
         setProperty(NUM_IO_THREADS, numThreads);
+        return this;
+    }
+
+    /**
+     * Set whether allows read and write requests to isolate in separate thread pools.
+     * @param isolateThreadPool
+     * @return
+     */
+    public ClientConfiguration setIsolateReadWriteThreadPool(boolean isolateThreadPool) {
+        setProperty(ISOLATE_READ_WRITE_THREAD_POOL, isolateThreadPool);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -287,6 +287,20 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
     }
 
     @Test
+    public void testIsolateReadWriteThreadPool() throws Exception {
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        conf.setIsolateReadWriteThreadPool(true);
+
+        BookKeeper bkc = new BookKeeper(conf);
+        LedgerHandle lh = bkc.createLedger(digestType, "testPasswd".getBytes());
+        assertTrue(lh.isolateReadWriteThreadPool());
+
+        lh.close();
+        bkc.close();
+    }
+
+    @Test
     public void testReadFailureCallback() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
         conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());


### PR DESCRIPTION
fix #3003
### Motivation
Now , when the Ledger is in the `Writable` state, the read and write of BookkeeperClient share the same orderExecutor. 
But, we can not guarantee that the data is not read from disk. 
In order to avoid reading from affecting writing, we need to add a configuration item to allow read and write requests to use different thread pools

### Changes
Add a param to support isolate read write thread pool.

