### PR TITLE
Correct the method signature within annotations

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookiesListener.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookiesListener.java
@@ -21,7 +21,7 @@ import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 
 /**
- * Listener for the the available bookies changes.
+ * Listener for the available bookies changes.
  */
 
 @InterfaceAudience.Private

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/EnsemblePlacementPolicy.java
@@ -57,11 +57,12 @@ import org.apache.bookkeeper.stats.StatsLogger;
  *
  * <p>The ensemble placement policy is constructed by jvm reflection during constructing bookkeeper client.
  * After the {@code EnsemblePlacementPolicy} is constructed, bookkeeper client will call
- * {@link #initialize(ClientConfiguration, Optional, HashedWheelTimer, FeatureProvider, StatsLogger)} to initialize
- * the placement policy.
+ * {@link #initialize(ClientConfiguration, Optional, HashedWheelTimer, FeatureProvider, StatsLogger,
+ * BookieAddressResolver)} to initialize the placement policy.
  *
- * <p>The {@link #initialize(ClientConfiguration, Optional, HashedWheelTimer, FeatureProvider, StatsLogger)}
- * method takes a few resources from bookkeeper for instantiating itself. These resources include:
+ * <p>The {@link #initialize(ClientConfiguration, Optional, HashedWheelTimer, FeatureProvider, StatsLogger,
+ * BookieAddressResolver)} method takes a few resources from bookkeeper for instantiating itself.
+ * These resources include:
  *
  * <ul>
  * <li>`ClientConfiguration` : The client configuration that used for constructing the bookkeeper client.
