### PR TITLE
Upgrade ZooKeeper to 3.8.0

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -250,9 +250,9 @@ Apache Software License, Version 2.
 - lib/net.java.dev.jna-jna-3.2.7.jar [18]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-lang3-3.6.jar [20]
-- lib/org.apache.zookeeper-zookeeper-3.6.2.jar [21]
-- lib/org.apache.zookeeper-zookeeper-jute-3.6.2.jar [21]
-- lib/org.apache.zookeeper-zookeeper-3.6.2-tests.jar [21]
+- lib/org.apache.zookeeper-zookeeper-3.8.0.jar [21]
+- lib/org.apache.zookeeper-zookeeper-jute-3.8.0.jar [21]
+- lib/org.apache.zookeeper-zookeeper-3.8.0-tests.jar [21]
 - lib/org.eclipse.jetty-jetty-http-9.4.43.v20210629.jar [22]
 - lib/org.eclipse.jetty-jetty-io-9.4.43.v20210629.jar [22]
 - lib/org.eclipse.jetty-jetty-security-9.4.43.v20210629.jar [22]
@@ -329,7 +329,7 @@ Apache Software License, Version 2.
 [18] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
-[21] Source available at https://github.com/apache/zookeeper/tree/release-3.6.2
+[21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.43.v20210629
 [23] Source available at https://github.com/facebook/rocksdb/tree/v6.22.1
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.78

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -290,7 +290,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
 - lib/org.inferred-freebuilder-2.7.0.jar [35]
 - lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [36]
-- lib/org.apache.yetus-audience-annotations-0.5.0.jar [37]
+- lib/org.apache.yetus-audience-annotations-0.12.0.jar [37]
 - lib/org.jctools-jctools-core-2.1.2.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [39]
 - lib/org.apache.httpcomponents-httpcore-4.4.13.jar [40]
@@ -342,7 +342,7 @@ Apache Software License, Version 2.
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
-[37] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
+[37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
 [38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -269,7 +269,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [33]
 - lib/org.inferred-freebuilder-2.7.0.jar [34]
 - lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [35]
-- lib/org.apache.yetus-audience-annotations-0.5.0.jar [36]
+- lib/org.apache.yetus-audience-annotations-0.12.0.jar [36]
 - lib/org.jctools-jctools-core-2.1.2.jar [37]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [38]
 - lib/org.apache.httpcomponents-httpcore-4.4.13.jar [39]
@@ -311,7 +311,7 @@ Apache Software License, Version 2.
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.1.0
 [34] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [35] Source available at https://github.com/google/error-prone/tree/v2.9.0
-[36] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
+[36] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
 [37] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [38] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [39] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -239,9 +239,9 @@ Apache Software License, Version 2.
 - lib/net.java.dev.jna-jna-3.2.7.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [18]
 - lib/org.apache.commons-commons-lang3-3.6.jar [19]
-- lib/org.apache.zookeeper-zookeeper-3.6.2.jar [20]
-- lib/org.apache.zookeeper-zookeeper-jute-3.6.2.jar [20]
-- lib/org.apache.zookeeper-zookeeper-3.6.2-tests.jar [20]
+- lib/org.apache.zookeeper-zookeeper-3.8.0.jar [20]
+- lib/org.apache.zookeeper-zookeeper-jute-3.8.0.jar [20]
+- lib/org.apache.zookeeper-zookeeper-3.8.0-tests.jar [20]
 - lib/com.beust-jcommander-1.78.jar [23]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
 - lib/com.google.api.grpc-proto-google-common-protos-2.0.1.jar [27]
@@ -301,7 +301,7 @@ Apache Software License, Version 2.
 [17] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
-[20] Source available at https://github.com/apache/zookeeper/tree/release-3.6.2
+[20] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [23] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [27] Source available at https://github.com/googleapis/googleapis

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -250,9 +250,9 @@ Apache Software License, Version 2.
 - lib/net.java.dev.jna-jna-3.2.7.jar [18]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-lang3-3.6.jar [20]
-- lib/org.apache.zookeeper-zookeeper-3.6.2.jar [21]
-- lib/org.apache.zookeeper-zookeeper-jute-3.6.2.jar [21]
-- lib/org.apache.zookeeper-zookeeper-3.6.2-tests.jar [21]
+- lib/org.apache.zookeeper-zookeeper-3.8.0.jar [21]
+- lib/org.apache.zookeeper-zookeeper-jute-3.8.0.jar [21]
+- lib/org.apache.zookeeper-zookeeper-3.8.0-tests.jar [21]
 - lib/org.eclipse.jetty-jetty-http-9.4.43.v20210629.jar [22]
 - lib/org.eclipse.jetty-jetty-io-9.4.43.v20210629.jar [22]
 - lib/org.eclipse.jetty-jetty-security-9.4.43.v20210629.jar [22]
@@ -327,7 +327,7 @@ Apache Software License, Version 2.
 [18] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
-[21] Source available at https://github.com/apache/zookeeper/tree/release-3.6.2
+[21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.43.v20210629
 [23] Source available at https://github.com/facebook/rocksdb/tree/v6.16.4
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.78

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -290,7 +290,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
 - lib/org.inferred-freebuilder-2.7.0.jar [35]
 - lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [36]
-- lib/org.apache.yetus-audience-annotations-0.5.0.jar [37]
+- lib/org.apache.yetus-audience-annotations-0.12.0.jar [37]
 - lib/org.jctools-jctools-core-2.1.2.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [39]
 - lib/org.apache.httpcomponents-httpcore-4.4.13.jar [40]
@@ -340,7 +340,7 @@ Apache Software License, Version 2.
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
-[37] Source available at https://github.com/apache/yetus/tree/rel/0.5.0
+[37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
 [38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.4.1
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.1

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -174,6 +174,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+       <!-- needed by ZooKeeper server tests utilities -->
+       <groupId>org.junit.jupiter</groupId>
+       <artifactId>junit-jupiter-api</artifactId>
+       <scope>test</scope>
+    </dependency>
+    <dependency>
        <!-- needed by ZooKeeper server -->
        <groupId>org.xerial.snappy</groupId>
        <artifactId>snappy-java</artifactId>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -29,7 +29,7 @@ depVersions = [
     commonsCli: "1.2",
     commonsCodec: "1.6",
     commonsCollections4: "4.1",
-    commonsCompress: "1.19",
+    commonsCompress: "1.21",
     commonsConfiguration: "1.10",
     commonsIO: "2.7",
     commonsLang2: "2.6",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -86,7 +86,7 @@ depVersions = [
     testcontainers: "1.16.3",
     vertx: "3.9.8",
     yahooDatasketches: "0.8.3",
-    zookeeper: "3.6.2",
+    zookeeper: "3.8.0"
 ]
 
 depLibs = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -29,7 +29,7 @@ depVersions = [
     commonsCli: "1.2",
     commonsCodec: "1.6",
     commonsCollections4: "4.1",
-    commonsCompress: "1.21",
+    commonsCompress: "1.19",
     commonsConfiguration: "1.10",
     commonsIO: "2.7",
     commonsLang2: "2.6",
@@ -74,7 +74,7 @@ depVersions = [
     prometheus: "0.8.1",
     protobuf: "3.16.1",
     reflections: "0.9.11",
-    rocksDb: "6.29.4.1",
+    rocksDb: "6.27.3",
     rxjava: "3.0.1",
     slf4j: "1.7.32",
     snakeyaml: "1.30",
@@ -86,7 +86,7 @@ depVersions = [
     testcontainers: "1.16.3",
     vertx: "3.9.8",
     yahooDatasketches: "0.8.3",
-    zookeeper: "3.8.0"
+    zookeeper: "3.8.0",
 ]
 
 depLibs = [
@@ -235,9 +235,11 @@ depLibs = [
     },
     yahooDatasketches: "com.yahoo.datasketches:sketches-core:${depVersions.yahooDatasketches}",
     zookeeper: dependencies.create("org.apache.zookeeper:zookeeper:${depVersions.zookeeper}") {
-        exclude group: 'io.netty', module: 'netty-transport-native-epoll'
-        exclude group: 'log4j', module: 'log4j'
-        exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+        exclude group: 'io.netty'
+        exclude group: 'ch.qos.logback'
     },
-    zookeeperTest: "org.apache.zookeeper:zookeeper:${depVersions.zookeeper}:tests"
+    zookeeperTest: dependencies.create("org.apache.zookeeper:zookeeper:${depVersions.zookeeper}:tests") {
+        exclude group: 'io.netty'
+        exclude group: 'ch.qos.logback'
+    }
 ]

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,8 @@
     <jsoup.version>1.14.3</jsoup.version>
     <jna.version>3.2.7</jna.version>
     <junit.version>4.12</junit.version>
+    <!-- required by zookeeper test utilities imported from ZooKeeper -->
+    <junit5.version>5.6.2</junit5.version>
     <libthrift.version>0.14.2</libthrift.version>
     <lombok.version>1.18.20</lombok.version>
     <log4j.version>2.17.1</log4j.version>
@@ -514,6 +516,13 @@
             <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+         <!-- needed by ZooKeeper server tests utilities -->
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit5.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <javax-annotations-api.version>1.3.2</javax-annotations-api.version>
     <testcontainers.version>1.15.1</testcontainers.version>
     <vertx.version>3.9.8</vertx.version>
-    <zookeeper.version>3.6.2</zookeeper.version>
+    <zookeeper.version>3.8.0</zookeeper.version>
     <snappy.version>1.1.7</snappy.version>
     <jctools.version>2.1.2</jctools.version>
     <!-- plugin dependencies -->
@@ -486,16 +486,8 @@
             <artifactId>javacc</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -511,15 +503,11 @@
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -108,6 +108,70 @@
         <packageUrl regex="true">^pkg:maven/org\.arquillian\.cube/arquillian\-cube\-docker@.*$</packageUrl>
         <cpe>cpe:/a:redhat:docker</cpe>
     </suppress>
-
+  <suppress>
+<!--    Zookkeeper false positive about Jetty and commons-io-->
+<!--    https://github.com/apache/zookeeper/pull/1824-->
+    <notes><![CDATA[
+   file name: zookeeper-3.8.0.jar
+   ]]></notes>
+    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
+    <cve>CVE-2021-28164</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-3.8.0.jar
+   ]]></notes>
+    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
+    <cve>CVE-2021-29425</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-3.8.0.jar
+   ]]></notes>
+    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
+    <cve>CVE-2021-34429</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-prometheus-metrics-3.8.0.jar
+   ]]></notes>
+    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
+    <cve>CVE-2021-28164</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-prometheus-metrics-3.8.0.jar
+   ]]></notes>
+    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
+    <cve>CVE-2021-29425</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-prometheus-metrics-3.8.0.jar
+   ]]></notes>
+    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
+    <cve>CVE-2021-34429</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-jute-3.8.0.jar
+   ]]></notes>
+    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
+    <cve>CVE-2021-28164</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-jute-3.8.0.jar
+   ]]></notes>
+    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
+    <cve>CVE-2021-29425</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: zookeeper-jute-3.8.0.jar
+   ]]></notes>
+    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
+    <cve>CVE-2021-34429</cve>
+  </suppress>
 </suppressions>
 

--- a/stream/statelib/pom.xml
+++ b/stream/statelib/pom.xml
@@ -76,53 +76,11 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>${zookeeper.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.java.dev.javacc</groupId>
-          <artifactId>javacc</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>${zookeeper.version}</version>
       <type>test-jar</type>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/stream/storage/impl/pom.xml
+++ b/stream/storage/impl/pom.xml
@@ -77,53 +77,11 @@
     <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>${zookeeper.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>net.java.dev.javacc</groupId>
-            <artifactId>javacc</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>${zookeeper.version}</version>
         <type>test-jar</type>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation

We are using an old version of ZooKeeper, 3.6.x (and ZooKeeper 3.5.x was declared EOL a few weeks ago).
We should upgrade to the latest version.

### Changes

- Upgraded ZooKeeper dependency.
- Exclude LogBack
- Add junit5 jupiter-api required by org.apache.zookeeper.test.ClientBase

### Notes
In PR #3084 I tried to update ZooKeeper in Gradle files, but without success.
This patch focuses only on Maven