### PR TITLE
Bump grpc from 1.45.1 to 1.47.0, solve dependency check FP

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -274,25 +274,25 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
 - lib/com.google.api.grpc-proto-google-common-protos-2.0.1.jar [28]
-- lib/com.google.code.gson-gson-2.8.9.jar [29]
+- lib/com.google.code.gson-gson-2.9.0.jar [29]
 - lib/io.opencensus-opencensus-api-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.45.1.jar [33]
-- lib/io.grpc-grpc-alts-1.45.1.jar [33]
-- lib/io.grpc-grpc-api-1.45.1.jar [33]
-- lib/io.grpc-grpc-auth-1.45.1.jar [33]
-- lib/io.grpc-grpc-context-1.45.1.jar [33]
-- lib/io.grpc-grpc-core-1.45.1.jar [33]
-- lib/io.grpc-grpc-grpclb-1.45.1.jar [33]
-- lib/io.grpc-grpc-netty-1.45.1.jar [33]
-- lib/io.grpc-grpc-protobuf-1.45.1.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.45.1.jar [33]
-- lib/io.grpc-grpc-services-1.45.1.jar [33]
-- lib/io.grpc-grpc-stub-1.45.1.jar [33]
-- lib/io.grpc-grpc-testing-1.45.1.jar [33]
-- lib/io.grpc-grpc-xds-1.45.1.jar [33]
-- lib/io.grpc-grpc-rls-1.45.1.jar[33]
+- lib/io.grpc-grpc-all-1.47.0.jar [33]
+- lib/io.grpc-grpc-alts-1.47.0.jar [33]
+- lib/io.grpc-grpc-api-1.47.0.jar [33]
+- lib/io.grpc-grpc-auth-1.47.0.jar [33]
+- lib/io.grpc-grpc-context-1.47.0.jar [33]
+- lib/io.grpc-grpc-core-1.47.0.jar [33]
+- lib/io.grpc-grpc-grpclb-1.47.0.jar [33]
+- lib/io.grpc-grpc-netty-1.47.0.jar [33]
+- lib/io.grpc-grpc-protobuf-1.47.0.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.47.0.jar [33]
+- lib/io.grpc-grpc-services-1.47.0.jar [33]
+- lib/io.grpc-grpc-stub-1.47.0.jar [33]
+- lib/io.grpc-grpc-testing-1.47.0.jar [33]
+- lib/io.grpc-grpc-xds-1.47.0.jar [33]
+- lib/io.grpc-grpc-rls-1.47.0.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -313,7 +313,7 @@ Apache Software License, Version 2.
 - lib/io.dropwizard.metrics-metrics-graphite-4.1.12.1.jar [47]
 - lib/io.dropwizard.metrics-metrics-jmx-4.1.12.1.jar [47]
 - lib/io.dropwizard.metrics-metrics-jvm-4.1.12.1.jar [47]
