### PR TITLE
Fix gradle publishToMavenLocal failed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,6 +328,12 @@ allprojects {
             implementation(enforcedPlatform(depLibs.guavaBom))
         }
 
+        tasks.withType(GenerateModuleMetadata).configureEach {
+            // The value 'enforced-platform' is provided in the validation
+            // error message you got
+            suppressedValidationErrors.add('enforced-platform')
+        }
+
     }
 
     repositories {


### PR DESCRIPTION
### Motivation
When run command `./gradlew publishToMavenLocal` to publish jars to local maven repository, it failed with the following exception.
```
Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetadataWarningsFor(variant)'):
  - Variant testFixturesApiElements:
      - Declares capability bookkeeper:bookkeeper-common-test-fixtures:unspecified which cannot be mapped to Maven
  - Variant testFixturesRuntimeElements:
      - Declares capability bookkeeper:bookkeeper-common-test-fixtures:unspecified which cannot be mapped to Maven
These issues indicate information that is lost in the published 'pom' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Maven.
The 'module' metadata file, which is used by Gradle 6+ is not affected.
> Task :generateMetadataFileForMavenPublication FAILED

FAILURE: Build failed with an exception.

```

### Changes
Disable the validation errors.
Refer to: https://docs.gradle.org/7.3.3/userguide/publishing_setup.html#sec:suppressing_validation_errors