### PR TITLE
Gradle build: add mavenLocal() repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -350,9 +350,9 @@ allprojects {
 
     repositories {
         mavenCentral()
+        mavenLocal()
     }
 }
-
 
 def javadocProjects = [
         ":bookkeeper-common",

--- a/build.gradle
+++ b/build.gradle
@@ -354,6 +354,7 @@ allprojects {
     }
 }
 
+
 def javadocProjects = [
         ":bookkeeper-common",
         ":bookkeeper-server",


### PR DESCRIPTION
### Motivation

In Gradle you need to add `mavenLocal()` repository if you want to test local versions of third party libraries built with Maven (like ZooKeeper, Curator...)


### Changes
Add `mavenLocal()`  repository