### PR TITLE
Fix force GC doesn't work under forceAllowCompaction when disk is full

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -413,9 +413,9 @@ public class GarbageCollectorThread extends SafeRunnable {
             }
 
             long curTime = System.currentTimeMillis();
-            if (((isForceMajorCompactionAllow && force) || (enableMajorCompaction
-                    && (force || curTime - lastMajorCompactionTime > majorCompactionInterval)))
-                    && (!suspendMajor)) {
+            if ((isForceMajorCompactionAllow && force) || ((enableMajorCompaction
+                    && (force || curTime - lastMajorCompactionTime > majorCompactionInterval))
+                    && (!suspendMajor))) {
                 // enter major compaction
                 LOG.info("Enter major compaction, suspendMajor {}", suspendMajor);
                 majorCompacting.set(true);
@@ -428,9 +428,9 @@ public class GarbageCollectorThread extends SafeRunnable {
                     gcStats.getMajorCompactionCounter().inc();
                     majorCompacting.set(false);
                 }
-            } else if (((isForceMinorCompactionAllow && force) || (enableMinorCompaction
-                    && (force || curTime - lastMinorCompactionTime > minorCompactionInterval)))
-                    && (!suspendMinor)) {
+            } else if ((isForceMinorCompactionAllow && force) || ((enableMinorCompaction
+                    && (force || curTime - lastMinorCompactionTime > minorCompactionInterval))
+                    && (!suspendMinor))) {
                 // enter minor compaction
                 LOG.info("Enter minor compaction, suspendMinor {}", suspendMinor);
                 minorCompacting.set(true);


### PR DESCRIPTION
## Motivation
When I set `forceAllowCompaction=true` and one ledger disk reaches max usage threshold and transfer bookie to readOnly mode, I expire some pulsar topics or delete some topics to free up disk space. I found that ledger compression cannot be triggered when using `curl -XPUT http://localhost:8000/api/v1/bookie/gc` command.

The root cause is that when one ledger disk reaches max usage threshold, it will suspend minor and major compaction
https://github.com/apache/bookkeeper/blob/f7579fd13d62ce630ea26638e73f5884da505ec8/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java#L1041-L1058

When we use `curl -XPUT http://localhost:8000/api/v1/bookie/gc` command to trigger compaction, it will be filtered by `suspendMajor` and `suspendMinor` flag.  

https://github.com/apache/bookkeeper/blob/f7579fd13d62ce630ea26638e73f5884da505ec8/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java#L416-L444

It will lead to 
- The bookie won't clean up deleted ledgers 
- Ledger disk can't free up disk usage
- Bookie can't recover from readOnly state into Writeable state.

And then we can only trigger compaction by the following steps.
- Increase max disk usage threshold
- Restart the bookie
- Use command `curl -XPUT http://localhost:8000/api/v1/bookie/gc` to trigger compaction

### Changes
1. Don't take the `suspendMajor` and `suspendMinor` flag into consideration when setting `forceAllowCompaction=true` and triggered by force GC.