### PR TITLE
Revert rocksdb compaction on checkpoint to reduce cpu intensive

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -201,7 +201,6 @@ public class EntryLocationIndex implements Closeable {
         long deletedEntriesInBatch = 0;
 
         Batch batch = locationsDb.newBatch();
-        final byte[] firstDeletedKey = new byte[keyToDelete.array.length];
 
         try {
             for (long ledgerId : ledgersToDelete) {
@@ -244,9 +243,6 @@ public class EntryLocationIndex implements Closeable {
                     }
                     batch.remove(keyToDelete.array);
                     ++deletedEntriesInBatch;
-                    if (deletedEntries++ == 0) {
-                        System.arraycopy(keyToDelete.array, 0, firstDeletedKey, 0, firstDeletedKey.length);
-                    }
                 }
 
                 if (deletedEntriesInBatch > DELETE_ENTRIES_BATCH_SIZE) {
@@ -259,9 +255,6 @@ public class EntryLocationIndex implements Closeable {
             try {
                 batch.flush();
                 batch.clear();
-                if (deletedEntries != 0) {
-                    locationsDb.compact(firstDeletedKey, keyToDelete.array);
-                }
             } finally {
                 firstKeyWrapper.recycle();
                 lastKeyWrapper.recycle();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
@@ -321,16 +321,12 @@ public class LedgerMetadataIndex implements Closeable {
 
     public void removeDeletedLedgers() throws IOException {
         LongWrapper key = LongWrapper.get();
-        final byte[] startKey = new byte[key.array.length];
 
         int deletedLedgers = 0;
         while (!pendingDeletedLedgers.isEmpty()) {
             long ledgerId = pendingDeletedLedgers.poll();
             key.set(ledgerId);
             ledgersDb.delete(key.array);
-            if (deletedLedgers++ == 0) {
-                System.arraycopy(key.array, 0, startKey, 0, startKey.length);
-            }
         }
 
         if (log.isDebugEnabled()) {
@@ -338,9 +334,6 @@ public class LedgerMetadataIndex implements Closeable {
         }
 
         ledgersDb.sync();
-        if (deletedLedgers != 0) {
-            ledgersDb.compact(startKey, key.array);
-        }
         key.recycle();
     }
 


### PR DESCRIPTION
### Motivation
https://github.com/apache/bookkeeper/pull/2686 introduce RocksDB compaction on checkpoint to fix seeking RocksDB metadata timeout issue. However, trigger RocksDB compaction is a heavy operation and the checkpoint will be triggered in high frequency, which cause db-storage-cleanup thread always into high load, and make the cpu keeps 100%. https://github.com/apache/bookkeeper/pull/2686#issuecomment-1065893543 

Related logs: https://github.com/apache/bookkeeper/pull/2686#issuecomment-1065888832
 
In order to fix this issue, we divide into two steps.
1. Remove the compactRange logic in during checkpoint
2. Figure out smarter solution for deleted entry compaction in RocksDB

This is the first part.

I have sent a discuss into dev mail list.
https://lists.apache.org/thread/jkfbodv6xv2szz8ldb5mvkb00hoor5yj


### Changes
1. Remove the compactRange logic during checkpoint.
