### PR TITLE
add async or sync for :entry location index's rocksdb write

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -482,7 +482,7 @@ public class DbLedgerStorage implements LedgerStorage {
         int dirIndex = MathUtils.signSafeMod(ledgerId, ledgerDirs.size());
         String indexBasePath = indexDirs.get(dirIndex).toString();
 
-        EntryLocationIndex entryLocationIndex = new EntryLocationIndex(serverConf,
+        EntryLocationIndex entryLocationIndex = EntryLocationIndex.newInstance(serverConf,
                 (basePath, subPath, dbConfigType, conf1) ->
                         new KeyValueStorageRocksDB(basePath, subPath, DbConfigType.Default, conf1, true),
                 indexBasePath, NullStatsLogger.INSTANCE);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class EntryLocationIndex implements Closeable {
 
-    private final KeyValueStorage locationsDb;
+    protected final KeyValueStorage locationsDb;
     private final ConcurrentLongHashSet deletedLedgers = ConcurrentLongHashSet.newBuilder().build();
 
     private final EntryLocationIndexStats stats;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -191,7 +191,7 @@ public abstract class EntryLocationIndex implements Closeable {
         long deletedEntriesInBatch = 0;
 
         Batch batch = newBatch();
-        final byte[] firstDeletedKey = new byte[keyToDelete.array.length];
+
         try {
             for (long ledgerId : ledgersToDelete) {
                 if (log.isDebugEnabled()) {
@@ -244,10 +244,6 @@ public abstract class EntryLocationIndex implements Closeable {
         } finally {
             try {
                 flush(batch);
-
-                if (deletedEntries != 0) {
-                    locationsDb.compact(firstDeletedKey, keyToDelete.array);
-                }
             } finally {
                 firstKeyWrapper.recycle();
                 lastKeyWrapper.recycle();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -20,7 +20,7 @@
  */
 package org.apache.bookkeeper.bookie.storage.ldb;
 
-import com.google.common.collect.Iterables;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map.Entry;
@@ -270,11 +270,11 @@ public abstract class EntryLocationIndex implements Closeable {
 
     public static EntryLocationIndex newInstance(ServerConfiguration conf, KeyValueStorageFactory storageFactory,
                                                  String basePath, StatsLogger stats) throws IOException {
-        if (conf.getLocationIndexSyncData()) {
+        if (!conf.getLocationIndexSyncData()) {
             return new EntryLocationIndexAsync(conf, storageFactory, basePath, stats);
         }
         return new EntryLocationIndexSync(conf, storageFactory, basePath, stats);
     }
 
-    protected static final Logger log = LoggerFactory.getLogger(EntryLocationIndex.class);
+    private static final Logger log = LoggerFactory.getLogger(EntryLocationIndex.class);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -243,9 +243,8 @@ public abstract class EntryLocationIndex implements Closeable {
             }
         } finally {
             try {
-                batch.flush();
-                batch.clear();
                 flush(batch);
+
                 if (deletedEntries != 0) {
                     locationsDb.compact(firstDeletedKey, keyToDelete.array);
                 }
@@ -270,7 +269,7 @@ public abstract class EntryLocationIndex implements Closeable {
 
     public static EntryLocationIndex newInstance(ServerConfiguration conf, KeyValueStorageFactory storageFactory,
                                                  String basePath, StatsLogger stats) throws IOException {
-        if (!conf.getLocationIndexSyncData()) {
+        if (!conf.getDbLedgerLocationIndexSyncEnable()) {
             return new EntryLocationIndexAsync(conf, storageFactory, basePath, stats);
         }
         return new EntryLocationIndexSync(conf, storageFactory, basePath, stats);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsync.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsync.java
@@ -1,0 +1,89 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie.storage.ldb;
+
+import com.google.common.collect.Iterables;
+import org.apache.bookkeeper.bookie.EntryLocation;
+import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorage.Batch;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.stats.StatsLogger;
+import java.io.IOException;
+
+/**
+ * Maintains an index of the entry locations in the EntryLogger.
+ *
+ * <p>For each ledger multiple entries are stored in the same "record", represented
+ * by the {@link LedgerIndexPage} class.
+ */
+public class EntryLocationIndexAsync extends EntryLocationIndex {
+
+    public EntryLocationIndexAsync(ServerConfiguration conf, KeyValueStorageFactory storageFactory, String basePath,
+                                   StatsLogger stats) throws IOException {
+        super(conf, storageFactory, basePath, stats);
+    }
+
+    @Override
+    public void addLocation(long ledgerId, long entryId, long location) throws IOException {
+        addLocation(null, ledgerId, entryId, location);
+        locationsDb.sync();
+    }
+
+    @Override
+    public Batch newBatch() {
+        return null;
+    }
+
+    @Override
+    public void updateLocations(Iterable<EntryLocation> newLocations) throws IOException {
+        if (log.isDebugEnabled()) {
+            log.debug("Update locations -- {}", Iterables.size(newLocations));
+        }
+
+        // Update all the ledger index pages with the new locations
+        for (EntryLocation e : newLocations) {
+            if (log.isDebugEnabled()) {
+                log.debug("Update location - ledger: {} -- entry: {}", e.ledger, e.entry);
+            }
+            addLocation(null, e.ledger, e.entry, e.location);
+        }
+        locationsDb.sync();
+    }
+
+    @Override
+    public void put(Batch batch, byte[] key, byte[] value) throws IOException {
+        locationsDb.put(key, value);
+    }
+
+    @Override
+    public void flush(Batch batch) throws IOException {
+        locationsDb.sync();
+    }
+
+    @Override
+    public void delete(Batch batch, LongPairWrapper keyToDelete) throws IOException {
+        locationsDb.delete(keyToDelete.array);
+    }
+
+    @Override
+    public void close(Batch batch) throws IOException {
+        // do nothing
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsync.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsync.java
@@ -21,9 +21,7 @@
 package org.apache.bookkeeper.bookie.storage.ldb;
 
 import com.google.common.collect.Iterables;
-
 import java.io.IOException;
-
 import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorage.Batch;
 import org.apache.bookkeeper.conf.ServerConfiguration;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsync.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsync.java
@@ -21,19 +21,24 @@
 package org.apache.bookkeeper.bookie.storage.ldb;
 
 import com.google.common.collect.Iterables;
+
+import java.io.IOException;
+
 import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorage.Batch;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;
-import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Maintains an index of the entry locations in the EntryLogger.
  *
- * <p>For each ledger multiple entries are stored in the same "record", represented
- * by the {@link LedgerIndexPage} class.
+ * <p>Asynchronous write mode class.
  */
 public class EntryLocationIndexAsync extends EntryLocationIndex {
+
+    private static final Logger log = LoggerFactory.getLogger(EntryLocationIndexAsync.class);
 
     public EntryLocationIndexAsync(ServerConfiguration conf, KeyValueStorageFactory storageFactory, String basePath,
                                    StatsLogger stats) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSync.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSync.java
@@ -1,0 +1,110 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie.storage.ldb;
+
+import com.google.common.collect.Iterables;
+import org.apache.bookkeeper.bookie.EntryLocation;
+import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorage.Batch;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.stats.StatsLogger;
+import java.io.IOException;
+
+/**
+ * Maintains an index of the entry locations in the EntryLogger.
+ *
+ * <p>For each ledger multiple entries are stored in the same "record", represented
+ * by the {@link LedgerIndexPage} class.
+ */
+public class EntryLocationIndexSync extends EntryLocationIndex {
+
+    public EntryLocationIndexSync(ServerConfiguration conf, KeyValueStorageFactory storageFactory, String basePath,
+                                  StatsLogger stats) throws IOException {
+        super(conf, storageFactory, basePath, stats);
+    }
+
+    public void addLocation(long ledgerId, long entryId, long location) throws IOException {
+        Batch batch = newBatch();
+        addLocation(batch, ledgerId, entryId, location);
+        batch.flush();
+        batch.close();
+    }
+
+    @Override
+    public Batch newBatch() {
+        return locationsDb.newBatch();
+    }
+
+    @Override
+    public void addLocation(Batch batch, long ledgerId, long entryId, long location) throws IOException {
+        LongPairWrapper key = LongPairWrapper.get(ledgerId, entryId);
+        LongWrapper value = LongWrapper.get(location);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Add location - ledger: {} -- entry: {} -- location: {}", ledgerId, entryId, location);
+        }
+
+        try {
+            batch.put(key.array, value.array);
+        } finally {
+            key.recycle();
+            value.recycle();
+        }
+    }
+
+    @Override
+    public void updateLocations(Iterable<EntryLocation> newLocations) throws IOException {
+        if (log.isDebugEnabled()) {
+            log.debug("Update locations -- {}", Iterables.size(newLocations));
+        }
+
+        Batch batch = newBatch();
+        // Update all the ledger index pages with the new locations
+        for (EntryLocation e : newLocations) {
+            if (log.isDebugEnabled()) {
+                log.debug("Update location - ledger: {} -- entry: {}", e.ledger, e.entry);
+            }
+            addLocation(batch, e.ledger, e.entry, e.location);
+        }
+        batch.flush();
+        batch.clear();
+    }
+
+    @Override
+    public void put(Batch batch, byte[] key, byte[] value) throws IOException {
+        batch.put(key, value);
+    }
+
+    @Override
+    public void flush(Batch batch) throws IOException {
+        batch.flush();
+        batch.clear();
+    }
+
+    @Override
+    public void delete(Batch batch, LongPairWrapper keyToDelete) throws IOException {
+        batch.remove(keyToDelete.array);
+    }
+
+    @Override
+    public void close(Batch batch) throws IOException {
+        batch.close();
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSync.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSync.java
@@ -21,19 +21,24 @@
 package org.apache.bookkeeper.bookie.storage.ldb;
 
 import com.google.common.collect.Iterables;
+
+import java.io.IOException;
+
 import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorage.Batch;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;
-import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Maintains an index of the entry locations in the EntryLogger.
  *
- * <p>For each ledger multiple entries are stored in the same "record", represented
- * by the {@link LedgerIndexPage} class.
+ * <p>Synchronous write mode class.
  */
 public class EntryLocationIndexSync extends EntryLocationIndex {
+
+    private static final Logger log = LoggerFactory.getLogger(EntryLocationIndexSync.class);
 
     public EntryLocationIndexSync(ServerConfiguration conf, KeyValueStorageFactory storageFactory, String basePath,
                                   StatsLogger stats) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSync.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSync.java
@@ -21,9 +21,7 @@
 package org.apache.bookkeeper.bookie.storage.ldb;
 
 import com.google.common.collect.Iterables;
-
 import java.io.IOException;
-
 import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorage.Batch;
 import org.apache.bookkeeper.conf.ServerConfiguration;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -124,6 +124,10 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
 
         optionCache.setFillCache(true);
         optionDontCache.setFillCache(false);
+        if (!conf.getLocationIndexSyncData()) {
+            optionSync.setSync(false);
+            optionCache.setFillCache(false);
+        }
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -124,7 +124,7 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
 
         optionCache.setFillCache(true);
         optionDontCache.setFillCache(false);
-        if (!conf.getLocationIndexSyncData()) {
+        if (!conf.getDbLedgerLocationIndexSyncEnable()) {
             optionSync.setSync(false);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -126,7 +126,6 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
         optionDontCache.setFillCache(false);
         if (!conf.getLocationIndexSyncData()) {
             optionSync.setSync(false);
-            optionCache.setFillCache(false);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -1001,9 +1001,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 });
             }
         }
-        
         entryLocationIndex.flush(batch);
-
         return numberOfEntries.longValue();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -1830,7 +1830,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get location index sync data
+     * Get location index sync data.
      *
      * @return true  - sync operate location index,
      *         false - async operate location index.
@@ -1840,7 +1840,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Set location index sync data
+     * Set location index sync data.
      *
      * @param syncSwitch true to sync operate location index
      *

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -170,7 +170,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String JOURNAL_DIRS = "journalDirectories";
     protected static final String LEDGER_DIRS = "ledgerDirectories";
     protected static final String INDEX_DIRS = "indexDirectories";
-    protected static final String LOCATION_INDEX_SYNC_DATA = "locationIndexSyncData";
+    protected static final String DB_LEDGERLOCATION_INDEX_SYNC_ENABLE = "dbLedgerLocationIndexSyncEnable";
     protected static final String ALLOW_STORAGE_EXPANSION = "allowStorageExpansion";
     // NIO and Netty Parameters
     protected static final String SERVER_TCP_NODELAY = "serverTcpNoDelay";
@@ -1830,24 +1830,24 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get location index sync data.
+     * Get db ledger location index sync enable.
      *
      * @return true  - sync operate location index,
      *         false - async operate location index.
      */
-    public boolean getLocationIndexSyncData() {
-        return getBoolean(LOCATION_INDEX_SYNC_DATA, true);
+    public boolean getDbLedgerLocationIndexSyncEnable() {
+        return getBoolean(DB_LEDGERLOCATION_INDEX_SYNC_ENABLE, true);
     }
 
     /**
-     * Set location index sync data.
+     * Set db ledger location index sync enable.
      *
      * @param syncSwitch true to sync operate location index
      *
      * @return ServerConfiguration
      */
-    public ServerConfiguration setLocationIndexSyncData(boolean syncSwitch) {
-        setProperty(LOCATION_INDEX_SYNC_DATA, syncSwitch);
+    public ServerConfiguration setDbLedgerLocationIndexSyncEnable(boolean syncSwitch) {
+        setProperty(DB_LEDGERLOCATION_INDEX_SYNC_ENABLE, syncSwitch);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -170,6 +170,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String JOURNAL_DIRS = "journalDirectories";
     protected static final String LEDGER_DIRS = "ledgerDirectories";
     protected static final String INDEX_DIRS = "indexDirectories";
+    protected static final String LOCATION_INDEX_SYNC_DATA = "locationIndexSyncData";
     protected static final String ALLOW_STORAGE_EXPANSION = "allowStorageExpansion";
     // NIO and Netty Parameters
     protected static final String SERVER_TCP_NODELAY = "serverTcpNoDelay";
@@ -1825,6 +1826,28 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setIsForceGCAllowWhenNoSpace(boolean force) {
         setProperty(IS_FORCE_GC_ALLOW_WHEN_NO_SPACE, force);
+        return this;
+    }
+
+    /**
+     * Get location index sync data
+     *
+     * @return true  - sync operate location index,
+     *         false - async operate location index.
+     */
+    public boolean getLocationIndexSyncData() {
+        return getBoolean(LOCATION_INDEX_SYNC_DATA, true);
+    }
+
+    /**
+     * Set location index sync data
+     *
+     * @param syncSwitch true to sync operate location index
+     *
+     * @return ServerConfiguration
+     */
+    public ServerConfiguration setLocationIndexSyncData(boolean syncSwitch) {
+        setProperty(LOCATION_INDEX_SYNC_DATA, syncSwitch);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsyncTest.java
@@ -21,11 +21,13 @@
 package org.apache.bookkeeper.bookie.storage.ldb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.test.TestStatsProvider;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -144,5 +146,32 @@ public class EntryLocationIndexAsyncTest {
         idx.delete(40313);
         idx.removeOffsetFromDeletedLedgers();
         assertEquals(0, idx.getLocation(40312, 10));
+    }
+
+    @Test
+    public void testEntryIndexLookupLatencyStats() throws IOException {
+        File tmpDir = File.createTempFile("bkTest", ".dir");
+        tmpDir.delete();
+        tmpDir.mkdir();
+        tmpDir.deleteOnExit();
+
+        TestStatsProvider statsProvider = new TestStatsProvider();
+        EntryLocationIndex idx = EntryLocationIndex.newInstance(serverConfiguration, KeyValueStorageRocksDB.factory,
+                tmpDir.getAbsolutePath(), statsProvider.getStatsLogger("scope"));
+
+        // Add some dummy indexes
+        idx.addLocation(40313, 11, 5);
+
+        // successful lookup
+        assertEquals(5, idx.getLocation(40313, 11));
+        TestStatsProvider.TestOpStatsLogger lookupEntryLocationOpStats =
+                statsProvider.getOpStatsLogger("scope.lookup-entry-location");
+        assertEquals(1, lookupEntryLocationOpStats.getSuccessCount());
+        assertTrue(lookupEntryLocationOpStats.getSuccessAverage() > 0);
+
+        // failed lookup
+        assertEquals(0, idx.getLocation(12345, 1));
+        assertEquals(1, lookupEntryLocationOpStats.getFailureCount());
+        assertEquals(1, lookupEntryLocationOpStats.getSuccessCount());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsyncTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.Before;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexAsyncTest.java
@@ -20,15 +20,15 @@
  */
 package org.apache.bookkeeper.bookie.storage.ldb;
 
-import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.stats.NullStatsLogger;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Unit test for {@link EntryLocationIndex}.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSyncTest.java
@@ -150,7 +150,7 @@ public class EntryLocationIndexSyncTest {
         tmpDir.deleteOnExit();
 
         TestStatsProvider statsProvider = new TestStatsProvider();
-        EntryLocationIndex idx = new EntryLocationIndex(serverConfiguration, KeyValueStorageRocksDB.factory,
+        EntryLocationIndex idx = EntryLocationIndex.newInstance(serverConfiguration, KeyValueStorageRocksDB.factory,
                 tmpDir.getAbsolutePath(), statsProvider.getStatsLogger("scope"));
 
         // Add some dummy indexes

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSyncTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexSyncTest.java
@@ -1,0 +1,171 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie.storage.ldb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.test.TestStatsProvider;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link EntryLocationIndex}.
+ */
+public class EntryLocationIndexSyncTest {
+
+    private final ServerConfiguration serverConfiguration = new ServerConfiguration();
+
+    @Test
+    public void deleteLedgerTest() throws Exception {
+        File tmpDir = File.createTempFile("bkTest", ".dir");
+        tmpDir.delete();
+        tmpDir.mkdir();
+        tmpDir.deleteOnExit();
+
+        EntryLocationIndex idx = EntryLocationIndex.newInstance(serverConfiguration, KeyValueStorageRocksDB.factory,
+                tmpDir.getAbsolutePath(), NullStatsLogger.INSTANCE);
+
+        // Add some dummy indexes
+        idx.addLocation(40312, 0, 1);
+        idx.addLocation(40313, 10, 2);
+        idx.addLocation(40320, 0, 3);
+
+        // Add more indexes in a different batch
+        idx.addLocation(40313, 11, 5);
+        idx.addLocation(40313, 12, 6);
+        idx.addLocation(40320, 1, 7);
+        idx.addLocation(40312, 3, 4);
+
+        idx.delete(40313);
+
+        assertEquals(1, idx.getLocation(40312, 0));
+        assertEquals(4, idx.getLocation(40312, 3));
+        assertEquals(3, idx.getLocation(40320, 0));
+        assertEquals(7, idx.getLocation(40320, 1));
+
+        assertEquals(2, idx.getLocation(40313, 10));
+        assertEquals(5, idx.getLocation(40313, 11));
+        assertEquals(6, idx.getLocation(40313, 12));
+
+        idx.removeOffsetFromDeletedLedgers();
+
+        // After flush the keys will be removed
+        assertEquals(0, idx.getLocation(40313, 10));
+        assertEquals(0, idx.getLocation(40313, 11));
+        assertEquals(0, idx.getLocation(40313, 12));
+
+        idx.close();
+    }
+
+    // this tests if a ledger is added after it has been deleted
+    @Test
+    public void addLedgerAfterDeleteTest() throws Exception {
+        File tmpDir = File.createTempFile("bkTest", ".dir");
+        tmpDir.delete();
+        tmpDir.mkdir();
+        tmpDir.deleteOnExit();
+
+        EntryLocationIndex idx = EntryLocationIndex.newInstance(serverConfiguration, KeyValueStorageRocksDB.factory,
+                tmpDir.getAbsolutePath(), NullStatsLogger.INSTANCE);
+
+        // Add some dummy indexes
+        idx.addLocation(40312, 0, 1);
+        idx.addLocation(40313, 10, 2);
+        idx.addLocation(40320, 0, 3);
+
+        idx.delete(40313);
+
+        // Add more indexes in a different batch
+        idx.addLocation(40313, 11, 5);
+        idx.addLocation(40313, 12, 6);
+        idx.addLocation(40320, 1, 7);
+        idx.addLocation(40312, 3, 4);
+
+        idx.removeOffsetFromDeletedLedgers();
+
+        assertEquals(0, idx.getLocation(40313, 11));
+        assertEquals(0, idx.getLocation(40313, 12));
+
+        idx.close();
+    }
+
+    // test non exist entry
+    @Test
+    public void testDeleteSpecialEntry() throws IOException {
+        File tmpDir = File.createTempFile("bkTest", ".dir");
+        tmpDir.delete();
+        tmpDir.mkdir();
+        tmpDir.deleteOnExit();
+
+        EntryLocationIndex idx = EntryLocationIndex.newInstance(serverConfiguration, KeyValueStorageRocksDB.factory,
+                                                        tmpDir.getAbsolutePath(), NullStatsLogger.INSTANCE);
+
+        // Add some dummy indexes
+        idx.addLocation(40312, -1, 1);
+        idx.addLocation(40313, 10, 2);
+        idx.addLocation(40320, 0, 3);
+
+        // Add more indexes in a different batch
+        idx.addLocation(40313, 11, 5);
+        idx.addLocation(40313, 12, 6);
+        idx.addLocation(40320, 1, 7);
+
+        // delete a non exist entry
+        idx.delete(40312);
+        idx.removeOffsetFromDeletedLedgers();
+
+        // another delete entry operation shouldn't effected
+        idx.delete(40313);
+        idx.removeOffsetFromDeletedLedgers();
+        assertEquals(0, idx.getLocation(40312, 10));
+    }
+
+    @Test
+    public void testEntryIndexLookupLatencyStats() throws IOException {
+        File tmpDir = File.createTempFile("bkTest", ".dir");
+        tmpDir.delete();
+        tmpDir.mkdir();
+        tmpDir.deleteOnExit();
+
+        TestStatsProvider statsProvider = new TestStatsProvider();
+        EntryLocationIndex idx = new EntryLocationIndex(serverConfiguration, KeyValueStorageRocksDB.factory,
+                tmpDir.getAbsolutePath(), statsProvider.getStatsLogger("scope"));
+
+        // Add some dummy indexes
+        idx.addLocation(40313, 11, 5);
+
+        // successful lookup
+        assertEquals(5, idx.getLocation(40313, 11));
+        TestStatsProvider.TestOpStatsLogger lookupEntryLocationOpStats =
+                statsProvider.getOpStatsLogger("scope.lookup-entry-location");
+        assertEquals(1, lookupEntryLocationOpStats.getSuccessCount());
+        assertTrue(lookupEntryLocationOpStats.getSuccessAverage() > 0);
+
+        // failed lookup
+        assertEquals(0, idx.getLocation(12345, 1));
+        assertEquals(1, lookupEntryLocationOpStats.getFailureCount());
+        assertEquals(1, lookupEntryLocationOpStats.getSuccessCount());
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexTest.java
@@ -44,7 +44,7 @@ public class EntryLocationIndexTest {
         tmpDir.mkdir();
         tmpDir.deleteOnExit();
 
-        EntryLocationIndex idx = new EntryLocationIndex(serverConfiguration, KeyValueStorageRocksDB.factory,
+        EntryLocationIndex idx = EntryLocationIndex.newInstance(serverConfiguration, KeyValueStorageRocksDB.factory,
                 tmpDir.getAbsolutePath(), NullStatsLogger.INSTANCE);
 
         // Add some dummy indexes
@@ -87,7 +87,7 @@ public class EntryLocationIndexTest {
         tmpDir.mkdir();
         tmpDir.deleteOnExit();
 
-        EntryLocationIndex idx = new EntryLocationIndex(serverConfiguration, KeyValueStorageRocksDB.factory,
+        EntryLocationIndex idx = EntryLocationIndex.newInstance(serverConfiguration, KeyValueStorageRocksDB.factory,
                 tmpDir.getAbsolutePath(), NullStatsLogger.INSTANCE);
 
         // Add some dummy indexes
@@ -119,7 +119,7 @@ public class EntryLocationIndexTest {
         tmpDir.mkdir();
         tmpDir.deleteOnExit();
 
-        EntryLocationIndex idx = new EntryLocationIndex(serverConfiguration, KeyValueStorageRocksDB.factory,
+        EntryLocationIndex idx = EntryLocationIndex.newInstance(serverConfiguration, KeyValueStorageRocksDB.factory,
                                                         tmpDir.getAbsolutePath(), NullStatsLogger.INSTANCE);
 
         // Add some dummy indexes


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

bookie timed to flush latency mainly composed of three pieces:
      1.  flush-entrylog:   it's  the latency for flushing entrylog 
      2. flush-locations-index: it's  the latency for flushing entrly location index,  use **sync** mode to flush
      3. flush-ledger-index:  it's  the latency for flushing ledger metadata index, this index(LedgerMetadataIndex) use **async** mode to flush

reduce entry location index flush latency to reduce bookie's flush latency,
so add async mode for entry location index's write: 
      1.  default sync mode: not change the original logic
      2. async mode : need update config to open, this mode is to speed up writing, this mode is the same as bookie's another index: LedgerMetadataIndex

sync is different from async：
- sync mode:  
      1.  create a batch; 
      4.  add msg to the batch
      5.  call method(batch.flush) to flush the batch

- sync mode:  
      1. just call method(locationsDb.sync)  to write the data
      2. the rocksdb server will be timed to flush the data 

### Changes

1. add async or sync for :location rocksdb write
2. add switch to open this feature, default not open, use default sync 