### PR TITLE
[build] support apple m1 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <!-- required by zookeeper test utilities imported from ZooKeeper -->
     <junit5.version>5.6.2</junit5.version>
     <libthrift.version>0.14.2</libthrift.version>
-    <lombok.version>1.18.20</lombok.version>
+    <lombok.version>1.18.22</lombok.version>
     <log4j.version>2.17.1</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.12.4</mockito.version>
@@ -1190,6 +1190,18 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>mac-apple-silicon</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <nar.aolProperties>src/apple_m1_aol.properties</nar.aolProperties>
+      </properties>
     </profile>
     <profile>
       <id>apache-release</id>

--- a/src/apple_m1_aol.properties
+++ b/src/apple_m1_aol.properties
@@ -1,0 +1,38 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+aarch64.MacOSX.linker=g++
+
+aarch64.MacOSX.gpp.c.compiler=gcc
+aarch64.MacOSX.gpp.c.defines=Darwin GNU_GCC
+aarch64.MacOSX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion
+aarch64.MacOSX.gpp.c.includes=**/*.c
+aarch64.MacOSX.gpp.c.excludes=
+
+aarch64.MacOSX.gpp.java.include=include;include/darwin
+aarch64.MacOSX.gpp.java.runtimeDirectory=IGNORED
+
+aarch64.MacOSX.gpp.lib.prefix=lib
+aarch64.MacOSX.gpp.shared.prefix=lib
+aarch64.MacOSX.gpp.static.extension=a
+aarch64.MacOSX.gpp.shared.extension=dylib
+aarch64.MacOSX.gpp.plugin.extension=bundle
+aarch64.MacOSX.gpp.jni.extension=jnilib
+aarch64.MacOSX.gpp.executable.extension=


### PR DESCRIPTION
### Motivation
Support apple m1 `mvn clean package -DskipTests`

### Changes
- add profile for apple m1 using different `aol.properties` based on https://github.com/maven-nar/nar-maven-plugin/pull/382
- bump lombok to 1.18.22 to support jdk17 package. I think that it was mis-reverted by #3130(the gradle is now 1.18.22) and it doesn't worth open a new pr. Please point out if I am wrong :)

### Tests
test on my apple m1 mbp