### PR TITLE
upgrade groovy from 2.5.17 to 3.0.11 to fix CVE-2019-11358(7.5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1138,6 +1138,7 @@
               <mixAuditAnalyzerEnabled>false</mixAuditAnalyzerEnabled>
               <nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
               <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+              <skipSystemScope>true</skipSystemScope>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1138,7 +1138,6 @@
               <mixAuditAnalyzerEnabled>false</mixAuditAnalyzerEnabled>
               <nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
               <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-              <skipSystemScope>true</skipSystemScope>
             </configuration>
             <executions>
               <execution>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -28,7 +28,7 @@
   <name>Apache BookKeeper :: Tests</name>
 
   <properties>
-    <groovy.version>2.5.17</groovy.version>
+    <groovy.version>3.0.11</groovy.version>
   </properties>
 
   <modules>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -28,7 +28,7 @@
   <name>Apache BookKeeper :: Tests</name>
 
   <properties>
-    <groovy.version>2.5.8</groovy.version>
+    <groovy.version>3.0.11</groovy.version>
   </properties>
 
   <modules>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -28,7 +28,7 @@
   <name>Apache BookKeeper :: Tests</name>
 
   <properties>
-    <groovy.version>3.0.11</groovy.version>
+    <groovy.version>2.5.17</groovy.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
### Motivation
There is a CVE in testing, which was introduced by groovy.

```
Error:  Failed to execute goal org.owasp:dependency-check-maven:7.1.0:aggregate (default) on project bookkeeper: 
Error: 
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error: 
Error:  testng-6.13.1.jar: CVE-2019-[11](https://github.com/apache/bookkeeper/runs/6953376087?check_suite_focus=true#step:6:12)358(7.5)
Error: 
Error:  See the dependency-check report for more details.
Error:  -> [Help 1]
Error: 
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error: 
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error: Process completed with exit code 1.
```

### Changes
Upgrade groovy version from 2.5.8 to 3.0.11