### PR TITLE
fix a metric error in bookieStats

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -1095,7 +1095,7 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
                 bookieStats.getReadBytesStats().registerSuccessfulValue(entrySize);
             } else {
                 bookieStats.getReadEntryStats().registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-                bookieStats.getReadEntryStats().registerFailedValue(entrySize);
+                bookieStats.getReadBytesStats().registerFailedValue(entrySize);
             }
         }
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

fix a metric error in bookieStats

### Changes

getReadEntryStats().registerFailedValue(entrySize) -> getReadBytesStats().registerFailedValue(entrySize)




