### PR TITLE
Bump prometheus client version to 0.15.0

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -239,10 +239,14 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-classes-epoll-4.1.75.Final.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.75.Final-linux-x86_64.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.75.Final.jar [11]
-- lib/io.prometheus-simpleclient-0.8.1.jar [12]
-- lib/io.prometheus-simpleclient_common-0.8.1.jar [12]
-- lib/io.prometheus-simpleclient_hotspot-0.8.1.jar [12]
-- lib/io.prometheus-simpleclient_servlet-0.8.1.jar [12]
+- lib/io.prometheus-simpleclient-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_servlet-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_servlet_common-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_tracer_common-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_tracer_otel-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar [12]
 - lib/io.vertx-vertx-auth-common-3.9.8.jar [13]
 - lib/io.vertx-vertx-bridge-common-3.9.8.jar [14]
 - lib/io.vertx-vertx-core-3.9.8.jar [15]
@@ -325,7 +329,7 @@ Apache Software License, Version 2.
 [9] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=tag;h=375459
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.75.Final
-[12] Source available at https://github.com/prometheus/client_java/tree/parent-0.8.1
+[12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/3.9.8
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
 [15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -239,10 +239,14 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-classes-epoll-4.1.75.Final.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.75.Final-linux-x86_64.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.75.Final.jar [11]
-- lib/io.prometheus-simpleclient-0.8.1.jar [12]
-- lib/io.prometheus-simpleclient_common-0.8.1.jar [12]
-- lib/io.prometheus-simpleclient_hotspot-0.8.1.jar [12]
-- lib/io.prometheus-simpleclient_servlet-0.8.1.jar [12]
+- lib/io.prometheus-simpleclient-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_servlet-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_servlet_common-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_tracer_common-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_tracer_otel-0.15.0.jar [12]
+- lib/io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar [12]
 - lib/io.vertx-vertx-auth-common-3.9.8.jar [13]
 - lib/io.vertx-vertx-bridge-common-3.9.8.jar [14]
 - lib/io.vertx-vertx-core-3.9.8.jar [15]
@@ -322,7 +326,7 @@ Apache Software License, Version 2.
 [9] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=tag;h=375459
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.75.Final
-[12] Source available at https://github.com/prometheus/client_java/tree/parent-0.8.1
+[12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/3.9.8
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
 [15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -69,10 +69,14 @@ License for the specific language governing permissions and limitations
 under the License.
 
 ------------------------------------------------------------------------------------
-- lib/io.prometheus-simpleclient-0.8.1.jar
-- lib/io.prometheus-simpleclient_common-0.8.1.jar
-- lib/io.prometheus-simpleclient_hotspot-0.8.1.jar
-- lib/io.prometheus-simpleclient_servlet-0.8.1.jar
+- lib/io.prometheus-simpleclient-0.15.0.jar
+- lib/io.prometheus-simpleclient_common-0.15.0.jar
+- lib/io.prometheus-simpleclient_hotspot-0.15.0.jar
+- lib/io.prometheus-simpleclient_servlet-0.15.0.jar
+- lib/io.prometheus-simpleclient_servlet_common-0.15.0.jar
+- lib/io.prometheus-simpleclient_tracer_common-0.15.0.jar
+- lib/io.prometheus-simpleclient_tracer_otel-0.15.0.jar
+- lib/io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar
 
 Prometheus instrumentation library for JVM applications
 Copyright 2012-2015 The Prometheus Authors

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -51,10 +51,14 @@ License for the specific language governing permissions and limitations
 under the License.
 
 ------------------------------------------------------------------------------------
-- lib/io.prometheus-simpleclient-0.8.1.jar
-- lib/io.prometheus-simpleclient_common-0.8.1.jar
-- lib/io.prometheus-simpleclient_hotspot-0.8.1.jar
-- lib/io.prometheus-simpleclient_servlet-0.8.1.jar
+- lib/io.prometheus-simpleclient-0.15.0.jar
+- lib/io.prometheus-simpleclient_common-0.15.0.jar
+- lib/io.prometheus-simpleclient_hotspot-0.15.0.jar
+- lib/io.prometheus-simpleclient_servlet-0.15.0.jar
+- lib/io.prometheus-simpleclient_servlet_common-0.15.0.jar
+- lib/io.prometheus-simpleclient_tracer_common-0.15.0.jar
+- lib/io.prometheus-simpleclient_tracer_otel-0.15.0.jar
+- lib/io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar
 
 Prometheus instrumentation library for JVM applications
 Copyright 2012-2015 The Prometheus Authors

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -72,7 +72,7 @@ depVersions = [
     netty: "4.1.75.Final",
     nettyTcnativeBoringSsl: "2.0.50.Final",
     powermock: "2.0.2",
-    prometheus: "0.8.1",
+    prometheus: "0.15.0",
     protobuf: "3.16.1",
     reflections: "0.9.11",
     rocksDb: "6.27.3",

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <netty-boringssl.version>2.0.50.Final</netty-boringssl.version>
     <ostrich.version>9.1.3</ostrich.version>
     <powermock.version>2.0.9</powermock.version>
-    <prometheus.version>0.8.1</prometheus.version>
+    <prometheus.version>0.15.0</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>


### PR DESCRIPTION
### Motivation
prometheus client `0.8.1` is release on Jan,2020, Keep update

### Changes
Bump prometheus client version from 0.8.1 to 0.15.0

### Test
Update prometheus client to 0.15.0, compare the metrics txt, the results are same.
