### PR TITLE
cleaning up leftover 4.15-snapshot versions

### DIFF
--- a/site/docs/4.14.0/overview/overview.md
+++ b/site/docs/4.14.0/overview/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Apache BookKeeper&trade; 4.15.0-SNAPSHOT
+title: Apache BookKeeper&trade; 4.14.0
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/site3/website/docs/overview/overview.md
+++ b/site3/website/docs/overview/overview.md
@@ -1,6 +1,6 @@
 ---
 id: overview
-title: Apache BookKeeper 4.15.0-SNAPSHOT
+title: Apache BookKeeper 4.16.0-SNAPSHOT
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/site3/website/src/pages/releases.md
+++ b/site3/website/src/pages/releases.md
@@ -30,6 +30,26 @@ Client Guide | API docs
 
 ## News
 
+### 9 May, 2022 Release 4.15.0 available
+
+This is the 31st release of Apache BookKeeper !
+See [BookKeeper 4.15.0 Release Notes](/release-notes#4150) for details.
+
+### 22 December, 2021 Release 4.14.4 available
+
+This is the 30th release of Apache BookKeeper !
+See [BookKeeper 4.14.4 Release Notes](/release-notes#4144) for details.
+
+### 9 November, 2021 Release 4.14.3 available
+
+This is the 29th release of Apache BookKeeper !
+See [BookKeeper 4.14.3 Release Notes](/release-notes#4143) for details.
+
+### 23 August, 2021 Release 4.14.2 available
+
+This is the 28th release of Apache BookKeeper !
+See [BookKeeper 4.14.2 Release Notes](/release-notes#4142) for details.
+
 ### 31 May, 2021 Release 4.14.1 available
 
 This is the 27th release of Apache BookKeeper !

--- a/site3/website/versioned_docs/version-4.15.0/overview/overview.md
+++ b/site3/website/versioned_docs/version-4.15.0/overview/overview.md
@@ -1,6 +1,6 @@
 ---
 id: overview
-title: Apache BookKeeper 4.15.0-SNAPSHOT
+title: Apache BookKeeper 4.15.0
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/version.gradle
+++ b/version.gradle
@@ -16,4 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-ext.buildVersion = "4.15.0-SNAPSHOT"
+ext.buildVersion = "4.16.0-SNAPSHOT"


### PR DESCRIPTION
### Motivation

Some files have version 4.15.0-SNAPSHOT in them (gradle, since it is not used in the release, and some docs that are actually visible on the website)

### Changes

Changed to correct versions