### PR TITLE
Enhance future sync wait.

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/concurrent/FutureUtils.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/concurrent/FutureUtils.java
@@ -69,7 +69,19 @@ public final class FutureUtils {
     public static <T, ExceptionT extends Throwable> T result(
         CompletableFuture<T> future, Function<Throwable, ExceptionT> exceptionHandler) throws ExceptionT {
         try {
-            return future.get();
+            try {
+                /*
+                 * CompletableFuture.get() in JDK8 spins before blocking and wastes CPU time.
+                 * CompletableFuture.get(long, TimeUnit) blocks immediately (if the result is
+                 * not yet available). While the implementation of get() has changed in JDK9
+                 * (not spinning any more), using CompletableFuture.get(long, TimeUnit) allows
+                 * us to avoid spinning for all current JDK versions.
+                 */
+                return future.get(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+            } catch (TimeoutException eignore) {
+                // it's ok to return null if we timeout after 292 years (2^63 nanos)
+                return null;
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw e;


### PR DESCRIPTION
Descriptions of the changes in this PR:

Enhance future sync wait. 
The same logicment:
https://github.com/apache/bookkeeper/blob/f887f8d7a507800b71b4143a40b0e45902f5f170/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/SyncCallbackUtils.java#L45-L71
