### PR TITLE
ISSUE#3275:fix hyperlink for bookkeeper.apache.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We feel that a welcoming open community is important and welcome contributions.
 
 ### Contributing Code
 
-1. See our [installation guide](https://bookkeeper.apache.org/docs/latest/getting-started/installation/) to get your local environment setup.
+1. See our [installation guide](https://bookkeeper.apache.org/docs/next/getting-started/installation/) to get your local environment setup.
 
 2. Take a look at our open issues: [Github Issues](https://github.com/apache/bookkeeper/issues).
 

--- a/site3/website/src/pages/community/issue-report.md
+++ b/site3/website/src/pages/community/issue-report.md
@@ -18,7 +18,7 @@ Here is an very useful artical [How to report bugs effectively]( http://www.chia
 
 #### If it is a question
 
--  Please check our [documentation](http://bookkeeper.apache.org/docs/latest/) first. 
+-  Please check our [documentation](https://bookkeeper.apache.org/docs/next/overview/) first. 
 -  If you could not find an answer there, please consider asking your question in our community mailing list at [dev@bookkeeper.apache.org](mailto:dev@bookkeeper.apache.org), or reach out us on our [Slack channel](slack).  It would benefit other members of our community.
 
 #### If it is a **FEATURE REQUEST**


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Invalid hyperlink for Apache Pulsar#persistent-storage
### Changes
Update hyperlinks
[installation guide](https://bookkeeper.apache.org/docs/next/getting-started/installation/)
[documentation](https://bookkeeper.apache.org/docs/next/overview/)

Master Issue: #3275 