### PR TITLE
[Client] Switch to rely on SslEngine for Hostname Verification

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
@@ -29,16 +29,12 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.ssl.SslHandler;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
-
-import javax.net.ssl.SSLSession;
 
 import org.apache.bookkeeper.auth.AuthCallbacks;
 import org.apache.bookkeeper.auth.AuthToken;
@@ -46,13 +42,11 @@ import org.apache.bookkeeper.auth.BookieAuthProvider;
 import org.apache.bookkeeper.auth.ClientAuthProvider;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class AuthHandler {
     static final Logger LOG = LoggerFactory.getLogger(AuthHandler.class);
-    private static final DefaultHostnameVerifier HOSTNAME_VERIFIER = new DefaultHostnameVerifier();
 
     static class ServerSideHandler extends ChannelInboundHandlerAdapter {
         volatile boolean authenticated = false;
@@ -443,35 +437,6 @@ class AuthHandler {
                     authenticationError(ctx, rc);
                 }
             }
-        }
-
-        public boolean verifyTlsHostName(Channel channel) {
-            SslHandler sslHandler = channel.pipeline().get(SslHandler.class);
-            if (sslHandler == null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("can't perform hostname-verification on non-ssl channel {}", channel);
-                }
-                return true;
-            }
-            SSLSession sslSession = sslHandler.engine().getSession();
-            String hostname = null;
-            if (channel.remoteAddress() instanceof InetSocketAddress) {
-                hostname = ((InetSocketAddress) channel.remoteAddress()).getHostName();
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("can't get remote hostName on ssl session {}", channel);
-                }
-                return true;
-            }
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Verifying HostName for {}, Cipher {}, Protocols {}, on {}", hostname,
-                        sslSession.getCipherSuite(), sslSession.getProtocol(), channel);
-            }
-            boolean verification = HOSTNAME_VERIFIER.verify(hostname, sslSession);
-            if (!verification) {
-                LOG.warn("Failed to validate hostname verification {} on {}", hostname, channel);
-            }
-            return verification;
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityHandlerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tls/SecurityHandlerFactory.java
@@ -41,4 +41,8 @@ public interface SecurityHandlerFactory {
     void init(NodeType type, AbstractConfiguration conf, ByteBufAllocator allocator) throws SecurityException;
 
     SslHandler newTLSHandler();
+
+    default SslHandler newTLSHandler(String host, int port) {
+        return this.newTLSHandler();
+    }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -42,7 +42,6 @@ import org.apache.bookkeeper.auth.AuthToken;
 import org.apache.bookkeeper.auth.BookieAuthProvider;
 import org.apache.bookkeeper.auth.ClientAuthProvider;
 import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.client.BKException.BKUnauthorizedAccessException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
@@ -1021,7 +1020,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
         try {
             testClient(clientConf, numBookies);
             fail("should have failed with unauthorized exception");
-        } catch (BKUnauthorizedAccessException e) {
+        } catch (BKException.BKNotEnoughBookiesException e) {
             // Ok.
         }
     }


### PR DESCRIPTION
### Motivation

Currently, we initiate hostname verification for the Bookkeeper Client in the `PerChannelBookieClient` class. In order to simplify the code, I propose that we refactor the client so it relies on Netty, its SslHandler/SslEngine, and the JVM, to perform the hostname verification.

When HTTPS is configured as the endpoint verification algorithm, it uses [RFC 2818](https://datatracker.ietf.org/doc/html/rfc2818) to perform hostname verification. This is defined by the Java Security Standard Algorithm Names documentation for JDK versions 8, 11, and 17. Here are the official docs:

* https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html
* https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html
* https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html

### Changes

* Rely on Netty and the SslEngine to perform hostname verification. With this change, CN matching is now deprecated, which brings the bookkeeper client in alignment with RFC 2818.
* Add new method to the `SecurityHandlerFactory` interface. It is named `newTLSHandler` and takes the `host` and `port` of the remote peer when creating a new SslEngine. To ensure backwards compatibility, the default implementation will call the original method. Note that the remote host and port are only needed when a client is using them for hostname verification.