### PR TITLE
Resolve network location if the bookie is down but history holds it

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -1026,7 +1026,14 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
             for (int j = 0; j < writeQuorumSize; j++) {
                 bookie = ensembleList.get((i + j) % ensembleSize);
                 try {
-                    racksInQuorum.add(knownBookies.get(bookie).getNetworkLocation());
+                    BookieNode bookieNode = knownBookies.get(bookie);
+                    if (bookieNode == null) {
+                        bookieNode = historyBookies.get(bookie);
+                    }
+                    if (bookieNode == null) {
+                        continue;
+                    }
+                    racksInQuorum.add(bookieNode.getNetworkLocation());
                 } catch (Exception e) {
                     /*
                      * any issue/exception in analyzing whether ensemble is


### PR DESCRIPTION
### Motivation

When resolve a bookie network location, only get from knownBookies. If the bookie shutdown, we can't resolve the network location. In fact, the history bookies maybe hold it.
