### PR TITLE
[ci] remaining-tests is running all the tests

### DIFF
--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Run remaining tests
-        run: ./gradlew bookkeeper-server:test -PexcludeTests="*org.apache.bookkeeper.bookie.*, *org.apache.bookkeeper.client.*, *org.apache.bookkeeper.replication.*, *org.apache.bookkeeper.tls.*" ${GRADLE_ARGS}
+        run: ./gradlew bookkeeper-server:test -PexcludeTests="**/org/apache/bookkeeper/bookie/*, **/org/apache/bookkeeper/client.*, **/org/apache/bookkeeper/replication/*, **/org/apache/bookkeeper/tls/*" ${GRADLE_ARGS}
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()


### PR DESCRIPTION
### Motivation

The 'remaining-tests' is supposed to exclude a lot of tests covered by the other checks but the syntax used is wrong

### Changes

* Correctly excluded all the tests not needed in 'remaining-tests' suite
