### PR TITLE
Upgrade jackson version to fix CVE-2020-36518

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
@@ -309,9 +309,9 @@ Apache Software License, Version 2.
 - lib/org.xerial.snappy-snappy-java-1.1.7.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 
-[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
-[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
+[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.2
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.2
+[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.13.2
 [4] Source available at https://github.com/google/guava/tree/v31.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
 [6] Source available at http://svn.apache.org/viewvc/commons/proper/codec/tags/1_6/

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
@@ -286,9 +286,9 @@ Apache Software License, Version 2.
 - lib/org.xerial.snappy-snappy-java-1.1.7.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 
-[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
-[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
+[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.2
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.2
+[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.13.2
 [4] Source available at https://github.com/google/guava/tree/v31.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
 [6] Source available at http://svn.apache.org/viewvc/commons/proper/codec/tags/1_6/

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.11.0.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.11.3.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.11.0.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
@@ -307,9 +307,9 @@ Apache Software License, Version 2.
 - lib/org.xerial.snappy-snappy-java-1.1.7.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 
-[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
-[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.11.0
+[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.2
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.2
+[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.13.2
 [4] Source available at https://github.com/google/guava/tree/v31.0
 [5] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-cli.git;a=tag;h=bc8f0e
 [6] Source available at http://svn.apache.org/viewvc/commons/proper/codec/tags/1_6/

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -49,7 +49,7 @@ depVersions = [
     hamcrest: "1.3",
     hdrhistogram: "2.1.10",
     httpclient: "4.5.13",
-    jackson: "2.11.0",
+    jackson: "2.13.2",
     javaxServlet: "4.0.0",
     javaAnnotations:"1.3.2",
     jcommander: "1.78",


### PR DESCRIPTION
### Motivation
Fix [CVE-2020-36518](https://www.cve.org/CVERecord?id=CVE-2020-36518)

jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.

### Modification
Upgrade jackson version from 2.11.0 to 2.13.2