### PR TITLE
add stats for throttled-write

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
@@ -59,7 +59,10 @@ class DbLedgerStorageStats {
     private static final String FLUSH_LOCATIONS_INDEX = "flush-locations-index";
     private static final String FLUSH_LEDGER_INDEX = "flush-ledger-index";
     private static final String FLUSH_SIZE = "flush-size";
+
+    @Deprecated
     private static final String THROTTLED_WRITE_REQUESTS = "throttled-write-requests";
+    // throttled-write-requests is deprecated, use new metric: throttled-write
     private static final String THROTTLED_WRITE = "throttled-write";
     private static final String REJECTED_WRITE_REQUESTS = "rejected-write-requests";
     private static final String WRITE_CACHE_SIZE = "write-cache-size";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
@@ -60,6 +60,7 @@ class DbLedgerStorageStats {
     private static final String FLUSH_LEDGER_INDEX = "flush-ledger-index";
     private static final String FLUSH_SIZE = "flush-size";
     private static final String THROTTLED_WRITE_REQUESTS = "throttled-write-requests";
+    private static final String THROTTLED_WRITE = "throttled-write";
     private static final String REJECTED_WRITE_REQUESTS = "rejected-write-requests";
     private static final String WRITE_CACHE_SIZE = "write-cache-size";
     private static final String WRITE_CACHE_COUNT = "write-cache-count";
@@ -160,6 +161,11 @@ class DbLedgerStorageStats {
     )
     private final Counter throttledWriteRequests;
     @StatsDoc(
+            name = THROTTLED_WRITE,
+            help = "The stats of throttled write due to write cache is full"
+    )
+    private final OpStatsLogger throttledWriteStats;
+    @StatsDoc(
         name = REJECTED_WRITE_REQUESTS,
         help = "The number of requests rejected due to write cache is full"
     )
@@ -209,6 +215,7 @@ class DbLedgerStorageStats {
         flushSizeStats = stats.getOpStatsLogger(FLUSH_SIZE);
 
         throttledWriteRequests = stats.getThreadScopedCounter(THROTTLED_WRITE_REQUESTS);
+        throttledWriteStats = stats.getOpStatsLogger(THROTTLED_WRITE);
         rejectedWriteRequests = stats.getThreadScopedCounter(REJECTED_WRITE_REQUESTS);
 
         writeCacheSizeGauge = new Gauge<Long>() {


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

method:triggerFlushAndAddEntry costing time is a changing,so add a stats metric focus on this method 

### Changes

1.the previous counter metrics(throttledWriteRequests) are retained
2.add throttledWriteStats to record cost time and count for the method(triggerFlushAndAddEntry) 
