### PR TITLE
fix journalCbQueueSize compute

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -403,6 +403,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     QueueEntry qe = forceWriteWaiters.get(i);
                     if (qe != null) {
                         qe.setEnqueueCbThreadPooleQueueTime(MathUtils.nowInNano());
+                        journalStats.getJournalCbQueueSize().inc();
                         cbThreadPool.execute(qe);
                     }
                 }
@@ -946,7 +947,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         entry.retain();
 
         journalStats.getJournalQueueSize().inc();
-        journalStats.getJournalCbQueueSize().inc();
 
         memoryLimitController.reserveMemory(entry.readableBytes());
 
@@ -968,7 +968,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                 callbackTime));
         // Increment afterwards because the add operation could fail.
         journalStats.getJournalQueueSize().inc();
-        journalStats.getJournalCbQueueSize().inc();
     }
 
     /**
@@ -1132,6 +1131,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                                     toFlush.set(i, null);
                                     numEntriesToFlush--;
                                     entry.setEnqueueCbThreadPooleQueueTime(MathUtils.nowInNano());
+                                    journalStats.getJournalCbQueueSize().inc();
                                     cbThreadPool.execute(entry);
                                 }
                             }


### PR DESCRIPTION
### Motivation

There is a problem with the statistics of the journalCbQueueSize indicator. The incrementing position of the indicator is wrong, which will cause the indicator to be larger than the actual queue size：

<img width="572" alt="image" src="https://user-images.githubusercontent.com/19296967/175611447-aebce84a-fdff-4505-83bb-fce321c9ed82.png">
