### PR TITLE
Bookie cache optimization

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -668,7 +668,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                     long entryId = entry.readLong();
                     entry.resetReaderIndex();
                     if (log.isDebugEnabled()) {
-                        log.debug("Found last entry for ledger {} in write cache being flushing: {}", ledgerId, entryId);
+                        log.debug("Found last entry for ledger {} in write cache flushing: {}", ledgerId, entryId);
                     }
                 }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -700,10 +700,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 if (entry != null) {
                     if (log.isDebugEnabled()) {
                         entry.readLong(); // ledgedId
-                        long entryId = entry.readLong();
+                        long eId = entry.readLong();
                         entry.resetReaderIndex();
                         if (log.isDebugEnabled()) {
-                            log.debug("Found last entry for ledger {} in write cache being flushed: {}", ledgerId, entryId);
+                            log.debug("Found last entry for ledger {} in write cache being flushed: {}", ledgerId, eId);
                         }
                     }
                     dbLedgerStorageStats.getWriteCacheHitCounter().inc();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -148,6 +148,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
     private final Counter flushExecutorTime;
 
+    private boolean isWriteCacheFixedLengthEnabled = false;
+
     public SingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
             LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager, StatsLogger statsLogger,
             ByteBufAllocator allocator, ScheduledExecutorService gcExecutor, long writeCacheSize, long readCacheSize,
@@ -155,16 +157,24 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         checkArgument(ledgerDirsManager.getAllLedgerDirs().size() == 1,
                 "Db implementation only allows for one storage dir");
 
+
         String baseDir = ledgerDirsManager.getAllLedgerDirs().get(0).toString();
         log.info("Creating single directory db ledger storage on {}", baseDir);
 
         StatsLogger ledgerDirStatsLogger = statsLogger.scopeLabel("ledgerDir",
                 ledgerDirsManager.getAllLedgerDirs().get(0).getPath());
 
+        this.isWriteCacheFixedLengthEnabled = conf.isWriteCacheFixedLengthEnabled();
         this.writeCacheMaxSize = writeCacheSize;
-        this.writeCache = new WriteCache(allocator, writeCacheMaxSize / 2);
-        this.writeCacheBeingFlushed = new WriteCache(allocator, writeCacheMaxSize / 2);
-        this.writeCacheLastFlushed = new WriteCache(allocator, writeCacheMaxSize / 2);
+        if (this.isWriteCacheFixedLengthEnabled) {
+            this.writeCache = new WriteCache(allocator, writeCacheMaxSize / 3);
+            this.writeCacheBeingFlushed = new WriteCache(allocator, writeCacheMaxSize / 3);
+            this.writeCacheLastFlushed = new WriteCache(allocator, writeCacheMaxSize / 3);
+        } else {
+            this.writeCache = new WriteCache(allocator, writeCacheMaxSize / 2);
+            this.writeCacheBeingFlushed = new WriteCache(allocator, writeCacheMaxSize / 2);
+            this.writeCacheLastFlushed = null;
+        }
         readCacheMaxSize = readCacheSize;
         this.readAheadCacheBatchSize = readAheadCacheBatchSize;
 
@@ -194,8 +204,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
         dbLedgerStorageStats = new DbLedgerStorageStats(
                 ledgerDirStatsLogger,
-            () -> writeCache.size() + writeCacheBeingFlushed.size() + writeCacheLastFlushed.size(),
-            () -> writeCache.count() + writeCacheBeingFlushed.count() + writeCacheLastFlushed.count(),
+            () -> this.isWriteCacheFixedLengthEnabled ? writeCache.size() + writeCacheBeingFlushed.size()
+                    + writeCacheLastFlushed.size() : writeCache.size() + writeCacheBeingFlushed.size(),
+            () -> this.isWriteCacheFixedLengthEnabled ? writeCache.count() + writeCacheBeingFlushed.count()
+                    + writeCacheLastFlushed.count() : writeCache.count() + writeCacheBeingFlushed.count(),
             () -> readCache.size(),
             () -> readCache.count()
         );
@@ -279,7 +291,9 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
             writeCache.close();
             writeCacheBeingFlushed.close();
-            writeCacheLastFlushed.close();
+            if (isWriteCacheFixedLengthEnabled) {
+                writeCacheLastFlushed.close();
+            }
             readCache.close();
             executor.shutdown();
 
@@ -325,10 +339,12 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             }
         }
 
