### PR TITLE
Apply the backpressure changes on the V2 requests

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -642,7 +642,7 @@ public class BookieRequestProcessor implements RequestProcessor {
                 }
                 getRequestStats().getAddEntryRejectedCounter().inc();
 
-                write.sendResponse(
+                write.sendWriteReqResponse(
                     BookieProtocol.ETOOMANYREQUESTS,
                     ResponseBuilder.buildErrorResponse(BookieProtocol.ETOOMANYREQUESTS, r),
                     requestStats.getAddRequestStats());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -52,6 +52,7 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
         rep.init(request, channel, requestProcessor);
         rep.fenceThreadPool = fenceThreadPool;
         rep.throttleReadResponses = throttleReadResponses;
+        requestProcessor.onReadRequestStart(channel);
         return rep;
     }
 
@@ -132,11 +133,7 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
             response = ResponseBuilder.buildErrorResponse(errorCode, request);
         }
 
-        if (throttleReadResponses) {
-            sendResponseAndWait(errorCode, response, stats.getReadRequestStats());
-        } else {
-            sendResponse(errorCode, response, stats.getReadRequestStats());
-        }
+        sendReadReqResponse(errorCode, response, stats.getReadRequestStats(), throttleReadResponses);
         recycle();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -53,6 +53,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
                                              BookieRequestProcessor requestProcessor) {
         WriteEntryProcessor wep = RECYCLER.get();
         wep.init(request, channel, requestProcessor);
+        requestProcessor.onAddRequestStart(channel);
         return wep;
     }
 
@@ -62,7 +63,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
             && !(request.isHighPriority() && requestProcessor.getBookie().isAvailableForHighPriorityWrites())) {
             LOG.warn("BookieServer is running in readonly mode,"
                     + " so rejecting the request from the client!");
-            sendResponse(BookieProtocol.EREADONLY,
+            sendWriteReqResponse(BookieProtocol.EREADONLY,
                          ResponseBuilder.buildErrorResponse(BookieProtocol.EREADONLY, request),
                          requestProcessor.getRequestStats().getAddRequestStats());
             request.release();
@@ -108,7 +109,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
         if (rc != BookieProtocol.EOK) {
             requestProcessor.getRequestStats().getAddEntryStats()
                 .registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
-            sendResponse(rc,
+            sendWriteReqResponse(rc,
                          ResponseBuilder.buildErrorResponse(rc, request),
                          requestProcessor.getRequestStats().getAddRequestStats());
             request.recycle();
@@ -125,7 +126,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
             requestProcessor.getRequestStats().getAddEntryStats()
                 .registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
         }
-        sendResponse(rc,
+        sendWriteReqResponse(rc,
                      ResponseBuilder.buildAddResponse(request),
                      requestProcessor.getRequestStats().getAddRequestStats());
         request.recycle();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.proto;
+
+import org.junit.Before;
+
+public class BookieBackpressureForV2Test extends BookieBackpressureTest {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        baseClientConf.setUseV2WireProtocol(true);
+        confByIndex(0).setReadWorkerThreadsThrottlingEnabled(false);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
@@ -20,6 +20,9 @@ package org.apache.bookkeeper.proto;
 
 import org.junit.Before;
 
+/**
+ * Tests for bckpressure handling on the server side with V2 protocol.
+ */
 public class BookieBackpressureForV2Test extends BookieBackpressureTest {
 
     @Before

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
@@ -30,6 +30,5 @@ public class BookieBackpressureForV2Test extends BookieBackpressureTest {
     public void setUp() throws Exception {
         super.setUp();
         baseClientConf.setUseV2WireProtocol(true);
-        confByIndex(0).setReadWorkerThreadsThrottlingEnabled(false);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
@@ -30,5 +30,7 @@ public class BookieBackpressureForV2Test extends BookieBackpressureTest {
     public void setUp() throws Exception {
         super.setUp();
         baseClientConf.setUseV2WireProtocol(true);
+        // the backpressure will bloc the read response, disable it to let it use backpressure mechanism
+        confByIndex(0).setReadWorkerThreadsThrottlingEnabled(false);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
@@ -72,6 +72,7 @@ public class WriteEntryProcessorTest {
         when(requestProcessor.getBookie()).thenReturn(bookie);
         when(requestProcessor.getRequestStats()).thenReturn(new RequestStats(NullStatsLogger.INSTANCE));
         when(channel.isActive()).thenReturn(true);
+        when(channel.isWritable()).thenReturn(true);
         processor = WriteEntryProcessor.create(
             request,
             channel,


### PR DESCRIPTION
---

*Motivation*

If one bookie is slow (not down, just slow), the BK client
will the acks to the user that the entries are written after
the first 2 acks. In the meantime, it will keep waiting for
the 3rd bookie to respond. If the bookie responds within the
timeout, the entries can now be dropped from memory, otherwise
the write will timeout internally and it will get replayed
to a new bookie.

In the V3 request, we have [server-side backpressure](https://github.com/apache/bookkeeper/pull/1410)
to impact the client-side behaviors. We should apply the same
changes to the V2 request. That would help this [issue](https://github.com/apache/pulsar/issues/14861)
to be resolved.

*Modification*

- Apply the change https://github.com/apache/bookkeeper/pull/1410 to V2 protocol

Descriptions of the changes in this PR:


