### PR TITLE
[feature] [distributedlog]  Add a api for delete empty zookeeper node

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/metadata/LogStreamMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/metadata/LogStreamMetadataStore.java
@@ -86,13 +86,25 @@ public interface LogStreamMetadataStore extends Closeable {
                                         boolean createIfNotExists);
 
     /**
-     * Delete the metadata of a log.
+     * Delete the metadata of a log, this method will delete all child node.
      *
      * @param uri the location to store the metadata of the log
      * @param streamName the name of the log stream
      * @return future represents the result of the deletion.
      */
     CompletableFuture<Void> deleteLog(URI uri, String streamName);
+
+    /**
+     * Delete the metadata of a log, this method will not delete any child node,
+     * When {@param streamName} is not empty, delete nothing.
+     *
+     * @param uri the location to store the metadata of the log
+     * @param streamName the name of the log stream
+     * @return When delete finish return {@link Boolean#TRUE};
+     *         when {@param streamName} not exists return {@link Boolean#TRUE}
+     *         when delete nothing return {@link Boolean#FALSE}
+     */
+    CompletableFuture<Boolean> deleteLogUnRecursive(URI uri, final String streamName);
 
     /**
      * Rename the log from <i>oldStreamName</i> to <i>newStreamName</i>.

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/impl/metadata/TestZKLogStreamMetadataStore.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/impl/metadata/TestZKLogStreamMetadataStore.java
@@ -82,6 +82,7 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -589,6 +590,23 @@ public class TestZKLogStreamMetadataStore extends ZooKeeperClusterTestCase {
 
         String newLogName = "path_rename_locked/to/new/" + logName;
         FutureUtils.result(metadataStore.renameLog(uri, logName, newLogName));
+    }
+
+    @Test(timeout = 60000)
+    public void testDeleteLogUnRecursive() throws Exception {
+        String logName = testName.getMethodName();
+        String logIdentifier = "<default>";
+        String rootPath = getLogRootPath(uri, logName, logIdentifier);
+        String testPath = rootPath + "/test";
+        String logNameChildTest = logName + "/test";
+        // no node
+        Assert.assertEquals(true, metadataStore.deleteLogUnRecursive(uri, logNameChildTest).get());
+        // delete nothing
+        Utils.zkCreateFullPathOptimistic(zkc, testPath, new byte[0],
+                zkc.getDefaultACL(), CreateMode.PERSISTENT);
+        Assert.assertEquals(false, metadataStore.deleteLogUnRecursive(uri, logName).get());
+        // delete finish
+        Assert.assertEquals(true, metadataStore.deleteLogUnRecursive(uri, logNameChildTest).get());
     }
 
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fixes #3132 

Master Issue: #3132 

### Motivation

Provide another API for delete log path.

Why not use `CompletableFuture<Void> deleteLog(URI uri, String streamName)` ? 
Because this method will delete node recursively.  If there's a case like this: 

````
// Thead-1
create log "default/example/v0.1"

// Thdead-2
delete log "default"

// Now thead-1's create-operate be removed
````



### Changes

Add a new API like this : 
` CompletableFuture<Boolean> deleteLogUnRecursive(URI uri, final String streamName)`

