### PR TITLE
Fix read empty ledger exception using bookkeeper admin

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -435,7 +435,8 @@ public class BookKeeperAdmin implements AutoCloseable {
             if ((lastEntryId == -1 || nextEntryId <= lastEntryId) && nextEntryId <= handle.getLastAddConfirmed()) {
                 try {
                     CompletableFuture<Enumeration<LedgerEntry>> result = new CompletableFuture<>();
-                    handle.asyncReadEntriesInternal(nextEntryId, nextEntryId, new SyncReadCallback(result), null, false);
+                    handle.asyncReadEntriesInternal(nextEntryId, nextEntryId,
+                        new SyncReadCallback(result), null, false);
 
                     currentEntry = SyncCallbackUtils.waitForResult(result).nextElement();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -432,10 +432,10 @@ public class BookKeeperAdmin implements AutoCloseable {
             if (currentEntry != null) {
                 return true;
             }
-            if (lastEntryId == -1 || nextEntryId <= lastEntryId) {
+            if ((lastEntryId == -1 || nextEntryId <= lastEntryId) && nextEntryId <= handle.getLastAddConfirmed()) {
                 try {
                     CompletableFuture<Enumeration<LedgerEntry>> result = new CompletableFuture<>();
-                    handle.asyncReadEntries(nextEntryId, nextEntryId, new SyncReadCallback(result), null);
+                    handle.asyncReadEntriesInternal(nextEntryId, nextEntryId, new SyncReadCallback(result), null, false);
 
                     currentEntry = SyncCallbackUtils.waitForResult(result).nextElement();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -435,9 +435,7 @@ public class BookKeeperAdmin implements AutoCloseable {
             if (lastEntryId == -1 || nextEntryId <= lastEntryId) {
                 try {
                     CompletableFuture<Enumeration<LedgerEntry>> result = new CompletableFuture<>();
-
-                    handle.asyncReadEntriesInternal(nextEntryId, nextEntryId,
-                                                    new SyncReadCallback(result), null, false);
+                    handle.asyncReadEntries(nextEntryId, nextEntryId, new SyncReadCallback(result), null);
 
                     currentEntry = SyncCallbackUtils.waitForResult(result).nextElement();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperAdminTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperAdminTest.java
@@ -491,6 +491,23 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
     }
 
     @Test
+    public void testGetEntriesFromEmptyLedger() throws Exception {
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        BookKeeper bkc = new BookKeeper(conf);
+        LedgerHandle lh = bkc.createLedger(numOfBookies, numOfBookies, digestType, "testPasswd".getBytes(UTF_8));
+        lh.close();
+        long ledgerId = lh.getId();
+
+        try (BookKeeperAdmin bkAdmin = new BookKeeperAdmin(zkUtil.getZooKeeperConnectString())) {
+            Iterator<LedgerEntry> iter = bkAdmin.readEntries(ledgerId, 0, 0).iterator();
+            assertFalse(iter.hasNext());
+        }
+
+        bkc.close();
+    }
+
+    @Test
     public void testGetListOfEntriesOfLedgerWithJustOneBookieInWriteQuorum() throws Exception {
         ClientConfiguration conf = new ClientConfiguration();
         conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());


### PR DESCRIPTION
### Motivation
Fix #3222 

The root cause is that BookKeeperAdmin use `asyncReadEntriesInternal` to read entries. However, the `asyncReadEntriesInternal` doesn't check the lastAddConfirm, which will lead to the exception list in issue 3222

### Changes

Add lastAddConfirm check before call `asyncReadEntriesInternal`