### PR TITLE
Enable maven batch mode to reduce log in mac and windows workflow

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -46,4 +46,4 @@ jobs:
           java-version: 11
 
       - name: mvn package
-        run: mvn clean package -DskipTests
+        run: mvn -B -nsu clean package -DskipTests

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -49,4 +49,4 @@ jobs:
           java-version: 11
 
       - name: mvn package
-        run: mvn clean package -DskipTests
+        run: mvn -B -nsu clean package -DskipTests


### PR DESCRIPTION
### Motivation
Enable maven batch mode to reduce log in mac and windows workflow