-        boolean inCache = localWriteCache.hasEntry(ledgerId, entryId)
-             || localWriteCacheBeingFlushed.hasEntry(ledgerId, entryId)
-             || writeCacheLastFlushed.hasEntry(ledgerId, entryId)
-             || readCache.hasEntry(ledgerId, entryId);
+        boolean inCache = isWriteCacheFixedLengthEnabled ? localWriteCache.hasEntry(ledgerId, entryId)
+                || localWriteCacheBeingFlushed.hasEntry(ledgerId, entryId)
+                || writeCacheLastFlushed.hasEntry(ledgerId, entryId)
+                || readCache.hasEntry(ledgerId, entryId) : localWriteCache.hasEntry(ledgerId, entryId)
+                || localWriteCacheBeingFlushed.hasEntry(ledgerId, entryId)
+                || readCache.hasEntry(ledgerId, entryId);
 
         if (inCache) {
             return true;
@@ -540,11 +556,13 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             return entry;
         }
 
-        // If there's a flush finished, the entry might be in the flush buffer
-        entry = writeCacheLastFlushed.get(ledgerId, entryId);
-        if (entry != null) {
-            dbLedgerStorageStats.getWriteCacheHitCounter().inc();
-            return entry;
+        if (isWriteCacheFixedLengthEnabled) {
+            // If there's a flush finished, the entry might be in the flush buffer
+            entry = writeCacheLastFlushed.get(ledgerId, entryId);
+            if (entry != null) {
+                dbLedgerStorageStats.getWriteCacheHitCounter().inc();
+                return entry;
+            }
         }
 
         dbLedgerStorageStats.getWriteCacheMissCounter().inc();
@@ -676,20 +694,21 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 return entry;
             }
 
