### PR TITLE
BookieAutoRecoveryTest.testEmptyLedgerLosesQuorumEventually fix flaky test, ensure that the Auditor is alive

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -270,7 +270,8 @@ public class BookieServer {
                     Thread.currentThread().interrupt();
                 }
                 if (!isBookieRunning()) {
-                    LOG.info("BookieDeathWatcher noticed the bookie is not running any more, exiting the watch loop!");
+                    LOG.info("BookieDeathWatcher noticed the bookie {} is not running any more, " +
+                            "exiting the watch loop!", bookie);
                     // death watcher has noticed that bookie is not running any more
                     // throw an exception to fail the death watcher thread and it will
                     // trigger the uncaught exception handler to handle this "bookie not running" situation.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -270,8 +270,7 @@ public class BookieServer {
                     Thread.currentThread().interrupt();
                 }
                 if (!isBookieRunning()) {
-                    LOG.info("BookieDeathWatcher noticed the bookie {} is not running any more, " +
-                            "exiting the watch loop!", bookie);
+                    LOG.info("BookieDeathWatcher noticed the bookie is not running any more, exiting the watch loop!");
                     // death watcher has noticed that bookie is not running any more
                     // throw an exception to fail the death watcher thread and it will
                     // trigger the uncaught exception handler to handle this "bookie not running" situation.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -185,6 +185,11 @@ public class AutoRecoveryMain {
         return auditorElector.getAuditor();
     }
 
+    @VisibleForTesting
+    public ReplicationWorker getReplicationWorker() {
+        return replicationWorker;
+    }
+
     /** Is auto-recovery service running? */
     public boolean isAutoRecoveryRunning() {
         return running;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -249,7 +249,6 @@ public class ReplicationWorker implements Runnable {
                 if (Thread.currentThread().isInterrupted()) {
                     LOG.error("Interrupted  while replicating fragments");
                     shutdown();
-                    Thread.currentThread().interrupt();
                     return;
                 }
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -403,8 +403,12 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         assertTrue("Should be marked as underreplicated", latch.await(5, TimeUnit.SECONDS));
         latch = new CountDownLatch(1);
         s = watchUrLedgerNode(urZNode, latch); // should be marked as replicated
+
+        startNewBookie();
+        getAuditor(10, TimeUnit.SECONDS).submitAuditTask().get(); // ensure auditor runs
+
         if (s != null) {
-            assertTrue("Should be marked as replicated", latch.await(5, TimeUnit.SECONDS));
+            assertTrue("Should be marked as replicated", latch.await(20, TimeUnit.SECONDS));
         }
 
         // should be able to open ledger without issue


### PR DESCRIPTION
### Motivation

The test testEmptyLedgerLosesQuorumEventually kills two bookies, and very often it kills the Auditor Bookie.

### Changes

- BookKeeperClusterTestCase.getAuditor(), ensure that we pick up a Auditor that is running and that is not going to die soon
- ReplicationWorker exits the main loop in case of InterruptedException masked by a UnavailableException (this reduces a lot the spam in the logs, because in any case the thread is deemed to always fail for InterruptedExceptions)
- in testEmptyLedgerLosesQuorumEventually ensure that the Auditor runs and start a new Bookie before the final check (the Auditor does nothing if the is no "bookie to audit", so there are races in which if the cluster does not change the Auditor does not kick in in any case)