### PR TITLE
Add get under replicated ledger count

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -647,11 +647,15 @@ public class BookieShell implements Tool {
 
         public ListUnderreplicatedCmd() {
             super(CMD_LISTUNDERREPLICATED);
-            opts.addOption("missingreplica", true, "Bookie Id of missing replica");
-            opts.addOption("excludingmissingreplica", true, "Bookie Id of missing replica to ignore");
-            opts.addOption("printmissingreplica", false, "Whether to print missingreplicas list?");
-            opts.addOption("printreplicationworkerid", false, "Whether to print replicationworkerid?");
-            opts.addOption("c", "onlyDisplayLedgerCount", false, "Only display underreplicated ledger count");
+            opts.addOption("mr", "missingreplica", true, "Bookie Id of missing replica");
+            opts.addOption("emr", "excludingmissingreplica", true,
+                "Bookie Id of missing replica to ignore");
+            opts.addOption("pmr", "printmissingreplica", false,
+                "Whether to print missingreplicas list?");
+            opts.addOption("prw", "printreplicationworkerid", false,
+                "Whether to print replicationworkerid?");
+            opts.addOption("c", "onlydisplayledgercount", false,
+                "Only display underreplicated ledger count");
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -682,7 +682,7 @@ public class BookieShell implements Tool {
             final String excludingBookieId = cmdLine.getOptionValue("excludingmissingreplica");
             final boolean printMissingReplica = cmdLine.hasOption("printmissingreplica");
             final boolean printReplicationWorkerId = cmdLine.hasOption("printreplicationworkerid");
-            final boolean onlyDisplayLedgerCount = cmdLine.hasOption("onlyDisplayLedgerCount");
+            final boolean onlyDisplayLedgerCount = cmdLine.hasOption("onlydisplayledgercount");
 
             ListUnderReplicatedCommand.LURFlags flags = new ListUnderReplicatedCommand.LURFlags()
                                                             .missingReplica(includingBookieId)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -651,6 +651,7 @@ public class BookieShell implements Tool {
             opts.addOption("excludingmissingreplica", true, "Bookie Id of missing replica to ignore");
             opts.addOption("printmissingreplica", false, "Whether to print missingreplicas list?");
             opts.addOption("printreplicationworkerid", false, "Whether to print replicationworkerid?");
+            opts.addOption("c", "onlyDisplayLedgerCount", false, "Only display underreplicated ledger count");
         }
 
         @Override
@@ -677,12 +678,14 @@ public class BookieShell implements Tool {
             final String excludingBookieId = cmdLine.getOptionValue("excludingmissingreplica");
             final boolean printMissingReplica = cmdLine.hasOption("printmissingreplica");
             final boolean printReplicationWorkerId = cmdLine.hasOption("printreplicationworkerid");
+            final boolean onlyDisplayLedgerCount = cmdLine.hasOption("onlyDisplayLedgerCount");
 
             ListUnderReplicatedCommand.LURFlags flags = new ListUnderReplicatedCommand.LURFlags()
                                                             .missingReplica(includingBookieId)
                                                             .excludingMissingReplica(excludingBookieId)
                                                             .printMissingReplica(printMissingReplica)
-                                                            .printReplicationWorkerId(printReplicationWorkerId);
+                                                            .printReplicationWorkerId(printReplicationWorkerId)
+                                                            .onlyDisplayLedgerCount(onlyDisplayLedgerCount);
             ListUnderReplicatedCommand cmd = new ListUnderReplicatedCommand(ledgerIdFormatter);
             cmd.apply(bkConf, flags);
             return 0;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
@@ -98,7 +98,8 @@ public class ListUnderReplicatedCommand extends BookieCommand<ListUnderReplicate
         @Parameter(names =  {"-l", "--ledgeridformatter"}, description = "Set ledger id formatter")
         private String ledgerIdFormatter = DEFAULT;
 
-        @Parameter(names = {"-c", "--onlyDisplayLedgerCount"}, description = "Only display underreplicated ledger count")
+        @Parameter(names = {"-c", "--onlyDisplayLedgerCount"},
+            description = "Only display underreplicated ledger count")
         private boolean onlyDisplayLedgerCount;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
@@ -98,7 +98,7 @@ public class ListUnderReplicatedCommand extends BookieCommand<ListUnderReplicate
         @Parameter(names =  {"-l", "--ledgeridformatter"}, description = "Set ledger id formatter")
         private String ledgerIdFormatter = DEFAULT;
 
-        @Parameter(names = {"-c", "--onlyDisplayLedgerCount"},
+        @Parameter(names = {"-c", "--onlydisplayledgercount"},
             description = "Only display underreplicated ledger count")
         private boolean onlyDisplayLedgerCount;
     }

--- a/site3/website/docs/reference/cli.md
+++ b/site3/website/docs/reference/cli.md
@@ -348,7 +348,7 @@ $ bin/bookkeeper shell listunderreplicated \
 | -excludingmissingreplica BOOKIE_ADDRESS | Bookie Id of missing replica to ignore | 
 | -printmissingreplica        | Whether to print missingreplicas list? | 
 | -printreplicationworkerid   | Whether to print replicationworkerid? | 
-| -c,--onlyDisplayLedgerCount | Only display underreplicated ledger count | 
+| -c,--onlydisplayledgercount | Only display underreplicated ledger count | 
 
 
 ### metaformat {#bookkeeper-shell-metaformat}

--- a/site3/website/docs/reference/cli.md
+++ b/site3/website/docs/reference/cli.md
@@ -342,12 +342,13 @@ $ bin/bookkeeper shell listunderreplicated \
 	<options>
 ```
 
-| Flag                                    | Description |
-|-----------------------------------------| ----------- |
-| -missingreplica BOOKIE_ADDRESS          | Bookie Id of missing replica | 
+| Flag                        | Description |
+|-----------------------------| ----------- |
+| -missingreplica BOOKIE_ADDRESS | Bookie Id of missing replica | 
 | -excludingmissingreplica BOOKIE_ADDRESS | Bookie Id of missing replica to ignore | 
-| -printmissingreplica                    | Whether to print missingreplicas list? | 
-| -printreplicationworkerid               | Whether to print replicationworkerid? | 
+| -printmissingreplica        | Whether to print missingreplicas list? | 
+| -printreplicationworkerid   | Whether to print replicationworkerid? | 
+| -c,--onlyDisplayLedgerCount | Only display underreplicated ledger count | 
 
 
 ### metaformat {#bookkeeper-shell-metaformat}

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommandTest.java
@@ -19,6 +19,8 @@
 package org.apache.bookkeeper.tools.cli.commands.autorecovery;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -126,6 +128,20 @@ public class ListUnderReplicatedCommandTest extends BookieCommandTestBase {
         verify(ledger, times(1)).getLedgerId();
         verify(ledger, times(1)).getCtime();
         verify(underreplicationManager, times(1)).getReplicationWorkerIdRereplicatingLedger(1L);
+    }
+
+    @Test
+    public void testOnlyDisplayLedgerCount() throws InterruptedException, KeeperException,
+        ReplicationException.CompatibilityException, ReplicationException.UnavailableException {
+        testCommand("-c");
+
+        verify(factory, times(1)).newLedgerUnderreplicationManager();
+        verify(underreplicationManager, times(1)).listLedgersToRereplicate(any());
+        verify(underreplicationManager, times(0))
+            .getReplicationWorkerIdRereplicatingLedger(anyLong());
+        verify(ledger, times(0)).getLedgerId();
+        verify(ledger, times(0)).getCtime();
+        verify(ledger, times(0)).getReplicaList();
     }
 
     @Test

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommandTest.java
@@ -19,7 +19,6 @@
 package org.apache.bookkeeper.tools.cli.commands.autorecovery;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;


### PR DESCRIPTION
### Motivation
Fix #3224 

### Changes
Add flag for `ListUnderreplicatedCmd` to control only display under replicated ledgers count

