### PR TITLE
Fix: NPE in RackawareEnsemblePlacementPolicyImpl logged by AutoRecovery

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -1026,7 +1026,11 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
             for (int j = 0; j < writeQuorumSize; j++) {
                 bookie = ensembleList.get((i + j) % ensembleSize);
                 try {
-                    racksInQuorum.add(knownBookies.get(bookie).getNetworkLocation());
+                    if (knownBookies.containsKey(bookie)) {
+                        racksInQuorum.add(knownBookies.get(bookie).getNetworkLocation());
+                    } else {
+                        LOG.debug("bookie {} is not in the list of knownBookies", bookie);
+                    }
                 } catch (Exception e) {
                     /*
                      * any issue/exception in analyzing whether ensemble is
@@ -1055,7 +1059,11 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
         readLock.lock();
         try {
             for (BookieId bookie : ackedBookies) {
-                rackCounter.add(knownBookies.get(bookie).getNetworkLocation());
+                if (knownBookies.containsKey(bookie)) {
+                    rackCounter.add(knownBookies.get(bookie).getNetworkLocation());
+                } else {
+                    LOG.debug("bookie {} is not in the list of knownBookies", bookie);
+                }
             }
 
             // Check to make sure that ensemble is writing to `minNumberOfRacks`'s number of racks at least.


### PR DESCRIPTION
### Motivation

AR keeps on logging NPE during rereplication:

```
[ReplicationWorker] WARN  org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl - Received exception while trying to get network location of bookie: ...
java.lang.NullPointerException: null 
```

The NPE seems to be easily avoidable, no need to throw exception and log it just to ignore.

### Changes

Added check for bookie being present in the knownBookies map before accessing it.
