### PR TITLE
[improve][client] release the bookie from QuarantinedBookies when health check is disabled

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -632,6 +632,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         }
         if (!isEnabled) {
             LOG.info("Health checks is currently disabled!");
+            bookieWatcher.releaseAllQuarantinedBookies();
             return;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcher.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcher.java
@@ -78,4 +78,9 @@ public interface BookieWatcher {
      * @param bookie
      */
     void quarantineBookie(BookieId bookie);
+
+    /**
+     * Release all quarantined bookies, let it can be chosen for new ensembles.
+     */
+    void releaseAllQuarantinedBookies();
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
@@ -359,6 +359,7 @@ class BookieWatcherImpl implements BookieWatcher {
         }
     }
 
+    @Override
     public void releaseAllQuarantinedBookies(){
         quarantinedBookies.invalidateAll();
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
@@ -360,8 +360,6 @@ class BookieWatcherImpl implements BookieWatcher {
     }
 
     public void releaseAllQuarantinedBookies(){
-        if (quarantinedBookies.size() > 0){
-            quarantinedBookies.invalidateAll();
-        }
+        quarantinedBookies.invalidateAll();
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
@@ -359,5 +359,9 @@ class BookieWatcherImpl implements BookieWatcher {
         }
     }
 
-
+    public void releaseAllQuarantinedBookies(){
+        if (quarantinedBookies.size() > 0){
+            quarantinedBookies.invalidateAll();
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
we need release all quarantined bookies when we use the dynamic config to disable the health check. In some case, we disable the health check when the client has add all bookies to `quarantinedBookies`, then we want to recovery all client's read/write capability immediately.
But now we need wait `BOOKIE_QUARANTINE_TIME_SECONDS` reached or we need restart all client, it's too slowly to recovery the client read/write for us.

### Changes
Release all `QuarantinedBookies`,  after we dynamic disable the  health check.
