### PR TITLE
Fix compaction throttle imprecise

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedReadChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedReadChannel.java
@@ -73,14 +73,15 @@ public class BufferedReadChannel extends BufferedChannelBase  {
      * from the file channel, return the prefetched bytes for throttle.
      * @param dest
      * @param pos
-     * @return Pair<Integer, Integer>
+     * @return
      * @throws IOException
      */
     public Pair<Integer, Integer> readWithPrefetchedBytes(ByteBuf dest, long pos) throws IOException {
         return readWithPrefetchedBytes(dest, pos, dest.writableBytes());
     }
 
-    public synchronized Pair<Integer, Integer> readWithPrefetchedBytes(ByteBuf dest, long pos, int length) throws IOException {
+    public synchronized Pair<Integer, Integer> readWithPrefetchedBytes(ByteBuf dest, long pos, int length)
+        throws IOException {
         invocationCount++;
         long currentPosition = pos;
         long eof = validateAndGetFileChannel().size();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedReadChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedReadChannel.java
@@ -27,6 +27,8 @@ import io.netty.buffer.Unpooled;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * A Buffered channel without a write buffer. Only reads are buffered.
@@ -63,6 +65,57 @@ public class BufferedReadChannel extends BufferedChannelBase  {
      */
     public int read(ByteBuf dest, long pos) throws IOException {
         return read(dest, pos, dest.writableBytes());
+    }
+
+    /**
+     * Read as many bytes into dest as dest.capacity() starting at position pos in the
+     * FileChannel. This function can read from the buffer or the file channel. If it fetched
+     * from the file channel, return the prefetched bytes for throttle.
+     * @param dest
+     * @param pos
+     * @return Pair<Integer, Integer>
+     * @throws IOException
+     */
+    public Pair<Integer, Integer> readWithPrefetchedBytes(ByteBuf dest, long pos) throws IOException {
+        return readWithPrefetchedBytes(dest, pos, dest.writableBytes());
+    }
+
+    public synchronized Pair<Integer, Integer> readWithPrefetchedBytes(ByteBuf dest, long pos, int length) throws IOException {
+        invocationCount++;
+        long currentPosition = pos;
+        long eof = validateAndGetFileChannel().size();
+        int bytesFetchedFromFile = 0;
+        // return -1 if the given position is greater than or equal to the file's current size.
+        if (pos >= eof) {
+            return new ImmutablePair<>(-1, 0);
+        }
+        while (length > 0) {
+            // Check if the data is in the buffer, if so, copy it.
+            if (readBufferStartPosition <= currentPosition
+                && currentPosition < readBufferStartPosition + readBuffer.readableBytes()) {
+                int posInBuffer = (int) (currentPosition - readBufferStartPosition);
+                int bytesToCopy = Math.min(length, readBuffer.readableBytes() - posInBuffer);
+                dest.writeBytes(readBuffer, posInBuffer, bytesToCopy);
+                currentPosition += bytesToCopy;
+                length -= bytesToCopy;
+                cacheHitCount++;
+            } else if (currentPosition >= eof) {
+                // here we reached eof.
+                break;
+            } else {
+                // We don't have it in the buffer, so put necessary data in the buffer
+                readBufferStartPosition = currentPosition;
+                int readBytes = 0;
+                if ((readBytes = validateAndGetFileChannel().read(readBuffer.internalNioBuffer(0, readCapacity),
+                    currentPosition)) <= 0) {
+                    throw new IOException("Reading from filechannel returned a non-positive value. Short read.");
+                }
+                readBuffer.writerIndex(readBytes);
+                bytesFetchedFromFile += readBytes;
+            }
+        }
+
+        return new ImmutablePair<>((int) (currentPosition - pos), bytesFetchedFromFile);
     }
 
     public synchronized int read(ByteBuf dest, long pos, int length) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
@@ -59,7 +59,7 @@ public class EntryLogCompactor extends AbstractLogCompactor {
     public boolean compact(EntryLogMetadata entryLogMeta) {
         try {
             entryLogger.scanEntryLog(entryLogMeta.getEntryLogId(),
-                scannerFactory.newScanner(entryLogMeta));
+                scannerFactory.newScanner(entryLogMeta), throttler);
             scannerFactory.flush();
             LOG.info("Removing entry log {} after compaction", entryLogMeta.getEntryLogId());
             logRemovalListener.removeEntryLog(entryLogMeta.getEntryLogId());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -406,8 +406,10 @@ public class EntryLogger {
      * @param pos The starting position from where we want to read.
      * @return
      */
-    private Pair<Integer, Integer> readFromLogChannel(long entryLogId, BufferedReadChannel channel, ByteBuf buff, long pos)
-            throws IOException {
+    private Pair<Integer, Integer> readFromLogChannel(long entryLogId,
+                                                      BufferedReadChannel channel,
+                                                      ByteBuf buff,
+                                                      long pos) throws IOException {
         BufferedLogChannel bc = entryLogManager.getCurrentLogIfPresent(entryLogId);
         if (null != bc) {
             synchronized (bc) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1049,7 +1049,7 @@ public class EntryLogger {
                     return;
                 }
 
-                if (throttler != null) {
+                if (readBytesPair.getRight() > 0 && throttler != null) {
                     throttler.acquire(readBytesPair.getRight());
                 }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SlowBufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SlowBufferedChannel.java
@@ -27,6 +27,7 @@ import io.netty.buffer.ByteBufAllocator;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Strictly for testing.
@@ -77,7 +78,7 @@ public class SlowBufferedChannel extends BufferedChannel {
     }
 
     @Override
-    public synchronized int read(ByteBuf dest, long pos) throws IOException {
+    public synchronized Pair<Integer, Integer> read(ByteBuf dest, long pos) throws IOException {
         delayMs(getDelay);
         return super.read(dest, pos);
     }


### PR DESCRIPTION
### Motivation
When do compaction for an entry log file, it will scan each entry header metadata from beginning to the end of the file. When an entry doesn't deleted, it will read the entry data and write into a new entry log file. The throttle only works on the entry which doesn't deleted.
https://github.com/apache/bookkeeper/blob/b0030ab5d9132e5c5cd5092b8e6dab79e9fbf16c/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java#L1012-L1051

For those deleted entries, the throttle strategy doesn't applied. However, we use `BufferedChannel` to read the entry log file which will prefetch data from file when the read buffer missed.
https://github.com/apache/bookkeeper/blob/b0030ab5d9132e5c5cd5092b8e6dab79e9fbf16c/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedReadChannel.java#L91-L97

For an entry log file, more than 90% of entries has been deleted, the compactor will scan those entry's header metadata one by one. When reading one entry's metadata, it will missed in BufferedChannel read buffer, it will trigger prefetch from disk. For the following entries, the header metadata reading will also missed in BufferedChannel read buffer, and will continue to prefetch from disk without throttle. It will lead to ledger disk IO util runs high. 

Moreover, for each prefetch operation from disk, it will also trigger OS PageCache prefetch. For the compaction model, the OS PageCache prefetch will lead to PageCache pollution，and maybe also affect the journal sync latency. For this one, we can use the Direct IO to reduce the PageCache effect. https://github.com/apache/bookkeeper/issues/2943

### Changes
Add throttle on entry header metadata check stage.