### PR TITLE
[build] Fix various spotbugs warnings 

### DIFF
--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Maven
-        run: mvn clean package -B -nsu -DskipBookKeeperServerTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        run: mvn clean package spotbugs:check -B -nsu -DskipBookKeeperServerTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: 'temurin'
           java-version: 11
       - name: Validate pull request
-        run: mvn clean -B -nsu apache-rat:check checkstyle:check package -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        run: mvn clean -B -nsu apache-rat:check checkstyle:check spotbugs:check package -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
         
       - name: Check license files
         run: dev/check-all-licenses

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.benchmark;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Enumeration;
@@ -31,8 +32,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
@@ -31,6 +31,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
@@ -147,6 +149,7 @@ public class BenchReadThroughputLatency {
     }
 
     @SuppressWarnings("deprecation")
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public static void main(String[] args) throws Exception {
         Options options = new Options();
         options.addOption("ledger", true, "Ledger to read. If empty, read all ledgers which come available. "

--- a/bookkeeper-http/servlet-http-server/build.gradle
+++ b/bookkeeper-http/servlet-http-server/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation depLibs.commonsIO
 
     compileOnly depLibs.lombok
+    compileOnly depLibs.spotbugsAnnotations
     annotationProcessor depLibs.lombok
 
     testImplementation depLibs.junit

--- a/bookkeeper-http/servlet-http-server/pom.xml
+++ b/bookkeeper-http/servlet-http-server/pom.xml
@@ -53,13 +53,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/bookkeeper-http/servlet-http-server/pom.xml
+++ b/bookkeeper-http/servlet-http-server/pom.xml
@@ -53,5 +53,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/bookkeeper-http/servlet-http-server/src/main/java/org/apache/bookkeeper/http/servlet/BookieHttpServiceServlet.java
+++ b/bookkeeper-http/servlet-http-server/src/main/java/org/apache/bookkeeper/http/servlet/BookieHttpServiceServlet.java
@@ -20,6 +20,7 @@
  */
 package org.apache.bookkeeper.http.servlet;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Enumeration;
@@ -69,6 +70,7 @@ public class BookieHttpServiceServlet extends HttpServlet {
   }
 
   @Override
+  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
   protected void service(HttpServletRequest httpRequest, HttpServletResponse httpResponse) throws IOException {
     HttpServiceRequest request = new HttpServiceRequest()
                                 .setMethod(httpServerMethod(httpRequest))

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -595,6 +595,7 @@ public class GarbageCollectorThread extends SafeRunnable {
      *
      * @throws InterruptedException if there is an exception stopping gc thread.
      */
+    @SuppressFBWarnings("SWL_SLEEP_WITH_LOCK_HELD")
     public synchronized void shutdown() throws InterruptedException {
         if (!this.running) {
             return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -24,6 +24,7 @@ package org.apache.bookkeeper.bookie;
 import static org.apache.bookkeeper.util.BookKeeperConstants.METADATA_CACHE;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.io.IOException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -35,6 +35,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.RateLimiter;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 
@@ -576,6 +577,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public List<DetectedInconsistency> localConsistencyCheck(Optional<RateLimiter> rateLimiter) throws IOException {
         long checkStart = MathUtils.nowInNano();
         LOG.info("Starting localConsistencyCheck");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -588,7 +588,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         }
     }
 
-    private class CbThreadFactory implements ThreadFactory {
+    private static class CbThreadFactory implements ThreadFactory {
         private int counter = 0;
         private String threadBaseName = "bookie-journal-callback";
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/UncleanShutdownDetectionImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/UncleanShutdownDetectionImpl.java
@@ -48,8 +48,12 @@ public class UncleanShutdownDetectionImpl implements UncleanShutdownDetection {
         for (File ledgerDir : ledgerDirsManager.getAllLedgerDirs()) {
             try {
                 File dirtyFile = new File(ledgerDir, DIRTY_FILENAME);
-                dirtyFile.createNewFile();
-                LOG.info("Created dirty file in ledger dir: {}", ledgerDir.getAbsolutePath());
+                if (dirtyFile.createNewFile()) {
+                    LOG.info("Created dirty file in ledger dir: {}", ledgerDir.getAbsolutePath());
+                } else {
+                    LOG.info("Dirty file already exists in ledger dir: {}", ledgerDir.getAbsolutePath());
+                }
+
             } catch (IOException e) {
                 LOG.error("Unable to register start-up (so an unclean shutdown cannot"
                         + " be detected). Dirty file of ledger dir {} could not be created.",

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCheckImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCheckImpl.java
@@ -24,6 +24,7 @@ import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.disposables.Disposable;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
@@ -39,8 +40,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-
-import io.reactivex.rxjava3.disposables.Disposable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.LedgerStorage;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCheckImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCheckImpl.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import io.reactivex.rxjava3.disposables.Disposable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.LedgerStorage;
@@ -84,12 +85,10 @@ public class DataIntegrityCheckImpl implements DataIntegrityCheck {
     }
 
     @Override
-    public CompletableFuture<Void> runPreBootCheck(String reason) {
+    public synchronized CompletableFuture<Void> runPreBootCheck(String reason) {
         // we only run this once, it could be kicked off by different checks
-        synchronized (this) {
-            if (preBootFuture == null) {
-                preBootFuture = runPreBootSequence(reason);
-            }
+        if (preBootFuture == null) {
+            preBootFuture = runPreBootSequence(reason);
         }
         return preBootFuture;
 
@@ -355,46 +354,47 @@ public class DataIntegrityCheckImpl implements DataIntegrityCheck {
     CompletableFuture<Set<LedgerResult>> checkAndRecoverLedgers(Map<Long, LedgerMetadata> ledgers,
                                                                 String runId) {
         CompletableFuture<Set<LedgerResult>> promise = new CompletableFuture<>();
-        Flowable.fromIterable(ledgers.entrySet())
-            .subscribeOn(scheduler, false)
-            .flatMapSingle((mapEntry) -> {
-                    long ledgerId = mapEntry.getKey();
-                    LedgerMetadata originalMetadata = mapEntry.getValue();
-                    return recoverLedgerIfInLimbo(ledgerId, mapEntry.getValue(), runId)
-                        .map(newMetadata -> LedgerResult.ok(ledgerId, newMetadata))
-                        .onErrorReturn(t -> LedgerResult.error(ledgerId, originalMetadata, t))
-                        .defaultIfEmpty(LedgerResult.missing(ledgerId))
-                        .flatMap((res) -> {
-                                try {
-                                    if (res.isOK()) {
-                                        this.ledgerStorage.clearLimboState(ledgerId);
-                                    }
-                                    return Single.just(res);
-                                } catch (IOException ioe) {
-                                    return Single.just(LedgerResult.error(res.getLedgerId(),
-                                                                          res.getMetadata(), ioe));
-                                }
-                            });
-                },
-                true /* delayErrors */,
-                MAX_INFLIGHT)
-            .flatMapSingle((res) -> {
-                    if (res.isOK()) {
-                        return checkAndRecoverLedgerEntries(res.getLedgerId(),
-                                                            res.getMetadata(), runId)
-                            .map(ignore -> LedgerResult.ok(res.getLedgerId(),
-                                                           res.getMetadata()))
-                            .onErrorReturn(t -> LedgerResult.error(res.getLedgerId(),
-                                                                   res.getMetadata(), t));
-                    } else {
-                        return Single.just(res);
-                    }
-                },
-                true /* delayErrors */,
-                1 /* copy 1 ledger at a time to keep entries together in entrylog */)
-            .collect(Collectors.toSet())
-            .subscribe(resolved -> promise.complete(resolved),
-                       throwable -> promise.completeExceptionally(throwable));
+        final Disposable disposable = Flowable.fromIterable(ledgers.entrySet())
+                .subscribeOn(scheduler, false)
+                .flatMapSingle((mapEntry) -> {
+                            long ledgerId = mapEntry.getKey();
+                            LedgerMetadata originalMetadata = mapEntry.getValue();
+                            return recoverLedgerIfInLimbo(ledgerId, mapEntry.getValue(), runId)
+                                    .map(newMetadata -> LedgerResult.ok(ledgerId, newMetadata))
+                                    .onErrorReturn(t -> LedgerResult.error(ledgerId, originalMetadata, t))
+                                    .defaultIfEmpty(LedgerResult.missing(ledgerId))
+                                    .flatMap((res) -> {
+                                        try {
+                                            if (res.isOK()) {
+                                                this.ledgerStorage.clearLimboState(ledgerId);
+                                            }
+                                            return Single.just(res);
+                                        } catch (IOException ioe) {
+                                            return Single.just(LedgerResult.error(res.getLedgerId(),
+                                                    res.getMetadata(), ioe));
+                                        }
+                                    });
+                        },
+                        true /* delayErrors */,
+                        MAX_INFLIGHT)
+                .flatMapSingle((res) -> {
+                            if (res.isOK()) {
+                                return checkAndRecoverLedgerEntries(res.getLedgerId(),
+                                        res.getMetadata(), runId)
+                                        .map(ignore -> LedgerResult.ok(res.getLedgerId(),
+                                                res.getMetadata()))
+                                        .onErrorReturn(t -> LedgerResult.error(res.getLedgerId(),
+                                                res.getMetadata(), t));
+                            } else {
+                                return Single.just(res);
+                            }
+                        },
+                        true /* delayErrors */,
+                        1 /* copy 1 ledger at a time to keep entries together in entrylog */)
+                .collect(Collectors.toSet())
+                .subscribe(resolved -> promise.complete(resolved),
+                        throwable -> promise.completeExceptionally(throwable));
+        promise.whenComplete((result, ex) -> disposable.dispose());
         return promise;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/EntryCopierImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/EntryCopierImpl.java
@@ -48,7 +48,6 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookieProtocol;
-import org.checkerframework.checker.units.qual.K;
 
 /**
  * Implementation for the EntryCopier interface. Handles the reading of entries
@@ -118,7 +117,7 @@ public class EntryCopierImpl implements EntryCopier {
         @VisibleForTesting
         void notifyBookieError(BookieId bookie) {
             if (sinBin.addFailed(bookie)) {
-                // updateWriteSets();
+                updateWriteSets();
             }
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/MetadataAsyncIterator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/MetadataAsyncIterator.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.bookie.datainteg;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.disposables.Disposable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
@@ -29,8 +30,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-
-import io.reactivex.rxjava3.disposables.Disposable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LedgerMetadata;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageFactory.DbConfigType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.rocksdb.ColumnFamilyDescriptor;
@@ -171,6 +172,7 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public Entry<byte[], byte[]> getFloor(byte[] key) throws IOException {
         try (Slice upperBound = new Slice(key);
                  ReadOptions option = new ReadOptions(optionCache).setIterateUpperBound(upperBound);
@@ -184,6 +186,7 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public Entry<byte[], byte[]> getCeil(byte[] key) throws IOException {
         try (RocksIterator iterator = db.newIterator(optionCache)) {
             // Position the iterator on the record whose key is >= to the supplied key

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.bookie.storage.ldb;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -29,8 +30,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageFactory.DbConfigType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.rocksdb.ColumnFamilyDescriptor;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
@@ -235,7 +235,10 @@ public class LedgerMetadataIndex implements Closeable {
         lock.lock();
         try {
             LedgerData ledgerData = get(ledgerId);
-            boolean oldValue = ledgerData != null ? ledgerData.getLimbo() : false;
+            if (ledgerData == null) {
+                throw new Bookie.NoLedgerException(ledgerId);
+            }
+            final boolean oldValue = ledgerData.getLimbo();
             LedgerData newLedgerData = LedgerData.newBuilder(ledgerData).setLimbo(false).build();
 
             if (ledgers.put(ledgerId, newLedgerData) == null) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgersIndexRebuildOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgersIndexRebuildOp.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.bookie.storage.ldb;
 
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.File;
@@ -71,6 +72,7 @@ public class LedgersIndexRebuildOp {
         this.verbose = verbose;
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public boolean initiate()  {
         LOG.info("Starting ledger index rebuilding");
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
@@ -622,7 +623,6 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     public ByteBuf getLastEntry(long ledgerId) throws IOException, BookieException {
         throwIfLimbo(ledgerId);
 
-        long startTime = MathUtils.nowInNano();
         long stamp = writeCacheRotationLock.readLock();
         try {
             // First try to read from the write cache of recent entries
@@ -696,11 +696,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             return;
         }
 
-        // Only a single flush operation can happen at a time
-        flushMutex.lock();
-
         long startTime = MathUtils.nowInNano();
 
+        // Only a single flush operation can happen at a time
+        flushMutex.lock();
         try {
             // Swap the write cache so that writes can continue to happen while the flush is
             // ongoing
@@ -963,6 +962,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
      *            Iterator over index pages from Indexed
      * @return the number of
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public long addLedgerToIndex(long ledgerId, boolean isFenced, byte[] masterKey,
             LedgerCache.PageEntriesIterable pages) throws Exception {
         LedgerData ledgerData = LedgerData.newBuilder().setExists(true).setFenced(isFenced)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,8 +52,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.SneakyThrows;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.BookieImpl;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MetadataDrivers.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MetadataDrivers.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Optional;
@@ -33,8 +34,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MetadataDrivers.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MetadataDrivers.java
@@ -33,6 +33,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -305,6 +307,7 @@ public final class MetadataDrivers {
      * @throws MetadataException when failed to access metadata store
      * @throws ExecutionException exception thrown when processing <tt>function</tt>.
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public static <T> T runFunctionWithMetadataClientDriver(ClientConfiguration conf,
                                                             Function<MetadataClientDriver, T> function,
                                                             ScheduledExecutorService executorService)
@@ -336,6 +339,7 @@ public final class MetadataDrivers {
      * @throws MetadataException when failed to access metadata store
      * @throws ExecutionException exception thrown when processing <tt>function</tt>.
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public static <T> T runFunctionWithMetadataBookieDriver(ServerConfiguration conf,
                                                             Function<MetadataBookieDriver, T> function)
             throws MetadataException, ExecutionException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
@@ -83,10 +83,7 @@ class DirectMemoryCRC32Digest implements CRC32Digest {
             updateBytesMethod = CRC32.class.getDeclaredMethod("updateBytes", int.class, byte[].class, int.class,
                     int.class);
             updateBytesMethod.setAccessible(true);
-        } catch (RuntimeException e) {
-            updateByteBufferMethod = null;
-            updateBytesMethod = null;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             updateByteBufferMethod = null;
             updateBytesMethod = null;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
@@ -83,6 +83,9 @@ class DirectMemoryCRC32Digest implements CRC32Digest {
             updateBytesMethod = CRC32.class.getDeclaredMethod("updateBytes", int.class, byte[].class, int.class,
                     int.class);
             updateBytesMethod.setAccessible(true);
+        } catch (RuntimeException e) {
+            updateByteBufferMethod = null;
+            updateBytesMethod = null;
         } catch (Exception e) {
             updateByteBufferMethod = null;
             updateBytesMethod = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -29,6 +29,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -44,8 +45,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.bookie.BookieThread;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsOnMetadataServerException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -44,6 +44,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.bookie.BookieThread;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.BKNoSuchLedgerExistsOnMetadataServerException;
@@ -349,6 +351,7 @@ public class ReplicationWorker implements Runnable {
         return (returnRCValue.get() == BKException.Code.OK);
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private boolean rereplicate(long ledgerIdToReplicate) throws InterruptedException, BKException,
             UnavailableException {
         if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.Collections;
 import java.util.Map;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.common.util.JsonUtil;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
@@ -42,6 +44,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * the same as desired. The output would be the current status after the action.
  *
  */
+@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
 public class AutoRecoveryStatusService implements HttpEndpointService {
     protected final ServerConfiguration conf;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
@@ -20,10 +20,9 @@ package org.apache.bookkeeper.server.http.service;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.Map;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.common.util.JsonUtil;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ExpandStorageService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ExpandStorageService.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.BookieImpl;
 import org.apache.bookkeeper.bookie.LegacyCookieValidation;
@@ -61,6 +63,7 @@ public class ExpandStorageService implements HttpEndpointService {
      * Update the directories info in the conf file before running the command.
      */
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public HttpServiceResponse handle(HttpServiceRequest request) throws Exception {
         HttpServiceResponse response = new HttpServiceResponse();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ExpandStorageService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ExpandStorageService.java
@@ -20,12 +20,11 @@ package org.apache.bookkeeper.server.http.service;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.BookieImpl;
 import org.apache.bookkeeper.bookie.LegacyCookieValidation;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLastLogMarkService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLastLogMarkService.java
@@ -97,7 +97,7 @@ public class GetLastLogMarkService implements HttpEndpointService {
                 response.setBody(jsonResponse);
                 response.setCode(HttpServer.StatusCode.OK);
                 return response;
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 LOG.error("Exception occurred while getting last log mark", e);
                 response.setCode(HttpServer.StatusCode.NOT_FOUND);
                 response.setBody("ERROR handling request: " + e.getMessage());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
@@ -21,6 +21,8 @@ package org.apache.bookkeeper.tools.cli.commands.autorecovery;
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.concurrent.ExecutionException;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -39,6 +41,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Command to enable or disable auto recovery in the cluster.
  */
+@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
 public class ToggleCommand extends BookieCommand<ToggleCommand.AutoRecoveryFlags> {
 
     static final Logger LOG = LoggerFactory.getLogger(ToggleCommand.class);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
@@ -20,9 +20,8 @@ package org.apache.bookkeeper.tools.cli.commands.autorecovery;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import java.util.concurrent.ExecutionException;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.concurrent.ExecutionException;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.conf.ServerConfiguration;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LedgerCommand.java
@@ -20,10 +20,9 @@ package org.apache.bookkeeper.tools.cli.commands.bookie;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.function.Consumer;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.bookie.BookieImpl;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LedgerCommand.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.IOException;
 import java.util.function.Consumer;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.bookie.BookieImpl;
@@ -164,6 +165,7 @@ public class LedgerCommand extends BookieCommand<LedgerCommand.LedgerFlags> {
         }
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private boolean printPageEntries(LedgerCache.PageEntries page) {
         final MutableLong curEntry = new MutableLong(page.getFirstEntry());
         try (LedgerEntryPage lep = page.getLEP()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
@@ -32,6 +32,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;
@@ -54,6 +56,7 @@ import org.slf4j.LoggerFactory;
  *  List active(exist in metadata storage) ledgers in a entry log file.
  *
  **/
+@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
 public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
     private static final Logger LOG = LoggerFactory.getLogger(ListActiveLedgersCommand.class);
     private static final String NAME = "active ledger";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
@@ -22,6 +22,7 @@ import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithLedgerMa
 
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,8 +33,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
@@ -22,12 +22,11 @@ import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithLedgerMa
 
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.client.BKException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
@@ -26,6 +26,8 @@ import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.client.BKException;
@@ -48,6 +50,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Command for list all ledgers on the cluster.
  */
+@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
 public class ListLedgersCommand extends BookieCommand<ListLedgersFlags> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ListLedgersCommand.class);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.tools.cli.commands.bookie;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.EventLoopGroup;
@@ -138,6 +139,7 @@ public class ReadLedgerCommand extends BookieCommand<ReadLedgerCommand.ReadLedge
         }
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private boolean readledger(ServerConfiguration serverConf, ReadLedgerFlags flags)
         throws InterruptedException, BKException, IOException {
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
@@ -20,10 +20,9 @@ package org.apache.bookkeeper.tools.cli.commands.bookie;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
@@ -22,6 +22,8 @@ import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.File;
 import java.io.IOException;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;
@@ -139,6 +141,7 @@ public class ReadLogMetadataCommand extends BookieCommand<ReadLogMetadataFlags> 
         });
     }
 
+    @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
     private synchronized void initEntryLogger(ServerConfiguration conf) throws IOException {
         // provide read only entry logger
         if (null == entryLogger) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
@@ -22,12 +22,11 @@ import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithLedgerMa
 
 import com.beust.jcommander.Parameter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.client.api.LedgerMetadata;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
@@ -26,6 +26,8 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
@@ -44,6 +46,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Print the metadata for a ledger.
  */
+@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
 public class LedgerMetaDataCommand extends BookieCommand<LedgerMetaDataCommand.LedgerMetadataFlag> {
 
     private static final String NAME = "show";

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
@@ -22,6 +22,8 @@ import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 
 import com.beust.jcommander.Parameter;
 import java.util.concurrent.TimeUnit;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.client.api.BookKeeper;
@@ -73,6 +75,7 @@ public class SimpleTestCommand extends ClientCommand<Flags> {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     protected void run(BookKeeper bk, Flags flags) throws Exception {
         byte[] data = new byte[100]; // test data
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
@@ -21,9 +21,8 @@ package org.apache.bookkeeper.tools.cli.commands.client;
 import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 
 import com.beust.jcommander.Parameter;
-import java.util.concurrent.TimeUnit;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.concurrent.TimeUnit;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.client.api.BookKeeper;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/DiscoveryCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/DiscoveryCommand.java
@@ -18,12 +18,11 @@
  */
 package org.apache.bookkeeper.tools.cli.helpers;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.BookKeeper;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/DiscoveryCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/helpers/DiscoveryCommand.java
@@ -22,6 +22,8 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.BookKeeper;
@@ -44,6 +46,7 @@ public abstract class DiscoveryCommand<DiscoveryFlagsT extends CliFlags> extends
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     protected boolean apply(ClientConfiguration clientConf, DiscoveryFlagsT cmdFlags) {
         try {
             URI metadataServiceUri = URI.create(clientConf.getMetadataServiceUri());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/verifier/BookkeeperVerifier.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/verifier/BookkeeperVerifier.java
@@ -27,9 +27,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -182,15 +182,12 @@ public class BookkeeperVerifier {
      */
     class EntryInfo {
         private final long entryID;
-        private final long seed;
-        EntryInfo(long entryID, long seed) {
+        EntryInfo(long entryID) {
             this.entryID = entryID;
-            this.seed = seed;
         }
         byte[] getBuffer() {
-            Random rand = new Random(seed);
             byte[] ret = new byte[targetEntrySize];
-            rand.nextBytes(ret);
+            ThreadLocalRandom.current().nextBytes(ret);
             return ret;
         }
         long getEntryID() {
@@ -200,8 +197,7 @@ public class BookkeeperVerifier {
 
     /**
      * Contains the state required to reconstruct the contents of any entry in the ledger.
-     * The seed value passed into the constructor fully determines the contents of the
-     * ledger.  Each EntryInfo has its own seed generated sequentially from a Random instance
+     * Each EntryInfo has its own seed generated sequentially from a ThreadLocalRandom instance
      * seeded from the original seed.  It then uses that seed to generate a secondary Random
      * instance for generating the bytes within the entry.  See EntryIterator for details.
      * Random(seed)
@@ -220,7 +216,6 @@ public class BookkeeperVerifier {
      */
     class LedgerInfo {
         private final long ledgerID;
-        private final long seed;
         private long lastEntryIDCompleted = -1;
         private long confirmedLAC = -1;
         private boolean closed = false;
@@ -233,9 +228,8 @@ public class BookkeeperVerifier {
 
         EntryIterator iter;
 
-        LedgerInfo(long ledgerID, long seed) {
+        LedgerInfo(long ledgerID) {
             this.ledgerID = ledgerID;
-            this.seed = seed;
             iter = new EntryIterator();
         }
 
@@ -256,9 +250,7 @@ public class BookkeeperVerifier {
         }
 
         class EntryIterator implements Iterator<EntryInfo> {
-            Random rand;
             long currentID;
-            long currentSeed;
 
             EntryIterator() {
                 seek(-1);
@@ -266,20 +258,17 @@ public class BookkeeperVerifier {
 
             void seek(long entryID) {
                 currentID = -1;
-                currentSeed = seed;
-                rand = new Random(seed);
                 while (currentID < entryID) {
                     advance();
                 }
             }
 
             void advance() {
-                currentSeed = rand.nextLong();
                 currentID++;
             }
 
             EntryInfo get() {
-                return new EntryInfo(currentID, currentSeed);
+                return new EntryInfo(currentID);
             }
 
             @Override
@@ -413,10 +402,9 @@ public class BookkeeperVerifier {
     private final Set<LedgerInfo> openingLedgers = new HashSet<>();
     private final Set<LedgerInfo> openLedgers = new HashSet<>();
     private final Set<LedgerInfo> liveLedgers = new HashSet<>();
-    private final Random opRand = new Random();
 
     private LedgerInfo getRandomLedger(Collection<LedgerInfo> ledgerCollection) {
-        int elem = opRand.nextInt(ledgerCollection.size());
+        int elem = ThreadLocalRandom.current().nextInt(ledgerCollection.size());
         Iterator<LedgerInfo> iter = ledgerCollection.iterator();
         for (int i = 0; i < elem; ++i) {
             iter.next();
@@ -431,7 +419,7 @@ public class BookkeeperVerifier {
             return false;
         }
         LedgerInfo ledger;
-        if (!openLedgers.isEmpty() && (opRand.nextDouble() > coldToHotRatio)) {
+        if (!openLedgers.isEmpty() && (ThreadLocalRandom.current().nextDouble() > coldToHotRatio)) {
             ledger = getRandomLedger(openLedgers);
             System.out.format("Reading from open ledger %d%n", ledger.ledgerID);
         } else if (!liveLedgers.isEmpty()) {
@@ -449,7 +437,7 @@ public class BookkeeperVerifier {
             /* Either startWrite can make progress or there are already a bunch in progress */
             return false;
         }
-        long start = Math.abs(opRand.nextLong() % lastEntryCompleted);
+        long start = Math.abs(ThreadLocalRandom.current().nextLong() % lastEntryCompleted);
         long end = start + targetReadGroup > lastEntryCompleted ? lastEntryCompleted : start + targetReadGroup;
         System.out.format("Reading %d -> %d from ledger %d%n", start, end, ledger.ledgerID);
         LedgerInfo finalLedger = ledger;
@@ -551,7 +539,7 @@ public class BookkeeperVerifier {
             /* Not enough open ledgers, open a new one -- counts as a write */
             long newID = getNextLedgerID();
             System.out.format("Creating new ledger %d%n", newID);
-            LedgerInfo ledger = new LedgerInfo(newID, opRand.nextLong());
+            LedgerInfo ledger = new LedgerInfo(newID);
             openingLedgers.add(ledger);
             driver.createLedger(newID, ensembleSize, writeQuorum, ackQuorum, (rc) -> {
                 synchronized (BookkeeperVerifier.this) {

--- a/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
+++ b/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
@@ -45,7 +45,7 @@ public class NativeUtils {
      * @throws Exception
      */
     @SuppressFBWarnings(
-            value = "OBL_UNSATISFIED_OBLIGATION",
+            value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
             justification = "work around for java 9: https://github.com/spotbugs/spotbugs/issues/493")
     public static void loadLibraryFromJar(String path) throws Exception {
         com.google.common.base.Preconditions.checkArgument(path.startsWith("/"), "absolute path must start with /");

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/ProtocolBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/ProtocolBenchmark.java
@@ -25,7 +25,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
 
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/ProtocolBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/ProtocolBenchmark.java
@@ -26,6 +26,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
 
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.proto.BookieProtoEncoding.EnDecoder;
@@ -69,12 +70,11 @@ public class ProtocolBenchmark {
     @Setup
     public void prepare() {
         this.masterKey = "test-benchmark-key".getBytes(UTF_8);
-        Random r = new Random(System.currentTimeMillis());
         byte[] data = new byte[this.size];
-        r.nextBytes(data);
+        ThreadLocalRandom.current().nextBytes(data);
         this.entry = Unpooled.wrappedBuffer(data);
-        this.ledgerId = r.nextLong();
-        this.entryId = r.nextLong();
+        this.ledgerId = ThreadLocalRandom.current().nextLong();
+        this.entryId = ThreadLocalRandom.current().nextLong();
         this.flags = 1;
 
         // prepare the encoder

--- a/pom.xml
+++ b/pom.xml
@@ -1176,25 +1176,6 @@
         </plugins>
       </build>
     </profile>
-
-    <profile>
-      <id>jdk11-no-spotbugs</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-           <plugin>
-             <groupId>com.github.spotbugs</groupId>
-             <artifactId>spotbugs-maven-plugin</artifactId>
-             <configuration>
-                 <skip>true</skip>
-             </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <profile>
       <id>apache-release</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -871,7 +871,6 @@
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>
         <configuration>
-<!--          <threshold>High</threshold>-->
           <excludeFilterFile>${session.executionRootDirectory}/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml</excludeFilterFile>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <shrinkwrap.version>3.0.1</shrinkwrap.version>
     <slf4j.version>1.7.32</slf4j.version>
     <snakeyaml.version>1.30</snakeyaml.version>
-    <spotbugs-annotations.version>4.6.0</spotbugs-annotations.version>
+    <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <javax-annotations-api.version>1.3.2</javax-annotations-api.version>
     <testcontainers.version>1.15.1</testcontainers.version>
     <vertx.version>3.9.8</vertx.version>
@@ -197,7 +197,7 @@
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
-    <spotbugs-maven-plugin.version>4.6.0.0</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
     <forkCount.variable>1</forkCount.variable>
     <servlet-api.version>4.0.0</servlet-api.version>
     <rxjava.version>3.0.1</rxjava.version>
@@ -871,7 +871,7 @@
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>
         <configuration>
-          <threshold>High</threshold>
+<!--          <threshold>High</threshold>-->
           <excludeFilterFile>${session.executionRootDirectory}/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml</excludeFilterFile>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <shrinkwrap.version>3.0.1</shrinkwrap.version>
     <slf4j.version>1.7.32</slf4j.version>
     <snakeyaml.version>1.30</snakeyaml.version>
-    <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
+    <spotbugs-annotations.version>4.6.0</spotbugs-annotations.version>
     <javax-annotations-api.version>1.3.2</javax-annotations-api.version>
     <testcontainers.version>1.15.1</testcontainers.version>
     <vertx.version>3.9.8</vertx.version>
@@ -197,7 +197,7 @@
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
-    <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.6.0.0</spotbugs-maven-plugin.version>
     <forkCount.variable>1</forkCount.variable>
     <servlet-api.version>4.0.0</servlet-api.version>
     <rxjava.version>3.0.1</rxjava.version>
@@ -871,6 +871,7 @@
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>
         <configuration>
+          <threshold>High</threshold>
           <excludeFilterFile>${session.executionRootDirectory}/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml</excludeFilterFile>
         </configuration>
       </plugin>

--- a/tests/backward-compat/pom.xml
+++ b/tests/backward-compat/pom.xml
@@ -38,4 +38,15 @@
     <module>yahoo-custom-version</module>
     <module>bc-non-fips</module>
   </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/tests/integration-tests-utils/build.gradle
+++ b/tests/integration-tests-utils/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation depLibs.arquillianCubeDocker
     implementation depLibs.zookeeper
     implementation depLibs.junit
+    compileOnly depLibs.spotbugsAnnotations
     compileOnly depLibs.lombok
     implementation depLibs.slf4j
     implementation depLibs.groovy

--- a/tests/integration-tests-utils/pom.xml
+++ b/tests/integration-tests-utils/pom.xml
@@ -87,10 +87,6 @@
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
-          <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-          </plugin>
     </plugins>
   </build>
 

--- a/tests/integration-tests-utils/pom.xml
+++ b/tests/integration-tests-utils/pom.xml
@@ -87,6 +87,10 @@
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+          </plugin>
     </plugins>
   </build>
 

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/DockerUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/DockerUtils.java
@@ -25,7 +25,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.InspectExecResponse;
 import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.Frame;
-
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -105,6 +105,7 @@ public class DockerUtils {
         }
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public static void dumpContainerDirToTargetCompressed(DockerClient dockerClient, String containerId,
                                                           String path) {
         final int readBlockSize = 10000;

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/MavenClassLoader.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/MavenClassLoader.java
@@ -18,7 +18,7 @@
 package org.apache.bookkeeper.tests.integration.utils;
 
 import com.google.common.collect.Lists;
-
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.Closure;
 
 import java.io.Closeable;
@@ -270,6 +270,7 @@ public class MavenClassLoader implements AutoCloseable {
         }
     }
 
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     private static void extractTarGz(File tarGz, File output) throws Exception {
         File tarFile = new File(output, tarGz.getName().replace(".gz", ""));
         tarFile.delete();
@@ -289,11 +290,12 @@ public class MavenClassLoader implements AutoCloseable {
         return tarFile;
     }
 
+    @SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"})
     private static void unTar(final File inputFile, final File outputDir) throws Exception {
-        try (TarArchiveInputStream debInputStream = (TarArchiveInputStream)
-                new ArchiveStreamFactory().createArchiveInputStream("tar",
-                        new FileInputStream(inputFile))) {
-            TarArchiveEntry entry = null;
+        try (final FileInputStream fis = new FileInputStream(inputFile);
+                TarArchiveInputStream debInputStream = (TarArchiveInputStream)
+                new ArchiveStreamFactory().createArchiveInputStream("tar", fis)) {
+            TarArchiveEntry entry;
             while ((entry = (TarArchiveEntry) debInputStream.getNextEntry()) != null) {
                 final File outputFile = new File(outputDir, entry.getName());
                 if (entry.isDirectory()) {

--- a/tools/perf/build.gradle
+++ b/tools/perf/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation project(':stream:distributedlog:protocol')
     implementation project(':stream:proto')
 
+    compileOnly depLibs.spotbugsAnnotations
     compileOnly depLibs.lombok
     implementation depLibs.commonsConfiguration
     implementation depLibs.guava

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/PerfClient.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/PerfClient.java
@@ -25,6 +25,7 @@ import com.beust.jcommander.Parameter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.util.concurrent.RateLimiter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -231,6 +232,7 @@ public class PerfClient implements Runnable {
         runBenchmarkTasks();
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private void runBenchmarkTasks() throws Exception {
         StorageClientSettings settings = StorageClientSettings.newBuilder()
             .serviceUri(serviceURI.getUri().toString())

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/cluster/InitClusterCommand.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/cluster/InitClusterCommand.java
@@ -24,9 +24,8 @@ import static org.apache.bookkeeper.stream.cli.Commands.OP_INIT;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import java.net.URI;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.net.ServiceURI;
 import org.apache.bookkeeper.conf.ServerConfiguration;

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/cluster/InitClusterCommand.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/cluster/InitClusterCommand.java
@@ -25,6 +25,8 @@ import com.beust.jcommander.Parameter;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.net.URI;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.net.ServiceURI;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -107,6 +109,7 @@ public class InitClusterCommand extends BKCommand<Flags> {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     protected boolean apply(ServiceURI ignored,
                             CompositeConfiguration conf,
                             BKFlags globalFlags,

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/DelCommand.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/DelCommand.java
@@ -23,6 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import static org.apache.bookkeeper.stream.cli.Commands.OP_DEL;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.bookkeeper.api.StorageClient;
@@ -56,6 +57,7 @@ public class DelCommand extends ClientCommand<Flags> {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     protected void run(StorageClient client, Flags flags) throws Exception {
         checkArgument(flags.arguments.size() >= 2,
             "table and key/value are not provided");

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/GetCommand.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/GetCommand.java
@@ -23,6 +23,7 @@ import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import static org.apache.bookkeeper.stream.cli.Commands.OP_GET;
 
 import com.beust.jcommander.Parameter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -62,6 +63,7 @@ public class GetCommand extends ClientCommand<Flags> {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     protected void run(StorageClient client, Flags flags) throws Exception {
         checkArgument(flags.arguments.size() >= 2,
             "table and key are not provided");

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/IncrementCommand.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/IncrementCommand.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import static org.apache.bookkeeper.stream.cli.Commands.OP_INC;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.bookkeeper.api.StorageClient;
@@ -55,6 +56,7 @@ public class IncrementCommand extends ClientCommand<Flags> {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     protected void run(StorageClient client, Flags flags) throws Exception {
         checkArgument(flags.arguments.size() >= 3,
             "table and key/amount are not provided");

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/PutCommand.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/PutCommand.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import static org.apache.bookkeeper.stream.cli.Commands.OP_PUT;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.bookkeeper.api.StorageClient;
@@ -55,6 +56,7 @@ public class PutCommand extends ClientCommand<Flags> {
     }
 
     @Override
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     protected void run(StorageClient client, Flags flags) throws Exception {
         checkArgument(flags.arguments.size() >= 3,
             "table and key/value are not provided");


### PR DESCRIPTION
### Motivation
If you run spotbugs with JDK8 it fail with many errors.

Spotbugs with jdk11 is disabled in maven and it explains why it doesn't fail in CI
In gradle we set the reportLevel to HIGH so we haven't seen the Medium level for a while

In branch-4.14 there's still a job with a spotbugs enabled and it fails

### Changes
* Fix spotbugs warnings
   * Mostly suppressions due to https://github.com/spotbugs/spotbugs/issues/756
   * RxJava usage - call dispose of `Disposable`
   * Better synchronization on `LedgerFragmentReplicator`
* Restore spotbugs check with jdk8 and jdk11 on CI 

We'll need to cherry-pick to branch-4.14 to fix the compilation
