### PR TITLE
[website] fix GITHUB_TOKEN used for deployment

### DIFF
--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -49,6 +49,8 @@ jobs:
           ruby-version: 2.6.9
 
       - name: publish
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           #!/bin/bash
           set -e

--- a/.github/workflows/website-staging-deploy.yaml
+++ b/.github/workflows/website-staging-deploy.yaml
@@ -55,6 +55,8 @@ jobs:
         run: npm install -g yarn
 
       - name: Publish
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           ./site3/website/scripts/build-website.sh
           ./site3/website/scripts/publish-website.sh

--- a/site/scripts/publish-website.sh
+++ b/site/scripts/publish-website.sh
@@ -32,7 +32,7 @@ echo "ORIGIN_REPO: $ORIGIN_REPO"
   cd $TMP_DIR
 
   # clone the remote repo
-  git clone --depth 1 -b asf-site "https://$GH_TOKEN@$ORIGIN_REPO" .
+  git clone --depth 1 -b asf-site "https://site-updater:${GITHUB_TOKEN}@$ORIGIN_REPO" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
   # copy the apache generated dir

--- a/site3/website/scripts/publish-website.sh
+++ b/site3/website/scripts/publish-website.sh
@@ -32,7 +32,7 @@ TMP_DIR=/tmp/bookkeeper-site
   cd $TMP_DIR
 
   # clone the remote repo
-  git clone --depth 1 -b asf-staging "https://$GH_TOKEN@$ORIGIN_REPO" .
+  git clone --depth 1 -b asf-staging "https://site-updater:${GITHUB_TOKEN}@$ORIGIN_REPO" .
   git config user.name "Apache BookKeeper Site Updater"
   git config user.email "dev@bookkeeper.apache.org"
   # copy the apache generated dir


### PR DESCRIPTION
### Motivation

GH_TOKEN is not set by default. At the moment it fails in this way:
>fatal: could not read Username for 'https://github.com/': No such device or address

### Changes
* Set GITHUB_TOKEN with the secrets.GITHUB_TOKEN value
* Add fake user while cloning