### PR TITLE
[ISSUE 2637] Fix jvm_memory_direct_bytes_used metrics when using jdk11+

### DIFF
--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -215,10 +215,8 @@ public class PrometheusMetricsProvider implements StatsProvider {
 
     private static final Logger log = LoggerFactory.getLogger(PrometheusMetricsProvider.class);
 
-    /*
-     * Try to get Netty counter of used direct memory. This will be correct, unlike the JVM values.
-     */
     private static final Optional<BufferPoolMXBean> poolMxBeanOp;
+
     static {
         List<BufferPoolMXBean> platformMXBeans = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class);
         poolMxBeanOp = platformMXBeans.stream()

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -30,19 +30,19 @@ import io.prometheus.client.hotspot.GarbageCollectorExports;
 import io.prometheus.client.hotspot.MemoryPoolsExports;
 import io.prometheus.client.hotspot.StandardExports;
 import io.prometheus.client.hotspot.ThreadExports;
-
 import java.io.IOException;
 import java.io.Writer;
-import java.lang.reflect.Field;
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.bookkeeper.stats.ThreadRegistry;
@@ -130,7 +130,7 @@ public class PrometheusMetricsProvider implements StatsProvider {
         registerMetrics(Gauge.build("jvm_memory_direct_bytes_used", "-").create().setChild(new Child() {
             @Override
             public double get() {
-                return directMemoryUsage != null ? directMemoryUsage.longValue() : Double.NaN;
+                return poolMxBeanOp.isPresent() ? poolMxBeanOp.get().getMemoryUsed() : Double.NaN;
             }
         }));
 
@@ -218,18 +218,10 @@ public class PrometheusMetricsProvider implements StatsProvider {
     /*
      * Try to get Netty counter of used direct memory. This will be correct, unlike the JVM values.
      */
-    private static final AtomicLong directMemoryUsage;
+    private static final Optional<BufferPoolMXBean> poolMxBeanOp;
     static {
-        AtomicLong tmpDirectMemoryUsage = null;
-
-        try {
-            Field field = PlatformDependent.class.getDeclaredField("DIRECT_MEMORY_COUNTER");
-            field.setAccessible(true);
-            tmpDirectMemoryUsage = (AtomicLong) field.get(null);
-        } catch (Throwable t) {
-            log.warn("Failed to access netty DIRECT_MEMORY_COUNTER field {}", t.getMessage());
-        }
-
-        directMemoryUsage = tmpDirectMemoryUsage;
+        List<BufferPoolMXBean> platformMXBeans = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class);
+        poolMxBeanOp = platformMXBeans.stream()
+                .filter(bufferPoolMXBean -> bufferPoolMXBean.getName().equals("direct")).findAny();
     }
 }


### PR DESCRIPTION
Fix #2637 #3247

### Motivation
The mertics about `jvm_memory_direct_bytes_used` is acquired by netty's `PlatformDependent#DIRECT_MEMORY_COUNTER`. Which can only acquired the memory used by netty.

### Changes
- use `java.nio.Bits#RESERVED_MEMORY` for jvm direct memory metrics.
- add tests to ensure `jvm_memory_direct_bytes_max` and `jvm_memory_direct_bytes_used` gets value.