### PR TITLE
Fix bookie shell help command exception

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -222,9 +222,11 @@ public class BookieShell implements Tool {
         abstract int runCmd(CommandLine cmdLine) throws Exception;
 
         String cmdName;
+        Options opts;
 
         MyCommand(String cmdName) {
             this.cmdName = cmdName;
+            opts = getOptionsWithHelp();
         }
 
         @Override
@@ -256,13 +258,18 @@ public class BookieShell implements Tool {
             System.err.println(cmdName + ": " + getDescription());
             hf.printHelp(getUsage(), getOptions());
         }
+
+        private Options getOptionsWithHelp() {
+            Options opts = new Options();
+            opts.addOption("h", "help", false, "Show the help");
+            return opts;
+        }
     }
 
     /**
      * Format the bookkeeper metadata present in zookeeper.
      */
     class MetaFormatCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         MetaFormatCmd() {
             super(CMD_METAFORMAT);
@@ -312,7 +319,6 @@ public class BookieShell implements Tool {
      * already existing.
      */
     class InitNewCluster extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         InitNewCluster() {
             super(CMD_INITNEWCLUSTER);
@@ -347,7 +353,6 @@ public class BookieShell implements Tool {
      * Nuke bookkeeper metadata of existing cluster in zookeeper.
      */
     class NukeExistingCluster extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         NukeExistingCluster() {
             super(CMD_NUKEEXISTINGCLUSTER);
@@ -392,7 +397,6 @@ public class BookieShell implements Tool {
      * Formats the local data present in current bookie server.
      */
     class BookieFormatCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public BookieFormatCmd() {
             super(CMD_BOOKIEFORMAT);
@@ -440,7 +444,6 @@ public class BookieShell implements Tool {
      * indexDirs are empty and there is no registered Bookie with this BookieId.
      */
     class InitBookieCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public InitBookieCmd() {
             super(CMD_INITBOOKIE);
@@ -474,7 +477,6 @@ public class BookieShell implements Tool {
      * Recover command for ledger data recovery for failed bookie.
      */
     class RecoverCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public RecoverCmd() {
             super(CMD_RECOVER);
@@ -543,11 +545,10 @@ public class BookieShell implements Tool {
      * Ledger Command Handles ledger related operations.
      */
     class LedgerCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         LedgerCmd() {
             super(CMD_LEDGER);
-            lOpts.addOption("m", "meta", false, "Print meta information");
+            opts.addOption("m", "meta", false, "Print meta information");
         }
 
         @Override
@@ -575,7 +576,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
     }
 
@@ -583,22 +584,21 @@ public class BookieShell implements Tool {
      * Command for reading ledger entries.
      */
     class ReadLedgerEntriesCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         ReadLedgerEntriesCmd() {
             super(CMD_READ_LEDGER_ENTRIES);
-            lOpts.addOption("m", "msg", false, "Print message body");
-            lOpts.addOption("l", "ledgerid", true, "Ledger ID");
-            lOpts.addOption("fe", "firstentryid", true, "First EntryID");
-            lOpts.addOption("le", "lastentryid", true, "Last EntryID");
-            lOpts.addOption("r", "force-recovery", false,
+            opts.addOption("m", "msg", false, "Print message body");
+            opts.addOption("l", "ledgerid", true, "Ledger ID");
+            opts.addOption("fe", "firstentryid", true, "First EntryID");
+            opts.addOption("le", "lastentryid", true, "Last EntryID");
+            opts.addOption("r", "force-recovery", false,
                 "Ensure the ledger is properly closed before reading");
-            lOpts.addOption("b", "bookie", true, "Only read from a specific bookie");
+            opts.addOption("b", "bookie", true, "Only read from a specific bookie");
         }
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
 
         @Override
@@ -647,7 +647,6 @@ public class BookieShell implements Tool {
      * Command for listing underreplicated ledgers.
      */
     class ListUnderreplicatedCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public ListUnderreplicatedCmd() {
             super(CMD_LISTUNDERREPLICATED);
@@ -699,12 +698,11 @@ public class BookieShell implements Tool {
      * Command to list all ledgers in the cluster.
      */
     class ListLedgersCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         ListLedgersCmd() {
             super(CMD_LISTLEDGERS);
-            lOpts.addOption("m", "meta", false, "Print metadata");
-            lOpts.addOption("bookieid", true, "List ledgers residing in this bookie");
+            opts.addOption("m", "meta", false, "Print metadata");
+            opts.addOption("bookieid", true, "List ledgers residing in this bookie");
         }
 
         @Override
@@ -732,7 +730,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
     }
 
@@ -740,12 +738,11 @@ public class BookieShell implements Tool {
      * List active ledgers on entry log file.
      **/
     class ListActiveLedgersCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         ListActiveLedgersCmd() {
             super(CMD_ACTIVE_LEDGERS_ON_ENTRY_LOG_FILE);
-            lOpts.addOption("l", "logId", true, "Entry log file id");
-            lOpts.addOption("t", "timeout", true, "Read timeout(ms)");
+            opts.addOption("l", "logId", true, "Entry log file id");
+            opts.addOption("t", "timeout", true, "Read timeout(ms)");
         }
 
         @Override
@@ -779,7 +776,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
     }
 
@@ -794,13 +791,12 @@ public class BookieShell implements Tool {
      * Print the metadata for a ledger.
      */
     class LedgerMetadataCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         LedgerMetadataCmd() {
             super(CMD_LEDGERMETADATA);
-            lOpts.addOption("l", "ledgerid", true, "Ledger ID");
-            lOpts.addOption("dumptofile", true, "Dump metadata for ledger, to a file");
-            lOpts.addOption("restorefromfile", true, "Restore metadata for ledger, from a file");
+            opts.addOption("l", "ledgerid", true, "Ledger ID");
+            opts.addOption("dumptofile", true, "Dump metadata for ledger, to a file");
+            opts.addOption("restorefromfile", true, "Restore metadata for ledger, from a file");
         }
 
         @Override
@@ -841,7 +837,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
     }
 
@@ -849,7 +845,6 @@ public class BookieShell implements Tool {
      * Check local storage for inconsistencies.
      */
     class LocalConsistencyCheck extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         LocalConsistencyCheck() {
             super(CMD_LOCALCONSISTENCYCHECK);
@@ -874,7 +869,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
     }
 
@@ -882,14 +877,13 @@ public class BookieShell implements Tool {
      * Simple test to create a ledger and write to it.
      */
     class SimpleTestCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         SimpleTestCmd() {
             super(CMD_SIMPLETEST);
-            lOpts.addOption("e", "ensemble", true, "Ensemble size (default 3)");
-            lOpts.addOption("w", "writeQuorum", true, "Write quorum size (default 2)");
-            lOpts.addOption("a", "ackQuorum", true, "Ack quorum size (default 2)");
-            lOpts.addOption("n", "numEntries", true, "Entries to write (default 1000)");
+            opts.addOption("e", "ensemble", true, "Ensemble size (default 3)");
+            opts.addOption("w", "writeQuorum", true, "Write quorum size (default 2)");
+            opts.addOption("a", "ackQuorum", true, "Ack quorum size (default 2)");
+            opts.addOption("n", "numEntries", true, "Entries to write (default 1000)");
         }
 
         @Override
@@ -923,7 +917,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
     }
 
@@ -931,17 +925,16 @@ public class BookieShell implements Tool {
      * Command to run a bookie sanity test.
      */
     class BookieSanityTestCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         BookieSanityTestCmd() {
             super(CMD_BOOKIESANITYTEST);
-            lOpts.addOption("e", "entries", true, "Total entries to be added for the test (default 10)");
-            lOpts.addOption("t", "timeout", true, "Timeout for write/read operations in seconds (default 1)");
+            opts.addOption("e", "entries", true, "Total entries to be added for the test (default 10)");
+            opts.addOption("t", "timeout", true, "Timeout for write/read operations in seconds (default 1)");
         }
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
 
         @Override
@@ -967,15 +960,14 @@ public class BookieShell implements Tool {
      * Command to read entry log files.
      */
     class ReadLogCmd extends MyCommand {
-        Options rlOpts = getOptionsWithHelp();
 
         ReadLogCmd() {
             super(CMD_READLOG);
-            rlOpts.addOption("m", "msg", false, "Print message body");
-            rlOpts.addOption("l", "ledgerid", true, "Ledger ID");
-            rlOpts.addOption("e", "entryid", true, "Entry ID");
-            rlOpts.addOption("sp", "startpos", true, "Start Position");
-            rlOpts.addOption("ep", "endpos", true, "End Position");
+            opts.addOption("m", "msg", false, "Print message body");
+            opts.addOption("l", "ledgerid", true, "Ledger ID");
+            opts.addOption("e", "entryid", true, "Entry ID");
+            opts.addOption("sp", "startpos", true, "Start Position");
+            opts.addOption("ep", "endpos", true, "End Position");
         }
 
         @Override
@@ -1027,7 +1019,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return rlOpts;
+            return opts;
         }
     }
 
@@ -1035,7 +1027,6 @@ public class BookieShell implements Tool {
      * Command to print metadata of entrylog.
      */
     class ReadLogMetadataCmd extends MyCommand {
-        Options rlOpts = getOptionsWithHelp();
 
         ReadLogMetadataCmd() {
             super(CMD_READLOGMETADATA);
@@ -1076,7 +1067,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return rlOpts;
+            return opts;
         }
     }
 
@@ -1084,12 +1075,11 @@ public class BookieShell implements Tool {
      * Command to read journal files.
      */
     class ReadJournalCmd extends MyCommand {
-        Options rjOpts = getOptionsWithHelp();
 
         ReadJournalCmd() {
             super(CMD_READJOURNAL);
-            rjOpts.addOption("dir", true, "Journal directory (needed if more than one journal configured)");
-            rjOpts.addOption("m", "msg", false, "Print message body");
+            opts.addOption("dir", true, "Journal directory (needed if more than one journal configured)");
+            opts.addOption("m", "msg", false, "Print message body");
         }
 
         @Override
@@ -1134,7 +1124,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return rjOpts;
+            return opts;
         }
     }
 
@@ -1142,7 +1132,6 @@ public class BookieShell implements Tool {
      * Command to print last log mark.
      */
     class LastMarkCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
         LastMarkCmd() {
             super(CMD_LASTMARK);
         }
@@ -1174,7 +1163,6 @@ public class BookieShell implements Tool {
      * List available bookies.
      */
     class ListBookiesCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         ListBookiesCmd() {
             super(CMD_LISTBOOKIES);
@@ -1236,7 +1224,6 @@ public class BookieShell implements Tool {
     }
 
     class ListDiskFilesCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         ListDiskFilesCmd() {
             super(CMD_LISTFILESONDISC);
@@ -1313,7 +1300,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return getOptionsWithHelp();
+            return opts;
         }
     }
 
@@ -1321,7 +1308,6 @@ public class BookieShell implements Tool {
      * Command for administration of autorecovery.
      */
     class AutoRecoveryCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public AutoRecoveryCmd() {
             super(CMD_AUTORECOVERY);
@@ -1365,7 +1351,6 @@ public class BookieShell implements Tool {
      * Command to query autorecovery status.
      */
     class QueryAutoRecoveryStatusCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public QueryAutoRecoveryStatusCmd() {
             super(CMD_QUERY_AUTORECOVERY_STATUS);
@@ -1401,7 +1386,6 @@ public class BookieShell implements Tool {
      * Setter and Getter for LostBookieRecoveryDelay value (in seconds) in metadata store.
      */
     class LostBookieRecoveryDelayCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public LostBookieRecoveryDelayCmd() {
             super(CMD_LOSTBOOKIERECOVERYDELAY);
@@ -1445,7 +1429,6 @@ public class BookieShell implements Tool {
      * Print which node has the auditor lock.
      */
     class WhoIsAuditorCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public WhoIsAuditorCmd() {
             super(CMD_WHOISAUDITOR);
@@ -1479,7 +1462,6 @@ public class BookieShell implements Tool {
      * Prints the instanceid of the cluster.
      */
     class WhatIsInstanceId extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public WhatIsInstanceId() {
             super(CMD_WHATISINSTANCEID);
@@ -1512,7 +1494,6 @@ public class BookieShell implements Tool {
      * Update cookie command.
      */
     class UpdateCookieCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
         private static final String BOOKIEID = "bookieId";
         private static final String EXPANDSTORAGE = "expandstorage";
         private static final String LIST = "list";
@@ -1599,7 +1580,6 @@ public class BookieShell implements Tool {
      * Update ledger command.
      */
     class UpdateLedgerCmd extends MyCommand {
-        private final Options opts = getOptionsWithHelp();
 
         UpdateLedgerCmd() {
             super(CMD_UPDATELEDGER);
@@ -1675,7 +1655,6 @@ public class BookieShell implements Tool {
      * Update bookie into ledger command.
      */
     class UpdateBookieInLedgerCmd extends MyCommand {
-        private final Options opts = getOptionsWithHelp();
 
         UpdateBookieInLedgerCmd() {
             super(CMD_UPDATE_BOOKIE_IN_LEDGER);
@@ -1754,12 +1733,11 @@ public class BookieShell implements Tool {
      * Command to delete a given ledger.
      */
     class DeleteLedgerCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         DeleteLedgerCmd() {
             super(CMD_DELETELEDGER);
-            lOpts.addOption("l", "ledgerid", true, "Ledger ID");
-            lOpts.addOption("f", "force", false, "Whether to force delete the Ledger without prompt..?");
+            opts.addOption("l", "ledgerid", true, "Ledger ID");
+            opts.addOption("f", "force", false, "Whether to force delete the Ledger without prompt..?");
         }
 
         @Override
@@ -1787,7 +1765,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
     }
 
@@ -1796,7 +1774,6 @@ public class BookieShell implements Tool {
      * the bookies in the cluster.
      */
     class BookieInfoCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         BookieInfoCmd() {
             super(CMD_BOOKIEINFO);
@@ -1814,7 +1791,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
 
         @Override
@@ -1829,7 +1806,6 @@ public class BookieShell implements Tool {
      * Command to trigger AuditTask by resetting lostBookieRecoveryDelay to its current value.
      */
     class TriggerAuditCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         TriggerAuditCmd() {
             super(CMD_TRIGGERAUDIT);
@@ -1859,7 +1835,6 @@ public class BookieShell implements Tool {
     }
 
     class ForceAuditorChecksCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         ForceAuditorChecksCmd() {
             super(CMD_FORCEAUDITCHECKS);
@@ -1935,11 +1910,10 @@ public class BookieShell implements Tool {
      * server.
      */
     class DecommissionBookieCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         DecommissionBookieCmd() {
             super(CMD_DECOMMISSIONBOOKIE);
-            lOpts.addOption("bookieid", true, "decommission a remote bookie");
+            opts.addOption("bookieid", true, "decommission a remote bookie");
         }
 
         @Override
@@ -1955,7 +1929,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
 
         @Override
@@ -1973,11 +1947,10 @@ public class BookieShell implements Tool {
      * Command to retrieve remote bookie endpoint information.
      */
     class EndpointInfoCmd extends MyCommand {
-        Options lOpts = getOptionsWithHelp();
 
         EndpointInfoCmd() {
             super(CMD_ENDPOINTINFO);
-            lOpts.addOption("b", "bookieid", true, "Bookie Id");
+            opts.addOption("b", "bookieid", true, "Bookie Id");
         }
 
         @Override
@@ -1992,7 +1965,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return lOpts;
+            return opts;
         }
 
         @Override
@@ -2023,7 +1996,6 @@ public class BookieShell implements Tool {
      * Convert bookie indexes from InterleavedStorage to DbLedgerStorage format.
      */
     class ConvertToDbStorageCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public ConvertToDbStorageCmd() {
             super(CMD_CONVERT_TO_DB_STORAGE);
@@ -2058,7 +2030,6 @@ public class BookieShell implements Tool {
      * Convert bookie indexes from DbLedgerStorage to InterleavedStorage format.
      */
     class ConvertToInterleavedStorageCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public ConvertToInterleavedStorageCmd() {
             super(CMD_CONVERT_TO_INTERLEAVED_STORAGE);
@@ -2092,7 +2063,6 @@ public class BookieShell implements Tool {
      * Rebuild DbLedgerStorage locations index.
      */
     class RebuildDbLedgerLocationsIndexCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public RebuildDbLedgerLocationsIndexCmd() {
             super(CMD_REBUILD_DB_LEDGER_LOCATIONS_INDEX);
@@ -2125,7 +2095,6 @@ public class BookieShell implements Tool {
      * Rebuild DbLedgerStorage ledgers index.
      */
     class RebuildDbLedgersIndexCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public RebuildDbLedgersIndexCmd() {
             super(CMD_REBUILD_DB_LEDGERS_INDEX);
@@ -2166,7 +2135,6 @@ public class BookieShell implements Tool {
      * Rebuild DbLedgerStorage ledgers index.
      */
     class CheckDbLedgersIndexCmd extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public CheckDbLedgersIndexCmd() {
             super(CMD_CHECK_DB_LEDGERS_INDEX);
@@ -2206,7 +2174,6 @@ public class BookieShell implements Tool {
      * Regenerate an index file for interleaved storage.
      */
     class RegenerateInterleavedStorageIndexFile extends MyCommand {
-        Options opts = getOptionsWithHelp();
 
         public RegenerateInterleavedStorageIndexFile() {
             super(CMD_REGENERATE_INTERLEAVED_STORAGE_INDEX_FILE);
@@ -2556,9 +2523,4 @@ public class BookieShell implements Tool {
         return StringUtils.equals(optValue, optName);
     }
 
-    private static Options getOptionsWithHelp() {
-        Options opts = new Options();
-        opts.addOption("h", "help", false, "Show the help");
-        return opts;
-    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -262,7 +262,7 @@ public class BookieShell implements Tool {
      * Format the bookkeeper metadata present in zookeeper.
      */
     class MetaFormatCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         MetaFormatCmd() {
             super(CMD_METAFORMAT);
@@ -271,7 +271,6 @@ public class BookieShell implements Tool {
             opts.addOption("f", "force", false,
                     "If [nonInteractive] is specified, then whether"
                             + " to force delete the old data without prompt.");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -313,11 +312,10 @@ public class BookieShell implements Tool {
      * already existing.
      */
     class InitNewCluster extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         InitNewCluster() {
             super(CMD_INITNEWCLUSTER);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -349,7 +347,7 @@ public class BookieShell implements Tool {
      * Nuke bookkeeper metadata of existing cluster in zookeeper.
      */
     class NukeExistingCluster extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         NukeExistingCluster() {
             super(CMD_NUKEEXISTINGCLUSTER);
@@ -358,7 +356,6 @@ public class BookieShell implements Tool {
             opts.addOption("f", "force", false,
                     "If instanceid is not specified, "
                     + "then whether to force nuke the metadata without validating instanceid");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -395,7 +392,7 @@ public class BookieShell implements Tool {
      * Formats the local data present in current bookie server.
      */
     class BookieFormatCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public BookieFormatCmd() {
             super(CMD_BOOKIEFORMAT);
@@ -405,7 +402,6 @@ public class BookieShell implements Tool {
                     "If [nonInteractive] is specified, then whether"
                             + " to force delete the old data without prompt..?");
             opts.addOption("d", "deleteCookie", false, "Delete its cookie on metadata store");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -444,11 +440,10 @@ public class BookieShell implements Tool {
      * indexDirs are empty and there is no registered Bookie with this BookieId.
      */
     class InitBookieCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public InitBookieCmd() {
             super(CMD_INITBOOKIE);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -479,7 +474,7 @@ public class BookieShell implements Tool {
      * Recover command for ledger data recovery for failed bookie.
      */
     class RecoverCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public RecoverCmd() {
             super(CMD_RECOVER);
@@ -491,7 +486,6 @@ public class BookieShell implements Tool {
             opts.addOption("d", "deleteCookie", false, "Delete cookie node for the bookie.");
             opts.addOption("sku", "skipUnrecoverableLedgers", false, "Skip unrecoverable ledgers.");
             opts.addOption("rate", "replicationRate", false, "Replication rate by bytes");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -549,12 +543,11 @@ public class BookieShell implements Tool {
      * Ledger Command Handles ledger related operations.
      */
     class LedgerCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         LedgerCmd() {
             super(CMD_LEDGER);
             lOpts.addOption("m", "meta", false, "Print meta information");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -590,7 +583,7 @@ public class BookieShell implements Tool {
      * Command for reading ledger entries.
      */
     class ReadLedgerEntriesCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         ReadLedgerEntriesCmd() {
             super(CMD_READ_LEDGER_ENTRIES);
@@ -601,7 +594,6 @@ public class BookieShell implements Tool {
             lOpts.addOption("r", "force-recovery", false,
                 "Ensure the ledger is properly closed before reading");
             lOpts.addOption("b", "bookie", true, "Only read from a specific bookie");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -655,7 +647,7 @@ public class BookieShell implements Tool {
      * Command for listing underreplicated ledgers.
      */
     class ListUnderreplicatedCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public ListUnderreplicatedCmd() {
             super(CMD_LISTUNDERREPLICATED);
@@ -663,7 +655,6 @@ public class BookieShell implements Tool {
             opts.addOption("excludingmissingreplica", true, "Bookie Id of missing replica to ignore");
             opts.addOption("printmissingreplica", false, "Whether to print missingreplicas list?");
             opts.addOption("printreplicationworkerid", false, "Whether to print replicationworkerid?");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -708,13 +699,12 @@ public class BookieShell implements Tool {
      * Command to list all ledgers in the cluster.
      */
     class ListLedgersCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         ListLedgersCmd() {
             super(CMD_LISTLEDGERS);
             lOpts.addOption("m", "meta", false, "Print metadata");
             lOpts.addOption("bookieid", true, "List ledgers residing in this bookie");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -750,13 +740,12 @@ public class BookieShell implements Tool {
      * List active ledgers on entry log file.
      **/
     class ListActiveLedgersCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         ListActiveLedgersCmd() {
             super(CMD_ACTIVE_LEDGERS_ON_ENTRY_LOG_FILE);
             lOpts.addOption("l", "logId", true, "Entry log file id");
             lOpts.addOption("t", "timeout", true, "Read timeout(ms)");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -805,14 +794,13 @@ public class BookieShell implements Tool {
      * Print the metadata for a ledger.
      */
     class LedgerMetadataCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         LedgerMetadataCmd() {
             super(CMD_LEDGERMETADATA);
             lOpts.addOption("l", "ledgerid", true, "Ledger ID");
             lOpts.addOption("dumptofile", true, "Dump metadata for ledger, to a file");
             lOpts.addOption("restorefromfile", true, "Restore metadata for ledger, from a file");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -861,11 +849,10 @@ public class BookieShell implements Tool {
      * Check local storage for inconsistencies.
      */
     class LocalConsistencyCheck extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         LocalConsistencyCheck() {
             super(CMD_LOCALCONSISTENCYCHECK);
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -895,7 +882,7 @@ public class BookieShell implements Tool {
      * Simple test to create a ledger and write to it.
      */
     class SimpleTestCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         SimpleTestCmd() {
             super(CMD_SIMPLETEST);
@@ -903,7 +890,6 @@ public class BookieShell implements Tool {
             lOpts.addOption("w", "writeQuorum", true, "Write quorum size (default 2)");
             lOpts.addOption("a", "ackQuorum", true, "Ack quorum size (default 2)");
             lOpts.addOption("n", "numEntries", true, "Entries to write (default 1000)");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -945,13 +931,12 @@ public class BookieShell implements Tool {
      * Command to run a bookie sanity test.
      */
     class BookieSanityTestCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         BookieSanityTestCmd() {
             super(CMD_BOOKIESANITYTEST);
             lOpts.addOption("e", "entries", true, "Total entries to be added for the test (default 10)");
             lOpts.addOption("t", "timeout", true, "Timeout for write/read operations in seconds (default 1)");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -982,7 +967,7 @@ public class BookieShell implements Tool {
      * Command to read entry log files.
      */
     class ReadLogCmd extends MyCommand {
-        Options rlOpts = new Options();
+        Options rlOpts = getOptionsWithHelp();
 
         ReadLogCmd() {
             super(CMD_READLOG);
@@ -991,7 +976,6 @@ public class BookieShell implements Tool {
             rlOpts.addOption("e", "entryid", true, "Entry ID");
             rlOpts.addOption("sp", "startpos", true, "Start Position");
             rlOpts.addOption("ep", "endpos", true, "End Position");
-            rlOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1051,11 +1035,10 @@ public class BookieShell implements Tool {
      * Command to print metadata of entrylog.
      */
     class ReadLogMetadataCmd extends MyCommand {
-        Options rlOpts = new Options();
+        Options rlOpts = getOptionsWithHelp();
 
         ReadLogMetadataCmd() {
             super(CMD_READLOGMETADATA);
-            rlOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1101,13 +1084,12 @@ public class BookieShell implements Tool {
      * Command to read journal files.
      */
     class ReadJournalCmd extends MyCommand {
-        Options rjOpts = new Options();
+        Options rjOpts = getOptionsWithHelp();
 
         ReadJournalCmd() {
             super(CMD_READJOURNAL);
             rjOpts.addOption("dir", true, "Journal directory (needed if more than one journal configured)");
             rjOpts.addOption("m", "msg", false, "Print message body");
-            rjOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1160,10 +1142,9 @@ public class BookieShell implements Tool {
      * Command to print last log mark.
      */
     class LastMarkCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
         LastMarkCmd() {
             super(CMD_LASTMARK);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1193,7 +1174,7 @@ public class BookieShell implements Tool {
      * List available bookies.
      */
     class ListBookiesCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         ListBookiesCmd() {
             super(CMD_LISTBOOKIES);
@@ -1202,7 +1183,6 @@ public class BookieShell implements Tool {
             opts.addOption("a", "all", false, "Print all bookies");
             // @deprecated 'rw'/'ro' option print both hostname and ip, so this option is not needed anymore
             opts.addOption("h", "hostnames", false, "Also print hostname of the bookie");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1256,14 +1236,13 @@ public class BookieShell implements Tool {
     }
 
     class ListDiskFilesCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         ListDiskFilesCmd() {
             super(CMD_LISTFILESONDISC);
             opts.addOption("txn", "journal", false, "Print list of Journal Files");
             opts.addOption("log", "entrylog", false, "Print list of EntryLog Files");
             opts.addOption("idx", "index", false, "Print list of Index files");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1334,7 +1313,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return new Options();
+            return getOptionsWithHelp();
         }
     }
 
@@ -1342,7 +1321,7 @@ public class BookieShell implements Tool {
      * Command for administration of autorecovery.
      */
     class AutoRecoveryCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public AutoRecoveryCmd() {
             super(CMD_AUTORECOVERY);
@@ -1350,7 +1329,6 @@ public class BookieShell implements Tool {
                     "Enable auto recovery of underreplicated ledgers");
             opts.addOption("d", "disable", false,
                     "Disable auto recovery of underreplicated ledgers");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1387,11 +1365,10 @@ public class BookieShell implements Tool {
      * Command to query autorecovery status.
      */
     class QueryAutoRecoveryStatusCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public QueryAutoRecoveryStatusCmd() {
             super(CMD_QUERY_AUTORECOVERY_STATUS);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1424,13 +1401,12 @@ public class BookieShell implements Tool {
      * Setter and Getter for LostBookieRecoveryDelay value (in seconds) in metadata store.
      */
     class LostBookieRecoveryDelayCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public LostBookieRecoveryDelayCmd() {
             super(CMD_LOSTBOOKIERECOVERYDELAY);
             opts.addOption("g", "get", false, "Get LostBookieRecoveryDelay value (in seconds)");
             opts.addOption("s", "set", true, "Set LostBookieRecoveryDelay value (in seconds)");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1469,11 +1445,10 @@ public class BookieShell implements Tool {
      * Print which node has the auditor lock.
      */
     class WhoIsAuditorCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public WhoIsAuditorCmd() {
             super(CMD_WHOISAUDITOR);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1504,11 +1479,10 @@ public class BookieShell implements Tool {
      * Prints the instanceid of the cluster.
      */
     class WhatIsInstanceId extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public WhatIsInstanceId() {
             super(CMD_WHATISINSTANCEID);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1538,7 +1512,7 @@ public class BookieShell implements Tool {
      * Update cookie command.
      */
     class UpdateCookieCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
         private static final String BOOKIEID = "bookieId";
         private static final String EXPANDSTORAGE = "expandstorage";
         private static final String LIST = "list";
@@ -1556,7 +1530,6 @@ public class BookieShell implements Tool {
             Option deleteOption = OptionBuilder.withLongOpt(DELETE).hasOptionalArgs(1)
                     .withDescription("Delete cookie both locally and in ZooKeeper").create("d");
             opts.addOption(deleteOption);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1626,7 +1599,7 @@ public class BookieShell implements Tool {
      * Update ledger command.
      */
     class UpdateLedgerCmd extends MyCommand {
-        private final Options opts = new Options();
+        private final Options opts = getOptionsWithHelp();
 
         UpdateLedgerCmd() {
             super(CMD_UPDATELEDGER);
@@ -1637,7 +1610,6 @@ public class BookieShell implements Tool {
             opts.addOption("v", "verbose", true, "Print status of the ledger updation (default: false)");
             opts.addOption("p", "printprogress", true,
                     "Print messages on every configured seconds if verbose turned on (default: 10 secs)");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1703,7 +1675,7 @@ public class BookieShell implements Tool {
      * Update bookie into ledger command.
      */
     class UpdateBookieInLedgerCmd extends MyCommand {
-        private final Options opts = new Options();
+        private final Options opts = getOptionsWithHelp();
 
         UpdateBookieInLedgerCmd() {
             super(CMD_UPDATE_BOOKIE_IN_LEDGER);
@@ -1715,7 +1687,6 @@ public class BookieShell implements Tool {
             opts.addOption("v", "verbose", true, "Print status of the ledger updation (default: false)");
             opts.addOption("p", "printprogress", true,
                     "Print messages on every configured seconds if verbose turned on (default: 10 secs)");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1783,13 +1754,12 @@ public class BookieShell implements Tool {
      * Command to delete a given ledger.
      */
     class DeleteLedgerCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         DeleteLedgerCmd() {
             super(CMD_DELETELEDGER);
             lOpts.addOption("l", "ledgerid", true, "Ledger ID");
             lOpts.addOption("f", "force", false, "Whether to force delete the Ledger without prompt..?");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1826,11 +1796,10 @@ public class BookieShell implements Tool {
      * the bookies in the cluster.
      */
     class BookieInfoCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         BookieInfoCmd() {
             super(CMD_BOOKIEINFO);
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1860,11 +1829,10 @@ public class BookieShell implements Tool {
      * Command to trigger AuditTask by resetting lostBookieRecoveryDelay to its current value.
      */
     class TriggerAuditCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         TriggerAuditCmd() {
             super(CMD_TRIGGERAUDIT);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1891,7 +1859,7 @@ public class BookieShell implements Tool {
     }
 
     class ForceAuditorChecksCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         ForceAuditorChecksCmd() {
             super(CMD_FORCEAUDITCHECKS);
@@ -1901,7 +1869,6 @@ public class BookieShell implements Tool {
                     + "upon next Auditor startup ");
             opts.addOption("rc", "replicascheck", false, "Force replicasCheck audit "
                     + "upon next Auditor startup ");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1968,12 +1935,11 @@ public class BookieShell implements Tool {
      * server.
      */
     class DecommissionBookieCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         DecommissionBookieCmd() {
             super(CMD_DECOMMISSIONBOOKIE);
             lOpts.addOption("bookieid", true, "decommission a remote bookie");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2007,12 +1973,11 @@ public class BookieShell implements Tool {
      * Command to retrieve remote bookie endpoint information.
      */
     class EndpointInfoCmd extends MyCommand {
-        Options lOpts = new Options();
+        Options lOpts = getOptionsWithHelp();
 
         EndpointInfoCmd() {
             super(CMD_ENDPOINTINFO);
             lOpts.addOption("b", "bookieid", true, "Bookie Id");
-            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2058,11 +2023,10 @@ public class BookieShell implements Tool {
      * Convert bookie indexes from InterleavedStorage to DbLedgerStorage format.
      */
     class ConvertToDbStorageCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public ConvertToDbStorageCmd() {
             super(CMD_CONVERT_TO_DB_STORAGE);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2094,11 +2058,10 @@ public class BookieShell implements Tool {
      * Convert bookie indexes from DbLedgerStorage to InterleavedStorage format.
      */
     class ConvertToInterleavedStorageCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public ConvertToInterleavedStorageCmd() {
             super(CMD_CONVERT_TO_INTERLEAVED_STORAGE);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2129,11 +2092,10 @@ public class BookieShell implements Tool {
      * Rebuild DbLedgerStorage locations index.
      */
     class RebuildDbLedgerLocationsIndexCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public RebuildDbLedgerLocationsIndexCmd() {
             super(CMD_REBUILD_DB_LEDGER_LOCATIONS_INDEX);
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2163,12 +2125,11 @@ public class BookieShell implements Tool {
      * Rebuild DbLedgerStorage ledgers index.
      */
     class RebuildDbLedgersIndexCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public RebuildDbLedgersIndexCmd() {
             super(CMD_REBUILD_DB_LEDGERS_INDEX);
             opts.addOption("v", "verbose", false, "Verbose logging, print the ledgers added to the new index");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2205,12 +2166,11 @@ public class BookieShell implements Tool {
      * Rebuild DbLedgerStorage ledgers index.
      */
     class CheckDbLedgersIndexCmd extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public CheckDbLedgersIndexCmd() {
             super(CMD_CHECK_DB_LEDGERS_INDEX);
             opts.addOption("v", "verbose", false, "Verbose logging, print the ledger data in the index.");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2246,7 +2206,7 @@ public class BookieShell implements Tool {
      * Regenerate an index file for interleaved storage.
      */
     class RegenerateInterleavedStorageIndexFile extends MyCommand {
-        Options opts = new Options();
+        Options opts = getOptionsWithHelp();
 
         public RegenerateInterleavedStorageIndexFile() {
             super(CMD_REGENERATE_INTERLEAVED_STORAGE_INDEX_FILE);
@@ -2265,7 +2225,6 @@ public class BookieShell implements Tool {
                            + "This must match the value in the ledger metadata.");
             opts.addOption("b64password", true,
                            "The password in base64 encoding, for cases where the password is not UTF-8.");
-            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2595,5 +2554,11 @@ public class BookieShell implements Tool {
 
     private static boolean getOptionalValue(String optValue, String optName) {
         return StringUtils.equals(optValue, optName);
+    }
+
+    private static Options getOptionsWithHelp() {
+        Options opts = new Options();
+        opts.addOption("h", "help", false, "Show the help");
+        return opts;
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -238,6 +238,10 @@ public class BookieShell implements Tool {
             try {
                 BasicParser parser = new BasicParser();
                 CommandLine cmdLine = parser.parse(getOptions(), args);
+                if (cmdLine.hasOption("help")) {
+                    printUsage();
+                    return 0;
+                }
                 return runCmd(cmdLine);
             } catch (ParseException e) {
                 LOG.error("Error parsing command line arguments : ", e);
@@ -267,6 +271,7 @@ public class BookieShell implements Tool {
             opts.addOption("f", "force", false,
                     "If [nonInteractive] is specified, then whether"
                             + " to force delete the old data without prompt.");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -312,6 +317,7 @@ public class BookieShell implements Tool {
 
         InitNewCluster() {
             super(CMD_INITNEWCLUSTER);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -352,6 +358,7 @@ public class BookieShell implements Tool {
             opts.addOption("f", "force", false,
                     "If instanceid is not specified, "
                     + "then whether to force nuke the metadata without validating instanceid");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -398,6 +405,7 @@ public class BookieShell implements Tool {
                     "If [nonInteractive] is specified, then whether"
                             + " to force delete the old data without prompt..?");
             opts.addOption("d", "deleteCookie", false, "Delete its cookie on metadata store");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -440,6 +448,7 @@ public class BookieShell implements Tool {
 
         public InitBookieCmd() {
             super(CMD_INITBOOKIE);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -482,6 +491,7 @@ public class BookieShell implements Tool {
             opts.addOption("d", "deleteCookie", false, "Delete cookie node for the bookie.");
             opts.addOption("sku", "skipUnrecoverableLedgers", false, "Skip unrecoverable ledgers.");
             opts.addOption("rate", "replicationRate", false, "Replication rate by bytes");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -544,6 +554,7 @@ public class BookieShell implements Tool {
         LedgerCmd() {
             super(CMD_LEDGER);
             lOpts.addOption("m", "meta", false, "Print meta information");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -590,6 +601,7 @@ public class BookieShell implements Tool {
             lOpts.addOption("r", "force-recovery", false,
                 "Ensure the ledger is properly closed before reading");
             lOpts.addOption("b", "bookie", true, "Only read from a specific bookie");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -651,6 +663,7 @@ public class BookieShell implements Tool {
             opts.addOption("excludingmissingreplica", true, "Bookie Id of missing replica to ignore");
             opts.addOption("printmissingreplica", false, "Whether to print missingreplicas list?");
             opts.addOption("printreplicationworkerid", false, "Whether to print replicationworkerid?");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -701,6 +714,7 @@ public class BookieShell implements Tool {
             super(CMD_LISTLEDGERS);
             lOpts.addOption("m", "meta", false, "Print metadata");
             lOpts.addOption("bookieid", true, "List ledgers residing in this bookie");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -742,6 +756,7 @@ public class BookieShell implements Tool {
             super(CMD_ACTIVE_LEDGERS_ON_ENTRY_LOG_FILE);
             lOpts.addOption("l", "logId", true, "Entry log file id");
             lOpts.addOption("t", "timeout", true, "Read timeout(ms)");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -797,6 +812,7 @@ public class BookieShell implements Tool {
             lOpts.addOption("l", "ledgerid", true, "Ledger ID");
             lOpts.addOption("dumptofile", true, "Dump metadata for ledger, to a file");
             lOpts.addOption("restorefromfile", true, "Restore metadata for ledger, from a file");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -849,6 +865,7 @@ public class BookieShell implements Tool {
 
         LocalConsistencyCheck() {
             super(CMD_LOCALCONSISTENCYCHECK);
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -886,6 +903,7 @@ public class BookieShell implements Tool {
             lOpts.addOption("w", "writeQuorum", true, "Write quorum size (default 2)");
             lOpts.addOption("a", "ackQuorum", true, "Ack quorum size (default 2)");
             lOpts.addOption("n", "numEntries", true, "Entries to write (default 1000)");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -933,6 +951,7 @@ public class BookieShell implements Tool {
             super(CMD_BOOKIESANITYTEST);
             lOpts.addOption("e", "entries", true, "Total entries to be added for the test (default 10)");
             lOpts.addOption("t", "timeout", true, "Timeout for write/read operations in seconds (default 1)");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -972,6 +991,7 @@ public class BookieShell implements Tool {
             rlOpts.addOption("e", "entryid", true, "Entry ID");
             rlOpts.addOption("sp", "startpos", true, "Start Position");
             rlOpts.addOption("ep", "endpos", true, "End Position");
+            rlOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1035,6 +1055,7 @@ public class BookieShell implements Tool {
 
         ReadLogMetadataCmd() {
             super(CMD_READLOGMETADATA);
+            rlOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1086,6 +1107,7 @@ public class BookieShell implements Tool {
             super(CMD_READJOURNAL);
             rjOpts.addOption("dir", true, "Journal directory (needed if more than one journal configured)");
             rjOpts.addOption("m", "msg", false, "Print message body");
+            rjOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1138,8 +1160,10 @@ public class BookieShell implements Tool {
      * Command to print last log mark.
      */
     class LastMarkCmd extends MyCommand {
+        Options opts = new Options();
         LastMarkCmd() {
             super(CMD_LASTMARK);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1161,7 +1185,7 @@ public class BookieShell implements Tool {
 
         @Override
         Options getOptions() {
-            return new Options();
+            return opts;
         }
     }
 
@@ -1178,6 +1202,7 @@ public class BookieShell implements Tool {
             opts.addOption("a", "all", false, "Print all bookies");
             // @deprecated 'rw'/'ro' option print both hostname and ip, so this option is not needed anymore
             opts.addOption("h", "hostnames", false, "Also print hostname of the bookie");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1238,6 +1263,7 @@ public class BookieShell implements Tool {
             opts.addOption("txn", "journal", false, "Print list of Journal Files");
             opts.addOption("log", "entrylog", false, "Print list of EntryLog Files");
             opts.addOption("idx", "index", false, "Print list of Index files");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1324,6 +1350,7 @@ public class BookieShell implements Tool {
                     "Enable auto recovery of underreplicated ledgers");
             opts.addOption("d", "disable", false,
                     "Disable auto recovery of underreplicated ledgers");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1364,6 +1391,7 @@ public class BookieShell implements Tool {
 
         public QueryAutoRecoveryStatusCmd() {
             super(CMD_QUERY_AUTORECOVERY_STATUS);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1402,6 +1430,7 @@ public class BookieShell implements Tool {
             super(CMD_LOSTBOOKIERECOVERYDELAY);
             opts.addOption("g", "get", false, "Get LostBookieRecoveryDelay value (in seconds)");
             opts.addOption("s", "set", true, "Set LostBookieRecoveryDelay value (in seconds)");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1444,6 +1473,7 @@ public class BookieShell implements Tool {
 
         public WhoIsAuditorCmd() {
             super(CMD_WHOISAUDITOR);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1478,6 +1508,7 @@ public class BookieShell implements Tool {
 
         public WhatIsInstanceId() {
             super(CMD_WHATISINSTANCEID);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1525,6 +1556,7 @@ public class BookieShell implements Tool {
             Option deleteOption = OptionBuilder.withLongOpt(DELETE).hasOptionalArgs(1)
                     .withDescription("Delete cookie both locally and in ZooKeeper").create("d");
             opts.addOption(deleteOption);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1605,6 +1637,7 @@ public class BookieShell implements Tool {
             opts.addOption("v", "verbose", true, "Print status of the ledger updation (default: false)");
             opts.addOption("p", "printprogress", true,
                     "Print messages on every configured seconds if verbose turned on (default: 10 secs)");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1682,6 +1715,7 @@ public class BookieShell implements Tool {
             opts.addOption("v", "verbose", true, "Print status of the ledger updation (default: false)");
             opts.addOption("p", "printprogress", true,
                     "Print messages on every configured seconds if verbose turned on (default: 10 secs)");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1755,6 +1789,7 @@ public class BookieShell implements Tool {
             super(CMD_DELETELEDGER);
             lOpts.addOption("l", "ledgerid", true, "Ledger ID");
             lOpts.addOption("f", "force", false, "Whether to force delete the Ledger without prompt..?");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1795,6 +1830,7 @@ public class BookieShell implements Tool {
 
         BookieInfoCmd() {
             super(CMD_BOOKIEINFO);
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1828,6 +1864,7 @@ public class BookieShell implements Tool {
 
         TriggerAuditCmd() {
             super(CMD_TRIGGERAUDIT);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1864,6 +1901,7 @@ public class BookieShell implements Tool {
                     + "upon next Auditor startup ");
             opts.addOption("rc", "replicascheck", false, "Force replicasCheck audit "
                     + "upon next Auditor startup ");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1935,6 +1973,7 @@ public class BookieShell implements Tool {
         DecommissionBookieCmd() {
             super(CMD_DECOMMISSIONBOOKIE);
             lOpts.addOption("bookieid", true, "decommission a remote bookie");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -1973,6 +2012,7 @@ public class BookieShell implements Tool {
         EndpointInfoCmd() {
             super(CMD_ENDPOINTINFO);
             lOpts.addOption("b", "bookieid", true, "Bookie Id");
+            lOpts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2022,6 +2062,7 @@ public class BookieShell implements Tool {
 
         public ConvertToDbStorageCmd() {
             super(CMD_CONVERT_TO_DB_STORAGE);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2057,6 +2098,7 @@ public class BookieShell implements Tool {
 
         public ConvertToInterleavedStorageCmd() {
             super(CMD_CONVERT_TO_INTERLEAVED_STORAGE);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2091,6 +2133,7 @@ public class BookieShell implements Tool {
 
         public RebuildDbLedgerLocationsIndexCmd() {
             super(CMD_REBUILD_DB_LEDGER_LOCATIONS_INDEX);
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
@@ -2124,11 +2167,12 @@ public class BookieShell implements Tool {
 
         public RebuildDbLedgersIndexCmd() {
             super(CMD_REBUILD_DB_LEDGERS_INDEX);
+            opts.addOption("v", "verbose", false, "Verbose logging, print the ledgers added to the new index");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
         Options getOptions() {
-            opts.addOption("v", "verbose", false, "Verbose logging, print the ledgers added to the new index");
             return opts;
         }
 
@@ -2165,11 +2209,12 @@ public class BookieShell implements Tool {
 
         public CheckDbLedgersIndexCmd() {
             super(CMD_CHECK_DB_LEDGERS_INDEX);
+            opts.addOption("v", "verbose", false, "Verbose logging, print the ledger data in the index.");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override
         Options getOptions() {
-            opts.addOption("v", "verbose", false, "Verbose logging, print the ledger data in the index.");
             return opts;
         }
 
@@ -2220,6 +2265,7 @@ public class BookieShell implements Tool {
                            + "This must match the value in the ledger metadata.");
             opts.addOption("b64password", true,
                            "The password in base64 encoding, for cases where the password is not UTF-8.");
+            opts.addOption("h", "help", false, "Show the help");
         }
 
         @Override


### PR DESCRIPTION
### Motivation
When run `bin/bookkeeper shell ledgermetadata -h` command, it throw the following exception.
```
23:02:41,236 ERROR Error parsing command line arguments :
org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: -h
	at org.apache.commons.cli.Parser.processOption(Parser.java:363) ~[commons-cli-commons-cli-1.2.jar:1.2]
	at org.apache.commons.cli.Parser.parse(Parser.java:199) ~[commons-cli-commons-cli-1.2.jar:1.2]
	at org.apache.commons.cli.Parser.parse(Parser.java:85) ~[commons-cli-commons-cli-1.2.jar:1.2]
	at org.apache.bookkeeper.bookie.BookieShell$MyCommand.runCmd(BookieShell.java:240) ~[org.apache.bookkeeper-bookkeeper-server-4.16.0-SNAPSHOT.jar:4.16.0-SNAPSHOT]
	at org.apache.bookkeeper.bookie.BookieShell.run(BookieShell.java:2372) ~[org.apache.bookkeeper-bookkeeper-server-4.16.0-SNAPSHOT.jar:4.16.0-SNAPSHOT]
	at org.apache.bookkeeper.bookie.BookieShell.main(BookieShell.java:2463) ~[org.apache.bookkeeper-bookkeeper-server-4.16.0-SNAPSHOT.jar:4.16.0-SNAPSHOT]
ledgermetadata: Print the metadata for a ledger, or optionally dump to a file.
usage: ledgermetadata -ledgerid <ledgerid> [--dump-to-file
                      FILENAME|--restore-from-file FILENAME]
 -dumptofile <arg>        Dump metadata for ledger, to a file
 -l,--ledgerid <arg>      Ledger ID
 -restorefromfile <arg>   Restore metadata for ledger, from a file
```

### Changes
Add `-h` and `--help` support.

