### PR TITLE
bump lombok from 1.18.20 to 1.18.22 to support java17 compile

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -63,7 +63,7 @@ depVersions = [
     junitFoundation: "11.0.0",
     kerby: "1.1.1",
     log4j: "2.17.1",
-    lombok: "1.18.20",
+    lombok: "1.18.22",
     lz4: "1.3.0",
     mockito: "3.12.4",
     netty: "4.1.74.Final",


### PR DESCRIPTION
### Motivation
- required for compilation on JDK 17
- see https://projectlombok.org/changelog