### PR TITLE
Fix bookie CI test not run

### DIFF
--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -53,14 +53,8 @@ jobs:
       - name: Maven build bookkeeper-server
         run: mvn -B -nsu -am -pl bookkeeper-server clean install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
-      - name: Run EntryLogTests
-        run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.TestEntryLog" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
-
-      - name: Run InterleavedLedgerStorageTest
-        run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.TestInterleavedLederStorage" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
-
       - name: Run bookie tests
-        run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.*Test" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.**" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Run shell tests
         run: mvn -B -nsu -pl tests/scripts install -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -991,6 +991,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             }
         }
 
+        ledgerIndex.flush();
         batch.flush();
         batch.close();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -452,8 +452,6 @@ public class DbLedgerStorageTest {
         } catch (BookieException.DataUnknownException e) {
             fail("Should have been able to read entry");
         }
-
-        storage.shutdown();
     }
 
     @Test
@@ -462,7 +460,7 @@ public class DbLedgerStorageTest {
 
         ByteBuf entry0 = Unpooled.buffer(1024);
         entry0.writeLong(1); // ledger id
-        entry0.writeLong(0); // entry id
+        entry0.writeLong(1); // entry id
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
@@ -491,6 +489,8 @@ public class DbLedgerStorageTest {
         } finally {
             restartedStorage.shutdown();
         }
+
+        storage = (DbLedgerStorage) new TestBookieImpl(conf).getLedgerStorage();
     }
 
     @Test
@@ -499,7 +499,7 @@ public class DbLedgerStorageTest {
 
         ByteBuf entry0 = Unpooled.buffer(1024);
         entry0.writeLong(1); // ledger id
-        entry0.writeLong(0); // entry id
+        entry0.writeLong(1); // entry id
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
@@ -530,7 +530,7 @@ public class DbLedgerStorageTest {
 
         ByteBuf entry0 = Unpooled.buffer(1024);
         entry0.writeLong(1); // ledger id
-        entry0.writeLong(0); // entry id
+        entry0.writeLong(1); // entry id
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
@@ -543,8 +543,6 @@ public class DbLedgerStorageTest {
         } catch (IOException ioe) {
             fail("Should have been able to get isFenced response");
         }
-
-        storage.shutdown();
     }
 
     @Test
@@ -553,7 +551,7 @@ public class DbLedgerStorageTest {
 
         ByteBuf entry0 = Unpooled.buffer(1024);
         entry0.writeLong(1); // ledger id
-        entry0.writeLong(0); // entry id
+        entry0.writeLong(1); // entry id
         entry0.writeBytes("entry-0".getBytes());
 
         storage.addEntry(entry0);
@@ -566,8 +564,6 @@ public class DbLedgerStorageTest {
         } catch (BookieException.DataUnknownException e) {
             // expected
         }
-
-        storage.shutdown();
     }
 
     @Test
@@ -631,5 +627,7 @@ public class DbLedgerStorageTest {
         } finally {
             restartedStorage2.shutdown();
         }
+
+        storage = (DbLedgerStorage) new TestBookieImpl(conf).getLedgerStorage();
     }
 }


### PR DESCRIPTION
### Motivation
The `bookie-tests` CI runs the following tests.
```
- name: Run bookie tests
        run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.*Test" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
```

For the `remaining-tests` CI runs the following tests.
```bash
- name: Run remaining tests
        run: mvn -B -nsu -am -pl bookkeeper-server clean install test -Dtest="!org.apache.bookkeeper.client.**,!org.apache.bookkeeper.bookie.**,!org.apache.bookkeeper.replication.**,!org.apache.bookkeeper.tls.**" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
```

The problem is that `bookie-tests` only run tests with the name `org.apache.bookkeeper.bookie.*Test`, however, the `remaining-tests` exclude tests with name `org.apache.bookkeeper.bookie.**`. It leads to a lot of tests in `org.apache.bookkeeper.bookie.*` package doesn't run at all in CI.

### Modification
Turn on `org.apache.bookkeeper.bookie.**` tests in `bookie-tests` CI. 

I have been testing on my laptop, there are many tests can't pass, I may need more time to make those failed tests to be passed.

The following tests need to fixed.
- [x] org.apache.bookkeeper.bookie.storage.ldb.ConversionTest.test
- [x] org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorageTest.testLimboStateThrowsInLimboWhenNoEntry
- [x] org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorageTest.testLimboStateSucceedsWhenFenced
- [x] org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorageTest.testLimboStateSucceedsWhenInLimboButHasEntry
- [x] org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorageTest.testLimboStateThrowsInLimboWhenNotFenced
- [x] org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorageTest.testStorageStateFlags