-            // If there's a flush finished, the entry might be in the flush buffer
-            entry = writeCacheLastFlushed.getLastEntry(ledgerId);
-            if (entry != null) {
-                if (log.isDebugEnabled()) {
-                    entry.readLong(); // ledgedId
-                    long entryId = entry.readLong();
-                    entry.resetReaderIndex();
+            if (isWriteCacheFixedLengthEnabled) {
+                // If there's a flush finished, the entry might be in the flush buffer
+                entry = writeCacheLastFlushed.getLastEntry(ledgerId);
+                if (entry != null) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Found last entry for ledger {} in write cache being flushed: {}", ledgerId, entryId);
+                        entry.readLong(); // ledgedId
+                        long entryId = entry.readLong();
+                        entry.resetReaderIndex();
+                        if (log.isDebugEnabled()) {
+                            log.debug("Found last entry for ledger {} in write cache being flushed: {}", ledgerId, entryId);
+                        }
                     }
+                    dbLedgerStorageStats.getWriteCacheHitCounter().inc();
+                    return entry;
                 }
-
-                dbLedgerStorageStats.getWriteCacheHitCounter().inc();
-                return entry;
             }
         } finally {
             writeCacheRotationLock.unlockRead(stamp);
@@ -792,7 +811,9 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
             lastCheckpoint = thisCheckpoint;
 
-            cloneFlushedCache2LastFlushCache(writeCacheBeingFlushed, writeCacheLastFlushed);
+            if (isWriteCacheFixedLengthEnabled) {
+                cloneFlushedCache2LastFlushCache(writeCacheBeingFlushed, writeCacheLastFlushed);
+            }
             // Discard all the entry from the write cache, since they're now persisted
             writeCacheBeingFlushed.clear();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -204,10 +204,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
         dbLedgerStorageStats = new DbLedgerStorageStats(
                 ledgerDirStatsLogger,
-            () -> this.isWriteCacheFixedLengthEnabled ? writeCache.size() + writeCacheBeingFlushed.size()
-                    + writeCacheLastFlushed.size() : writeCache.size() + writeCacheBeingFlushed.size(),
-            () -> this.isWriteCacheFixedLengthEnabled ? writeCache.count() + writeCacheBeingFlushed.count()
-                    + writeCacheLastFlushed.count() : writeCache.count() + writeCacheBeingFlushed.count(),
+            this.isWriteCacheFixedLengthEnabled ? () ->  writeCache.size() + writeCacheBeingFlushed.size()
+                    + writeCacheLastFlushed.size() : () -> writeCache.size() + writeCacheBeingFlushed.size(),
+            this.isWriteCacheFixedLengthEnabled ? () -> writeCache.count() + writeCacheBeingFlushed.count()
+                    + writeCacheLastFlushed.count() : () -> writeCache.count() + writeCacheBeingFlushed.count(),
             () -> readCache.size(),
             () -> readCache.count()
         );

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -333,6 +333,9 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     // Used for location index, lots of writes and much bigger dataset
     protected static final String LEDGER_METADATA_ROCKSDB_CONF = "ledgerMetadataRocksdbConf";
 
+    // guaranteed writeCache fixed length for cache read
+    protected static final String IS_WRITECACHE_FIXED_LENGTH_ENABLE = "isWriteCacheFixedLengthEnabled";
+
     /**
      * Construct a default configuration object.
      */
@@ -3965,5 +3968,14 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     public ServerConfiguration setLedgerMetadataRocksdbConf(String ledgerMetadataRocksdbConf) {
         this.setProperty(LEDGER_METADATA_ROCKSDB_CONF, ledgerMetadataRocksdbConf);
         return this;
+    }
+
+    public ServerConfiguration setIsWriteCacheFixedLengthEnabled(boolean enabled) {
+        this.setProperty(IS_WRITECACHE_FIXED_LENGTH_ENABLE, Boolean.toString(enabled));
+        return this;
+    }
+
+    public boolean isWriteCacheFixedLengthEnabled() {
+        return this.getBoolean(IS_WRITECACHE_FIXED_LENGTH_ENABLE, false);
     }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

When flushing, trigger flush to exchange writeCache and flushBeingCache
flushBeingCache will be cleaned up immediately after flushed
this logic causes the cache capacity to fluctuate greatly

### Changes

This optimization mainly solves this point and realizes the logic:
1. When flushBeingCache is flushed to disk, it is not deleted immediately, but dumped to lastFlushCache
2. After the dump is completed, clear the flushBeingCache again
Eventually: the cache has a fixed cache duration

### Test conclusion
if open this bookie cache optimization,with same qps/bps,it can make writecache increase cache data by 80%
`isWriteCacheFixedLengthEnabled=true  #  open this bookie cache optimization`

### Test Data
The following is the environmental information and test data:
1. Old Config:
     jvm important config:
            -XX:MaxDirectMemorySize=32g
     bookie important config:
             entryLogPerLedgerEnabled=true
             flushInterval=18000

2. Optimized Config:
     jvm important config:
            -XX:MaxDirectMemorySize=32g
     bookie important config:
             isWriteCacheFixedLengthEnabled=true  #  open this bookie cache optimization
             entryLogPerLedgerEnabled=true
             flushInterval=18000

#### Test Data
write cache size :  use metric bookie_write_cache_size
max cache data compare: old config is 3386866184, optimized config is 6210369204, it can make writecache increase cache data by 80%
<img width="2540" alt="image" src="https://user-images.githubusercontent.com/42990025/174601316-d1e92b11-bd4b-40a6-a85f-b94c7f43714d.png">



Bps compare :  use metric rate(bookie_BOOKIE_ADD_ENTRY_BYTES_sum)
<img width="2544" alt="image" src="https://user-images.githubusercontent.com/42990025/174601674-02d83f68-3b0a-407a-9229-4c2118df23f2.png">


qps compare : use metric  rate(bookkeeper_server_ADD_ENTRY_REQUEST_count)
<img width="2551" alt="image" src="https://user-images.githubusercontent.com/42990025/174601869-002550ae-5e32-4147-adce-8536c7109d0b.png">

