### PR TITLE
Fix the PendingAddOp is not recycled when LedgerHandler closed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1326,6 +1326,7 @@ public class LedgerHandle implements WriteHandle {
                         LOG.warn("Attempt to add to closed ledger: {}", ledgerId);
                         op.cb.addCompleteWithLatency(BKException.Code.LedgerClosedException,
                                 LedgerHandle.this, INVALID_ENTRY_ID, 0, op.ctx);
+                        op.recyclePendAddOpObject();
                     }
 
                     @Override
@@ -1337,6 +1338,7 @@ public class LedgerHandle implements WriteHandle {
                 op.cb.addCompleteWithLatency(BookKeeper.getReturnRc(clientCtx.getBookieClient(),
                                                                     BKException.Code.InterruptedException),
                         LedgerHandle.this, INVALID_ENTRY_ID, 0, op.ctx);
+                op.recyclePendAddOpObject();
             }
             return;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -499,7 +499,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
         }
     }
 
-    private void recyclePendAddOpObject() {
+    public void recyclePendAddOpObject() {
         entryId = LedgerHandle.INVALID_ENTRY_ID;
         currentLedgerLength = -1;
         if (payload != null) {


### PR DESCRIPTION
---

### Motivation

When adding an entry into a bookie, the entry data lifecycle
is handled by the bookie client. The data buffer will be
released after receiving a corresponding response from the
bookie server. So the user doesn't care about the entry
buffer releasing.
But when the ledgerHandler is closed, the PendingAddOp is not
recycled which leads to the data buffer never being released.
We should release that after the callback is executed.

