### PR TITLE
Added flag to control whether to transition to read-only mode when any disks full

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -741,6 +741,9 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
 
             @Override
             public void diskWritable(File disk) {
+                if (conf.isReadOnlyModeOnAnyDiskFullEnabled()) {
+                    return;
+                }
                 // Transition to writable mode when a disk becomes writable again.
                 stateManager.setHighPriorityWritesAvailability(true);
                 stateManager.transitionToWritableMode();
@@ -748,6 +751,24 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
 
             @Override
             public void diskJustWritable(File disk) {
+                if (conf.isReadOnlyModeOnAnyDiskFullEnabled()) {
+                    return;
+                }
+                // Transition to writable mode when a disk becomes writable again.
+                stateManager.setHighPriorityWritesAvailability(true);
+                stateManager.transitionToWritableMode();
+            }
+
+            @Override
+            public void anyDiskFull(boolean highPriorityWritesAllowed) {
+                if (conf.isReadOnlyModeOnAnyDiskFullEnabled()) {
+                    stateManager.setHighPriorityWritesAvailability(highPriorityWritesAllowed);
+                    stateManager.transitionToReadOnlyMode();
+                }
+            }
+
+            @Override
+            public void allDisksWritable() {
                 // Transition to writable mode when a disk becomes writable again.
                 stateManager.setHighPriorityWritesAvailability(true);
                 stateManager.transitionToWritableMode();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -435,6 +435,19 @@ public class LedgerDirsManager {
         default void allDisksFull(boolean highPriorityWritesAllowed) {}
 
         /**
+         * This will be notified whenever all disks are detected as not full.
+         *
+         */
+        default void allDisksWritable() {}
+
+        /**
+         * This will be notified whenever any disks are detected as full.
+         *
+         * @param highPriorityWritesAllowed the parameter indicates we are still have disk spaces for high priority
+         *          *                                  writes even disks are detected as "full"
+         */
+        default void anyDiskFull(boolean highPriorityWritesAllowed) {}
+        /**
          * This will notify the fatal errors.
          */
         default void fatalError() {}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
@@ -68,9 +68,9 @@ class LedgerDirsMonitor {
 
     private void check(final LedgerDirsManager ldm) {
         final ConcurrentMap<File, Float> diskUsages = ldm.getDiskUsages();
-        boolean anyDiskFulled = false;
+        boolean someDiskFulled = false;
         boolean highPriorityWritesAllowed = true;
-        boolean anyDiskRecovered = false;
+        boolean someDiskRecovered = false;
 
         try {
             List<File> writableDirs = ldm.getWritableLedgerDirs();
@@ -103,7 +103,7 @@ class LedgerDirsMonitor {
                     });
                     // Notify disk full to all listeners
                     ldm.addToFilledDirs(dir);
-                    anyDiskFulled = true;
+                    someDiskFulled = true;
                 }
             }
             // Let's get NoWritableLedgerDirException without waiting for the next iteration
@@ -150,7 +150,7 @@ class LedgerDirsMonitor {
                     if (makeWritable) {
                         ldm.addToWritableDirs(dir, true);
                     }
-                    anyDiskRecovered = true;
+                    someDiskRecovered = true;
                 } catch (DiskErrorException e) {
                     // Notify disk failure to all the listeners
                     for (LedgerDirsListener listener : ldm.getListeners()) {
@@ -162,7 +162,7 @@ class LedgerDirsMonitor {
                     if (makeWritable) {
                         ldm.addToWritableDirs(dir, false);
                     }
-                    anyDiskRecovered = true;
+                    someDiskRecovered = true;
                 } catch (DiskOutOfSpaceException e) {
                     // the full-filled dir is still full-filled
                     diskUsages.put(dir, e.getUsage());
@@ -176,14 +176,14 @@ class LedgerDirsMonitor {
         }
 
         if (conf.isReadOnlyModeOnAnyDiskFullEnabled()) {
-            if (anyDiskFulled && !ldm.getFullFilledLedgerDirs().isEmpty()) {
+            if (someDiskFulled && !ldm.getFullFilledLedgerDirs().isEmpty()) {
                 // notify any disk full.
                 for (LedgerDirsListener listener : ldm.getListeners()) {
                     listener.anyDiskFull(highPriorityWritesAllowed);
                 }
             }
 
-            if (anyDiskRecovered && ldm.getFullFilledLedgerDirs().isEmpty()) {
+            if (someDiskRecovered && ldm.getFullFilledLedgerDirs().isEmpty()) {
                 // notify all disk recovered.
                 for (LedgerDirsListener listener : ldm.getListeners()) {
                     listener.allDisksWritable();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
@@ -113,7 +113,6 @@ class LedgerDirsMonitor {
             ldm.getWritableLedgerDirs();
         } catch (NoWritableLedgerDirException e) {
             LOG.warn("LedgerDirsMonitor check process: All ledger directories are non writable");
-            anyDiskFulled = true;
             try {
                 // disk check can be frequent, so disable 'loggingNoWritable' to avoid log flooding.
                 ldm.getDirsAboveUsableThresholdSize(minUsableSizeForHighPriorityWrites, false);
@@ -163,6 +162,7 @@ class LedgerDirsMonitor {
                     if (makeWritable) {
                         ldm.addToWritableDirs(dir, false);
                     }
+                    anyDiskRecovered = true;
                 } catch (DiskOutOfSpaceException e) {
                     // the full-filled dir is still full-filled
                     diskUsages.put(dir, e.getUsage());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
@@ -52,7 +52,7 @@ class LedgerDirsMonitor {
     private final ServerConfiguration conf;
     private final DiskChecker diskChecker;
     private final List<LedgerDirsManager> dirsManagers;
-    private long minUsableSizeForHighPriorityWrites;
+    private final long minUsableSizeForHighPriorityWrites;
     private ScheduledExecutorService executor;
     private ScheduledFuture<?> checkTask;
 
@@ -68,6 +68,10 @@ class LedgerDirsMonitor {
 
     private void check(final LedgerDirsManager ldm) {
         final ConcurrentMap<File, Float> diskUsages = ldm.getDiskUsages();
+        boolean anyDiskFulled = false;
+        boolean highPriorityWritesAllowed = true;
+        boolean anyDiskRecovered = false;
+
         try {
             List<File> writableDirs = ldm.getWritableLedgerDirs();
             // Check all writable dirs disk space usage.
@@ -99,6 +103,7 @@ class LedgerDirsMonitor {
                     });
                     // Notify disk full to all listeners
                     ldm.addToFilledDirs(dir);
+                    anyDiskFulled = true;
                 }
             }
             // Let's get NoWritableLedgerDirException without waiting for the next iteration
@@ -108,7 +113,7 @@ class LedgerDirsMonitor {
             ldm.getWritableLedgerDirs();
         } catch (NoWritableLedgerDirException e) {
             LOG.warn("LedgerDirsMonitor check process: All ledger directories are non writable");
-            boolean highPriorityWritesAllowed = true;
+            anyDiskFulled = true;
             try {
                 // disk check can be frequent, so disable 'loggingNoWritable' to avoid log flooding.
                 ldm.getDirsAboveUsableThresholdSize(minUsableSizeForHighPriorityWrites, false);
@@ -146,6 +151,7 @@ class LedgerDirsMonitor {
                     if (makeWritable) {
                         ldm.addToWritableDirs(dir, true);
                     }
+                    anyDiskRecovered = true;
                 } catch (DiskErrorException e) {
                     // Notify disk failure to all the listeners
                     for (LedgerDirsListener listener : ldm.getListeners()) {
@@ -166,6 +172,22 @@ class LedgerDirsMonitor {
             LOG.error("Got IOException while monitoring Dirs", ioe);
             for (LedgerDirsListener listener : ldm.getListeners()) {
                 listener.fatalError();
+            }
+        }
+
+        if (conf.isReadOnlyModeOnAnyDiskFullEnabled()) {
+            if (anyDiskFulled && !ldm.getFullFilledLedgerDirs().isEmpty()) {
+                // notify any disk full.
+                for (LedgerDirsListener listener : ldm.getListeners()) {
+                    listener.anyDiskFull(highPriorityWritesAllowed);
+                }
+            }
+
+            if (anyDiskRecovered && ldm.getFullFilledLedgerDirs().isEmpty()) {
+                // notify all disk recovered.
+                for (LedgerDirsListener listener : ldm.getListeners()) {
+                    listener.allDisksWritable();
+                }
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -187,6 +187,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String LOCK_RELEASE_OF_FAILED_LEDGER_GRACE_PERIOD = "lockReleaseOfFailedLedgerGracePeriod";
     //ReadOnly mode support on all disk full
     protected static final String READ_ONLY_MODE_ENABLED = "readOnlyModeEnabled";
+    protected static final String READ_ONLY_MODE_ON_ANY_DISK_FULL_ENABLED = "readOnlyModeOnAnyDiskFullEnabled";
     //Whether the bookie is force started in ReadOnly mode
     protected static final String FORCE_READ_ONLY_BOOKIE = "forceReadOnlyBookie";
     //Whether to persist the bookie status
@@ -2393,6 +2394,27 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public boolean isReadOnlyModeEnabled() {
         return getBoolean(READ_ONLY_MODE_ENABLED, true);
+    }
+
+    /**
+     * Set whether the bookie is able to go into read-only mode when any disk is full.
+     * If this set to false, it will behave to READ_ONLY_MODE_ENABLED flag.
+     *
+     * @param enabled whether to enable read-only mode when any disk is full.
+     * @return
+     */
+    public ServerConfiguration setReadOnlyModeOnAnyDiskFullEnabled(boolean enabled) {
+        setProperty(READ_ONLY_MODE_ON_ANY_DISK_FULL_ENABLED, enabled);
+        return this;
+    }
+
+    /**
+     * Get whether read-only mode is enable when any disk is full. The default is false.
+     *
+     * @return boolean
+     */
+    public boolean isReadOnlyModeOnAnyDiskFullEnabled() {
+        return getBoolean(READ_ONLY_MODE_ON_ANY_DISK_FULL_ENABLED, false);
     }
 
     /**

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -170,7 +170,7 @@ extraServerComponents=
 # If all ledger directories configured are full, then support only read requests for clients.
 # If "readOnlyModeEnabled=true" then on all ledger disks full, bookie will be converted
 # to read-only mode and serve only read requests. Otherwise the bookie will be shutdown.
-# By default this will be disabled.
+# By default this will be enabled.
 # readOnlyModeEnabled=true
 
 # Whether the bookie is force started in read only mode or not
@@ -179,6 +179,13 @@ extraServerComponents=
 # Persiste the bookie status locally on the disks. So the bookies can keep their status upon restarts
 # @Since 4.6
 # persistBookieStatusEnabled=false
+
+# If any ledger directories configured are full, then support only read requests for clients.
+# If "readOnlyModeOnAnyDiskFullEnabled=true" then on any ledger disks full, bookie will be converted
+# to read-only mode and serve only read requests. When all disks recovered,
+# the bookie will be converted to read-write mode.Otherwise it will obey the `readOnlyModeEnabled` behavior.
+# By default this will be disabled.
+# readOnlyModeOnAnyDiskFullEnabled=false
 
 #############################################################################
 ## Netty server settings

--- a/site3/website/docs/reference/config.md
+++ b/site3/website/docs/reference/config.md
@@ -51,11 +51,11 @@ The table below lists parameters that you can set to configure bookies. All conf
 ## Read-only mode support
 
 | Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| readOnlyModeEnabled | If all ledger directories configured are full, then support only read requests for clients. If "readOnlyModeEnabled=true" then on all ledger disks full, bookie will be converted to read-only mode and serve only read requests. Otherwise the bookie will be shutdown. By default this will be disabled. | true | 
+| -- | ----------- | ------- | 
+| readOnlyModeEnabled | If all ledger directories configured are full, then support only read requests for clients. If "readOnlyModeEnabled=true" then on all ledger disks full, bookie will be converted to read-only mode and serve only read requests. Otherwise the bookie will be shutdown. By default, this will be enabled. | true | 
 | forceReadOnlyBookie | Whether the bookie is force started in read only mode or not. | false | 
 | persistBookieStatusEnabled | Persist the bookie status locally on the disks. So the bookies can keep their status upon restarts. | false | 
-
+| readOnlyModeOnAnyDiskFullEnabled | If any ledger directories configured are full, then support only read requests for clients. If "readOnlyModeOnAnyDiskFullEnabled=true" then on any ledger disks full, bookie will be converted to read-only mode and serve only read requests. When all disks recovered, the bookie will be converted to read-write mode.Otherwise it will obey the `readOnlyModeEnabled` behavior. By default, this will be disabled. | false |
 
 ## Netty server settings
 


### PR DESCRIPTION
### Motivation
Fix #3141 

If we configure multi ledger disks, the bookie will transition to read-only mode when all disks are reached max usage threshold. However, if just one ledger disk reached max usage threshold, the bookie will continue to receive write requests, which will lead to the ledger disk out of space.

### Changes
Add a flag to control whether to transition to read-only mode when any disks reaches max usage threshold, and when all disks recovered to less than max usage threshold, the bookie will transition to read-write mode.