-- lib/io.perfmark-perfmark-api-0.23.0.jar [48]
+- lib/io.perfmark-perfmark-api-0.25.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.7.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
@@ -345,9 +345,9 @@ Apache Software License, Version 2.
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [28] Source available at https://github.com/googleapis/googleapis
-[29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.9
+[29] Source available at https://github.com/google/gson/tree/gson-parent-2.9.0
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.45.1
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.47.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
@@ -362,7 +362,7 @@ Apache Software License, Version 2.
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.5
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
-[48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.23.0
+[48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.25.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
 [50] Source available at https://github.com/google/snappy/releases/tag/1.1.7.7
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -249,25 +249,25 @@ Apache Software License, Version 2.
 - lib/com.beust-jcommander-1.78.jar [23]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
 - lib/com.google.api.grpc-proto-google-common-protos-2.0.1.jar [27]
-- lib/com.google.code.gson-gson-2.8.9.jar [28]
+- lib/com.google.code.gson-gson-2.9.0.jar [28]
 - lib/io.opencensus-opencensus-api-0.28.0.jar [29]
 - lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [29]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [29]
-- lib/io.grpc-grpc-all-1.45.1.jar [32]
-- lib/io.grpc-grpc-alts-1.45.1.jar [32]
-- lib/io.grpc-grpc-api-1.45.1.jar [32]
-- lib/io.grpc-grpc-auth-1.45.1.jar [32]
-- lib/io.grpc-grpc-context-1.45.1.jar [32]
-- lib/io.grpc-grpc-core-1.45.1.jar [32]
-- lib/io.grpc-grpc-grpclb-1.45.1.jar [32]
-- lib/io.grpc-grpc-netty-1.45.1.jar [32]
-- lib/io.grpc-grpc-protobuf-1.45.1.jar [32]
-- lib/io.grpc-grpc-protobuf-lite-1.45.1.jar [32]
-- lib/io.grpc-grpc-services-1.45.1.jar [32]
-- lib/io.grpc-grpc-stub-1.45.1.jar [32]
-- lib/io.grpc-grpc-testing-1.45.1.jar [32]
-- lib/io.grpc-grpc-xds-1.45.1.jar [32]
-- lib/io.grpc-grpc-rls-1.45.1.jar[32]
+- lib/io.grpc-grpc-all-1.47.0.jar [32]
+- lib/io.grpc-grpc-alts-1.47.0.jar [32]
+- lib/io.grpc-grpc-api-1.47.0.jar [32]
+- lib/io.grpc-grpc-auth-1.47.0.jar [32]
+- lib/io.grpc-grpc-context-1.47.0.jar [32]
+- lib/io.grpc-grpc-core-1.47.0.jar [32]
+- lib/io.grpc-grpc-grpclb-1.47.0.jar [32]
+- lib/io.grpc-grpc-netty-1.47.0.jar [32]
+- lib/io.grpc-grpc-protobuf-1.47.0.jar [32]
+- lib/io.grpc-grpc-protobuf-lite-1.47.0.jar [32]
+- lib/io.grpc-grpc-services-1.47.0.jar [32]
+- lib/io.grpc-grpc-stub-1.47.0.jar [32]
+- lib/io.grpc-grpc-testing-1.47.0.jar [32]
+- lib/io.grpc-grpc-xds-1.47.0.jar [32]
+- lib/io.grpc-grpc-rls-1.47.0.jar[32]
 - lib/org.apache.curator-curator-client-5.1.0.jar [33]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [33]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [33]
@@ -285,7 +285,7 @@ Apache Software License, Version 2.
 - lib/com.google.j2objc-j2objc-annotations-1.3.jar [44]
 - lib/com.google.re2j-re2j-1.5.jar [45]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [46]
-- lib/io.perfmark-perfmark-api-0.23.0.jar [47]
+- lib/io.perfmark-perfmark-api-0.25.0.jar [47]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.7.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
@@ -309,9 +309,9 @@ Apache Software License, Version 2.
 [23] Source available at https://github.com/cbeust/jcommander/tree/1.78
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [27] Source available at https://github.com/googleapis/googleapis
-[28] Source available at https://github.com/google/gson/tree/gson-parent-2.8.9
+[28] Source available at https://github.com/google/gson/tree/gson-parent-2.9.0
 [29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
-[32] Source available at https://github.com/grpc/grpc-java/tree/v1.45.1
+[32] Source available at https://github.com/grpc/grpc-java/tree/v1.47.0
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.1.0
 [34] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [35] Source available at https://github.com/google/error-prone/tree/v2.9.0
@@ -326,7 +326,7 @@ Apache Software License, Version 2.
 [44] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [45] Source available at https://github.com/google/re2j/releases/tag/re2j-1.5
 [46] Source available at https://github.com/dropwizard/metrics/releases/tag/v3.1.0
-[47] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.23.0
+[47] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.25.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
 [50] Source available at https://github.com/google/snappy/releases/tag/1.1.7.7
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -274,25 +274,25 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
 - lib/com.google.api.grpc-proto-google-common-protos-2.0.1.jar [28]
-- lib/com.google.code.gson-gson-2.8.9.jar [29]
+- lib/com.google.code.gson-gson-2.9.0.jar [29]
 - lib/io.opencensus-opencensus-api-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.45.1.jar [33]
-- lib/io.grpc-grpc-alts-1.45.1.jar [33]
-- lib/io.grpc-grpc-api-1.45.1.jar [33]
-- lib/io.grpc-grpc-auth-1.45.1.jar [33]
-- lib/io.grpc-grpc-context-1.45.1.jar [33]
-- lib/io.grpc-grpc-core-1.45.1.jar [33]
-- lib/io.grpc-grpc-grpclb-1.45.1.jar [33]
-- lib/io.grpc-grpc-netty-1.45.1.jar [33]
-- lib/io.grpc-grpc-protobuf-1.45.1.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.45.1.jar [33]
-- lib/io.grpc-grpc-services-1.45.1.jar [33]
-- lib/io.grpc-grpc-stub-1.45.1.jar [33]
-- lib/io.grpc-grpc-testing-1.45.1.jar [33]
-- lib/io.grpc-grpc-xds-1.45.1.jar [33]
-- lib/io.grpc-grpc-rls-1.45.1.jar[33]
+- lib/io.grpc-grpc-all-1.47.0.jar [33]
+- lib/io.grpc-grpc-alts-1.47.0.jar [33]
+- lib/io.grpc-grpc-api-1.47.0.jar [33]
+- lib/io.grpc-grpc-auth-1.47.0.jar [33]
+- lib/io.grpc-grpc-context-1.47.0.jar [33]
+- lib/io.grpc-grpc-core-1.47.0.jar [33]
+- lib/io.grpc-grpc-grpclb-1.47.0.jar [33]
+- lib/io.grpc-grpc-netty-1.47.0.jar [33]
+- lib/io.grpc-grpc-protobuf-1.47.0.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.47.0.jar [33]
+- lib/io.grpc-grpc-services-1.47.0.jar [33]
+- lib/io.grpc-grpc-stub-1.47.0.jar [33]
+- lib/io.grpc-grpc-testing-1.47.0.jar [33]
+- lib/io.grpc-grpc-xds-1.47.0.jar [33]
+- lib/io.grpc-grpc-rls-1.47.0.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -310,7 +310,7 @@ Apache Software License, Version 2.
 - lib/com.google.j2objc-j2objc-annotations-1.3.jar [45]
 - lib/com.google.re2j-re2j-1.5.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
-- lib/io.perfmark-perfmark-api-0.23.0.jar [48]
+- lib/io.perfmark-perfmark-api-0.25.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.7.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
@@ -342,9 +342,9 @@ Apache Software License, Version 2.
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [28] Source available at https://github.com/googleapis/googleapis
-[29] Source available at https://github.com/google/gson/tree/gson-parent-2.8.9
+[29] Source available at https://github.com/google/gson/tree/gson-parent-2.9.0
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.45.1
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.47.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [35] Source available at https://github.com/inferred/FreeBuilder/tree/v2.7.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
@@ -359,7 +359,7 @@ Apache Software License, Version 2.
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.5
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
-[48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.23.0
+[48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.25.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
 [50] Source available at https://github.com/google/snappy/releases/tag/1.1.7.7
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -132,15 +132,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.45.1.jar
-- lib/io.grpc-grpc-auth-1.45.1.jar
-- lib/io.grpc-grpc-context-1.45.1.jar
-- lib/io.grpc-grpc-core-1.45.1.jar
-- lib/io.grpc-grpc-netty-1.45.1.jar
-- lib/io.grpc-grpc-protobuf-1.45.1.jar
-- lib/io.grpc-grpc-protobuf-lite-1.45.1.jar
-- lib/io.grpc-grpc-stub-1.45.1.jar
-- lib/io.grpc-grpc-testing-1.45.1.jar
+- lib/io.grpc-grpc-all-1.47.0.jar
+- lib/io.grpc-grpc-auth-1.47.0.jar
+- lib/io.grpc-grpc-context-1.47.0.jar
+- lib/io.grpc-grpc-core-1.47.0.jar
+- lib/io.grpc-grpc-netty-1.47.0.jar
+- lib/io.grpc-grpc-protobuf-1.47.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.47.0.jar
+- lib/io.grpc-grpc-stub-1.47.0.jar
+- lib/io.grpc-grpc-testing-1.47.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -54,15 +54,15 @@ under the License.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.45.1.jar
-- lib/io.grpc-grpc-auth-1.45.1.jar
-- lib/io.grpc-grpc-context-1.45.1.jar
-- lib/io.grpc-grpc-core-1.45.1.jar
-- lib/io.grpc-grpc-netty-1.45.1.jar
-- lib/io.grpc-grpc-protobuf-1.45.1.jar
-- lib/io.grpc-grpc-protobuf-lite-1.45.1.jar
-- lib/io.grpc-grpc-stub-1.45.1.jar
-- lib/io.grpc-grpc-testing-1.45.1.jar
+- lib/io.grpc-grpc-all-1.47.0.jar
+- lib/io.grpc-grpc-auth-1.47.0.jar
+- lib/io.grpc-grpc-context-1.47.0.jar
+- lib/io.grpc-grpc-core-1.47.0.jar
+- lib/io.grpc-grpc-netty-1.47.0.jar
+- lib/io.grpc-grpc-protobuf-1.47.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.47.0.jar
+- lib/io.grpc-grpc-stub-1.47.0.jar
+- lib/io.grpc-grpc-testing-1.47.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -114,15 +114,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.45.1.jar
-- lib/io.grpc-grpc-auth-1.45.1.jar
-- lib/io.grpc-grpc-context-1.45.1.jar
-- lib/io.grpc-grpc-core-1.45.1.jar
-- lib/io.grpc-grpc-netty-1.45.1.jar
-- lib/io.grpc-grpc-protobuf-1.45.1.jar
-- lib/io.grpc-grpc-protobuf-lite-1.45.1.jar
-- lib/io.grpc-grpc-stub-1.45.1.jar
-- lib/io.grpc-grpc-testing-1.45.1.jar
+- lib/io.grpc-grpc-all-1.47.0.jar
+- lib/io.grpc-grpc-auth-1.47.0.jar
+- lib/io.grpc-grpc-context-1.47.0.jar
+- lib/io.grpc-grpc-core-1.47.0.jar
+- lib/io.grpc-grpc-netty-1.47.0.jar
+- lib/io.grpc-grpc-protobuf-1.47.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.47.0.jar
+- lib/io.grpc-grpc-stub-1.47.0.jar
+- lib/io.grpc-grpc-testing-1.47.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,7 +43,7 @@ depVersions = [
     freebuilder: "2.7.0",
     googleHTTPClient: "1.34.0",
     gradleTooling: "4.0.1",
-    grpc: "1.45.1",
+    grpc: "1.47.0",
     groovy: "2.5.8",
     guava: "31.0.1-jre",
     hamcrest: "1.3",

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <freebuilder.version>2.7.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.9.0</google.errorprone.version>
-    <grpc.version>1.45.1</grpc.version>
+    <grpc.version>1.47.0</grpc.version>
     <guava.version>31.0.1-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>2.10.0</hadoop.version>
@@ -197,7 +197,7 @@
     <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-    <dependency-check-maven.version>7.0.4</dependency-check-maven.version>
+    <dependency-check-maven.version>7.1.0</dependency-check-maven.version>
     <nar-maven-plugin.version>3.10.1</nar-maven-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -445,6 +445,11 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-unix-common</artifactId>
         <version>${netty.version}</version>
       </dependency>
       <dependency>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -194,5 +194,21 @@
      <sha1>9b78a289a3aa34eb47fac8c432f664fc140387df</sha1>
      <cve>CVE-2021-28165</cve>
   </suppress>
+    <!-- https://github.com/jeremylong/DependencyCheck/issues/4487 -->
+    <suppress>
+        <notes><![CDATA[
+   file name: google-http-client-gson-1.41.0.jar
+   ]]></notes>
+        <sha1>1a754a5dd672218a2ac667d7ff2b28df7a5a240e</sha1>
+        <cve>CVE-2022-25647</cve>
+    </suppress>
+    <!-- only use maven-settings for integration-test -->
+    <suppress>
+        <notes><![CDATA[
+   file name: maven-settings-3.3.9.jar
+   ]]></notes>
+        <sha1>68d4180c51468ae8f45869f8f9c569092262fcca</sha1>
+        <cve>CVE-2021-26291</cve>
+    </suppress>
 </suppressions>
 


### PR DESCRIPTION
### Changes
- Bump grpc from 1.45.1 to 1.47.0
- Bump gson from 2.8.9 to 2.9.0
- Bump perfmark-api from 0.23.0 to 0.25.0
- add dependency check suppressions