### PR TITLE
Use scheduleWithFixedDelay instead of scheduleAtFixedRate

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -465,7 +465,7 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
 
                 @Override
                 public void start() {
-                    executor.scheduleAtFixedRate(() -> {
+                    executor.scheduleWithFixedDelay(() -> {
                         doCheckpoint(checkpointSource.newCheckpoint());
                     }, conf.getFlushInterval(), conf.getFlushInterval(), TimeUnit.MILLISECONDS);
                 }


### PR DESCRIPTION
### Motivation
Use scheduleWithFixedDelay instead of scheduleAtFixedRate in syncThread.

After triggering a FULL GC, scheduleAtFixedRate may cause the doCheckpoint method to execute multiple times within a short period of time.

### Changes
Use scheduleWithFixedDelay instead of scheduleAtFixedRate in syncThread.