### PR TITLE
Simplify throttle code in metadata scanning

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1178,7 +1178,7 @@ public class EntryLogger {
             @Override
             public void process(long ledgerId, long offset, ByteBuf entry) throws IOException {
                 if (throttler != null) {
-                    throttler.acquire(conf.getIsThrottleByBytes() ? entry.readableBytes() : 1);
+                    throttler.acquire(entry.readableBytes());
                 }
                 // add new entry size of a ledger to entry log meta
                 meta.addLedgerSize(ledgerId, entry.readableBytes() + 4);


### PR DESCRIPTION
### Motivation
The throttler has been checked whether throttle by bytes in `acquire` method, we doesn't need double check.

### Changes

Remove the double check of whether throttle by bytes.
