### PR TITLE
Fix ledger still is writable even if it had been removed from disk by GC thread

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
@@ -38,6 +38,9 @@ public abstract class LedgerDescriptor {
     static LedgerDescriptor create(byte[] masterKey,
                                    long ledgerId,
                                    LedgerStorage ledgerStorage) throws IOException {
+        if (!ledgerStorage.ledgerExists(ledgerId)) {
+            throw new Bookie.NoLedgerException(ledgerId);
+        }
         LedgerDescriptor ledger = new LedgerDescriptorImpl(masterKey, ledgerId, ledgerStorage);
         ledgerStorage.setMasterKey(ledgerId, masterKey);
         return ledger;


### PR DESCRIPTION

### Motivation
Ledgers are still writable even  it had been deleted from disk by GC thread

### Changes

When `getHandle` we should throw exception if `!ledgerStorage.ledgerExists(ledgerId)`.
