### PR TITLE
fix some jdk17 test problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <jna.version>3.2.7</jna.version>
     <junit.version>4.12</junit.version>
     <!-- required by zookeeper test utilities imported from ZooKeeper -->
-    <junit5.version>5.6.2</junit5.version>
+    <junit5.version>5.8.2</junit5.version>
     <libthrift.version>0.14.2</libthrift.version>
     <lombok.version>1.18.22</lombok.version>
     <log4j.version>2.17.2</log4j.version>
@@ -158,7 +158,7 @@
     <netty.version>4.1.75.Final</netty.version>
     <netty-boringssl.version>2.0.50.Final</netty-boringssl.version>
     <ostrich.version>9.1.3</ostrich.version>
-    <powermock.version>2.0.2</powermock.version>
+    <powermock.version>2.0.9</powermock.version>
     <prometheus.version>0.8.1</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>
@@ -1214,10 +1214,14 @@
         <test.additional.args>
           --add-opens java.base/java.io=ALL-UNNAMED
           --add-opens java.base/java.lang=ALL-UNNAMED
+          --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+          --add-opens java.base/java.net=ALL-UNNAMED
           --add-opens java.base/java.nio=ALL-UNNAMED
           --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
+          --add-opens java.base/java.nio.file=ALL-UNNAMED
           --add-opens java.base/java.util=ALL-UNNAMED
           --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+          --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
           --add-opens java.base/java.util.stream=ALL-UNNAMED
           --add-opens java.base/java.time=ALL-UNNAMED
           --add-opens java.base/jdk.internal.loader=ALL-UNNAMED


### PR DESCRIPTION
### Changes
- add jdk17 required module opens
- bump junit5 version from 5.6.2 to 5.8.2
- bump powermock version from 2.0.2 to 2.0.9