### PR TITLE
fix reduce  unnecessary expansions

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
@@ -169,6 +169,14 @@ public class ConcurrentOpenHashSet<V> {
         return capacity;
     }
 
+    long getUsedBucketCount() {
+        long usedBucketCount = 0;
+        for (Section<V> s : sections) {
+            usedBucketCount += s.usedBuckets;
+        }
+        return usedBucketCount;
+    }
+
     public boolean isEmpty() {
         for (Section<V> s : sections) {
             if (s.size != 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
@@ -385,8 +385,8 @@ public class ConcurrentOpenHashSet<V> {
                             // Cleanup all the buckets that were in `DeletedValue` state,
                             // so that we can reduce unnecessary expansions
                             int lastBucket = signSafeMod(bucket - 1, capacity);
-                            while (values[bucket] == DeletedValue) {
-                                values[bucket] = (V) EmptyValue;
+                            while (values[lastBucket] == DeletedValue) {
+                                values[lastBucket] = (V) EmptyValue;
                                 --usedBuckets;
 
                                 lastBucket = signSafeMod(--lastBucket, capacity);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSetTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSetTest.java
@@ -159,6 +159,26 @@ public class ConcurrentOpenHashSetTest {
     }
 
     @Test
+    public void testReduceUnnecessaryExpansions(){
+        ConcurrentOpenHashSet<String> set =
+                ConcurrentOpenHashSet.<String>newBuilder()
+                        .expectedItems(2)
+                        .concurrencyLevel(1)
+                        .build();
+
+        assertTrue(set.add("1"));
+        assertTrue(set.add("2"));
+        assertTrue(set.add("3"));
+        assertTrue(set.add("4"));
+
+        assertTrue(set.remove("1"));
+        assertTrue(set.remove("2"));
+        assertTrue(set.remove("3"));
+        assertTrue(set.remove("4"));
+        assertEquals(0, set.getUsedBucketCount());
+    }
+
+    @Test
     public void testRemove() {
         ConcurrentOpenHashSet<String> set =
                 ConcurrentOpenHashSet.<String>newBuilder().build();


### PR DESCRIPTION
### Motivation
In the ConcurrentOpenHashSet class, when reducing unnecessary expansion logic, lastBucket should be used for comparison.


