### PR TITLE
ISSUE 2898: DistributedLogManager can skip over a segment on read.

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadAheadEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadAheadEntryReader.java
@@ -608,7 +608,7 @@ class ReadAheadEntryReader implements
 
         if (cause instanceof EndOfLogSegmentException) {
             // we reach end of the log segment
-            moveToNextLogSegment();
+            moveToNextLogSegment(currentSegmentReader);
             return;
         }
         if (cause instanceof IOException) {
@@ -906,11 +906,15 @@ class ReadAheadEntryReader implements
         return true;
     }
 
-    void moveToNextLogSegment() {
+    void moveToNextLogSegment(final SegmentReader prevSegmentReader) {
         orderedSubmit(new CloseableRunnable() {
             @Override
             public void safeRun() {
-                unsafeMoveToNextLogSegment();
+                // Do not move forward if previous enqueued runnable
+                // already moved the segment forward.
+                if (prevSegmentReader == currentSegmentReader) {
+                    unsafeMoveToNextLogSegment();
+                }
             }
         });
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:
### Motivation

DLM test suite was flaky.
Repro/troubleshooting shows that DLM can skip over a data segment on read.

### Changes

Test + fix (don't move segment if it moved already).

Master Issue: #2898 

