### PR TITLE
Allow run LocalBookkeeper directly in `bookkeeper-server` module or on IDE

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -129,12 +129,14 @@
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <!-- needed by ZooKeeper server -->
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <!-- testing dependencies -->
     <dependency>

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -123,6 +123,19 @@
       <groupId>io.reactivex.rxjava3</groupId>
       <artifactId>rxjava</artifactId>
     </dependency>
+    <!-- used on test and main method like `LocalBookKeeper` -->
+    <dependency>
+      <!-- needed by ZooKeeper server -->
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <!-- needed by ZooKeeper server -->
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <!-- testing dependencies -->
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
@@ -165,18 +178,6 @@
        <!-- needed by ZooKeeper server tests utilities -->
        <groupId>org.junit.jupiter</groupId>
        <artifactId>junit-jupiter-api</artifactId>
-       <scope>test</scope>
-    </dependency>
-    <dependency>
-       <!-- needed by ZooKeeper server -->
-       <groupId>org.xerial.snappy</groupId>
-       <artifactId>snappy-java</artifactId>
-       <scope>test</scope>
-    </dependency>
-    <dependency>
-        <!-- needed by ZooKeeper server -->
-       <groupId>io.dropwizard.metrics</groupId>
-       <artifactId>metrics-core</artifactId>
        <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fix #3243 
### Motivation
Allow run LocalBookkeeper directly on IDE. It's typicaly useful for beginners or who want to figure out how bookkeeper works.

### Changes
- change `snappy-java` and `metrics-core` scope from test to runtime
- mark `snappy-java` and `metrics-core`  dependency optional

### What's different in the jar built there/shell scripts that launch it
we have scope compile dependency in `bookkeeper-dist-server`, so the shell goes well