### PR TITLE
Make netty acceptor threadPool size configurable

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -178,6 +178,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String SERVER_SOCK_LINGER = "serverTcpLinger";
     protected static final String SERVER_WRITEBUFFER_LOW_WATER_MARK = "serverWriteBufferLowWaterMark";
     protected static final String SERVER_WRITEBUFFER_HIGH_WATER_MARK = "serverWriteBufferHighWaterMark";
+
+    protected static final String SERVER_NUM_ACCEPTOR_THREADS = "serverNumAcceptorThreads";
     protected static final String SERVER_NUM_IO_THREADS = "serverNumIOThreads";
 
     // Zookeeper Parameters
@@ -1473,6 +1475,15 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public int getServerNumIOThreads() {
         return getInt(SERVER_NUM_IO_THREADS, 2 * Runtime.getRuntime().availableProcessors());
+    }
+
+    /**
+     * Get the number of Acceptor threads.
+     *
+     * @return the number of Acceptor threads
+     */
+    public int getServerNumAcceptorThreads() {
+        return getInt(SERVER_NUM_ACCEPTOR_THREADS, 1);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -93,6 +93,7 @@ class BookieNettyServer {
     final int maxFrameSize;
     final ServerConfiguration conf;
     final EventLoopGroup eventLoopGroup;
+    final EventLoopGroup acceptorGroup;
     final EventLoopGroup jvmEventLoopGroup;
     RequestProcessor requestProcessor;
     final AtomicBoolean isRunning = new AtomicBoolean(false);
@@ -119,9 +120,11 @@ class BookieNettyServer {
 
         if (!conf.isDisableServerSocketBind()) {
             this.eventLoopGroup = EventLoopUtil.getServerEventLoopGroup(conf, new DefaultThreadFactory("bookie-io"));
+            this.acceptorGroup = EventLoopUtil.getServerAcceptorGroup(conf, new DefaultThreadFactory("bookie-acceptor"));
             allChannels = new CleanupChannelGroup(eventLoopGroup);
         } else {
             this.eventLoopGroup = null;
+            this.acceptorGroup = null;
         }
 
         if (conf.isEnableLocalTransport()) {
@@ -301,7 +304,7 @@ class BookieNettyServer {
             ServerBootstrap bootstrap = new ServerBootstrap();
             bootstrap.option(ChannelOption.ALLOCATOR, allocator);
             bootstrap.childOption(ChannelOption.ALLOCATOR, allocator);
-            bootstrap.group(eventLoopGroup, eventLoopGroup);
+            bootstrap.group(acceptorGroup, eventLoopGroup);
             bootstrap.childOption(ChannelOption.TCP_NODELAY, conf.getServerTcpNoDelay());
             bootstrap.childOption(ChannelOption.SO_LINGER, conf.getServerSockLinger());
             bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -440,6 +440,14 @@ class BookieNettyServer {
 
         allChannels.close().awaitUninterruptibly();
 
+        if (acceptorGroup != null) {
+            try {
+                acceptorGroup.shutdownGracefully(0, 10, TimeUnit.MILLISECONDS).await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
         if (eventLoopGroup != null) {
             try {
                 eventLoopGroup.shutdownGracefully(0, 10, TimeUnit.MILLISECONDS).await();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -119,8 +119,10 @@ class BookieNettyServer {
         this.authProviderFactory = AuthProviderFactoryFactory.newBookieAuthProviderFactory(conf);
 
         if (!conf.isDisableServerSocketBind()) {
-            this.eventLoopGroup = EventLoopUtil.getServerEventLoopGroup(conf, new DefaultThreadFactory("bookie-io"));
-            this.acceptorGroup = EventLoopUtil.getServerAcceptorGroup(conf, new DefaultThreadFactory("bookie-acceptor"));
+            this.eventLoopGroup = EventLoopUtil.getServerEventLoopGroup(conf,
+                    new DefaultThreadFactory("bookie-io"));
+            this.acceptorGroup = EventLoopUtil.getServerAcceptorGroup(conf,
+                    new DefaultThreadFactory("bookie-acceptor"));
             allChannels = new CleanupChannelGroup(eventLoopGroup);
         } else {
             this.eventLoopGroup = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/EventLoopUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/EventLoopUtil.java
@@ -47,6 +47,10 @@ public class EventLoopUtil {
         return getEventLoopGroup(threadFactory, conf.getServerNumIOThreads(), conf.isBusyWaitEnabled());
     }
 
+    public static EventLoopGroup getServerAcceptorGroup(ServerConfiguration conf, ThreadFactory threadFactory) {
+        return getEventLoopGroup(threadFactory, conf.getServerNumAcceptorThreads(), conf.isBusyWaitEnabled());
+    }
+
     private static EventLoopGroup getEventLoopGroup(ThreadFactory threadFactory,
             int numThreads, boolean enableBusyWait) {
         if (!SystemUtils.IS_OS_LINUX) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/EventLoopUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/EventLoopUtil.java
@@ -48,7 +48,7 @@ public class EventLoopUtil {
     }
 
     public static EventLoopGroup getServerAcceptorGroup(ServerConfiguration conf, ThreadFactory threadFactory) {
-        return getEventLoopGroup(threadFactory, conf.getServerNumAcceptorThreads(), conf.isBusyWaitEnabled());
+        return getEventLoopGroup(threadFactory, conf.getServerNumAcceptorThreads(), false);
     }
 
     private static EventLoopGroup getEventLoopGroup(ThreadFactory threadFactory,


### PR DESCRIPTION
Descriptions of the changes in this PR:
default value of acceptor threadPool is 2*cpu core, it is unnecessary and not separate configuration。

### Motivation

Make Netty acceptor threads  separate configurable

### Changes

(Describe: what changes you have made)

- [x] `no-need-doc` 
  
  (Please explain why)

