### PR TITLE
Fix testCompactionPersistence do not cleanup created directory

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -78,6 +78,7 @@ import org.apache.bookkeeper.util.HardLink;
 import org.apache.bookkeeper.util.TestUtils;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zookeeper.AsyncCallback;
 import org.junit.Before;
 import org.junit.Test;
@@ -1009,7 +1010,10 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
          */
         newBookieConf.setMetadataServiceUri(null);
         String entryLogCachePath = newBookieConf.getGcEntryLogMetadataCachePath();
-        newBookieConf.setGcEntryLogMetadataCachePath(entryLogCachePath + "-bk2");
+        if (StringUtils.isBlank(entryLogCachePath)) {
+            entryLogCachePath = tmpDirs.createNew("entryLogCache", "bk2").getAbsolutePath();
+        }
+        newBookieConf.setGcEntryLogMetadataCachePath(entryLogCachePath);
         Bookie newbookie = new TestBookieImpl(newBookieConf);
 
         DigestManager digestManager = DigestManager.instantiate(ledgerId, passwdBytes,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -78,7 +78,6 @@ import org.apache.bookkeeper.util.HardLink;
 import org.apache.bookkeeper.util.TestUtils;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.zookeeper.AsyncCallback;
 import org.junit.Before;
 import org.junit.Test;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -1009,10 +1009,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
          * purpose.
          */
         newBookieConf.setMetadataServiceUri(null);
-        String entryLogCachePath = newBookieConf.getGcEntryLogMetadataCachePath();
-        if (StringUtils.isBlank(entryLogCachePath)) {
-            entryLogCachePath = tmpDirs.createNew("entryLogCache", "bk2").getAbsolutePath();
-        }
+        String entryLogCachePath = tmpDirs.createNew("entry", "bk2").getAbsolutePath();
         newBookieConf.setGcEntryLogMetadataCachePath(entryLogCachePath);
         Bookie newbookie = new TestBookieImpl(newBookieConf);
 


### PR DESCRIPTION
### Motivation
In `CompactionTest.testCompactionPersistence()`, it specified a directory as rocksdb storage path, but does't clean up it when the test finished.
https://github.com/apache/bookkeeper/blob/e937ae9a6838fd533c3973d6ae6c32d98b6619bd/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java#L1011-L1012


### Changes
Use tmpDir to manage the created directory and clean up the resources when test finished.

