### PR TITLE
Revert "Issue #1791: Read Submission should bypass OSE Threads"

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -887,14 +887,7 @@ public class LedgerHandle implements WriteHandle {
                 ws.recycle();
             }
 
-            if (isHandleWritable()) {
-                // Ledger handle in read/write mode: submit to OSE for ordered execution.
-                clientCtx.getMainWorkerPool().executeOrdered(ledgerId, op);
-            } else {
-                // Read-only ledger handle: bypass OSE and execute read directly in client thread.
-                // This avoids a context-switch to OSE thread and thus reduces latency.
-                op.run();
-            }
+            clientCtx.getMainWorkerPool().executeOrdered(ledgerId, op);
         } else {
             op.future().completeExceptionally(BKException.create(ClientClosedException));
         }


### PR DESCRIPTION
This reverts commit 6b99ff73278d4e655509f61ea44284e54716f5a8.

Descriptions of the changes in this PR:
Revert #1792 "Issue #1791: Read Submission should bypass OSE Threads"


### Motivation
See https://github.com/apache/bookkeeper/issues/3104

