### PR TITLE
[website] Make download page fully ASF compliant

### DIFF
--- a/site3/website/docusaurus.config.js
+++ b/site3/website/docusaurus.config.js
@@ -13,7 +13,6 @@ const variables = {
   github_master: "https://github.com/apache/bookkeeper/tree/master",
   mirror_base_url: "https://www.apache.org/dyn/closer.lua/bookkeeper",
   dist_base_url: "https://www.apache.org/dist/bookkeeper",
-  archive_base_url: "https://archive.apache.org/dist/bookkeeper",
   javadoc_base_url: deployUrl + "/docs/latest/api/javadoc",
   archive_releases_base_url: deployUrl + "/archives",
 }

--- a/site3/website/src/components/RecentReleases/index.js
+++ b/site3/website/src/components/RecentReleases/index.js
@@ -6,8 +6,8 @@ const releases = versions.slice(0, 4)
 export default function RecentReleases() {
 
   const mappedReleases = releases.map(r => {
-    const sourceDownloadUrl = `https://archive.apache.org/dist/bookkeeper/bookkeeper-${r}/bookkeeper-${r}-src.tar.gz`
-    const binaryDownloadUrl = `https://archive.apache.org/dist/bookkeeper/bookkeeper-${r}/bookkeeper-server-${r}-bin.tar.gz`
+    const sourceDownloadUrl = `https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=bookkeeper/bookkeeper-${r}/bookkeeper-${r}-src.tar.gz`
+    const binaryDownloadUrl = `https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=bookkeeper/bookkeeper-${r}/bookkeeper-server-${r}-bin.tar.gz`
     return (
       <div>
       <h3 id={r}>Version {r}</h3>
@@ -21,12 +21,12 @@ export default function RecentReleases() {
           <tr>
             <td>Source</td>
             <td><a href={sourceDownloadUrl}>bookkeeper-{r}-src.tar.gz</a></td>
-            <td><a href={sourceDownloadUrl + '.asc'}>asc</a>, <a href={sourceDownloadUrl + '.sha1'}>sha1</a></td>
+            <td><a href={sourceDownloadUrl + '.asc'}>asc</a>, <a href={sourceDownloadUrl + '.sha512'}>sha512</a></td>
           </tr>
           <tr>
             <td>Binary</td>
             <td><a href={binaryDownloadUrl}>bookkeeper-server-{r}-bin.tar.gz</a></td>
-            <td><a href={binaryDownloadUrl + '.asc'}>asc</a>, <a href={binaryDownloadUrl + '.sha1'}>sha1</a></td>
+            <td><a href={binaryDownloadUrl + '.asc'}>asc</a>, <a href={binaryDownloadUrl + '.sha512'}>sha512</a></td>
           </tr>
         </tbody>
       </table>

--- a/site3/website/src/pages/releases.md
+++ b/site3/website/src/pages/releases.md
@@ -12,7 +12,7 @@ import RecentReleases from "@site/src/components/RecentReleases"
 <RecentReleases />
 
 ## Release Integrity
-You must [verify](https://www.apache.org/info/verification.htm) the integrity of the downloaded files. We provide OpenPGP signatures for every release file. This signature should be matched against the [KEYS]({{ site.dist_base_url }}/KEYS) file which contains the OpenPGP keys of BookKeeper's Release Managers. We also provide SHA-512 checksums for every release file. After you download the file, you should calculate a checksum for your download, and make sure it is the same as ours.
+You must [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files. We provide OpenPGP signatures for every release file. This signature should be matched against the [KEYS]({{ site.dist_base_url }}/KEYS) file which contains the OpenPGP keys of BookKeeper's Release Managers. We also provide SHA-512 checksums for every release file. After you download the file, you should calculate a checksum for your download, and make sure it is the same as ours.
 
 If you want to download older, archived releases, they are available in the [Apache archive](http://archive.apache.org/dist/bookkeeper/).
 

--- a/site3/website/src/pages/releases.md
+++ b/site3/website/src/pages/releases.md
@@ -11,7 +11,8 @@ import RecentReleases from "@site/src/components/RecentReleases"
 
 <RecentReleases />
 
-> You can verify your download by following these [procedures](http://www.apache.org/info/verification.html) and using these [KEYS]({{ site.dist_base_url }}/KEYS).
+## Release Integrity
+You must [verify](https://www.apache.org/info/verification.htm) the integrity of the downloaded files. We provide OpenPGP signatures for every release file. This signature should be matched against the [KEYS]({{ site.dist_base_url }}/KEYS) file which contains the OpenPGP keys of BookKeeper's Release Managers. We also provide SHA-512 checksums for every release file. After you download the file, you should calculate a checksum for your download, and make sure it is the same as ours.
 
 If you want to download older, archived releases, they are available in the [Apache archive](http://archive.apache.org/dist/bookkeeper/).
 


### PR DESCRIPTION
Fix #3290

### Changes

* Fixed the SHA link, we use SHA512
* Fixed source and binary links to use closer.lua instead of archive.apache.org
* Increased the visibility of the checksum validation procedure

Master Issue: #3290 
