### PR TITLE
[build] [windows] fix broken master code compile error strerror_s

### DIFF
--- a/cpu-affinity/src/main/affinity/cpp/affinity_jni.c
+++ b/cpu-affinity/src/main/affinity/cpp/affinity_jni.c
@@ -44,6 +44,10 @@ static int set_affinity(int cpuid) { return NOT_IMPLEMENTED; }
 
 static const int IS_AVAILABLE = 0;
 
+#endif
+
+#ifdef _WIN32
+
 #define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
 
 #endif

--- a/native-io/src/main/native-io-jni/cpp/native_io_jni.c
+++ b/native-io/src/main/native-io-jni/cpp/native_io_jni.c
@@ -28,6 +28,12 @@
 
 #include <org_apache_bookkeeper_common_util_nativeio_NativeIOJni.h>
 
+#ifdef _WIN32
+
+#define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
+
+#endif
+
 static void throwExceptionWithErrno(JNIEnv* env, const char* message) {
     char err_msg[1024];
     strerror_r(errno, err_msg, sizeof(err_msg));


### PR DESCRIPTION
### Motivation
master compile is broken by #2549 

### Changes

Add windows `#ifdef _WIN32` directive on `define`. Test on my m1 mac and windows 10.
