### PR TITLE
[ISSUE 3295]Fix JVM exited when running localbookie with jdk17 (#3295)

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -96,7 +96,6 @@ else
     -XX:MaxGCPauseMillis=10 \
     -XX:+ParallelRefProcEnabled \
     -XX:+UnlockExperimentalVMOptions \
-    -XX:+AggressiveOpts \
     -XX:+DoEscapeAnalysis \
     -XX:ParallelGCThreads=32 \
     -XX:ConcGCThreads=32 \

--- a/deploy/kubernetes/gke/bookkeeper.statefulset.yml
+++ b/deploy/kubernetes/gke/bookkeeper.statefulset.yml
@@ -33,7 +33,7 @@ kind: ConfigMap
 metadata:
     name: bookie-config
 data:
-    BK_BOOKIE_EXTRA_OPTS: "\"-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\""
+    BK_BOOKIE_EXTRA_OPTS: "\"-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\""
     BK_bookiePort: "3181"
     BK_journalDirectory: "/bookkeeper/data/journal"
     BK_ledgerDirectories: "/bookkeeper/data/ledgers"

--- a/deploy/kubernetes/gke/bookkeeper.yaml
+++ b/deploy/kubernetes/gke/bookkeeper.yaml
@@ -24,7 +24,7 @@ kind: ConfigMap
 metadata:
     name: bookie-config
 data:
-    BK_BOOKIE_EXTRA_OPTS: "\"-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\""
+    BK_BOOKIE_EXTRA_OPTS: "\"-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\""
     BK_bookiePort: "3181"
     BK_journalDirectory: "/bookkeeper/data/journal"
     BK_ledgerDirectories: "/bookkeeper/data/ledgers"

--- a/stream/conf/streamstorage_cli_env.sh
+++ b/stream/conf/streamstorage_cli_env.sh
@@ -45,7 +45,7 @@
 SS_MEM=" -Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g"
 
 # Garbage collection options
-SS_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
+SS_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
 
 # Extra options to be passed to the jvm
 SS_EXTRA_OPTS="${SS_EXTRA_OPTS} ${SS_MEM} ${SS_GC} -Dio.netty.leakDetectionLevel=disabled"

--- a/stream/conf/streamstorage_env.sh
+++ b/stream/conf/streamstorage_env.sh
@@ -45,7 +45,7 @@
 SS_MEM=" -Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g"
 
 # Garbage collection options
-SS_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
+SS_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
 
 # Extra options to be passed to the jvm
 SS_EXTRA_OPTS="${SS_EXTRA_OPTS} ${SS_MEM} ${SS_GC} -Dio.netty.leakDetectionLevel=disabled"


### PR DESCRIPTION
Fix #3295
### Motivation
Currently, localbookie can't run with jdk17

### Changes
- remove flag AggressiveOpts
- add flag AutoBoxCacheMax=20000
- add flag BiasedLockingStartupDelay=500
