### PR TITLE
 Fix the V2 AddRequest object leak issue

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1135,6 +1135,14 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                     StringUtils.requestToString(request));
 
             errorOut(key, BKException.Code.TooManyRequestsException);
+
+            // If the request is a V2 add request, we retained the data's reference when creating the AddRequest
+            // object. To avoid the object leak, we need to release the reference if we met any errors
+            // before sending it.
+            if (request instanceof BookieProtocol.AddRequest) {
+                BookieProtocol.AddRequest ar = (BookieProtocol.AddRequest) request;
+                ar.recycle();
+            }
             return;
         }
 


### PR DESCRIPTION
---

**Motivation**

If the request is a V2 add request, we retained the data's
reference when creating the AddRequest object. To avoid the
object leak, we need to release the reference if we met
any errors before sending it.

