### PR TITLE
Remove unused value assign in BookKeeperTestClient

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
@@ -58,7 +58,6 @@ public class BookKeeperTestClient extends BookKeeper {
             throws IOException, InterruptedException, BKException {
         super(conf, zkc, null, new UnpooledByteBufAllocator(false),
                 NullStatsLogger.INSTANCE, null, null, null);
-        this.statsProvider = statsProvider;
     }
 
     public BookKeeperTestClient(ClientConfiguration conf)


### PR DESCRIPTION
### Changes
`statsProvider` is actually null, no need assign
