### PR TITLE
[branch-4.14] Bump Python client version to 4.14.5

### DIFF
--- a/stream/clients/python/setup.py
+++ b/stream/clients/python/setup.py
@@ -19,7 +19,7 @@ import setuptools
 
 name = 'apache-bookkeeper-client'
 description = 'Apache BookKeeper client library'
-version = '4.14.2'
+version = '4.14.5'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
### Motivation
Prepare python client for 4.14.5 release as described in the [release guide](https://bookkeeper.apache.org/community/release_guide/#change-python-client-version)
### Changes
* Bump python client to 4.14.5