### PR TITLE
Set BOOKIE_HTTP_PORT to make it optional in docker run

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,8 @@ ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
 ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
 
 ENV BOOKIE_PORT=3181
-EXPOSE $BOOKIE_PORT
+ENV BOOKIE_HTTP_PORT=8080
+EXPOSE $BOOKIE_PORT $BOOKIE_HTTP_PORT
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
 ENV JAVA_HOME=/usr/lib/jvm/java-11


### PR DESCRIPTION
### Motivation
Make `BOOKIE_HTTP_PORT` optional in `docker run`.

### Changes

Docker entrypoint will replace `httpServerPort` with `BOOKIE_HTTP_PORT`.
This will cause invalid port if `BOOKIE_HTTP_PORT` is unset in docker
run.

Fixes #3075.

Master Issue: #3075