### PR TITLE
Format log statements

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
@@ -144,14 +144,14 @@ public class ListUnderReplicatedCommand extends BookieCommand<ListUnderReplicate
             while (iter.hasNext()) {
                 UnderreplicatedLedger underreplicatedLedger = iter.next();
                 long urLedgerId = underreplicatedLedger.getLedgerId();
-                LOG.info(ledgerIdFormatter.formatLedgerId(urLedgerId));
+                LOG.info("{}", ledgerIdFormatter.formatLedgerId(urLedgerId));
                 long ctime = underreplicatedLedger.getCtime();
                 if (ctime != UnderreplicatedLedger.UNASSIGNED_CTIME) {
-                    LOG.info("\tCtime : " + ctime);
+                    LOG.info("\tCtime : {}", ctime);
                 }
                 if (printMissingReplica) {
                     underreplicatedLedger.getReplicaList().forEach((missingReplica) -> {
-                        LOG.info("\tMissingReplica : " + missingReplica);
+                        LOG.info("\tMissingReplica : {}", missingReplica);
                     });
                 }
                 if (printReplicationWorkerId) {
@@ -159,7 +159,7 @@ public class ListUnderReplicatedCommand extends BookieCommand<ListUnderReplicate
                         String replicationWorkerId = underreplicationManager
                                                          .getReplicationWorkerIdRereplicatingLedger(urLedgerId);
                         if (replicationWorkerId != null) {
-                            LOG.info("\tReplicationWorkerId : " + replicationWorkerId);
+                            LOG.info("\tReplicationWorkerId : {}", replicationWorkerId);
                         }
                     } catch (ReplicationException.UnavailableException e) {
                         LOG.error("Failed to get ReplicationWorkerId rereplicating ledger {} -- {}", urLedgerId,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
@@ -90,7 +90,7 @@ public class ToggleCommand extends BookieCommand<ToggleCommand.AutoRecoveryFlags
                 try (LedgerUnderreplicationManager underreplicationManager = mFactory
                          .newLedgerUnderreplicationManager()) {
                     if (flags.status) {
-                        LOG.info("Autorecovery is " + (underreplicationManager.isLedgerReplicationEnabled()
+                        LOG.info("Autorecovery is {}", (underreplicationManager.isLedgerReplicationEnabled()
                                                                      ? "enabled." : "disabled."));
                         return null;
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/FormatUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/FormatUtil.java
@@ -50,15 +50,14 @@ public class FormatUtil {
         long ledgerId = recBuff.readLong();
         long entryId = recBuff.readLong();
 
-        LOG.info(
-            "--------- Lid=" + ledgerIdFormatter.formatLedgerId(ledgerId) + ", Eid=" + entryId + ", ByteOffset=" + pos
-                + ", EntrySize=" + entrySize + " ---------");
+        LOG.info("--------- Lid={}, Eid={}, ByteOffset={}, EntrySize={} ---------",
+            ledgerIdFormatter.formatLedgerId(ledgerId), entryId, pos, entrySize);
         if (entryId == BookieImpl.METAENTRY_ID_LEDGER_KEY) {
             int masterKeyLen = recBuff.readInt();
             byte[] masterKey = new byte[masterKeyLen];
             recBuff.readBytes(masterKey);
             LOG.info("Type:           META");
-            LOG.info("MasterKey:      " + bytes2Hex(masterKey));
+            LOG.info("MasterKey:      {}", bytes2Hex(masterKey));
             LOG.info("");
             return;
         }
@@ -71,7 +70,7 @@ public class FormatUtil {
         // process a data entry
         long lastAddConfirmed = recBuff.readLong();
         LOG.info("Type:           DATA");
-        LOG.info("LastConfirmed:  " + lastAddConfirmed);
+        LOG.info("LastConfirmed:  {}", lastAddConfirmed);
         if (!printMsg) {
             LOG.info("");
             return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LastMarkCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/LastMarkCommand.java
@@ -60,9 +60,10 @@ public class LastMarkCommand extends BookieCommand<CliFlags> {
             for (int idx = 0; idx < journalDirs.length; idx++) {
                 Journal journal = new Journal(idx, journalDirs[idx], conf, dirsManager);
                 LogMark lastLogMark = journal.getLastLogMark().getCurMark();
-                LOG.info("LastLogMark : Journal Id - " + lastLogMark.getLogFileId() + "("
-                                   + Long.toHexString(lastLogMark.getLogFileId()) + ".txn), Pos - "
-                                   + lastLogMark.getLogFileOffset());
+                LOG.info("LastLogMark : Journal Id - {}({}.txn), Pos - {}",
+                    lastLogMark.getLogFileId(),
+                    Long.toHexString(lastLogMark.getLogFileId()),
+                    lastLogMark.getLogFileOffset());
             }
             return true;
         } catch (IOException e) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
@@ -163,13 +163,13 @@ public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
 
     public void printActiveLedgerOnEntryLog(long logId, List<Long> activeLedgers){
       if (activeLedgers.size() == 0){
-        LOG.info("No active ledgers on log file " + logId);
+        LOG.info("No active ledgers on log file {}", logId);
       } else {
-        LOG.info("Active ledgers on entry log " + logId + " as follow:");
+        LOG.info("Active ledgers on entry log {} as follow:", logId);
       }
       Collections.sort(activeLedgers);
-      for (long a:activeLedgers){
-        LOG.info(ledgerIdFormatter.formatLedgerId(a) + " ");
+      for (long a : activeLedgers){
+        LOG.info("{} ", ledgerIdFormatter.formatLedgerId(a));
       }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommand.java
@@ -81,7 +81,7 @@ public class ListFilesOnDiscCommand extends BookieCommand<ListFilesOnDiscCommand
             List<File> journalFiles = BookieShell.listFilesAndSort(journalDirs, "txn");
             LOG.info("--------- Printing the list of Journal Files ---------");
             for (File journalFile : journalFiles) {
-                LOG.info(journalFile.getCanonicalPath());
+                LOG.info("{}", journalFile.getCanonicalPath());
             }
             LOG.info("");
         }
@@ -90,7 +90,7 @@ public class ListFilesOnDiscCommand extends BookieCommand<ListFilesOnDiscCommand
             List<File> ledgerFiles = BookieShell.listFilesAndSort(ledgerDirs, "log");
             LOG.info("--------- Printing the list of EntryLog/Ledger Files ---------");
             for (File ledgerFile : ledgerFiles) {
-                LOG.info(ledgerFile.getCanonicalPath());
+                LOG.info("{}", ledgerFile.getCanonicalPath());
             }
             LOG.info("");
         }
@@ -99,7 +99,7 @@ public class ListFilesOnDiscCommand extends BookieCommand<ListFilesOnDiscCommand
             List<File> indexFiles = BookieShell.listFilesAndSort(indexDirs, "idx");
             LOG.info("--------- Printing the list of Index Files ---------");
             for (File indexFile : indexFiles) {
-                LOG.info(indexFile.getCanonicalPath());
+                LOG.info("{}", indexFile.getCanonicalPath());
             }
         }
         return true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
@@ -189,9 +189,9 @@ public class ListLedgersCommand extends BookieCommand<ListLedgersFlags> {
     }
 
     private void printLedgerMetadata(long ledgerId, LedgerMetadata md, boolean printMeta) {
-        LOG.info("ledgerID: " + ledgerIdFormatter.formatLedgerId(ledgerId));
+        LOG.info("ledgerID: {}", ledgerIdFormatter.formatLedgerId(ledgerId));
         if (printMeta) {
-            LOG.info(md.toString());
+            LOG.info("{}", md.toString());
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadJournalCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadJournalCommand.java
@@ -154,7 +154,7 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
             File f = new File(cmd.fileName);
             String name = f.getName();
             if (!name.endsWith(".txn")) {
-                LOG.error("ERROR: invalid journal file name " + cmd.fileName);
+                LOG.error("ERROR: invalid journal file name {}", cmd.fileName);
                 usage();
                 return false;
             }
@@ -194,14 +194,14 @@ public class ReadJournalCommand extends BookieCommand<ReadJournalCommand.ReadJou
       * @param printMsg Whether printing the entry data.
       */
     private void scanJournal(Journal journal, long journalId, final boolean printMsg) throws IOException {
-        LOG.info("Scan journal " + journalId + " (" + Long.toHexString(journalId) + ".txn)");
+        LOG.info("Scan journal {} ({}.txn)", journalId, Long.toHexString(journalId));
         scanJournal(journal, journalId, new Journal.JournalScanner() {
             boolean printJournalVersion = false;
 
             @Override
             public void process(int journalVersion, long offset, ByteBuffer entry) throws IOException {
                 if (!printJournalVersion) {
-                    LOG.info("Journal Version : " + journalVersion);
+                    LOG.info("Journal Version : {}", journalVersion);
                     printJournalVersion = true;
                 }
                 FormatUtil

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
@@ -201,9 +201,8 @@ public class ReadLedgerCommand extends BookieCommand<ReadLedgerCommand.ReadLedge
                                                    return;
                                                }
 
-                                               LOG.info(
-                                                   "--------- Lid=" + ledgerIdFormatter.formatLedgerId(flags.ledgerId)
-                                                   + ", Eid=" + entryId + " ---------");
+                                               LOG.info("--------- Lid={}, Eid={} ---------",
+                                                   ledgerIdFormatter.formatLedgerId(flags.ledgerId), entryId);
                                                if (flags.msg) {
                                                    LOG.info("Data: " + ByteBufUtil.prettyHexDump(buffer));
                                                }
@@ -238,8 +237,10 @@ public class ReadLedgerCommand extends BookieCommand<ReadLedgerCommand.ReadLedge
         long ledgerId = entry.getLedgerId();
         long entryId = entry.getEntryId();
         long entrySize = entry.getLength();
-        LOG.info("--------- Lid=" + ledgerIdFormatter.formatLedgerId(ledgerId) + ", Eid=" + entryId
-                           + ", EntrySize=" + entrySize + " ---------");
+
+        LOG.info("--------- Lid={}, Eid={}, EntrySize={} ---------",
+            ledgerIdFormatter.formatLedgerId(ledgerId), entryId, entrySize);
+
         if (printMsg) {
             entryFormatter.formatEntry(entry.getEntry());
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogCommand.java
@@ -131,7 +131,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             File f = new File(flags.filename);
             String name = f.getName();
             if (!name.endsWith(".log")) {
-                LOG.error("Invalid entry log file name " + flags.filename);
+                LOG.error("Invalid entry log file name {}", flags.filename);
                 usage();
                 return false;
             }
@@ -147,8 +147,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
         // scan entry log
         if (startpos != -1) {
             if ((endpos != -1) && (endpos < startpos)) {
-                System.err
-                    .println("ERROR: StartPosition of the range should be lesser than or equal to EndPosition");
+                LOG.error("ERROR: StartPosition of the range should be lesser than or equal to EndPosition");
                 return false;
             }
             scanEntryLogForPositionRange(conf, logId, startpos, endpos, flags.msg);
@@ -172,8 +171,8 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
     private void scanEntryLogForPositionRange(ServerConfiguration conf, long logId, final long rangeStartPos,
                                               final long rangeEndPos,
                                                 final boolean printMsg) throws Exception {
-        LOG.info("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)" + " for PositionRange: "
-                           + rangeStartPos + " - " + rangeEndPos);
+        LOG.info("Scan entry log {} ({}.log) for PositionRange: {} - {}",
+            logId, Long.toHexString(logId), rangeStartPos, rangeEndPos);
         final MutableBoolean entryFound = new MutableBoolean(false);
         scanEntryLog(conf, logId, new EntryLogger.EntryLogScanner() {
             private MutableBoolean stopScanning = new MutableBoolean(false);
@@ -208,11 +207,10 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             }
         });
         if (!entryFound.booleanValue()) {
-            LOG.info(
-                "Entry log " + logId + " (" + Long.toHexString(logId) + ".log) doesn't has any entry in the range "
-                + rangeStartPos + " - " + rangeEndPos
-                + ". Probably the position range, you have provided is lesser than the LOGFILE_HEADER_SIZE (1024) "
-                + "or greater than the current log filesize.");
+            LOG.info("Entry log {} ({}.log) doesn't has any entry in the range {} - {}. "
+                + "Probably the position range, you have provided is lesser than the LOGFILE_HEADER_SIZE (1024) "
+                + "or greater than the current log filesize.",
+                logId, Long.toHexString(logId), rangeStartPos, rangeEndPos);
         }
     }
 
@@ -247,8 +245,8 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
     private void scanEntryLogForSpecificEntry(ServerConfiguration conf, long logId, final long ledgerId,
                                                 final long entryId,
                                                 final boolean printMsg) throws Exception {
-        LOG.info("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)" + " for LedgerId "
-                           + ledgerId + ((entryId == -1) ? "" : " for EntryId " + entryId));
+        LOG.info("Scan entry log {} ({}.log) for LedgerId {} {}", logId, Long.toHexString(logId), ledgerId,
+            ((entryId == -1) ? "" : " for EntryId " + entryId));
         final MutableBoolean entryFound = new MutableBoolean(false);
         scanEntryLog(conf, logId, new EntryLogger.EntryLogScanner() {
             @Override
@@ -268,9 +266,8 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             }
         });
         if (!entryFound.booleanValue()) {
-            LOG.info("LedgerId " + ledgerId + ((entryId == -1) ? "" : " EntryId " + entryId)
-                               + " is not available in the entry log " + logId + " (" + Long.toHexString(logId)
-                               + ".log)");
+            LOG.info("LedgerId {} {} is not available in the entry log {} ({}.log)",
+                ledgerId, ((entryId == -1) ? "" : " EntryId " + entryId), logId, Long.toHexString(logId));
         }
     }
 
@@ -283,7 +280,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
      *          Whether printing the entry data.
      */
     private void scanEntryLog(ServerConfiguration conf, long logId, final boolean printMsg) throws Exception {
-        LOG.info("Scan entry log " + logId + " (" + Long.toHexString(logId) + ".log)");
+        LOG.info("Scan entry log {} ({}.log)", logId, Long.toHexString(logId));
         scanEntryLog(conf, logId, new EntryLogger.EntryLogScanner() {
             @Override
             public boolean accept(long ledgerId) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/EndpointInfoCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/EndpointInfoCommand.java
@@ -87,25 +87,25 @@ public class EndpointInfoCommand extends BookieCommand<EndpointInfoCommand.Endpo
             BookieId bookieId = BookieId.parse(bookieIdStr);
             Collection<BookieId> allBookies = admin.getAllBookies();
             if (!allBookies.contains(bookieId)) {
-                LOG.info("Bookie " + bookieId + " does not exist, only " + allBookies);
+                LOG.info("Bookie {} does not exist, only {}", bookieId, allBookies);
                 return false;
             }
             BookieServiceInfo bookieServiceInfo = admin.getBookieServiceInfo(bookieId);
 
-            LOG.info("BookiedId: " + bookieId);
+            LOG.info("BookiedId: {}", bookieId);
             if (!bookieServiceInfo.getProperties().isEmpty()) {
                 LOG.info("Properties");
                 bookieServiceInfo.getProperties().forEach((k, v) -> {
-                    LOG.info(k + ":" + v);
+                    LOG.info("{} : {}", k, v);
                 });
             }
             if (!bookieServiceInfo.getEndpoints().isEmpty()) {
                 bookieServiceInfo.getEndpoints().forEach(e -> {
-                    LOG.info("Endpoint: " + e.getId());
-                    LOG.info("Protocol: " + e.getProtocol());
-                    LOG.info("Address: " + e.getHost() + ":" + e.getPort());
-                    LOG.info("Auth: " + e.getAuth());
-                    LOG.info("Extensions: " + e.getExtensions());
+                    LOG.info("Endpoint: {}", e.getId());
+                    LOG.info("Protocol: {}", e.getProtocol());
+                    LOG.info("Address: {} : {}", e.getHost(), e.getPort());
+                    LOG.info("Auth: {}", e.getAuth());
+                    LOG.info("Extensions: {}", e.getExtensions());
                 });
             } else {
                 LOG.info("Bookie did not publish any endpoint info. Maybe it is down");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/InfoCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/InfoCommand.java
@@ -87,10 +87,10 @@ public class InfoCommand extends BookieCommand<CliFlags> {
             for (Map.Entry<BookieId, BookieInfo> e : map.entrySet()) {
                 BookieInfo bInfo = e.getValue();
                 BookieId bookieId = e.getKey();
-                LOG.info(CommandHelpers.getBookieSocketAddrStringRepresentation(bookieId,
-                        bk.getBookieAddressResolver())
-                    + ":\tFree: " + bInfo.getFreeDiskSpace() + getReadable(bInfo.getFreeDiskSpace())
-                    + "\tTotal: " + bInfo.getTotalDiskSpace() + getReadable(bInfo.getTotalDiskSpace()));
+                LOG.info("{}: \tFree: {}\tTotal: {}",
+                    CommandHelpers.getBookieSocketAddrStringRepresentation(bookieId, bk.getBookieAddressResolver()),
+                    bInfo.getFreeDiskSpace() + getReadable(bInfo.getFreeDiskSpace()),
+                    bInfo.getTotalDiskSpace() + getReadable(bInfo.getTotalDiskSpace()));
             }
 
             // group by hostname
@@ -106,8 +106,8 @@ public class InfoCommand extends BookieCommand<CliFlags> {
                 total += bookieInfo.getTotalDiskSpace();
             }
 
-            LOG.info("Total free disk space in the cluster:\t" + totalFree + getReadable(totalFree));
-            LOG.info("Total disk capacity in the cluster:\t" + total + getReadable(total));
+            LOG.info("Total free disk space in the cluster:\t{}", totalFree + getReadable(totalFree));
+            LOG.info("Total disk capacity in the cluster:\t{}", total + getReadable(total));
             bk.close();
 
             return true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/ListBookiesCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/ListBookiesCommand.java
@@ -121,7 +121,7 @@ public class ListBookiesCommand extends DiscoveryCommand<Flags> {
 
     private static void printBookies(Collection<BookieId> bookies, BookieAddressResolver bookieAddressResolver) {
         for (BookieId b : bookies) {
-            LOG.info(getBookieSocketAddrStringRepresentation(b, bookieAddressResolver));
+            LOG.info("{}", getBookieSocketAddrStringRepresentation(b, bookieAddressResolver));
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/RecoverCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/RecoverCommand.java
@@ -136,14 +136,13 @@ public class RecoverCommand extends BookieCommand<RecoverCommand.RecoverFlags> {
             try {
                 bookieAddrs.add(BookieId.parse(bookieStr));
             } catch (IllegalArgumentException err) {
-                LOG.error("BookieSrcs has invalid bookie id format: "
-                                   + bookieStr);
+                LOG.error("BookieSrcs has invalid bookie id format: {}", bookieStr);
                 return false;
             }
         }
 
         if (!force) {
-            LOG.error("Bookies : " + bookieAddrs);
+            LOG.error("Bookies : {}", bookieAddrs);
             if (!IOUtils.confirmPrompt("Are you sure to recover them : (Y/N)")) {
                 LOG.error("Give up!");
                 return false;
@@ -174,12 +173,12 @@ public class RecoverCommand extends BookieCommand<RecoverCommand.RecoverFlags> {
             bkAdmin.getLedgersContainBookies(bookieAddrs);
         LOG.error("NOTE: Bookies in inspection list are marked with '*'.");
         for (Map.Entry<Long, LedgerMetadata> ledger : ledgersContainBookies.entrySet()) {
-            LOG.info("ledger " + ledger.getKey() + " : " + ledger.getValue().getState());
+            LOG.info("ledger {} : {}", ledger.getKey(), ledger.getValue().getState());
             Map<Long, Integer> numBookiesToReplacePerEnsemble =
                 inspectLedger(ledger.getValue(), bookieAddrs);
             LOG.info("summary: [");
             for (Map.Entry<Long, Integer> entry : numBookiesToReplacePerEnsemble.entrySet()) {
-                LOG.info(entry.getKey() + "=" + entry.getValue() + ", ");
+                LOG.info("{}={}, ", entry.getKey(), entry.getValue());
             }
             LOG.info("]");
             LOG.info("");
@@ -193,10 +192,10 @@ public class RecoverCommand extends BookieCommand<RecoverCommand.RecoverFlags> {
         for (Map.Entry<Long, ? extends List<BookieId>> ensemble :
             metadata.getAllEnsembles().entrySet()) {
             List<BookieId> bookieList = ensemble.getValue();
-            LOG.info(ensemble.getKey() + ":\t");
+            LOG.info("{}:\t", ensemble.getKey());
             int numBookiesToReplace = 0;
             for (BookieId bookie : bookieList) {
-                LOG.info(bookie.toString());
+                LOG.info("{}", bookie.toString());
                 if (bookiesToInspect.contains(bookie)) {
                     LOG.info("*");
                     ++numBookiesToReplace;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
@@ -137,9 +137,9 @@ public class LedgerMetaDataCommand extends BookieCommand<LedgerMetaDataCommand.L
     }
 
     private void printLedgerMetadata(long ledgerId, LedgerMetadata md, boolean printMeta) {
-        LOG.info("ledgerID: " + ledgerIdFormatter.formatLedgerId(ledgerId));
+        LOG.info("ledgerID: {}", ledgerIdFormatter.formatLedgerId(ledgerId));
         if (printMeta) {
-            LOG.info(md.toString());
+            LOG.info("{}", md.toString());
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
@@ -86,17 +86,17 @@ public class SimpleTestCommand extends ClientCommand<Flags> {
             .withPassword(new byte[0])
             .execute())) {
 
-            LOG.info("Ledger ID: " + wh.getId());
+            LOG.info("Ledger ID: {}", wh.getId());
             long lastReport = System.nanoTime();
             for (int i = 0; i < flags.numEntries; i++) {
                 wh.append(data);
                 if (TimeUnit.SECONDS.convert(System.nanoTime() - lastReport,
                         TimeUnit.NANOSECONDS) > 1) {
-                    LOG.info(i + " entries written");
+                    LOG.info("{} entries written", i);
                     lastReport = System.nanoTime();
                 }
             }
-            LOG.info(flags.numEntries + " entries written to ledger " + wh.getId());
+            LOG.info("{} entries written to ledger {}", flags.numEntries, wh.getId());
         }
     }
 }


### PR DESCRIPTION
### Motivation
In PR #2455 , It convert all `System.*.print` statements to `LOG.* statements`. However, in `LOG.*` statements, it uses string concatenation to print messages, which is low performance.

### Changes
Change the string concatenation format to `LOG.*` standard statements

