### PR TITLE
Fix publish do not include test jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,6 +258,7 @@ allprojects {
                     version = buildVersion
 
                     from components.java
+                    artifact testJar
                 }
             }
         }


### PR DESCRIPTION
### Motivation
When use `./gradlew publishToMavenLocal` command to publish jars to local maven repository, it doesn't include test jars.

### Changes
When publish, including the test jars.