### PR TITLE
Bump jetty to 9.4.46.v20220331(avoids CVE-2022-2296)

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -257,13 +257,13 @@ Apache Software License, Version 2.
 - lib/org.apache.zookeeper-zookeeper-3.8.0.jar [21]
 - lib/org.apache.zookeeper-zookeeper-jute-3.8.0.jar [21]
 - lib/org.apache.zookeeper-zookeeper-3.8.0-tests.jar [21]
-- lib/org.eclipse.jetty-jetty-http-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-io-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-security-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-server-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-servlet-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-util-ajax-9.4.43.v20210629.jar [22]
+- lib/org.eclipse.jetty-jetty-http-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-io-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-security-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-server-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-servlet-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-util-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-util-ajax-9.4.46.v20220331.jar [22]
 - lib/org.rocksdb-rocksdbjni-6.29.4.1.jar [23]
 - lib/com.beust-jcommander-1.78.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
@@ -335,7 +335,7 @@ Apache Software License, Version 2.
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
-[22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.43.v20210629
+[22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.46.v20220331
 [23] Source available at https://github.com/facebook/rocksdb/tree/v6.22.1
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -257,13 +257,13 @@ Apache Software License, Version 2.
 - lib/org.apache.zookeeper-zookeeper-3.8.0.jar [21]
 - lib/org.apache.zookeeper-zookeeper-jute-3.8.0.jar [21]
 - lib/org.apache.zookeeper-zookeeper-3.8.0-tests.jar [21]
-- lib/org.eclipse.jetty-jetty-http-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-io-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-security-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-server-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-servlet-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar [22]
-- lib/org.eclipse.jetty-jetty-util-ajax-9.4.43.v20210629.jar [22]
+- lib/org.eclipse.jetty-jetty-http-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-io-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-security-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-server-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-servlet-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-util-9.4.46.v20220331.jar [22]
+- lib/org.eclipse.jetty-jetty-util-ajax-9.4.46.v20220331.jar [22]
 - lib/org.rocksdb-rocksdbjni-6.29.4.1.jar [23]
 - lib/com.beust-jcommander-1.78.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
@@ -332,7 +332,7 @@ Apache Software License, Version 2.
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
-[22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.43.v20210629
+[22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.46.v20220331
 [23] Source available at https://github.com/facebook/rocksdb/tree/v6.16.4
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -86,13 +86,13 @@ SoundCloud Ltd. (http://soundcloud.com/).
 This product includes software developed as part of the
 Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
 ------------------------------------------------------------------------------------
-- lib/org.eclipse.jetty-jetty-http-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-io-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-security-9.4.43.v20210629jar
-- lib/org.eclipse.jetty-jetty-server-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-servlet-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-util-ajax-9.4.43.v20210629.jar
+- lib/org.eclipse.jetty-jetty-http-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-io-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-security-9.4.46.v20220331jar
+- lib/org.eclipse.jetty-jetty-server-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-servlet-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-util-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-util-ajax-9.4.46.v20220331.jar
 
 ==============================================================
  Jetty Web Container
@@ -114,7 +114,7 @@ Jetty is dual licensed under both
 
 Jetty may be distributed under either license.
 
-lib/org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar bundles UnixCrypt
+lib/org.eclipse.jetty-jetty-util-9.4.46.v20220331.jar bundles UnixCrypt
 
 The UnixCrypt.java code implements the one way cryptography used by
 Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -68,13 +68,13 @@ SoundCloud Ltd. (http://soundcloud.com/).
 This product includes software developed as part of the
 Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
 ------------------------------------------------------------------------------------
-- lib/org.eclipse.jetty-jetty-http-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-io-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-security-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-server-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-servlet-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar
-- lib/org.eclipse.jetty-jetty-util-ajax-9.4.43.v20210629.jar
+- lib/org.eclipse.jetty-jetty-http-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-io-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-security-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-server-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-servlet-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-util-9.4.46.v20220331.jar
+- lib/org.eclipse.jetty-jetty-util-ajax-9.4.46.v20220331.jar
 
 ==============================================================
  Jetty Web Container
@@ -96,7 +96,7 @@ Jetty is dual licensed under both
 
 Jetty may be distributed under either license.
 
-lib/org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar bundles UnixCrypt
+lib/org.eclipse.jetty-jetty-util-9.4.46.v20220331.jar bundles UnixCrypt
 
 The UnixCrypt.java code implements the one way cryptography used by
 Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,7 +57,7 @@ depVersions = [
     javaAnnotations:"1.3.2",
     jcommander: "1.78",
     jctools: "2.1.2",
-    jetty: "9.4.43.v20210629",
+    jetty: "9.4.46.v20220331",
     jmh: "1.19",
     jmock: "2.8.2",
     jna: "3.2.7",

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
     <jackson.version>2.13.2.20220328</jackson.version>
     <jcommander.version>1.78</jcommander.version>
-    <jetty.version>9.4.43.v20210629</jetty.version>
+    <jetty.version>9.4.46.v20220331</jetty.version>
     <jmh.version>1.19</jmh.version>
     <jmock.version>2.8.2</jmock.version>
     <jsoup.version>1.14.3</jsoup.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

Bump jetty to 9.4.46.v20220331 avoids CVE-2022-2296
