### PR TITLE
Fix bkperf message rate limit to 2GB/s

### DIFF
--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/journal/JournalWriter.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/journal/JournalWriter.java
@@ -89,7 +89,7 @@ public class JournalWriter implements Runnable {
                 "-r", "--rate"
             },
             description = "Write rate bytes/s across journals")
-        public int writeRate = 0;
+        public long writeRate = 0;
 
         @Parameter(
             names = {


### PR DESCRIPTION
### Motivation
Current bkperf message rate limit use `int` to store the rate value, however, max rate will be limit by `MAX_INTEGER` value to 2GB. We'd better use long to support higher message rate limiter.

### Changes

Use `long` instead of `int` to store the message rate limit value.

