### PR TITLE
Issue #3105: Optimize OrderedExecutor performance by using GrowableArrayBlockingQueue

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/GrowableArrayBlockingQueue.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/GrowableArrayBlockingQueue.java
@@ -18,7 +18,7 @@
  * under the License.
  *
  */
-package org.apache.bookkeeper.util.collections;
+package org.apache.bookkeeper.common.collections;
 
 import java.util.AbstractQueue;
 import java.util.Collection;
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
-
 import org.apache.bookkeeper.util.MathUtils;
 
 

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.bookkeeper.common.collections.BlockingMpscQueue;
+import org.apache.bookkeeper.common.collections.GrowableArrayBlockingQueue;
 import org.apache.bookkeeper.common.util.affinity.CpuAffinity;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -305,7 +306,7 @@ public class OrderedExecutor implements ExecutorService {
             queue = new BlockingMpscQueue<>(maxTasksInQueue > 0 ? maxTasksInQueue : DEFAULT_MAX_ARRAY_QUEUE_SIZE);
         } else {
             // By default, use regular JDK LinkedBlockingQueue
-            queue = new LinkedBlockingQueue<>();
+            queue = new GrowableArrayBlockingQueue<>();
         }
         return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, queue, factory);
     }

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/collections/GrowableArrayBlockingQueueTest.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/collections/GrowableArrayBlockingQueueTest.java
@@ -18,7 +18,7 @@
  * under the License.
  *
  */
-package org.apache.bookkeeper.util.collections;
+package org.apache.bookkeeper.common.collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Fixes #3105

### Motivation

- See #3105 for details. OrderedExecutor uses LinkedBlockingQueue which isn't the most performant BlockingQueue implementation. For example, it causes object allocations each time new items are added to the queue. More details in #153 where GrowableArrayBlockingQueue was added.

### Changes

- Use GrowableArrayBlockingQueue introduced in #153

