### PR TITLE
support change compaction rate dynamically

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/AbstractLogCompactor.java
@@ -22,7 +22,6 @@
 package org.apache.bookkeeper.bookie;
 
 import com.google.common.util.concurrent.RateLimiter;
-
 import org.apache.bookkeeper.conf.ServerConfiguration;
 
 /**
@@ -59,10 +58,12 @@ public abstract class AbstractLogCompactor {
 
     static class Throttler {
         private final RateLimiter rateLimiter;
-        private final boolean isThrottleByBytes;
+        private final ServerConfiguration conf;
+        private boolean isThrottleByBytes;
 
         Throttler(ServerConfiguration conf) {
-            this.isThrottleByBytes  = conf.getIsThrottleByBytes();
+            this.conf = conf;
+            this.isThrottleByBytes = conf.getIsThrottleByBytes();
             this.rateLimiter = RateLimiter.create(this.isThrottleByBytes
                 ? conf.getCompactionRateByBytes() : conf.getCompactionRateByEntries());
         }
@@ -70,6 +71,18 @@ public abstract class AbstractLogCompactor {
         // acquire. if bybytes: bytes of this entry; if byentries: 1.
         void acquire(int permits) {
             rateLimiter.acquire(this.isThrottleByBytes ? permits : 1);
+        }
+
+        // reset rate of limiter before compact one entry log file
+        void resetRate() {
+            this.isThrottleByBytes = conf.getIsThrottleByBytes();
+            this.rateLimiter.setRate(this.isThrottleByBytes
+                ? conf.getCompactionRateByBytes() : conf.getCompactionRateByEntries());
+        }
+
+        // get rate of limiter for unit test
+        double getRate() {
+            return this.rateLimiter.getRate();
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
@@ -22,11 +22,9 @@
 package org.apache.bookkeeper.bookie;
 
 import io.netty.buffer.ByteBuf;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,10 +56,14 @@ public class EntryLogCompactor extends AbstractLogCompactor {
     @Override
     public boolean compact(EntryLogMetadata entryLogMeta) {
         try {
+            long start = System.currentTimeMillis();
+            throttler.resetRate();
             entryLogger.scanEntryLog(entryLogMeta.getEntryLogId(),
                 scannerFactory.newScanner(entryLogMeta));
+            long scan = System.currentTimeMillis();
             scannerFactory.flush();
-            LOG.info("Removing entry log {} after compaction", entryLogMeta.getEntryLogId());
+            LOG.info("Removing entry log {} after compaction, scan {}ms ,flush {}ms",
+                entryLogMeta.getEntryLogId(), scan - start, System.currentTimeMillis() - scan);
             logRemovalListener.removeEntryLog(entryLogMeta.getEntryLogId());
         } catch (LedgerDirsManager.NoWritableLedgerDirException nwlde) {
             LOG.warn("No writable ledger directory available, aborting compaction", nwlde);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -23,7 +23,6 @@ package org.apache.bookkeeper.bookie;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.concurrent.DefaultThreadFactory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -35,9 +34,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import java.util.concurrent.atomic.AtomicLong;
-
 import lombok.Getter;
 import org.apache.bookkeeper.bookie.GarbageCollector.GarbageCleaner;
 import org.apache.bookkeeper.bookie.stats.GarbageCollectorStats;
@@ -497,8 +494,9 @@ public class GarbageCollectorThread extends SafeRunnable {
             }
         }
         LOG.info(
-                "Compaction: entry log usage buckets[10% 20% 30% 40% 50% 60% 70% 80% 90% 100%] = {}, compacted {}",
-                entryLogUsageBuckets, compactedBuckets);
+            "Compaction: entry log usage buckets[10% 20% 30% 40% 50% 60% 70% 80% 90% 100%] = {}, compacted {}, cost " 
+                + "{}ms",
+            entryLogUsageBuckets, compactedBuckets, System.currentTimeMillis() - start);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -494,8 +494,8 @@ public class GarbageCollectorThread extends SafeRunnable {
             }
         }
         LOG.info(
-            "Compaction: entry log usage buckets[10% 20% 30% 40% 50% 60% 70% 80% 90% 100%] = {}, compacted {}, cost " 
-                + "{}ms",
+            "Compaction: entry log usage buckets[10% 20% 30% 40% 50% 60% 70% 80% 90% 100%] = {}, compacted {}, cost"
+                + " {}ms",
             entryLogUsageBuckets, compactedBuckets, System.currentTimeMillis() - start);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -22,12 +22,10 @@
 package org.apache.bookkeeper.bookie;
 
 import io.netty.buffer.ByteBuf;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.util.HardLink;
@@ -171,6 +169,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
         void start() throws IOException {
             // scan entry log into compaction log and offset list
             entryLogger.createNewCompactionLog();
+            throttler.resetRate();
             entryLogger.scanEntryLog(metadata.getEntryLogId(), new EntryLogScanner() {
                 @Override
                 public boolean accept(long ledgerId) {


### PR DESCRIPTION
Fix #3147 

### Motivation

when disk will be full for compaction rate of limiter  is too small , we want change the  rate dynamically by rest admin api without restart this bookie. 

### Changes

get and reset the rate of limiter from server config before compact one entry log file 

