### PR TITLE
Fix underReplicatedLedgerTotalSize calculate problem.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -1233,8 +1233,9 @@ public class Auditor implements AutoCloseable {
                         if (exception == null) {
                             underReplicatedSize.add(metadata.getValue().getLength());
                         }
-                    }), null);
-        underReplicatedLedgerTotalSize.registerSuccessfulValue(underReplicatedSize.longValue());
+                    }), null).whenComplete((res, e) -> {
+            underReplicatedLedgerTotalSize.registerSuccessfulValue(underReplicatedSize.longValue());
+        });
 
         return FutureUtils.processList(
             Lists.newArrayList(ledgers),


### PR DESCRIPTION
Descriptions of the changes in this PR:
```
  LongAdder underReplicatedSize = new LongAdder();
        FutureUtils.processList(
                Lists.newArrayList(ledgers),
                ledgerId ->
                    ledgerManager.readLedgerMetadata(ledgerId).whenComplete((metadata, exception) -> {
                        if (exception == null) {
                            underReplicatedSize.add(metadata.getValue().getLength());
                        }
                    }), null);
        underReplicatedLedgerTotalSize.registerSuccessfulValue(underReplicatedSize.longValue());
```
`FutureUtils.processList`  is async process, should record `underReplicatedLedgerTotalSize` when it completed.