### PR TITLE
Add sizeInBytes interface for ConcurrentLong map and set

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
@@ -85,6 +85,14 @@ public class ConcurrentLongHashSet {
         return size;
     }
 
+    public long sizeInBytes() {
+        long size = 0;
+        for (Section s : sections) {
+            size += (long) s.table.length * Long.BYTES;
+        }
+        return size;
+    }
+
     public long capacity() {
         long capacity = 0;
         for (Section s : sections) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
@@ -106,6 +106,14 @@ public class ConcurrentLongLongHashMap {
         return size;
     }
 
+    public long sizeInBytes() {
+        long size = 0;
+        for (Section s : sections) {
+            size += (long) s.table.length * Long.BYTES;
+        }
+        return size;
+    }
+
     public long capacity() {
         long capacity = 0;
         for (Section s : sections) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -106,6 +106,14 @@ public class ConcurrentLongLongPairHashMap {
         return size;
     }
 
+    public long sizeInBytes() {
+        long size = 0;
+        for (Section s : sections) {
+            size += (long) s.table.length * Long.BYTES;
+        }
+        return size;
+    }
+
     public long capacity() {
         long capacity = 0;
         for (Section s : sections) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSetTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSetTest.java
@@ -275,4 +275,24 @@ public class ConcurrentLongHashSetTest {
         assertTrue(set.isEmpty());
     }
 
+    @Test
+    public void testSizeInBytes() {
+        ConcurrentLongHashSet set = new ConcurrentLongHashSet(4, 2);
+        assertEquals(64, set.sizeInBytes());
+        set.add(1);
+        assertEquals(64, set.sizeInBytes());
+        set.add(2);
+        assertEquals(64, set.sizeInBytes());
+        set.add(3);
+        assertEquals(64, set.sizeInBytes());
+        set.add(4);
+        assertEquals(96, set.sizeInBytes());
+        set.add(5);
+        assertEquals(96, set.sizeInBytes());
+        set.add(6);
+        assertEquals(128, set.sizeInBytes());
+        set.add(7);
+        assertEquals(128, set.sizeInBytes());
+    }
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMapTest.java
@@ -473,4 +473,24 @@ public class ConcurrentLongLongHashMapTest {
 
         assertEquals(map, lmap.asMap());
     }
+
+    @Test
+    public void testSizeInBytes() {
+        ConcurrentLongLongHashMap lmap = new ConcurrentLongLongHashMap(4, 2);
+        assertEquals(128, lmap.sizeInBytes());
+        lmap.put(1, 1);
+        assertEquals(128, lmap.sizeInBytes());
+        lmap.put(2, 2);
+        assertEquals(128, lmap.sizeInBytes());
+        lmap.put(3, 3);
+        assertEquals(128, lmap.sizeInBytes());
+        lmap.put(4, 4);
+        assertEquals(192, lmap.sizeInBytes());
+        lmap.put(5, 5);
+        assertEquals(192, lmap.sizeInBytes());
+        lmap.put(6, 6);
+        assertEquals(256, lmap.sizeInBytes());
+        lmap.put(7, 7);
+        assertEquals(256, lmap.sizeInBytes());
+    }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMapTest.java
@@ -343,4 +343,24 @@ public class ConcurrentLongLongPairHashMapTest {
 
         assertEquals(map, lmap.asMap());
     }
+
+    @Test
+    public void testSizeInBytes() {
+        ConcurrentLongLongPairHashMap lmap = new ConcurrentLongLongPairHashMap(4, 2);
+        assertEquals(256, lmap.sizeInBytes());
+        lmap.put(1, 1, 1, 1);
+        assertEquals(256, lmap.sizeInBytes());
+        lmap.put(2, 2, 2, 2);
+        assertEquals(256, lmap.sizeInBytes());
+        lmap.put(3, 3, 3, 3);
+        assertEquals(256, lmap.sizeInBytes());
+        lmap.put(4, 4, 4, 4);
+        assertEquals(256, lmap.sizeInBytes());
+        lmap.put(5, 5, 5, 5);
+        assertEquals(384, lmap.sizeInBytes());
+        lmap.put(6, 6, 6, 6);
+        assertEquals(512, lmap.sizeInBytes());
+        lmap.put(7, 7, 7, 7);
+        assertEquals(512, lmap.sizeInBytes());
+    }
 }


### PR DESCRIPTION
### Motivation
We provide some concurrent maps and sets for specific usage, and provide size() and capacity() interface for user to get the real item number and the max item number. 

However, if user want to monitor how much memory those current maps and set allocated, there is not interface to expose this metric.

### Changes
Add `sizeInBytes()` interface to expose the memory size has been allocated for those concurrent maps and sets.

