### PR TITLE
Fix getMetadataServiceUri

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/AbstractConfiguration.java
@@ -268,7 +268,11 @@ public abstract class AbstractConfiguration<T extends AbstractConfiguration>
      * @throws ConfigurationException if the metadata service uri is invalid.
      */
     public String getMetadataServiceUri() throws ConfigurationException {
-        String serviceUri = getString(METADATA_SERVICE_URI);
+        List servers = getList(METADATA_SERVICE_URI, null);
+        if (null == servers || 0 == servers.size()) {
+            return null;
+        }
+        String serviceUri = StringUtils.join(servers, ",");
         if (StringUtils.isBlank(serviceUri)) {
             // no service uri is defined, fallback to old settings
             String ledgerManagerType;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/AbstractConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/AbstractConfigurationTest.java
@@ -58,8 +58,8 @@ public class AbstractConfigurationTest {
 
     @Test
     public void testSetGetServiceUri() throws Exception {
-        this.conf.setMetadataServiceUri("zk1:2181,zk2:2181/test");
-        assertEquals("zk1:2181,zk2:2181/test", this.conf.getMetadataServiceUri());
+        this.conf.setMetadataServiceUri("zk+null://zk1:2181,zk2:2181/test");
+        assertEquals("zk+null://zk1:2181,zk2:2181/test", this.conf.getMetadataServiceUri());
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/AbstractConfigurationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/AbstractConfigurationTest.java
@@ -57,6 +57,12 @@ public class AbstractConfigurationTest {
     }
 
     @Test
+    public void testSetGetServiceUri() throws Exception {
+        this.conf.setMetadataServiceUri("zk1:2181,zk2:2181/test");
+        assertEquals("zk1:2181,zk2:2181/test", this.conf.getMetadataServiceUri());
+    }
+
+    @Test
     public void testDefaultServiceUri() throws Exception {
         assertEquals(
             DEFAULT_METADATA_SERVICE_URI,


### PR DESCRIPTION

### Motivation
when config metadataStoreUri like `zk1:2181,zk2:2181/test`, `getMetadataServiceUri ` will only return  `zk1:2181`.  it's incorrect.


### Changes
Use `getList ` instead of `getString`
