### PR TITLE
Support set local region for RegionAwareEnsemblePlacementPolicy

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -63,6 +63,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
     public static final String REPP_DISABLE_DURABILITY_ENFORCEMENT_FEATURE = "reppDisableDurabilityEnforcementFeature";
     public static final String REPP_ENABLE_VALIDATION = "reppEnableValidation";
     public static final String REGION_AWARE_ANOMALOUS_ENSEMBLE = "region_aware_anomalous_ensemble";
+    public static final String REPP_LOCAL_REGION = "reppLocalRegion";
     static final int MINIMUM_REGIONS_FOR_DURABILITY_DEFAULT = 2;
     static final int REGIONID_DISTANCE_FROM_LEAVES = 2;
     static final String UNKNOWN_REGION = "UnknownRegion";
@@ -79,7 +80,7 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
     protected Feature disableDurabilityFeature;
     private int lastRegionIndex = 0;
 
-    RegionAwareEnsemblePlacementPolicy() {
+    protected RegionAwareEnsemblePlacementPolicy() {
         super();
         perRegionPlacement = new HashMap<String, TopologyAwareEnsemblePlacementPolicy>();
         address2Region = new ConcurrentHashMap<BookieId, String>();
@@ -173,6 +174,10 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
         super.initialize(conf, optionalDnsResolver, timer, featureProvider, statsLogger, bookieAddressResolver)
                 .withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK);
         myRegion = getLocalRegion(localNode);
+        String localRegion = conf.getString(REPP_LOCAL_REGION, null);
+        if (null != localRegion) {
+            myRegion = localRegion;
+        }
         enableValidation = conf.getBoolean(REPP_ENABLE_VALIDATION, true);
         // We have to statically provide regions we want the writes to go through and how many regions
         // are required for durability. This decision cannot be driven by the active bookies as the

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -1208,13 +1208,13 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
     @Test
     public void testBasicReorderReadSequenceWithLocalRegion() throws Exception {
-        prepareNetworkTopologyForReorderTests(myRegion);
+        prepareNetworkTopologyForReorderTests("region2");
         basicReorderReadSequenceWithLocalRegionTest("region2", false);
     }
 
     @Test
     public void testBasicReorderReadLACSequenceWithLocalRegion() throws Exception {
-        prepareNetworkTopologyForReorderTests(myRegion);
+        prepareNetworkTopologyForReorderTests("region2");
         basicReorderReadSequenceWithLocalRegionTest("region2", true);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -1208,16 +1208,31 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
 
     @Test
     public void testBasicReorderReadSequenceWithLocalRegion() throws Exception {
+        prepareNetworkTopologyForReorderTests(myRegion);
         basicReorderReadSequenceWithLocalRegionTest("region2", false);
     }
 
     @Test
     public void testBasicReorderReadLACSequenceWithLocalRegion() throws Exception {
+        prepareNetworkTopologyForReorderTests(myRegion);
+        basicReorderReadSequenceWithLocalRegionTest("region2", true);
+    }
+
+    @Test
+    public void testBasicReorderReadSequenceWithLocalRegionConfig() throws Exception {
+        conf.setProperty("reppLocalRegion", "region2");
+        prepareNetworkTopologyForReorderTests("dummyRegion");
+        basicReorderReadSequenceWithLocalRegionTest("region2", false);
+    }
+
+    @Test
+    public void testBasicReorderReadLACSequenceWithLocalRegionConfig() throws Exception {
+        conf.setProperty("reppLocalRegion", "region2");
+        prepareNetworkTopologyForReorderTests("dummyRegion");
         basicReorderReadSequenceWithLocalRegionTest("region2", true);
     }
 
     private void basicReorderReadSequenceWithLocalRegionTest(String myRegion, boolean isReadLAC) throws Exception {
-        prepareNetworkTopologyForReorderTests(myRegion);
         List<BookieId> ensemble = repp.newEnsemble(9, 9, 5, null,
                                                               new HashSet<BookieId>()).getResult();
         assertEquals(9, getNumCoveredRegionsInWriteQuorum(ensemble, 9));


### PR DESCRIPTION
### Motivation

When RegionAwareEnsemblePlacementPolicy is enabled, write set of one entry contains bookie nodes in different region.
When bookkeeper client read entries, the policy provide a read sequence to read from bookies in the same region first.  see  
https://github.com/apache/bookkeeper/blob/4debbbf84db09f80ffeb4154e8e6feed134be0c0/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java#L834

It depend on `myRegion` which indicate the local region of bookkeeper client (mostly pulsar broker).
Local region  is not a configurable value, and it's generated by local host address. see https://github.com/apache/bookkeeper/blob/4debbbf84db09f80ffeb4154e8e6feed134be0c0/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java#L208

It's okey when there is a bookie in the same host of broker.
But in most case, brokers were deployed in other nodes (or pod in kubernetes), and bookkeeper client will fail to get local region value.

### Changes

Add configuration of local region for bookkeeper client.
