### PR TITLE
Fix checkpointComplete invoked twice in SyncThread

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -467,7 +467,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     }
 
     @Override
-    public synchronized void flush() throws IOException {
+    public synchronized void flush(boolean doCheckpointComplete) throws IOException {
         if (!somethingWritten.compareAndSet(true, false)) {
             return;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -180,8 +180,9 @@ public interface LedgerStorage {
      * Flushes all data in the storage. Once this is called,
      * add data written to the LedgerStorage up until this point
      * has been persisted to perminant storage
+     * @param doCheckpointComplete
      */
-    void flush() throws IOException;
+    void flush(boolean doCheckpointComplete) throws IOException;
 
     /**
      * Ask the ledger storage to sync data until the given <i>checkpoint</i>.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -129,7 +129,7 @@ public class SortedLedgerStorage
     @Override
     public void start() {
         try {
-            flush();
+            flush(true);
         } catch (IOException e) {
             LOG.error("Exception thrown while flushing ledger cache.", e);
         }
@@ -291,9 +291,9 @@ public class SortedLedgerStorage
     }
 
     @Override
-    public void flush() throws IOException {
+    public void flush(boolean doCheckpointComplete) throws IOException {
         memTable.flush(this, Checkpoint.MAX);
-        interleavedLedgerStorage.flush();
+        interleavedLedgerStorage.flush(doCheckpointComplete);
     }
 
     // CacheCallback functions.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -133,7 +133,7 @@ class SyncThread implements Checkpointer {
     private void flush() {
         Checkpoint checkpoint = checkpointSource.newCheckpoint();
         try {
-            ledgerStorage.flush();
+            ledgerStorage.flush(false);
         } catch (NoWritableLedgerDirException e) {
             log.error("No writeable ledger directories", e);
             dirsListener.allDisksFull(true);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCheckImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCheckImpl.java
@@ -129,7 +129,7 @@ public class DataIntegrityCheckImpl implements DataIntegrityCheck {
                         promise.completeExceptionally(exception);
                     } else {
                         try {
-                            this.ledgerStorage.flush();
+                            this.ledgerStorage.flush(true);
 
                             updateMetadataCache(ledgersCache);
 
@@ -196,7 +196,7 @@ public class DataIntegrityCheckImpl implements DataIntegrityCheck {
                     (ledgers) -> {
                         CompletableFuture<Void> promise = new CompletableFuture<>();
                         try {
-                            this.ledgerStorage.flush();
+                            this.ledgerStorage.flush(true);
                             if (ledgers.isEmpty()) {
                                 log.info("Event: {}, runId: {}", Events.CLEAR_INTEGCHECK_FLAG, runId);
                                 this.ledgerStorage.clearStorageStateFlag(

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -283,9 +283,9 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     @Override
-    public void flush() throws IOException {
+    public void flush(boolean doCheckpointComplete) throws IOException {
         for (LedgerStorage ls : ledgerStorageList) {
-            ls.flush();
+            ls.flush(doCheckpointComplete);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -263,7 +263,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     @Override
     public void shutdown() throws InterruptedException {
         try {
-            flush();
+            flush(true);
 
             gcThread.shutdown();
             entryLogger.close();
@@ -447,7 +447,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 executor.execute(() -> {
                         long startTime = System.nanoTime();
                         try {
-                            flush();
+                            flush(true);
                         } catch (IOException e) {
                             log.error("Error during flush", e);
                         } finally {
@@ -820,10 +820,12 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     }
 
     @Override
-    public void flush() throws IOException {
+    public void flush(boolean doCheckpointComplete) throws IOException {
         Checkpoint cp = checkpointSource.newCheckpoint();
         checkpoint(cp);
-        checkpointSource.checkpointComplete(cp, true);
+        if (doCheckpointComplete) {
+            checkpointSource.checkpointComplete(cp, true);
+        }
     }
 
     @Override
@@ -862,7 +864,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     @Override
     public void updateEntriesLocations(Iterable<EntryLocation> locations) throws IOException {
         // Trigger a flush to have all the entries being compacted in the db storage
-        flush();
+        flush(true);
 
         entryLocationIndex.updateLocations(locations);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommand.java
@@ -158,7 +158,7 @@ public class ConvertToInterleavedStorageCommand extends BookieCommand<ConvertToI
         dbStorage.shutdown();
 
         interleavedLedgerCache.flushLedger(true);
-        interleavedStorage.flush();
+        interleavedStorage.flush(true);
         interleavedStorage.shutdown();
 
         String baseDir = ledgerDirsManager.getAllLedgerDirs().get(0).toString();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieAccessor.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieAccessor.java
@@ -34,7 +34,7 @@ public class BookieAccessor {
     public static void forceFlush(BookieImpl b) throws IOException {
         CheckpointSourceList source = new CheckpointSourceList(b.journals);
         Checkpoint cp = source.newCheckpoint();
-        b.ledgerStorage.flush();
+        b.ledgerStorage.flush(true);
         source.checkpointComplete(cp, true);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalBypassTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalBypassTest.java
@@ -63,15 +63,15 @@ public class BookieJournalBypassTest extends BookKeeperClusterTestCase {
         Journal journal1 = bookieImpl.journals.get(0);
         LedgerStorage ls1 = serverByIndex(1).getBookie().getLedgerStorage();
 
-        ls0.flush();
-        ls1.flush();
+        ls0.flush(true);
+        ls1.flush(true);
 
         long bk0OffsetBefore = journal0.getLastLogMark().getCurMark().getLogFileOffset();
         long bk1OffsetBefore = journal1.getLastLogMark().getCurMark().getLogFileOffset();
 
         writeEntries(conf);
-        ls0.flush();
-        ls1.flush();
+        ls0.flush(true);
+        ls1.flush(true);
 
         long bk0OffsetAfter = journal0.getLastLogMark().getCurMark().getLogFileOffset();
         long bk1OffsetAfter = journal1.getLastLogMark().getCurMark().getLogFileOffset();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -695,7 +695,7 @@ public class BookieJournalTest {
 
         BookieImpl b = new TestBookieImpl(conf);
         b.readJournal();
-        b.ledgerStorage.flush();
+        b.ledgerStorage.flush(true);
         b.readEntry(1, 80);
         b.readEntry(1, 99);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -856,7 +856,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         }
         for (int i = 0; i < bookieCount(); i++) {
             BookieImpl bookie = ((BookieImpl) serverByIndex(i).getBookie());
-            bookie.getLedgerStorage().flush();
+            bookie.getLedgerStorage().flush(true);
             bookie.dirsMonitor.shutdown();
             LedgerDirsManager ledgerDirsManager = bookie.getLedgerDirsManager();
             List<File> ledgerDirs = ledgerDirsManager.getAllLedgerDirs();
@@ -1117,7 +1117,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
             lh.close();
         }
 
-        serverByIndex(0).getBookie().getLedgerStorage().flush();
+        serverByIndex(0).getBookie().getLedgerStorage().flush(true);
         assertTrue(
                 "entry log file ([0,1,2].log should be available in ledgerDirectory: "
                         + serverConfig.getLedgerDirs()[0],
@@ -1344,7 +1344,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         storage.addEntry(genEntry(2, 1, ENTRY_SIZE));
         storage.addEntry(genEntry(2, 2, ENTRY_SIZE));
         storage.addEntry(genEntry(3, 2, ENTRY_SIZE));
-        storage.flush();
+        storage.flush(true);
         storage.shutdown();
 
         assertTrue("Log should exist", log0.exists());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/DefaultEntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/DefaultEntryLogTest.java
@@ -604,7 +604,7 @@ public class DefaultEntryLogTest {
         @Override
         public Boolean call() throws IOException {
             try {
-                ledgerStorage.flush();
+                ledgerStorage.flush(true);
             } catch (IOException e) {
                 LOG.error("Got Exception for flush call", e);
                 throw new IOException("Got Exception for Flush call", e);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorageTest.java
@@ -220,7 +220,7 @@ public class InterleavedLedgerStorageTest {
 
     @Test
     public void testGetListOfEntriesOfLedgerAfterFlush() throws IOException {
-        interleavedStorage.flush();
+        interleavedStorage.flush(true);
 
         // Insert some more ledger & entries in the interleaved storage
         for (long entryId = numWrites; entryId < moreNumOfWrites; entryId++) {
@@ -253,7 +253,7 @@ public class InterleavedLedgerStorageTest {
         final LinkedBlockingQueue<Long> toCompact = new LinkedBlockingQueue<>();
         final Semaphore awaitingCompaction = new Semaphore(0);
 
-        interleavedStorage.flush();
+        interleavedStorage.flush(true);
         final long lastLogId = entryLogger.getLeastUnflushedLogId();
 
         final MutableInt counter = new MutableInt(0);
@@ -348,7 +348,7 @@ public class InterleavedLedgerStorageTest {
 
     @Test
     public void testShellCommands() throws Exception {
-        interleavedStorage.flush();
+        interleavedStorage.flush(true);
         interleavedStorage.shutdown();
         final Pattern entryPattern = Pattern.compile(
                 "entry (?<entry>\\d+)\t:\t((?<na>N/A)|\\(log:(?<logid>\\d+), pos: (?<pos>\\d+)\\))");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -287,7 +287,7 @@ public class LedgerCacheTest {
         // Add entries
         ledgerStorage.addEntry(generateEntry(1, 1));
         ledgerStorage.addEntry(generateEntry(1, 2));
-        ledgerStorage.flush();
+        ledgerStorage.flush(true);
 
         ledgerStorage.addEntry(generateEntry(1, 3));
         // add the dir to failed dirs
@@ -295,7 +295,7 @@ public class LedgerCacheTest {
                 fileInfo.getLf().getParentFile().getParentFile().getParentFile());
         File before = fileInfo.getLf();
         // flush after disk is added as failed.
-        ledgerStorage.flush();
+        ledgerStorage.flush(true);
         File after = fileInfo.getLf();
 
         assertFalse("After flush index file should be changed", before.equals(after));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
@@ -566,7 +566,7 @@ public class LedgerStorageCheckpointTest {
         }
 
         @Override
-        public synchronized void flush() throws IOException {
+        public synchronized void flush(boolean doCheckpointComplete) throws IOException {
             // this method will be called by SyncThread.shutdown.
             // During BookieServer shutdown we want this method to be noop
             // do nothing

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageTest.java
@@ -227,7 +227,7 @@ public class LedgerStorageTest extends BookKeeperClusterTestCase {
         /*
          * flush ledgerStorage so that header of fileinfo is flushed.
          */
-        serverByIndex(0).getBookie().getLedgerStorage().flush();
+        serverByIndex(0).getBookie().getLedgerStorage().flush(true);
 
         ReadOnlyFileInfo fileInfo = getFileInfo(ledgerId,
                                                 BookieImpl.getCurrentDirectories(confByIndex(0).getLedgerDirs()));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/MockLedgerStorage.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/MockLedgerStorage.java
@@ -233,7 +233,7 @@ public class MockLedgerStorage implements CompactableLedgerStorage {
     }
 
     @Override
-    public void flush() throws IOException {
+    public void flush(boolean doCheckpointComplete) throws IOException {
         // this is a noop, as we dont hit disk anyhow
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageTest.java
@@ -168,7 +168,7 @@ public class SortedLedgerStorageTest {
             }
         }
 
-        sortedLedgerStorage.flush();
+        sortedLedgerStorage.flush(true);
 
         // Insert some more ledger & entries in the interleaved storage
         for (long entryId = numWrites; entryId < moreNumOfWrites; entryId++) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SyncThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SyncThreadTest.java
@@ -95,7 +95,7 @@ public class SyncThreadTest {
         final AtomicBoolean failedSomewhere = new AtomicBoolean(false);
         LedgerStorage storage = new DummyLedgerStorage() {
                 @Override
-                public void flush() throws IOException {
+                public void flush(boolean doCheckpointComplete) throws IOException {
                     flushCalledLatch.countDown();
                     try {
                         flushLatch.await();
@@ -346,7 +346,7 @@ public class SyncThreadTest {
         }
 
         @Override
-        public void flush() throws IOException {
+        public void flush(boolean doCheckpointComplete) throws IOException {
         }
 
         @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCheckTest.java
@@ -225,9 +225,9 @@ public class DataIntegrityCheckTest {
                                                                  mock(EntryCopier.class),
                                                                  mock(BookKeeperAdmin.class),
                                                                  Schedulers.io());
-        verify(storage, times(0)).flush();
+        verify(storage, times(0)).flush(true);
         impl.runPreBootCheck("test").get();
-        verify(storage, times(1)).flush();
+        verify(storage, times(1)).flush(true);
 
         assertThat(storage.hasLimboState(0xbeefL), is(true));
         assertThat(storage.isFenced(0xbeefL), is(true));
@@ -409,7 +409,7 @@ public class DataIntegrityCheckTest {
 
         Set<DataIntegrityCheckImpl.LedgerResult> results = impl.checkAndRecoverLedgers(ledgers, "test").get();
 
-        verify(storage, times(0)).flush();
+        verify(storage, times(0)).flush(true);
     }
 
     // TODO: what is this test?
@@ -1333,7 +1333,7 @@ public class DataIntegrityCheckTest {
 
         assertThat(StorageState.NEEDS_INTEGRITY_CHECK,
                    isIn(storage.getStorageStateFlags()));
-        verify(storage, times(1)).flush();
+        verify(storage, times(1)).flush(true);
 
         assertThat(storage.ledgerExists(id1), equalTo(true));
         assertThat(storage.ledgerExists(id2), equalTo(true));
@@ -1346,7 +1346,7 @@ public class DataIntegrityCheckTest {
 
         assertThat(StorageState.NEEDS_INTEGRITY_CHECK,
                    not(isIn(storage.getStorageStateFlags())));
-        verify(storage, times(2)).flush();
+        verify(storage, times(2)).flush(true);
 
         assertThat(storage.ledgerExists(id3), equalTo(true));
         assertThat(storage.entryExists(id3, 0), equalTo(true));
@@ -1401,7 +1401,7 @@ public class DataIntegrityCheckTest {
 
         assertThat(StorageState.NEEDS_INTEGRITY_CHECK,
                    isIn(storage.getStorageStateFlags()));
-        verify(storage, times(1)).flush();
+        verify(storage, times(1)).flush(true);
 
         assertThat(storage.ledgerExists(id1), equalTo(true));
         assertThat(storage.ledgerExists(id2), equalTo(true));
@@ -1417,7 +1417,7 @@ public class DataIntegrityCheckTest {
 
         assertThat(StorageState.NEEDS_INTEGRITY_CHECK,
                    not(isIn(storage.getStorageStateFlags())));
-        verify(storage, times(2)).flush();
+        verify(storage, times(2)).flush(true);
 
         assertThat(storage.ledgerExists(id3), equalTo(true));
         assertThat(storage.entryExists(id3, 0), equalTo(true));
@@ -1474,7 +1474,7 @@ public class DataIntegrityCheckTest {
 
         impl.runFullCheck().get();
 
-        verify(storage, times(1)).flush();
+        verify(storage, times(1)).flush(true);
 
         assertThat(StorageState.NEEDS_INTEGRITY_CHECK,
                    not(isIn(storage.getStorageStateFlags())));
@@ -1488,7 +1488,7 @@ public class DataIntegrityCheckTest {
         AtomicInteger count = new AtomicInteger(0);
         MockLedgerStorage storage = spy(new MockLedgerStorage() {
                 @Override
-                public void flush() throws IOException {
+                public void flush(boolean doCheckpointComplete) throws IOException {
                     if (count.getAndIncrement() == 0) {
                         throw new IOException("broken flush");
                     }
@@ -1528,7 +1528,7 @@ public class DataIntegrityCheckTest {
         }
         assertThat(StorageState.NEEDS_INTEGRITY_CHECK,
                    isIn(storage.getStorageStateFlags()));
-        verify(storage, times(1)).flush();
+        verify(storage, times(1)).flush(true);
 
         assertThat(storage.ledgerExists(id1), equalTo(true));
         assertThat(storage.ledgerExists(id2), equalTo(true));
@@ -1539,7 +1539,7 @@ public class DataIntegrityCheckTest {
 
         assertThat(StorageState.NEEDS_INTEGRITY_CHECK,
                    not(isIn(storage.getStorageStateFlags())));
-        verify(storage, times(2)).flush();
+        verify(storage, times(2)).flush(true);
     }
 }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionRollbackTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionRollbackTest.java
@@ -110,7 +110,7 @@ public class ConversionRollbackTest {
             }
         }
 
-        dbStorage.flush();
+        dbStorage.flush(true);
         dbStorage.shutdown();
 
         // Run conversion tool

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/ConversionTest.java
@@ -108,7 +108,7 @@ public class ConversionTest {
             }
         }
 
-        interleavedStorage.flush();
+        interleavedStorage.flush(true);
         interleavedStorage.shutdown();
 
         // Run conversion tool

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -143,7 +143,7 @@ public class DbLedgerStorageTest {
         ByteBuf res = storage.getEntry(4, 1);
         assertEquals(entry, res);
 
-        storage.flush();
+        storage.flush(true);
 
         assertEquals(false, ((DbLedgerStorage) storage).isFlushRequired());
 
@@ -199,7 +199,7 @@ public class DbLedgerStorageTest {
         assertEquals(false, storage.ledgerExists(4));
 
         // remove entries for ledger 4 from cache
-        storage.flush();
+        storage.flush(true);
 
         try {
             storage.getEntry(4, 4);
@@ -274,7 +274,7 @@ public class DbLedgerStorageTest {
         entry1.writeBytes("entry-1".getBytes());
 
         storage.addEntry(entry1);
-        storage.flush();
+        storage.flush(true);
 
         ByteBuf newEntry1 = Unpooled.buffer(1024);
         newEntry1.writeLong(1); // ledger id
@@ -282,7 +282,7 @@ public class DbLedgerStorageTest {
         newEntry1.writeBytes("new-entry-1".getBytes());
 
         storage.addEntry(newEntry1);
-        storage.flush();
+        storage.flush(true);
 
         ByteBuf response = storage.getEntry(1, 1);
         assertEquals(newEntry1, response);
@@ -322,7 +322,7 @@ public class DbLedgerStorageTest {
         res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
 
-        storage.flush();
+        storage.flush(true);
 
         res = storage.getEntry(1, 1);
         assertEquals(entry1, res);
@@ -353,7 +353,7 @@ public class DbLedgerStorageTest {
         assertEquals(entry2, res);
         res.release();
 
-        storage.flush();
+        storage.flush(true);
 
         try {
             storage.getEntry(1, 1);
@@ -381,7 +381,7 @@ public class DbLedgerStorageTest {
         assertEquals(entry2, res);
         res.release();
 
-        storage.flush();
+        storage.flush(true);
 
         res = storage.getEntry(1, 1);
         assertEquals(entry1, res);
@@ -409,7 +409,7 @@ public class DbLedgerStorageTest {
         storage.addEntry(entry0);
         storage.addEntry(entry1);
 
-        storage.flush();
+        storage.flush(true);
 
         storage.deleteLedger(1);
 
@@ -431,7 +431,7 @@ public class DbLedgerStorageTest {
         assertEquals(entry0, storage.getEntry(1, 0));
         assertEquals(entry1, storage.getEntry(1, 1));
 
-        storage.flush();
+        storage.flush(true);
     }
 
     @Test
@@ -444,7 +444,7 @@ public class DbLedgerStorageTest {
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
-        storage.flush();
+        storage.flush(true);
         storage.setLimboState(1);
 
         try {
@@ -466,7 +466,7 @@ public class DbLedgerStorageTest {
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
-        storage.flush();
+        storage.flush(true);
         storage.setLimboState(1);
 
         try {
@@ -503,7 +503,7 @@ public class DbLedgerStorageTest {
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
-        storage.flush();
+        storage.flush(true);
         storage.setLimboState(1);
 
         try {
@@ -534,7 +534,7 @@ public class DbLedgerStorageTest {
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
-        storage.flush();
+        storage.flush(true);
         storage.setFenced(1);
         storage.setLimboState(1);
 
@@ -557,7 +557,7 @@ public class DbLedgerStorageTest {
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
-        storage.flush();
+        storage.flush(true);
         storage.setLimboState(1);
 
         try {
@@ -586,7 +586,7 @@ public class DbLedgerStorageTest {
         assertTrue(storage.entryExists(ledgerId, 0));
         assertFalse(storage.entryExists(ledgerId, 1));
 
-        storage.flush();
+        storage.flush(true);
 
         // should come from storage
         assertTrue(storage.entryExists(ledgerId, 0));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
@@ -72,7 +72,7 @@ public class DbLedgerStorageWriteCacheTest {
             }
 
           @Override
-          public void flush() throws IOException {
+          public void flush(boolean doCheckpointComplete) throws IOException {
               flushMutex.lock();
               try {
                   // Swap the write caches and block indefinitely to simulate a slow disk

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/LedgersIndexRebuildTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/LedgersIndexRebuildTest.java
@@ -100,7 +100,7 @@ public class LedgersIndexRebuildTest {
             }
         }
 
-        ledgerStorage.flush();
+        ledgerStorage.flush(true);
         ledgerStorage.shutdown();
 
         // Rebuild index through the tool

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildTest.java
@@ -108,7 +108,7 @@ public class LocationsIndexRebuildTest {
             }
         }
 
-        ledgerStorage.flush();
+        ledgerStorage.flush(true);
         ledgerStorage.shutdown();
 
         // Rebuild index through the tool

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -650,7 +650,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         }
 
         @Override
-        public void flush() throws IOException {
+        public void flush(boolean doCheckpointComplete) throws IOException {
         }
 
         @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -238,7 +238,7 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
         }
 
         @Override
-        public void flush() throws IOException {
+        public void flush(boolean doCheckpointComplete) throws IOException {
         }
 
         @Override

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommandTest.java
@@ -84,7 +84,7 @@ public class ConvertToInterleavedStorageCommandTest extends BookieCommandTestBas
 
         mockConstruction(InterleavedLedgerStorage.class,
                 (interleavedLedgerStorage, context) -> {
-                    doNothing().when(interleavedLedgerStorage).flush();
+                    doNothing().when(interleavedLedgerStorage).flush(true);
                     doNothing().when(interleavedLedgerStorage).shutdown();
                     when(interleavedLedgerStorage.getLedgerCache()).thenReturn(interleavedLedgerCache);
                 });
@@ -135,7 +135,7 @@ public class ConvertToInterleavedStorageCommandTest extends BookieCommandTestBas
             verify(dbStorage, times(10)).getLocation(anyLong(), anyLong());
             verify(dbStorage, times(1)).shutdown();
             verify(interleavedLedgerCache, times(1)).flushLedger(true);
-            verify(interleavedLedgerStorage, times(1)).flush();
+            verify(interleavedLedgerStorage, times(1)).flush(true);
             verify(interleavedLedgerStorage, times(1)).shutdown();
         } catch (Exception e) {
             throw new UncheckedExecutionException(e.getMessage(), e);


### PR DESCRIPTION
### Motivation

SyncThread flush would invoke  `checkpointSource.checkpointComplete`  twice. it's unnecessary.  
### Changes

Change `org.apache.bookkeeper.bookie.LedgerStorage#flush` signature . add `doCheckpointComplete` parameter.

default value is true,  only set to false in `org.apache.bookkeeper.bookie.SyncThread#flush`
