### PR TITLE
Remove useless and duplicated ledger directory metrics

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -186,13 +186,15 @@ public class DbLedgerStorage implements LedgerStorage {
             File[] lDirs = new File[1];
             // Remove the `/current` suffix which will be appended again by LedgersDirManager
             lDirs[0] = ledgerDir.getParentFile();
-            LedgerDirsManager ldm = new LedgerDirsManager(conf, lDirs, ledgerDirsManager.getDiskChecker(), statsLogger);
+            LedgerDirsManager ldm = new LedgerDirsManager(conf, lDirs, ledgerDirsManager.getDiskChecker(),
+                    NullStatsLogger.INSTANCE);
 
             // Create a index dirs manager for the single directory
             File[] iDirs = new File[1];
             // Remove the `/current` suffix which will be appended again by LedgersDirManager
             iDirs[0] = indexDir.getParentFile();
-            LedgerDirsManager idm = new LedgerDirsManager(conf, iDirs, indexDirsManager.getDiskChecker(), statsLogger);
+            LedgerDirsManager idm = new LedgerDirsManager(conf, iDirs, indexDirsManager.getDiskChecker(),
+                    NullStatsLogger.INSTANCE);
 
             EntryLogger entrylogger;
             if (directIOEntryLogger) {


### PR DESCRIPTION
### Motivation

The disk usage metric and the number of writable directories about ledger directories is duplicated cause `LedgerDirsManager` was created with same ledgerDir more than once, here it is:
1. with `bookie_ledger` scope
https://github.com/apache/bookkeeper/blob/38dc3281f5f175a7d194d4c0d4b255472886187b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java#L365-L366
- `bookie_ledger_dir_<ledger directory>_usage`
- `bookie_ledger_writable_dirs`

2. with `bookie` score
https://github.com/apache/bookkeeper/blob/38dc3281f5f175a7d194d4c0d4b255472886187b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java#L155
- `bookie_dir_<ledger directory>_usage`
- `bookie_writable_dirs`

The second one wasn't bind with a `DiskChecker`, so it's metric never changes.

### Changes

Remove second one, remove metrics below:
- `bookie_dir_<ledger directory>_usage`
- `bookie_writable_dirs`