### PR TITLE
[website] Update current stable version to 4.14.4

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -49,7 +49,7 @@ archived_versions:
 - "4.0.0"
 latest_version: "4.15.0-SNAPSHOT"
 latest_release: "4.14.4"
-stable_release: "4.11.1"
+stable_release: "4.14.4"
 eol_releases:
 - "4.9.2"
 - "4.9.1"

--- a/site3/website/docusaurus.config.js
+++ b/site3/website/docusaurus.config.js
@@ -8,7 +8,7 @@ const deployUrl = process.env.DEPLOY_URL || "https://bookkeeper.apache.org";
 const variables = {
   /** They are used in .md files*/
   latest_release: "4.14.4",
-  stable_release: "4.11.1",
+  stable_release: "4.14.4",
   github_repo: "https://github.com/apache/bookkeeper",
   github_master: "https://github.com/apache/bookkeeper/tree/master",
   mirror_base_url: "https://www.apache.org/dyn/closer.lua/bookkeeper",

--- a/site3/website/src/components/RecentReleases/index.js
+++ b/site3/website/src/components/RecentReleases/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import versions from "@site/versions.json"
 
-const releases = versions.slice(1, 6)
+const releases = versions.slice(0, 4)
 
 export default function RecentReleases() {
 

--- a/site3/website/src/pages/releases.md
+++ b/site3/website/src/pages/releases.md
@@ -3,33 +3,18 @@ id: releases
 title: Apache BookKeeper Releases
 ---
 
-Version **{{ site.latest_release }}** is the [latest release](#latest-release) of BookKeeper. The current [stable version](#latest-stable-release) is **{{ site.stable_release }}**.
+Version **{{ site.latest_release }}** is the latest release of BookKeeper. The current stable version is **{{ site.stable_release }}**.
+
+[Release notes](/release-notes#)
+
+import RecentReleases from "@site/src/components/RecentReleases"
+
+<RecentReleases />
 
 > You can verify your download by following these [procedures](http://www.apache.org/info/verification.html) and using these [KEYS]({{ site.dist_base_url }}/KEYS).
 
 If you want to download older, archived releases, they are available in the [Apache archive](http://archive.apache.org/dist/bookkeeper/).
 
-[Release notes](/release-notes#)
-## Latest release (version {{ site.latest_release }}) {#latest-release}
-
-Release | Link | Crypto files
-:-------|:-----|:------------
-Source | [bookkeeper-{{ site.latest_release }}-src.tar.gz]({{ site.mirror_base_url }}/bookkeeper-{{ site.latest_release }}/bookkeeper-{{ site.latest_release }}-src.tar.gz) | [asc]({{ site.dist_base_url }}/bookkeeper-{{ site.latest_release }}/bookkeeper-{{ site.latest_release }}-src.tar.gz.asc), [sha512]({{ site.dist_base_url }}/bookkeeper-{{ site.latest_release }}/bookkeeper-{{ site.latest_release }}-src.tar.gz.sha512)
-Binary | [bookkeeper-server-{{ site.latest_release }}-bin.tar.gz]({{ site.mirror_base_url }}/bookkeeper-{{ site.latest_release }}/bookkeeper-server-{{ site.latest_release }}-bin.tar.gz) | [asc]({{ site.dist_base_url }}/bookkeeper-{{ site.latest_release }}/bookkeeper-server-{{ site.latest_release }}-bin.tar.gz.asc), [sha512]({{ site.dist_base_url }}/bookkeeper-{{ site.latest_release }}/bookkeeper-server-{{ site.latest_release }}-bin.tar.gz.sha512)
-
-## Latest stable release (version {{ site.stable_release }}) {#latest-stable-release}
-
-Release | Link | Crypto files
-:-------|:-----|:------------
-Source | [bookkeeper-{{ site.stable_release }}-src.tar.gz]({{ site.archive_base_url }}/bookkeeper-{{ site.stable_release }}/bookkeeper-{{ site.stable_release }}-src.tar.gz) | [asc]({{ site.archive_base_url }}/bookkeeper-{{ site.stable_release }}/bookkeeper-{{ site.stable_release }}-src.tar.gz.asc), [sha1]({{ site.archive_base_url }}/bookkeeper-{{ site.stable_release }}/bookkeeper-{{ site.stable_release }}-src.tar.gz.sha1)
-Binary | [bookkeeper-server-{{ site.stable_release }}-bin.tar.gz]({{ site.archive_base_url }}/bookkeeper-{{ site.stable_release }}/bookkeeper-server-{{ site.stable_release }}-bin.tar.gz) | [asc]({{ site.archive_base_url }}/bookkeeper-{{ site.stable_release }}/bookkeeper-server-{{ site.stable_release }}-bin.tar.gz.asc), [sha1]({{ site.archive_base_url }}/bookkeeper-{{ site.stable_release }}/bookkeeper-server-{{ site.stable_release }}-bin.tar.gz.sha1)
-
-## Recent releases
-
-
-import RecentReleases from "@site/src/components/RecentReleases"
-
-<RecentReleases />
 
 ## Getting Started
 


### PR DESCRIPTION
### Motivation

The current stable version is 4.14.4 but in the website is still 4.11.1

### Changes

* Edit variables to point to 4.14.4
* Cleanup staging website "download" page
