### PR TITLE
Expose Netty threads num config to bk_server.conf

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -148,6 +148,11 @@ extraServerComponents=
 # reduce the number of threads in the main workers pool and Netty event loop to only have few CPU cores busy.
 # enableBusyWait=false
 
+# This is the number of threads used by Netty to handle TCP connections.
+# Default is 2 *  Runtime.getRuntime().availableProcessors()
+# serverNumIOThreads=
+
+
 #############################################################################
 ## Long poll request parameter settings
 #############################################################################


### PR DESCRIPTION
### Motivation
https://github.com/apache/bookkeeper/pull/1612 this PR make the Netty io threads number configurable, but doesn't expose to the `bk_server.conf`. This parameter will be usually changed in performance tuning especially deploy this bookie on bare metal which have many cpus. For operation engineer who is unfamiliar with the source code will be hard to do performance tuning.

### Changes
Expose this parameter configuration into `bk_server.conf` and website. And add more explanation about it. 

