### PR TITLE
remove unnecessary exception catch

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
@@ -94,9 +94,6 @@ class ReadLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
         } catch (Bookie.NoLedgerException e) {
             status = StatusCode.ENOLEDGER;
             logger.debug("No ledger found while trying to read last entry: {}", ledgerId, e);
-        } catch (Bookie.NoEntryException e) {
-            status = StatusCode.ENOENTRY;
-            logger.warn("No Entry found while trying to read last entry: {}", ledgerId, e);
         } catch (BookieException.DataUnknownException e) {
             status = StatusCode.EUNKNOWNLEDGERSTATE;
             logger.error("Ledger in an unknown state while trying to read last entry: {}", ledgerId, e);


### PR DESCRIPTION
### Motivation
When read Lac from ledger, we won't throw NoEntryException, remove this exception catch.


### Changes
Remove the NoEntryException catch in ReadLac operation.


