### PR TITLE
[website] use GH_TOKEN to push to asf-site and asf-staging branches

### DIFF
--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -29,6 +29,7 @@ on:
 jobs:
   build-website:
     name: Build and publish website
+    if: ${{ github.repository == 'apache/bookkeeper' }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:

--- a/.github/workflows/website-staging-deploy.yaml
+++ b/.github/workflows/website-staging-deploy.yaml
@@ -33,6 +33,7 @@ env:
 jobs:
   stage-website:
     name: Build and stage website
+    if: ${{ github.repository == 'apache/bookkeeper' }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:

--- a/site/scripts/publish-website.sh
+++ b/site/scripts/publish-website.sh
@@ -21,6 +21,8 @@
 # NOTE: this is the script used by CI to push to apache. If you are looking for
 #       staging the changes, try the `staging-website.sh` script.
 source scripts/common.sh
+ORIGIN_REPO=$(git remote show origin | grep 'Push  URL' | awk -F// '{print $NF}')
+echo "ORIGIN_REPO: $ORIGIN_REPO"
 
 (
   cd $APACHE_GENERATED_DIR
@@ -30,8 +32,7 @@ source scripts/common.sh
   cd $TMP_DIR
 
   # clone the remote repo
-  # Workaround: https://stackoverflow.com/questions/22147574/fatal-could-not-read-username-for-https-github-com-no-such-file-or-directo
-  git clone "git@github.com:apache/bookkeeper.git" .
+  git clone --depth 1 -b asf-site "https://$GH_TOKEN@$ORIGIN_REPO" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
   git checkout asf-site

--- a/site/scripts/publish-website.sh
+++ b/site/scripts/publish-website.sh
@@ -35,7 +35,6 @@ echo "ORIGIN_REPO: $ORIGIN_REPO"
   git clone --depth 1 -b asf-site "https://$GH_TOKEN@$ORIGIN_REPO" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
-  git checkout asf-site
   # copy the apache generated dir
   cp -r $APACHE_GENERATED_DIR/content/* $TMP_DIR/content
 

--- a/site3/website/scripts/publish-website.sh
+++ b/site3/website/scripts/publish-website.sh
@@ -32,10 +32,9 @@ TMP_DIR=/tmp/bookkeeper-site
   cd $TMP_DIR
 
   # clone the remote repo
-  git clone --depth 1 -b asf-site "https://$GH_TOKEN@$ORIGIN_REPO" .
+  git clone --depth 1 -b asf-staging "https://$GH_TOKEN@$ORIGIN_REPO" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
-  git checkout asf-staging
   # copy the apache generated dir
   mkdir -p content
   cp -r $ROOT_DIR/site3/website/build/* content

--- a/site3/website/scripts/publish-website.sh
+++ b/site3/website/scripts/publish-website.sh
@@ -32,7 +32,7 @@ TMP_DIR=/tmp/bookkeeper-site
   cd $TMP_DIR
 
   # clone the remote repo
-  git clone "https://$ORIGIN_REPO" .
+  git clone --depth 1 -b asf-site "https://$GH_TOKEN@$ORIGIN_REPO" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
   git checkout asf-staging


### PR DESCRIPTION
### Motivation

At the moment the website deployment fail due to lack of write permissions to the repo. we can use the GH_TOKEN for the authentication


### Changes
* Clone repositories with GH_TOKEN before pushing
