### PR TITLE
[website] Fix deploy push to git - use ssh

### DIFF
--- a/.github/workflows/website-staging-deploy.yaml
+++ b/.github/workflows/website-staging-deploy.yaml
@@ -55,6 +55,5 @@ jobs:
 
       - name: Publish
         run: |
-          git remote set-url origin git@github.com:apache/bookkeeper.git
           ./site3/website/scripts/build-website.sh
           ./site3/website/scripts/publish-website.sh

--- a/.github/workflows/website-staging-deploy.yaml
+++ b/.github/workflows/website-staging-deploy.yaml
@@ -55,5 +55,6 @@ jobs:
 
       - name: Publish
         run: |
+          git remote set-url origin git@github.com:apache/bookkeeper.git
           ./site3/website/scripts/build-website.sh
           ./site3/website/scripts/publish-website.sh

--- a/site/scripts/publish-website.sh
+++ b/site/scripts/publish-website.sh
@@ -22,9 +22,6 @@
 #       staging the changes, try the `staging-website.sh` script.
 source scripts/common.sh
 
-ORIGIN_REPO=$(git remote show origin | grep 'Push  URL' | awk -F// '{print $NF}')
-echo "ORIGIN_REPO: $ORIGIN_REPO"
-
 (
   cd $APACHE_GENERATED_DIR
 
@@ -33,7 +30,8 @@ echo "ORIGIN_REPO: $ORIGIN_REPO"
   cd $TMP_DIR
 
   # clone the remote repo
-  git clone "https://$ORIGIN_REPO" .
+  # Workaround: https://stackoverflow.com/questions/22147574/fatal-could-not-read-username-for-https-github-com-no-such-file-or-directo
+  git clone "git@github.com:apache/bookkeeper.git" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
   git checkout asf-site

--- a/site3/website/scripts/build-website.sh
+++ b/site3/website/scripts/build-website.sh
@@ -15,5 +15,4 @@ node $SCRIPTS_DIR/replace.js
 yarn build
 
 # inject Javadocs
-$SCRIPTS_DIR/javadoc-gen.sh all
 $SCRIPTS_DIR/javadoc-gen.sh latest


### PR DESCRIPTION
### Motivation

The website deploy fails in this way: https://github.com/apache/bookkeeper/runs/5588066218?check_suite_focus=true

A workaround is to clone the repo using SSH instead of HTTPS
https://stackoverflow.com/questions/22147574/fatal-could-not-read-username-for-https-github-com-no-such-file-or-directo

### Changes
* Clone repo using ssh before pushing to asf-site
* Remove javadoc generation for old javadoc in staging site - this could be done in another PR but in this way we should be able to unblock it with less PR overhead - we'll add javadoc manually later on (atm [it fails](https://github.com/apache/bookkeeper/runs/5588079677?check_suite_focus=true) but there is no need to rebuild them everytime