### PR TITLE
reduce unnecessary expansions for  ConcurrentLong map and set

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -378,7 +378,8 @@ public class ConcurrentLongHashMap<V> {
                                 values[bucket] = (V) EmptyValue;
                                 --usedBuckets;
 
-                                // Cleanup all the buckets that were in `DeletedValue` state, so that we can reduce unnecessary expansions
+                                // Cleanup all the buckets that were in `DeletedValue` state,
+                                // so that we can reduce unnecessary expansions
                                 int lastBucket = signSafeMod(bucket - 1, capacity);
                                 while (values[lastBucket] == DeletedValue) {
                                     values[lastBucket] = (V) EmptyValue;
@@ -428,6 +429,16 @@ public class ConcurrentLongHashMap<V> {
                             if (nextValueInArray == EmptyValue) {
                                 values[bucket] = (V) EmptyValue;
                                 --usedBuckets;
+
+                                // Cleanup all the buckets that were in `DeletedValue` state,
+                                // so that we can reduce unnecessary expansions
+                                int lastBucket = signSafeMod(bucket - 1, capacity);
+                                while (values[lastBucket] == DeletedValue) {
+                                    values[lastBucket] = (V) EmptyValue;
+                                    --usedBuckets;
+
+                                    lastBucket = signSafeMod(--lastBucket, capacity);
+                                }
                             } else {
                                 values[bucket] = (V) DeletedValue;
                             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -355,6 +355,18 @@ public class ConcurrentLongHashMap<V> {
             }
         }
 
+        private void cleanDeletedStatus(int startBucket) {
+            // Cleanup all the buckets that were in `DeletedValue` state,
+            // so that we can reduce unnecessary expansions
+            int lastBucket = signSafeMod(startBucket - 1, capacity);
+            while (values[lastBucket] == DeletedValue) {
+                values[lastBucket] = (V) EmptyValue;
+                --usedBuckets;
+
+                lastBucket = signSafeMod(--lastBucket, capacity);
+            }
+        }
+
         private V remove(long key, Object value, int keyHash) {
             int bucket = keyHash;
             long stamp = writeLock();
@@ -378,15 +390,7 @@ public class ConcurrentLongHashMap<V> {
                                 values[bucket] = (V) EmptyValue;
                                 --usedBuckets;
 
-                                // Cleanup all the buckets that were in `DeletedValue` state,
-                                // so that we can reduce unnecessary expansions
-                                int lastBucket = signSafeMod(bucket - 1, capacity);
-                                while (values[lastBucket] == DeletedValue) {
-                                    values[lastBucket] = (V) EmptyValue;
-                                    --usedBuckets;
-
-                                    lastBucket = signSafeMod(--lastBucket, capacity);
-                                }
+                                cleanDeletedStatus(bucket);
                             } else {
                                 values[bucket] = (V) DeletedValue;
                             }
@@ -430,15 +434,7 @@ public class ConcurrentLongHashMap<V> {
                                 values[bucket] = (V) EmptyValue;
                                 --usedBuckets;
 
-                                // Cleanup all the buckets that were in `DeletedValue` state,
-                                // so that we can reduce unnecessary expansions
-                                int lastBucket = signSafeMod(bucket - 1, capacity);
-                                while (values[lastBucket] == DeletedValue) {
-                                    values[lastBucket] = (V) EmptyValue;
-                                    --usedBuckets;
-
-                                    lastBucket = signSafeMod(--lastBucket, capacity);
-                                }
+                                cleanDeletedStatus(bucket);
                             } else {
                                 values[bucket] = (V) DeletedValue;
                             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -377,6 +377,15 @@ public class ConcurrentLongHashMap<V> {
                             if (nextValueInArray == EmptyValue) {
                                 values[bucket] = (V) EmptyValue;
                                 --usedBuckets;
+
+                                // Cleanup all the buckets that were in `DeletedValue` state, so that we can reduce unnecessary expansions
+                                int lastBucket = signSafeMod(bucket - 1, capacity);
+                                while (values[lastBucket] == DeletedValue) {
+                                    values[lastBucket] = (V) EmptyValue;
+                                    --usedBuckets;
+
+                                    lastBucket = signSafeMod(--lastBucket, capacity);
+                                }
                             } else {
                                 values[bucket] = (V) DeletedValue;
                             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
@@ -305,6 +305,15 @@ public class ConcurrentLongHashSet {
             if (table[nextInArray] == EmptyItem) {
                 table[bucket] = EmptyItem;
                 --usedBuckets;
+
+                // Cleanup all the buckets that were in `DeletedKey` state, so that we can reduce unnecessary expansions
+                bucket = (bucket - 1) & (table.length - 1);
+                while (table[bucket] == DeletedItem) {
+                    table[bucket] = EmptyItem;
+                    --usedBuckets;
+
+                    bucket = (bucket - 1) & (table.length - 1);
+                }
             } else {
                 table[bucket] = DeletedItem;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
@@ -306,7 +306,8 @@ public class ConcurrentLongHashSet {
                 table[bucket] = EmptyItem;
                 --usedBuckets;
 
-                // Cleanup all the buckets that were in `DeletedKey` state, so that we can reduce unnecessary expansions
+                // Cleanup all the buckets that were in `DeletedKey` state,
+                // so that we can reduce unnecessary expansions
                 bucket = (bucket - 1) & (table.length - 1);
                 while (table[bucket] == DeletedItem) {
                     table[bucket] = EmptyItem;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
@@ -608,6 +608,16 @@ public class ConcurrentLongLongHashMap {
                 table[bucket] = EmptyKey;
                 table[bucket + 1] = ValueNotFound;
                 --usedBuckets;
+
+                // Cleanup all the buckets that were in `DeletedKey` state, so that we can reduce unnecessary expansions
+                bucket = (bucket - 2) & (table.length - 1);
+                while (table[bucket] == DeletedKey) {
+                    table[bucket] = EmptyKey;
+                    table[bucket + 1] = ValueNotFound;
+                    --usedBuckets;
+
+                    bucket = (bucket - 2) & (table.length - 1);
+                }
             } else {
                 table[bucket] = DeletedKey;
                 table[bucket + 1] = ValueNotFound;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -499,7 +499,8 @@ public class ConcurrentLongLongPairHashMap {
                 table[bucket + 3] = ValueNotFound;
                 --usedBuckets;
 
-                // Cleanup all the buckets that were in `DeletedKey` state, so that we can reduce unnecessary expansions
+                // Cleanup all the buckets that were in `DeletedKey` state,
+                // so that we can reduce unnecessary expansions
                 bucket = (bucket - 4) & (table.length - 1);
                 while (table[bucket] == DeletedKey) {
                     table[bucket] = EmptyKey;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
@@ -429,6 +429,16 @@ public class ConcurrentOpenHashMap<K, V> {
                 table[bucket] = EmptyKey;
                 table[bucket + 1] = null;
                 --usedBuckets;
+
+                // Cleanup all the buckets that were in `DeletedKey` state, so that we can reduce unnecessary expansions
+                bucket = (bucket - 2) & (table.length - 1);
+                while (table[bucket] == DeletedKey) {
+                    table[bucket] = EmptyKey;
+                    table[bucket + 1] = null;
+                    --usedBuckets;
+
+                    bucket = (bucket - 2) & (table.length - 1);
+                }
             } else {
                 table[bucket] = DeletedKey;
                 table[bucket + 1] = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
@@ -430,7 +430,8 @@ public class ConcurrentOpenHashMap<K, V> {
                 table[bucket + 1] = null;
                 --usedBuckets;
 
-                // Cleanup all the buckets that were in `DeletedKey` state, so that we can reduce unnecessary expansions
+                // Cleanup all the buckets that were in `DeletedKey` state,
+                // so that we can reduce unnecessary expansions
                 bucket = (bucket - 2) & (table.length - 1);
                 while (table[bucket] == DeletedKey) {
                     table[bucket] = EmptyKey;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
@@ -286,7 +286,8 @@ public class ConcurrentOpenHashSet<V> {
                             values[bucket] = (V) EmptyValue;
                             --usedBuckets;
 
-                            // Cleanup all the buckets that were in `DeletedValue` state, so that we can reduce unnecessary expansions
+                            // Cleanup all the buckets that were in `DeletedValue` state,
+                            // so that we can reduce unnecessary expansions
                             int lastBucket = signSafeMod(bucket - 1, capacity);
                             while (values[bucket] == DeletedValue) {
                                 values[bucket] = (V) EmptyValue;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
@@ -285,6 +285,15 @@ public class ConcurrentOpenHashSet<V> {
                         if (values[nextInArray] == EmptyValue) {
                             values[bucket] = (V) EmptyValue;
                             --usedBuckets;
+
+                            // Cleanup all the buckets that were in `DeletedValue` state, so that we can reduce unnecessary expansions
+                            int lastBucket = signSafeMod(bucket - 1, capacity);
+                            while (values[bucket] == DeletedValue) {
+                                values[bucket] = (V) EmptyValue;
+                                --usedBuckets;
+
+                                lastBucket = signSafeMod(--lastBucket, capacity);
+                            }
                         } else {
                             values[bucket] = (V) DeletedValue;
                         }


### PR DESCRIPTION
### Motivation
Cleanup all the buckets that were in Deleted state, so that we can reduce unnecessary expansions.

### Changes
when removing，Cleanup all the buckets that were in Deleted state.