@@ -81,7 +82,8 @@ import org.apache.bookkeeper.stats.StatsLogger;
  * <p>The ensemble placement policy is a single instance per bookkeeper client. The instance will
  * be {@link #uninitalize()} when closing the bookkeeper client. The implementation of a placement policy should be
  * responsible for releasing all the resources that allocated during
- * {@link #initialize(ClientConfiguration, Optional, HashedWheelTimer, FeatureProvider, StatsLogger)}.
+ * {@link #initialize(ClientConfiguration, Optional, HashedWheelTimer, FeatureProvider, StatsLogger,
+ * BookieAddressResolver)}.
  *
  * <h3>How to choose bookies to place data</h3>
  *
@@ -89,8 +91,7 @@ import org.apache.bookkeeper.stats.StatsLogger;
  * bookie changes, the ensemble placement policy will be notified with new list of bookies via
  * {@link #onClusterChanged(Set, Set)}. The implementation of the ensemble placement policy will react on those
  * changes to build new network topology. Subsequent operations like {@link #newEnsemble(int, int, int, Map, Set)} or
- * {@link #replaceBookie(int, int, int, java.util.Map, java.util.Set,
- * org.apache.bookkeeper.net.BookieSocketAddress, java.util.Set)}
+ * {@link #replaceBookie(int, int, int, java.util.Map, java.util.List, BookieId, java.util.Set)}
  * hence can operate on the new
  * network topology.
  *
@@ -231,8 +232,7 @@ public interface EnsemblePlacementPolicy {
      *
      * <p>The implementation should take actions when the cluster view is changed. So subsequent
      * {@link #newEnsemble(int, int, int, Map, Set)} and
-     * {@link #replaceBookie(int, int, int, java.util.Map, java.util.Set,
-     * org.apache.bookkeeper.net.BookieSocketAddress, java.util.Set) }
+     * {@link #replaceBookie(int, int, int, java.util.Map, java.util.List, BookieId, java.util.Set) }
      * can choose proper bookies.
      *
      * @param writableBookies

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -926,7 +926,7 @@ public class LedgerHandle implements WriteHandle {
     /**
      * Add entry synchronously to an open ledger. This can be used only with
      * {@link LedgerHandleAdv} returned through ledgers created with {@link
-     * BookKeeper#createLedgerAdv(int, int, int, DigestType, byte[])}.
+     * BookKeeper#createLedgerAdv(int, int, int, BookKeeper.DigestType, byte[])}.
      *
      *
      * @param entryId
@@ -968,7 +968,7 @@ public class LedgerHandle implements WriteHandle {
     /**
      * Add entry synchronously to an open ledger. This can be used only with
      * {@link LedgerHandleAdv} returned through ledgers created with {@link
-     * BookKeeper#createLedgerAdv(int, int, int, DigestType, byte[])}.
+     * BookKeeper#createLedgerAdv(int, int, int, BookKeeper.DigestType, byte[])}.
      *
      * @param entryId
      *            entryId to be added.
@@ -1006,7 +1006,7 @@ public class LedgerHandle implements WriteHandle {
     /**
      * Add entry asynchronously to an open ledger. This can be used only with
      * {@link LedgerHandleAdv} returned through ledgers created with {@link
-     * BookKeeper#createLedgerAdv(int, int, int, DigestType, byte[])}.
+     * BookKeeper#createLedgerAdv(int, int, int, BookKeeper.DigestType, byte[])}.
      *
      * @param entryId
      *            entryId to be added
@@ -1060,7 +1060,7 @@ public class LedgerHandle implements WriteHandle {
      * Add entry asynchronously to an open ledger, using an offset and range.
      * This can be used only with {@link LedgerHandleAdv} returned through
      * ledgers created with
-     * {@link BookKeeper#createLedgerAdv(int, int, int, org.apache.bookkeeper.client.BookKeeper.DigestType, byte[])}.
+     * {@link BookKeeper#createLedgerAdv(int, int, int, BookKeeper.DigestType, byte[])}.
      *
      * @param entryId
      *            entryId of the entry to add.
@@ -1114,7 +1114,7 @@ public class LedgerHandle implements WriteHandle {
     /**
      * Add entry asynchronously to an open ledger, using an offset and range.
      * This can be used only with {@link LedgerHandleAdv} returned through
-     * ledgers created with {@link createLedgerAdv(int, int, int, DigestType, byte[])}.
+     * ledgers created with {@link BookKeeper#createLedgerAdv(int, int, int, BookKeeper.DigestType, byte[])}.
      *
      * @param entryId
      *            entryId of the entry to add.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -189,7 +189,7 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
     /**
      * Add entry asynchronously to an open ledger, using an offset and range.
      * This can be used only with {@link LedgerHandleAdv} returned through
-     * ledgers created with {@link createLedgerAdv(int, int, int, DigestType, byte[])}.
+     * ledgers created with {@link BookKeeper#createLedgerAdv(int, int, int, BookKeeper.DigestType, byte[])}.
      *
      * @param entryId
      *            entryId of the entry to add.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -70,7 +70,7 @@ class LedgerOpenOp {
      *
      * @param bk
      * @param ledgerId
-     * @param digestType. Ignored if conf.getEnableDigestTypeAutodetection() is true
+     * @param digestType Ignored if conf.getEnableDigestTypeAutodetection() is true
      * @param passwd
      * @param cb
      * @param ctx

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutionPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SpeculativeRequestExecutionPolicy.java
@@ -37,9 +37,9 @@ public interface SpeculativeRequestExecutionPolicy {
      * Initialize the speculative request execution policy and initiate requests.
      *
      * @param scheduler The scheduler service to issue the speculative request
-     * @param requestExectuor The executor is used to issue the actual speculative requests
+     * @param requestExecutor The executor is used to issue the actual speculative requests
      * @return ScheduledFuture, in case caller needs to cancel it.
      */
     ScheduledFuture<?> initiateSpeculativeRequest(ScheduledExecutorService scheduler,
-            SpeculativeRequestExecutor requestExectuor);
+            SpeculativeRequestExecutor requestExecutor);
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClient.java
@@ -74,7 +74,7 @@ public interface BookieClient {
      * to a bookie at {@code address} for a ledger with {@code ledgerId}.
      * It is necessary to specify the ledgerId as there may be multiple
      * channels for a single bookie if pooling is in use.
-     * If the bookie is not {@link #isWritable(BookieSocketAddress,long) writable},
+     * If the bookie is not {@link #isWritable(BookieId,long) writable},
      * then the {@link #PENDINGREQ_NOTWRITABLE_MASK} will be logically or'd with
      * the returned value.
      *
@@ -135,9 +135,9 @@ public interface BookieClient {
      * @param options a bit mask of flags from BookieProtocol.FLAG_*
      *                {@link org.apache.bookkeeper.proto.BookieProtocol}
      * @param allowFastFail fail the add immediately if the channel is non-writable
-     *                      {@link #isWritable(BookieSocketAddress,long)}
+     *                      {@link #isWritable(BookieId,long)}
      * @param writeFlags a set of write flags
-     *                   {@link org.apache.bookkeeper.client.api.WriteFlags}
+     *                   {@link org.apache.bookkeeper.client.api.WriteFlag}
      */
     void addEntry(BookieId address, long ledgerId, byte[] masterKey,
                   long entryId, ByteBufList toSend, WriteCallback cb, Object ctx,
@@ -145,7 +145,7 @@ public interface BookieClient {
 
     /**
      * Read entry with a null masterkey, disallowing failfast.
-     * @see #readEntry(BookieSocketAddress,long,long,ReadEntryCallback,Object,int,byte[],boolean)
+     * @see #readEntry(BookieId,long,long,ReadEntryCallback,Object,int,byte[],boolean)
      */
     default void readEntry(BookieId address, long ledgerId, long entryId,
                            ReadEntryCallback cb, Object ctx, int flags) {
@@ -154,7 +154,7 @@ public interface BookieClient {
 
     /**
      * Read entry, disallowing failfast.
-     * @see #readEntry(BookieSocketAddress,long,long,ReadEntryCallback,Object,int,byte[],boolean)
+     * @see #readEntry(BookieId,long,long,ReadEntryCallback,Object,int,byte[],boolean)
      */
     default void readEntry(BookieId address, long ledgerId, long entryId,
                            ReadEntryCallback cb, Object ctx, int flags, byte[] masterKey) {
@@ -174,7 +174,7 @@ public interface BookieClient {
      * @param masterKey the master key of the ledger being read from. This is only required
      *                  if the FLAG_DO_FENCING is specified.
      * @param allowFastFail fail the read immediately if the channel is non-writable
-     *                      {@link #isWritable(BookieSocketAddress,long)}
+     *                      {@link #isWritable(BookieId,long)}
      */
     void readEntry(BookieId address, long ledgerId, long entryId,
                    ReadEntryCallback cb, Object ctx, int flags, byte[] masterKey,


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

Some interfaces have modified the method signature but the annotations have not.

### Changes

Correct the method signature within annotations and fix typos