### PR TITLE
Fix the queue size in writeThreadPool exceeds the configured size

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/BoundedExecutorService.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/BoundedExecutorService.java
@@ -59,51 +59,67 @@ public class BoundedExecutorService extends ForwardingExecutorService {
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        checkQueue(tasks.size());
-        return super.invokeAll(tasks);
+        synchronized (this) {
+            checkQueue(tasks.size());
+            return super.invokeAll(tasks);
+        }
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException {
-        checkQueue(tasks.size());
-        return super.invokeAll(tasks, timeout, unit);
+        synchronized (this) {
+            checkQueue(tasks.size());
+            return super.invokeAll(tasks, timeout, unit);
+        }
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        checkQueue(tasks.size());
-        return super.invokeAny(tasks);
+        synchronized (this) {
+            checkQueue(tasks.size());
+            return super.invokeAny(tasks);
+        }
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
-        checkQueue(tasks.size());
-        return super.invokeAny(tasks, timeout, unit);
+        synchronized (this) {
+            checkQueue(tasks.size());
+            return super.invokeAny(tasks, timeout, unit);
+        }
     }
 
     @Override
     public void execute(Runnable command) {
-        checkQueue(1);
-        super.execute(command);
+        synchronized (this) {
+            checkQueue(1);
+            super.execute(command);
+        }
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        checkQueue(1);
-        return super.submit(task);
+        synchronized (this) {
+            checkQueue(1);
+            return super.submit(task);
+        }
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        checkQueue(1);
-        return super.submit(task);
+        synchronized (this) {
+            checkQueue(1);
+            return super.submit(task);
+        }
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        checkQueue(1);
-        return super.submit(task, result);
+        synchronized (this) {
+            checkQueue(1);
+            return super.submit(task, result);
+        }
     }
 }

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/BoundedScheduledExecutorService.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/BoundedScheduledExecutorService.java
@@ -59,78 +59,102 @@ public class BoundedScheduledExecutorService extends ForwardingListeningExecutor
 
     @Override
     public ListenableScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        this.checkQueue(1);
-        return this.thread.schedule(command, delay, unit);
+        synchronized (this) {
+            this.checkQueue(1);
+            return this.thread.schedule(command, delay, unit);
+        }
     }
 
     @Override
     public <V> ListenableScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-        this.checkQueue(1);
-        return this.thread.schedule(callable, delay, unit);
+        synchronized (this) {
+            this.checkQueue(1);
+            return this.thread.schedule(callable, delay, unit);
+        }
     }
 
     @Override
     public ListenableScheduledFuture<?> scheduleAtFixedRate(Runnable command,
                                                             long initialDelay, long period, TimeUnit unit) {
-        this.checkQueue(1);
-        return this.thread.scheduleAtFixedRate(command, initialDelay, period, unit);
+        synchronized (this) {
+            this.checkQueue(1);
+            return this.thread.scheduleAtFixedRate(command, initialDelay, period, unit);
+        }
     }
 
     @Override
     public ListenableScheduledFuture<?> scheduleWithFixedDelay(Runnable command,
                                                                long initialDelay, long delay, TimeUnit unit) {
-        this.checkQueue(1);
-        return this.thread.scheduleAtFixedRate(command, initialDelay, delay, unit);
+        synchronized (this) {
+            this.checkQueue(1);
+            return this.thread.scheduleAtFixedRate(command, initialDelay, delay, unit);
+        }
     }
 
     @Override
     public <T> ListenableFuture<T> submit(Callable<T> task) {
-        this.checkQueue(1);
-        return super.submit(task);
+        synchronized (this) {
+            this.checkQueue(1);
+            return super.submit(task);
+        }
     }
 
     @Override
     public ListenableFuture<?> submit(Runnable task) {
-        this.checkQueue(1);
-        return super.submit(task);
+        synchronized (this) {
+            this.checkQueue(1);
+            return super.submit(task);
+        }
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        this.checkQueue(tasks.size());
-        return super.invokeAll(tasks);
+        synchronized (this) {
+            this.checkQueue(tasks.size());
+            return super.invokeAll(tasks);
+        }
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks,
                                          long timeout, TimeUnit unit) throws InterruptedException {
-        this.checkQueue(tasks.size());
-        return super.invokeAll(tasks, timeout, unit);
+        synchronized (this) {
+            this.checkQueue(tasks.size());
+            return super.invokeAll(tasks, timeout, unit);
+        }
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        this.checkQueue(tasks.size());
-        return super.invokeAny(tasks);
+        synchronized (this) {
+            this.checkQueue(tasks.size());
+            return super.invokeAny(tasks);
+        }
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout,
                            TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        this.checkQueue(tasks.size());
-        return super.invokeAny(tasks, timeout, unit);
+        synchronized (this) {
+            this.checkQueue(tasks.size());
+            return super.invokeAny(tasks, timeout, unit);
+        }
     }
 
     @Override
     public <T> ListenableFuture<T> submit(Runnable task, T result) {
-        this.checkQueue(1);
-        return super.submit(task, result);
+        synchronized (this) {
+            this.checkQueue(1);
+            return super.submit(task, result);
+        }
     }
 
     @Override
     public void execute(Runnable command) {
-        this.checkQueue(1);
-        super.execute(command);
+        synchronized (this) {
+            this.checkQueue(1);
+            super.execute(command);
+        }
     }
 
     private void checkQueue(int numberOfTasks) {


### PR DESCRIPTION
### Motivation
Fix the queue size in writeThreadPool exceeds the configured size.

I print out the queue size every time I submit a task, and then set the queue size to 1:
maxPendingAddRequestsPerThread=1

The queue size of the log output is greater than 1：

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/19296967/174629381-e6814938-a7c8-4668-9531-0b0e4a19092a.png">

It means that the queue size set by maxPendingAddRequestsPerThread does not limit the queue size.