### PR TITLE
Bump testcontainers version to 1.16.3

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -81,7 +81,7 @@ depVersions = [
     shrinkwrap:"3.1.4",
     snappy: "1.1.7",
     thrift: "0.14.2",
-    testcontainers: "1.15.1",
+    testcontainers: "1.16.3",
     vertx: "3.9.8",
     yahooDatasketches: "0.8.3",
     zookeeper: "3.6.2",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,7 +36,7 @@ depVersions = [
     commonsLang3: "3.6",
     commonsBeanutils: "1.9.3",
     curator: "5.1.0",
-    dockerJava: "3.2.5",
+    dockerJava: "3.2.13",
     dropwizard: "3.2.5",
     errorprone: "2.4.0",
     etcd: "0.5.11",


### PR DESCRIPTION
### Motivation
- Bump the testcontainers version to make tests can run on the latest docker on `Mac Intel Chip`
- Bump `docker-java` version to `3.2.13`