### PR TITLE
Fix the pid occupied check when use bookkeeper-daemon.sh start or stop

### DIFF
--- a/bin/bookkeeper-daemon.sh
+++ b/bin/bookkeeper-daemon.sh
@@ -112,7 +112,7 @@ start()
 {
   if [ -f $pid_file ]; then
     PREVIOUS_PID=$(cat $pid_file)
-    if kill -0 $PREVIOUS_PID > /dev/null 2>&1; then
+    if ps -p $PREVIOUS_PID > /dev/null 2>&1; then
       echo $command running as process $PREVIOUS_PID.  Stop it first.
       exit 1
     fi
@@ -125,7 +125,7 @@ start()
   echo $! > $pid_file
   sleep 1; head $out
   sleep 2;
-  if ! kill -0 $! > /dev/null ; then
+  if ! ps -p $! > /dev/null ; then
     exit 1
   fi
 }
@@ -134,13 +134,13 @@ stop()
 {
   if [ -f $pid_file ]; then
     TARGET_PID=$(cat $pid_file)
-    if kill -0 $TARGET_PID > /dev/null 2>&1; then
+    if ps -p $TARGET_PID > /dev/null 2>&1; then
       echo stopping $command
       kill $TARGET_PID
 
       count=0
       location=$BOOKIE_LOG_DIR
-      while kill -0 $TARGET_PID > /dev/null 2>&1;
+      while ps -p $TARGET_PID > /dev/null 2>&1;
       do
         echo "Shutdown is in progress... Please wait..."
         sleep 1
@@ -155,7 +155,7 @@ stop()
         echo "Shutdown completed."
       fi
 
-      if kill -0 $TARGET_PID > /dev/null 2>&1; then
+      if ps -p $TARGET_PID > /dev/null 2>&1; then
         fileName=$location/$command.out
         # Check for the java to use
         if [[ -z ${JAVA_HOME} ]]; then


### PR DESCRIPTION
Master Issue: #3112

### Motivation

Fix the failed pid occupied check. we'll fail when use bookkeeper-daemon.sh start or stop bookie, after the last time we exit the bookie direct kill or the bookie occurred non-normal exit, then the bin/bookkeeper-bookie.pid are retained, and the pid in the file is occupied by the thread in other progress.

### Changes
Change the pid occupied check from 'kill -0 $pid' to 'ps -p $pid'. The both will return true when the pid is occupied by one progress, but 'kill -0 $pid' will return true and the 'ps -p $pid' will return false when the pid is occupied by one progress's sub thread.

StackOverflow discussion:
https://stackoverflow.com/questions/30958964/why-do-kill-0-pid-echo-and-ps-ppid-echo-sometimes-differ

