### PR TITLE
Issue 3306: Bookie can't start after rebooting due the cookie mistmatch

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LegacyCookieValidation.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LegacyCookieValidation.java
@@ -136,23 +136,28 @@ public class LegacyCookieValidation implements CookieValidation {
         // we are checking all possibilities here, so we don't need to fail if we can only get
         // loopback address. it will fail anyway when the bookie attempts to listen on loopback address.
         try {
-            // ip address
-            addresses.add(BookieImpl.getBookieAddress(
-                    new ServerConfiguration(conf)
-                            .setUseHostNameAsBookieID(false)
-                            .setAdvertisedAddress(null)
-                            .setAllowLoopback(true)
-            ).toBookieId());
-            // host name
-            addresses.add(BookieImpl.getBookieAddress(
-                    new ServerConfiguration(conf)
-                            .setUseHostNameAsBookieID(true)
-                            .setAdvertisedAddress(null)
-                            .setAllowLoopback(true)
-            ).toBookieId());
-            // advertised address
-            if (null != conf.getAdvertisedAddress()) {
+            if (null != conf.getBookieId()) {
+                // If BookieID is configured, it takes precedence over default network information used as id.
                 addresses.add(BookieImpl.getBookieId(conf));
+            } else {
+                // ip address
+                addresses.add(BookieImpl.getBookieAddress(
+                        new ServerConfiguration(conf)
+                                .setUseHostNameAsBookieID(false)
+                                .setAdvertisedAddress(null)
+                                .setAllowLoopback(true)
+                ).toBookieId());
+                // host name
+                addresses.add(BookieImpl.getBookieAddress(
+                        new ServerConfiguration(conf)
+                                .setUseHostNameAsBookieID(true)
+                                .setAdvertisedAddress(null)
+                                .setAllowLoopback(true)
+                ).toBookieId());
+                // advertised address
+                if (null != conf.getAdvertisedAddress()) {
+                    addresses.add(BookieImpl.getBookieAddress(conf).toBookieId());
+                }
             }
         } catch (UnknownHostException e) {
             throw new BookieException.UnknownBookieIdException(e);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CookieTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import org.apache.bookkeeper.bookie.BookieException.InvalidCookieException;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
@@ -52,6 +53,7 @@ import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.slf4j.Logger;
@@ -754,5 +756,27 @@ public class CookieTest extends BookKeeperClusterTestCase {
         Versioned<Cookie> zkCookie = Cookie.readFromRegistrationManager(rm, conf);
         Cookie cookie = zkCookie.getValue();
         cookie.deleteFromRegistrationManager(rm, conf, zkCookie.getVersion());
+    }
+
+    /**
+     * Tests that custom Bookie Id is properly set in the Cookie (via {@link LegacyCookieValidation}).
+     */
+    @Test
+    public void testBookieIdSetting() throws Exception {
+        final String customBookieId = "myCustomBookieId" + new Random().nextInt();
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setJournalDirName(newDirectory())
+                .setLedgerDirNames(new String[] { newDirectory() , newDirectory() })
+                .setBookiePort(bookiePort)
+                .setBookieId(customBookieId)
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        validateConfig(conf);
+        Versioned<Cookie> zkCookie = Cookie.readFromRegistrationManager(rm, conf);
+        Version version1 = zkCookie.getVersion();
+        assertTrue("Invalid type expected ZkVersion type",
+                version1 instanceof LongVersion);
+        Cookie cookie = zkCookie.getValue();
+        cookie.writeToRegistrationManager(rm, conf, version1);
+        Assert.assertTrue(cookie.toString().contains(customBookieId));
     }
 }


### PR DESCRIPTION
### Motivation
Fixes a bug when validating the Cookie that may fail to consider a custom Bookie ID when configured.

### Changes

Added custom Bookie ID when executing `possibleBookieIds()` in `LegacyCookieValidation`. Note that this was already fixed few months back, concretely in this PR: https://github.com/apache/bookkeeper/pull/2796
But it seems that the regression bringing back the old behavior was introduced in PR #2901.

This change may need to be cherry-picked to `branch-4.15`.

Master Issue: #3306

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>
