### PR TITLE
bookeeper-all package missing stream binary

### DIFF
--- a/bookkeeper-dist/src/assemble/bin-all.xml
+++ b/bookkeeper-dist/src/assemble/bin-all.xml
@@ -45,6 +45,11 @@
       <outputDirectory>bin</outputDirectory>
     </fileSet>
     <fileSet>
+      <directory>../../stream/bin</directory>
+      <fileMode>755</fileMode>
+      <outputDirectory>bin</outputDirectory>
+    </fileSet>
+    <fileSet>
       <fileMode>644</fileMode>
       <includes>
         <include>${basedir}/*.txt</include>


### PR DESCRIPTION
### Changes
add the missing binary to package