### PR TITLE
Fix broken link of code guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ We feel that a welcoming open community is important and welcome contributions.
 
 2. Take a look at our open issues: [Github Issues](https://github.com/apache/bookkeeper/issues).
 
-3. Review our [coding style](https://bookkeeper.apache.org/community/coding_guide/) and follow our [pull requests](https://github.com/apache/bookkeeper/pulls) to learn more about our conventions.
+3. Review our [coding style](https://bookkeeper.apache.org/community/coding-guide/) and follow our [pull requests](https://github.com/apache/bookkeeper/pulls) to learn more about our conventions.
 
 4. Make your changes according to our [contributing guide](https://bookkeeper.apache.org/community/contributing/)


### PR DESCRIPTION
### Motivation

The code guide link https://bookkeeper.apache.org/community/coding_guide is not found.

### Changes

Change the link to https://bookkeeper.apache.org/community/coding-guide