### PR TITLE
Log NoLedgerException at debug level

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
@@ -75,7 +75,7 @@ class ReadLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             }
         } catch (Bookie.NoLedgerException e) {
             status = StatusCode.ENOLEDGER;
-            logger.error("No ledger found while performing readLac from ledger: {}", ledgerId, e);
+            logger.debug("No ledger found while performing readLac from ledger: {}", ledgerId, e);
         } catch (BookieException.DataUnknownException e) {
             status = StatusCode.EUNKNOWNLEDGERSTATE;
             logger.error("Ledger {} in unknown state and cannot serve reacLac requests", ledgerId, e);
@@ -93,7 +93,7 @@ class ReadLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             }
         } catch (Bookie.NoLedgerException e) {
             status = StatusCode.ENOLEDGER;
-            logger.warn("No ledger found while trying to read last entry: {}", ledgerId, e);
+            logger.debug("No ledger found while trying to read last entry: {}", ledgerId, e);
         } catch (Bookie.NoEntryException e) {
             status = StatusCode.ENOENTRY;
             logger.warn("No Entry found while trying to read last entry: {}", ledgerId, e);


### PR DESCRIPTION
### Motivation

NoLedgerException does not signify an error in the Bookie that needs
to be fixed. Instead it is a user error that the user is notified about via
the status code `ENOLEDGER`.
Logging this problem at error level introduces an odd difference
between the behaviour of readLac using v2 versus v3 protocol version.
In the former case ReadEntryProcessor logs the same problem at debug
level. As a result changing protocol version appears to be introducing
an error.


