### PR TITLE
[website] update website every time there is a change

### DIFF
--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -19,12 +19,13 @@
 
 name: Website deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
     paths:
       - 'site/**'
-
+      - '.github/workflows/website-deploy.yaml'
 jobs:
   build-website:
     name: Build and publish website
@@ -44,7 +45,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6 # Not needed with a .ruby-version file
+          ruby-version: 3.0.3 # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: publish

--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -19,8 +19,11 @@
 
 name: Website deploy
 on:
-  schedule:
-    - cron: '0 */24 * * *'
+  push:
+    branches:
+      - master
+    paths:
+      - 'site/**'
 
 jobs:
   build-website:


### PR DESCRIPTION
### Motivation

At the moment every night at 00:00 UTC the website job will try to update the `asf-site` branch content.
It is better to run this job whenever a new change is committed to the master branch in order to easy rollback changes and know exactly when the website will be updated.

### Changes

* the job now runs whenever a commit is pushed to `master` and it change at least a file inside `site/`
