### PR TITLE
Bump jackson databind version to 2.13.2.2

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -207,7 +207,7 @@ Apache Software License, Version 2.
 
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
 - lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.1.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -207,7 +207,7 @@ Apache Software License, Version 2.
 
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
 - lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.1.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -207,7 +207,7 @@ Apache Software License, Version 2.
 
 - lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
 - lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.1.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/pom.xml
+++ b/pom.xml
@@ -139,8 +139,7 @@
     <hadoop.version>2.10.0</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
-    <jackson.version>2.13.2</jackson.version>
-    <jackson-databind.version>2.13.2.1</jackson-databind.version>
+    <jackson.version>2.13.2.20220328</jackson.version>
     <jcommander.version>1.78</jcommander.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <jmh.version>1.19</jmh.version>
@@ -358,11 +357,6 @@
         <scope>import</scope>
       </dependency>
 
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson-databind.version}</version>
-      </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>


### PR DESCRIPTION
### Changes
- jackson bom will release a version when everytime its components releases, so we don't need to define variables like `jackson-data.version`
- bump jackson databind version to 2.13.2.2