### PR TITLE
Issue 3165: Bookie does not show logs in 4.15.0rc0

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -248,10 +248,10 @@ Apache Software License, Version 2.
 - lib/io.vertx-vertx-core-3.9.8.jar [15]
 - lib/io.vertx-vertx-web-3.9.8.jar [16]
 - lib/io.vertx-vertx-web-common-3.9.8.jar [16]
-- lib/org.apache.logging.log4j-log4j-1.2-api-2.17.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-api-2.17.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-core-2.17.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.1.jar [17]
+- lib/org.apache.logging.log4j-log4j-1.2-api-2.17.2.jar [17]
+- lib/org.apache.logging.log4j-log4j-api-2.17.2.jar [17]
+- lib/org.apache.logging.log4j-log4j-core-2.17.2.jar [17]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.2.jar [17]
 - lib/net.java.dev.jna-jna-3.2.7.jar [18]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-lang3-3.6.jar [20]
@@ -330,7 +330,7 @@ Apache Software License, Version 2.
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
 [15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8
 [16] Source available at https://github.com/vert-x3/vertx-web/tree/3.9.8
-[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.1
+[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.2
 [18] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -237,10 +237,10 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-classes-epoll-4.1.75.Final.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.75.Final-linux-x86_64.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.75.Final.jar [11]
-- lib/org.apache.logging.log4j-log4j-1.2-api-2.17.1.jar [16]
-- lib/org.apache.logging.log4j-log4j-api-2.17.1.jar [16]
-- lib/org.apache.logging.log4j-log4j-core-2.17.1.jar [16]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.1.jar [16]
+- lib/org.apache.logging.log4j-log4j-1.2-api-2.17.2.jar [16]
+- lib/org.apache.logging.log4j-log4j-api-2.17.2.jar [16]
+- lib/org.apache.logging.log4j-log4j-core-2.17.2.jar [16]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.2.jar [16]
 - lib/net.java.dev.jna-jna-3.2.7.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [18]
 - lib/org.apache.commons-commons-lang3-3.6.jar [19]
@@ -302,7 +302,7 @@ Apache Software License, Version 2.
 [9] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=tag;h=375459
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.75.Final
-[16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.1
+[16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.2
 [17] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -248,10 +248,10 @@ Apache Software License, Version 2.
 - lib/io.vertx-vertx-core-3.9.8.jar [15]
 - lib/io.vertx-vertx-web-3.9.8.jar [16]
 - lib/io.vertx-vertx-web-common-3.9.8.jar [16]
-- lib/org.apache.logging.log4j-log4j-1.2-api-2.17.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-api-2.17.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-core-2.17.1.jar [17]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.1.jar [17]
+- lib/org.apache.logging.log4j-log4j-1.2-api-2.17.2.jar [17]
+- lib/org.apache.logging.log4j-log4j-api-2.17.2.jar [17]
+- lib/org.apache.logging.log4j-log4j-core-2.17.2.jar [17]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.2.jar [17]
 - lib/net.java.dev.jna-jna-3.2.7.jar [18]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-lang3-3.6.jar [20]
@@ -328,7 +328,7 @@ Apache Software License, Version 2.
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
 [15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8
 [16] Source available at https://github.com/vert-x3/vertx-web/tree/3.9.8
-[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.1
+[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.2
 [18] Source available at https://github.com/java-native-access/jna/tree/3.2.7
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -65,7 +65,7 @@ depVersions = [
     junit: "4.12",
     junitFoundation: "11.0.0",
     kerby: "1.1.1",
-    log4j: "2.17.1",
+    log4j: "2.17.2",
     lombok: "1.18.22",
     lz4: "1.3.0",
     mockito: "3.12.4",

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <junit5.version>5.6.2</junit5.version>
     <libthrift.version>0.14.2</libthrift.version>
     <lombok.version>1.18.22</lombok.version>
-    <log4j.version>2.17.1</log4j.version>
+    <log4j.version>2.17.2</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.12.4</mockito.version>
     <netty.version>4.1.75.Final</netty.version>


### PR DESCRIPTION
### Motivation

Upgrades log4j2 version to fix a problem using the log4j bridge.

### Changes

Upgrade log4j2 version from `2.17.1` to `2.17.2`.

The motivation is that there are multiple issues related to log4j bridge fixed in that minor version: https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.2 

Note that this issue should be cherry-picked to `branch-4.15`.

Master Issue: #3165

### Tests
The problem was introduced in `2.17.1`. This is the result we obtained running a local Bookie with `2.17.1`:

```
bin/bookkeeper localbookie 1
2022-04-06T18:54:18,075 - WARN  - [main:ServerCnxnFactory@309] - maxCnxns is not configured, using default value 0.
2022-04-06T18:54:18,250 - WARN  - [main-SendThread(127.0.0.1:2181):ClientCnxn$SendThread@1279] - An exception was thrown while closing send thread for session 0x10001aa9e8d0000.
org.apache.zookeeper.ClientCnxn$EndOfStreamException: Unable to read additional data from server sessionid 0x10001aa9e8d0000, likely server has closed socket
	at org.apache.zookeeper.ClientCnxnSocketNIO.doIO(ClientCnxnSocketNIO.java:77) ~[org.apache.zookeeper-zookeeper-3.6.2.jar:3.6.2]
	at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:350) ~[org.apache.zookeeper-zookeeper-3.6.2.jar:3.6.2]
	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1275) [org.apache.zookeeper-zookeeper-3.6.2.jar:3.6.2]
2022-04-06T18:54:18,905 - ERROR - [main:Journal$LastLogMark@252] - Problems reading from /tmp/bk-data/bookie0/current/lastMark (this is okay if it is the first time starting this bookie
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.bookkeeper.util.NativeIO (file:/home/raul/Documents/workspace/bookkeeper-security-upgrade-new/bookkeeper/bookkeeper-dist/server/target/bookkeeper-server-4.14.3-SNAPSHOT/lib/org.apache.bookkeeper-bookkeeper-server-4.14.3-SNAPSHOT.jar) to field java.io.FileDescriptor.fd
WARNING: Please consider reporting this to the maintainers of org.apache.bookkeeper.util.NativeIO
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

(NO MORE LOGS BEYOND THIS POINT)
```

After applying the current change, we see the expected logs again:
```
bin/bookkeeper localbookie 1
2022-04-06T18:57:05,103 - INFO  - [main:LocalBookKeeper@458] - Using configuration file /home/raul/Documents/workspace/bookkeeper-security-upgrade-new/bookkeeper/bookkeeper-dist/server/target/bookkeeper-server-4.14.3-SNAPSHOT/conf/bk_server.conf
2022-04-06T18:57:05,110 - INFO  - [main:LocalBookKeeper@90] - Running 1 bookie(s) on zk ensemble = '127.0.0.1:2181'.
2022-04-06T18:57:05,112 - INFO  - [main:LocalBookKeeper@120] - Starting ZK server
2022-04-06T18:57:05,117 - INFO  - [main:ZookeeperBanner@42] - 
2022-04-06T18:57:05,117 - INFO  - [main:ZookeeperBanner@42] -   ______                  _                                          
2022-04-06T18:57:05,117 - INFO  - [main:ZookeeperBanner@42] -  |___  /                 | |                                         
2022-04-06T18:57:05,117 - INFO  - [main:ZookeeperBanner@42] -     / /    ___     ___   | | __   ___    ___   _ __     ___   _ __   
2022-04-06T18:57:05,118 - INFO  - [main:ZookeeperBanner@42] -    / /    / _ \   / _ \  | |/ /  / _ \  / _ \ | '_ \   / _ \ | '__|
2022-04-06T18:57:05,118 - INFO  - [main:ZookeeperBanner@42] -   / /__  | (_) | | (_) | |   <  |  __/ |  __/ | |_) | |  __/ | |    
2022-04-06T18:57:05,118 - INFO  - [main:ZookeeperBanner@42] -  /_____|  \___/   \___/  |_|\_\  \___|  \___| | .__/   \___| |_|
2022-04-06T18:57:05,118 - INFO  - [main:ZookeeperBanner@42] -                                               | |                     
2022-04-06T18:57:05,118 - INFO  - [main:ZookeeperBanner@42] -                                               |_|                     
2022-04-06T18:57:05,118 - INFO  - [main:ZookeeperBanner@42] - 
2022-04-06T18:57:05,119 - INFO  - [main:Environment@98] - Server environment:zookeeper.version=3.6.2--803c7f1a12f85978cb049af5e4ef23bd8b688715, built on 09/04/2020 12:44 GMT
2022-04-06T18:57:05,120 - INFO  - [main:Environment@98] - Server environment:host.name=ignatius
2022-04-06T18:57:05,120 - INFO  - [main:Environment@98] - Server environment:java.version=11.0.14.1
2022-04-06T18:57:05,120 - INFO  - [main:Environment@98] - Server environment:java.vendor=Ubuntu
2022-04-06T18:57:05,121 - INFO  - [main:Environment@98] - Server environment:java.home=/usr/lib/jvm/java-11-openjdk-amd64
```



