### PR TITLE
Enable Netty and BookKeeper IO optimizations on jdk17

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -284,14 +284,13 @@ build_cli_jvm_opts() {
 }
 
 build_netty_opts() {
-  NETTY_OPTS="-Dio.netty.leakDetectionLevel=${NETTY_LEAK_DETECTION_LEVEL}"
-  echo "-Dio.netty.leakDetectionLevel=${NETTY_LEAK_DETECTION_LEVEL}"
-
+  NETTY_OPTS="-Dio.netty.leakDetectionLevel=${NETTY_LEAK_DETECTION_LEVEL} -Dio.netty.tryReflectionSetAccessible=true"
   # --add-opens does not exist on jdk8
   if [ "$USING_JDK8" -eq "0" ]; then
     # Enable java.nio.DirectByteBuffer
     # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-    NETTY_OPTS="$NETTY_OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
+    # https://github.com/netty/netty/issues/12265
+    NETTY_OPTS="$NETTY_OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
   fi
   echo $NETTY_OPTS
 }
@@ -326,6 +325,8 @@ build_bookie_opts() {
   if [ "$USING_JDK8" -eq "0" ]; then
     # enable posix_fadvise usage in the Journal
     BOOKIE_OPTS="$BOOKIE_OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+    # DirectMemoryCRC32Digest
+    BOOKIE_OPTS="$BOOKIE_OPTS --add-opens java.base/java.util.zip=ALL-UNNAMED"
   fi
   echo $BOOKIE_OPTS
 }

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -284,7 +284,16 @@ build_cli_jvm_opts() {
 }
 
 build_netty_opts() {
+  NETTY_OPTS="-Dio.netty.leakDetectionLevel=${NETTY_LEAK_DETECTION_LEVEL}"
   echo "-Dio.netty.leakDetectionLevel=${NETTY_LEAK_DETECTION_LEVEL}"
+
+  # --add-opens does not exist on jdk8
+  if [ "$USING_JDK8" -eq "0" ]; then
+    # Enable java.nio.DirectByteBuffer
+    # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+    NETTY_OPTS="$NETTY_OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
+  fi
+  echo $NETTY_OPTS
 }
 
 build_logging_opts() {
@@ -312,7 +321,13 @@ build_cli_logging_opts() {
 }
 
 build_bookie_opts() {
-  echo "-Djava.net.preferIPv4Stack=true"
+  BOOKIE_OPTS="-Djava.net.preferIPv4Stack=true"
+  # --add-opens does not exist on jdk8
+  if [ "$USING_JDK8" -eq "0" ]; then
+    # enable posix_fadvise usage in the Journal
+    BOOKIE_OPTS="$BOOKIE_OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+  fi
+  echo $BOOKIE_OPTS
 }
 
 find_table_service() {

--- a/bin/common_gradle.sh
+++ b/bin/common_gradle.sh
@@ -266,11 +266,13 @@ build_cli_jvm_opts() {
 }
 
 build_netty_opts() {
+    NETTY_OPTS="-Dio.netty.leakDetectionLevel=${NETTY_LEAK_DETECTION_LEVEL} -Dio.netty.tryReflectionSetAccessible=true"
     # --add-opens does not exist on jdk8
     if [ "$USING_JDK8" -eq "0" ]; then
       # Enable java.nio.DirectByteBuffer
       # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-      NETTY_OPTS="$NETTY_OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
+      # https://github.com/netty/netty/issues/12265
+      NETTY_OPTS="$NETTY_OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
     fi
     echo $NETTY_OPTS
 }
@@ -305,6 +307,8 @@ build_bookie_opts() {
   if [ "$USING_JDK8" -eq "0" ]; then
     # enable posix_fadvise usage in the Journal
     BOOKIE_OPTS="$BOOKIE_OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+    # DirectMemoryCRC32Digest
+    BOOKIE_OPTS="$BOOKIE_OPTS --add-opens java.base/java.util.zip=ALL-UNNAMED"
   fi
   echo $BOOKIE_OPTS
 }

--- a/bin/common_gradle.sh
+++ b/bin/common_gradle.sh
@@ -266,7 +266,13 @@ build_cli_jvm_opts() {
 }
 
 build_netty_opts() {
-  echo "-Dio.netty.leakDetectionLevel=${NETTY_LEAK_DETECTION_LEVEL}"
+    # --add-opens does not exist on jdk8
+    if [ "$USING_JDK8" -eq "0" ]; then
+      # Enable java.nio.DirectByteBuffer
+      # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+      NETTY_OPTS="$NETTY_OPTS --add-opens java.base/sun.nio=ALL-UNNAMED"
+    fi
+    echo $NETTY_OPTS
 }
 
 build_logging_opts() {
@@ -294,7 +300,13 @@ build_cli_logging_opts() {
 }
 
 build_bookie_opts() {
-  echo "-Djava.net.preferIPv4Stack=true"
+  BOOKIE_OPTS="-Djava.net.preferIPv4Stack=true"
+  # --add-opens does not exist on jdk8
+  if [ "$USING_JDK8" -eq "0" ]; then
+    # enable posix_fadvise usage in the Journal
+    BOOKIE_OPTS="$BOOKIE_OPTS --add-opens java.base/java.io=ALL-UNNAMED"
+  fi
+  echo $BOOKIE_OPTS
 }
 
 find_table_service() {

--- a/pom.xml
+++ b/pom.xml
@@ -1226,6 +1226,7 @@
           --add-opens java.base/java.util=ALL-UNNAMED
           --add-opens java.base/java.util.concurrent=ALL-UNNAMED
           --add-opens java.base/java.util.stream=ALL-UNNAMED
+          --add-opens java.base/java.util.zip=ALL-UNNAMED
           --add-opens java.base/java.time=ALL-UNNAMED
           --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
           --add-opens java.base/sun.net.dns=ALL-UNNAMED

--- a/tests/scripts/src/test/bash/bk_test_bin_common.sh
+++ b/tests/scripts/src/test/bash/bk_test_bin_common.sh
@@ -228,10 +228,11 @@ testBuildNettyOpts() {
   source ${BK_BINDIR}/common.sh
 
   ACTUAL_NETTY_OPTS=$(build_netty_opts)
+  EXPECTED_NETTY_OPTS=""
   if [ "$USING_JDK8" -ne "1" ]; then
-    EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled --add-opens java.base/java.nio=ALL-UNNAMED"
+      EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled -Dio.netty.tryReflectionSetAccessible=true --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
   else
-    EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled"
+      EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled -Dio.netty.tryReflectionSetAccessible=true"
   fi
 
   assertEquals "Netty OPTS is not set correctly" "${EXPECTED_NETTY_OPTS}" "${ACTUAL_NETTY_OPTS}"
@@ -245,7 +246,7 @@ testBuildBookieOpts() {
 
   USEJDK8=$(detect_jdk8)
   if [ "$USING_JDK8" -ne "1" ]; then
-    EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true --add-opens java.base/java.io=ALL-UNNAMED"
+    EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"
   else
     EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true"
   fi

--- a/tests/scripts/src/test/bash/bk_test_bin_common.sh
+++ b/tests/scripts/src/test/bash/bk_test_bin_common.sh
@@ -228,9 +228,13 @@ testBuildNettyOpts() {
   source ${BK_BINDIR}/common.sh
 
   ACTUAL_NETTY_OPTS=$(build_netty_opts)
-  EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled"
+  if [ "$USING_JDK8" -ne "1" ]; then
+    EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled --add-opens java.base/java.nio=ALL-UNNAMED"
+  else
+    EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled"
+  fi
 
-    assertEquals "Netty OPTS is not set correctly" "${EXPECTED_NETTY_OPTS}" "${ACTUAL_NETTY_OPTS}"
+  assertEquals "Netty OPTS is not set correctly" "${EXPECTED_NETTY_OPTS}" "${ACTUAL_NETTY_OPTS}"
 }
 
 testBuildBookieOpts() {
@@ -238,6 +242,13 @@ testBuildBookieOpts() {
 
   ACTUAL_OPTS=$(build_bookie_opts)
   EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true"
+
+  USEJDK8=$(detect_jdk8)
+  if [ "$USING_JDK8" -ne "1" ]; then
+    EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true --add-opens java.base/java.io=ALL-UNNAMED"
+  else
+    EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true"
+  fi
 
   assertEquals "Bookie OPTS is not set correctly" "${EXPECTED_OPTS}" "${ACTUAL_OPTS}"
 }

--- a/tests/scripts/src/test/bash/gradle/bk_test_bin_common.sh
+++ b/tests/scripts/src/test/bash/gradle/bk_test_bin_common.sh
@@ -205,11 +205,11 @@ testBuildNettyOpts() {
   source ${BK_BINDIR}/common_gradle.sh
 
   ACTUAL_NETTY_OPTS=$(build_netty_opts)
-  EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled"
+  EXPECTED_NETTY_OPTS=""
   if [ "$USING_JDK8" -ne "1" ]; then
-      EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled --add-opens java.base/java.nio=ALL-UNNAMED"
+      EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled -Dio.netty.tryReflectionSetAccessible=true --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
   else
-      EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled"
+      EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled -Dio.netty.tryReflectionSetAccessible=true"
   fi
 
     assertEquals "Netty OPTS is not set correctly" "${EXPECTED_NETTY_OPTS}" "${ACTUAL_NETTY_OPTS}"
@@ -221,7 +221,7 @@ testBuildBookieOpts() {
   ACTUAL_OPTS=$(build_bookie_opts)
   USEJDK8=$(detect_jdk8)
   if [ "$USING_JDK8" -ne "1" ]; then
-    EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true --add-opens java.base/java.io=ALL-UNNAMED"
+    EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"
   else
     EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true"
   fi

--- a/tests/scripts/src/test/bash/gradle/bk_test_bin_common.sh
+++ b/tests/scripts/src/test/bash/gradle/bk_test_bin_common.sh
@@ -206,6 +206,11 @@ testBuildNettyOpts() {
 
   ACTUAL_NETTY_OPTS=$(build_netty_opts)
   EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled"
+  if [ "$USING_JDK8" -ne "1" ]; then
+      EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled --add-opens java.base/java.nio=ALL-UNNAMED"
+  else
+      EXPECTED_NETTY_OPTS="-Dio.netty.leakDetectionLevel=disabled"
+  fi
 
     assertEquals "Netty OPTS is not set correctly" "${EXPECTED_NETTY_OPTS}" "${ACTUAL_NETTY_OPTS}"
 }
@@ -214,7 +219,12 @@ testBuildBookieOpts() {
   source ${BK_BINDIR}/common_gradle.sh
 
   ACTUAL_OPTS=$(build_bookie_opts)
-  EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true"
+  USEJDK8=$(detect_jdk8)
+  if [ "$USING_JDK8" -ne "1" ]; then
+    EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true --add-opens java.base/java.io=ALL-UNNAMED"
+  else
+    EXPECTED_OPTS="-Djava.net.preferIPv4Stack=true"
+  fi
 
   assertEquals "Bookie OPTS is not set correctly" "${EXPECTED_OPTS}" "${ACTUAL_OPTS}"
 }


### PR DESCRIPTION
### Motivation

Starting from JDK17 the reflection is not allowed in the jdk internals modules. Until JDK16, it will print a warning like this:
```
Error:  WARNING: An illegal reflective access operation has occurred
Error:  WARNING: Illegal reflective access by org.apache.bookkeeper.proto.checksum.DirectMemoryCRC32Digest (file:/home/runner/work/bookkeeper/bookkeeper/bookkeeper-server/target/classes/) to method java.util.zip.CRC32.updateByteBuffer(int,long,int,int)
Error:  WARNING: Please consider reporting this to the maintainers of org.apache.bookkeeper.proto.checksum.DirectMemoryCRC32Digest
Error:  WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
Error:  WARNING: All illegal access operations will be denied in a future release
```

With JDK17, BookKeeper and Netty work well even if this optimization are not allowed. In order to continue to use them, we need to open the required modules

For Netty, we can follow this issue: https://github.com/netty/netty/issues/12265
For BookKeeper, I identified DirectMemoryCRC32Digest and NativeIO classes

### Changes

* Add the open modules options to open the required module (only if jdk9+ because jdk8 doesn't know the `--add-opens` instruction