### PR TITLE
Shut down ReplicationWorker and Auditor on non-recoverable ZK error

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -106,7 +106,6 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1897,7 +1896,7 @@ public class BookieShell implements Tool {
                                 underreplicationManager.setReplicasCheckCTime(time);
                             }
                         }
-                    } catch (InterruptedException | KeeperException | ReplicationException e) {
+                    } catch (InterruptedException | ReplicationException e) {
                         LOG.error("Exception while trying to reset last run time ", e);
                         return -1;
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1471,7 +1471,7 @@ public class BookKeeperAdmin implements AutoCloseable {
     }
 
     private LedgerUnderreplicationManager getUnderreplicationManager()
-            throws CompatibilityException, KeeperException, InterruptedException {
+            throws CompatibilityException, UnavailableException, InterruptedException {
         if (underreplicationManager == null) {
             underreplicationManager = mFactory.newLedgerUnderreplicationManager();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManagerFactory.java
@@ -28,7 +28,6 @@ import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.ACL;
 
 /**
@@ -86,7 +85,8 @@ public class FlatLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
 
     @Override
     public LedgerUnderreplicationManager newLedgerUnderreplicationManager()
-            throws KeeperException, InterruptedException, ReplicationException.CompatibilityException {
+            throws ReplicationException.UnavailableException, InterruptedException,
+            ReplicationException.CompatibilityException {
         return new ZkLedgerUnderreplicationManager(conf, zk);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManagerFactory.java
@@ -84,7 +84,8 @@ public interface LedgerManagerFactory extends AutoCloseable {
      * @see LedgerUnderreplicationManager
      */
     LedgerUnderreplicationManager newLedgerUnderreplicationManager()
-            throws KeeperException, InterruptedException, ReplicationException.CompatibilityException;
+            throws ReplicationException.UnavailableException,
+            InterruptedException, ReplicationException.CompatibilityException;
 
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LegacyHierarchicalLedgerManagerFactory.java
@@ -28,7 +28,6 @@ import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.ACL;
 
 /**
@@ -93,7 +92,8 @@ public class LegacyHierarchicalLedgerManagerFactory extends AbstractZkLedgerMana
 
     @Override
     public LedgerUnderreplicationManager newLedgerUnderreplicationManager()
-            throws KeeperException, InterruptedException, ReplicationException.CompatibilityException{
+            throws ReplicationException.UnavailableException, InterruptedException,
+            ReplicationException.CompatibilityException{
         return new ZkLedgerUnderreplicationManager(conf, zk);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/MSLedgerManagerFactory.java
@@ -671,7 +671,8 @@ public class MSLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
     }
 
     @Override
-    public LedgerUnderreplicationManager newLedgerUnderreplicationManager() throws KeeperException,
+    public LedgerUnderreplicationManager newLedgerUnderreplicationManager()
+            throws ReplicationException.UnavailableException,
             InterruptedException, ReplicationException.CompatibilityException {
         // TODO: currently just use zk ledger underreplication manager
         return new ZkLedgerUnderreplicationManager(conf, zk);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java
@@ -128,7 +128,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
     private final SubTreeCache subTreeCache;
 
     public ZkLedgerUnderreplicationManager(AbstractConfiguration conf, ZooKeeper zkc)
-            throws KeeperException, InterruptedException, ReplicationException.CompatibilityException {
+            throws UnavailableException, InterruptedException, ReplicationException.CompatibilityException {
         this.conf = conf;
         rootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(conf);
         basePath = getBasePath(rootPath);
@@ -149,7 +149,11 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             }
         });
 
-        checkLayout();
+        try {
+            checkLayout();
+        } catch (KeeperException ke) {
+            throw ReplicationException.fromKeeperException("", ke);
+        }
     }
 
     public static String getBasePath(String rootPath) {
@@ -284,7 +288,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             underreplicatedLedger.setReplicaList(replicaList);
             return underreplicatedLedger;
         } catch (KeeperException ke) {
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while connecting zookeeper", ie);
@@ -424,7 +428,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             // znode in place, so the ledger is checked.
         } catch (KeeperException ke) {
             LOG.error("Error deleting underreplicated ledger znode", ke);
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -578,7 +582,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
         try {
             return getLedgerToRereplicateFromHierarchy(urLedgerPath, 0);
         } catch (KeeperException ke) {
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while connecting zookeeper", ie);
@@ -608,7 +612,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
                 // nothing found, wait for a watcher to trigger
                 changedLatch.await();
             } catch (KeeperException ke) {
-                throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+                throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
                 throw new ReplicationException.UnavailableException("Interrupted while connecting zookeeper", ie);
@@ -639,7 +643,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             // this is ok
         } catch (KeeperException ke) {
             LOG.error("Error deleting underreplicated ledger lock", ke);
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while connecting zookeeper", ie);
@@ -660,7 +664,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             // this is ok
         } catch (KeeperException ke) {
             LOG.error("Error deleting underreplicated ledger lock", ke);
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while connecting zookeeper", ie);
@@ -684,8 +688,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
                     "AutoRecovery is already disabled!", ke);
         } catch (KeeperException ke) {
             LOG.error("Exception while stopping auto ledger re-replication", ke);
-            throw new ReplicationException.UnavailableException(
-                    "Exception while stopping auto ledger re-replication", ke);
+            throw ReplicationException.fromKeeperException("Exception while stopping auto ledger re-replication", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException(
@@ -708,8 +711,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
                     "AutoRecovery is already enabled!", ke);
         } catch (KeeperException ke) {
             LOG.error("Exception while resuming ledger replication", ke);
-            throw new ReplicationException.UnavailableException(
-                    "Exception while resuming auto ledger re-replication", ke);
+            throw ReplicationException.fromKeeperException("Exception while resuming auto ledger re-replication", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException(
@@ -729,8 +731,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
         } catch (KeeperException ke) {
             LOG.error("Error while checking the state of "
                     + "ledger re-replication", ke);
-            throw new ReplicationException.UnavailableException(
-                    "Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException(
@@ -765,8 +766,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
         } catch (KeeperException ke) {
             LOG.error("Error while checking the state of "
                     + "ledger re-replication", ke);
-            throw new ReplicationException.UnavailableException(
-                    "Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException(
@@ -791,10 +791,14 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
      */
     public static String acquireUnderreplicatedLedgerLock(ZooKeeper zkc, String zkLedgersRootPath,
         long ledgerId, List<ACL> zkAcls)
-            throws KeeperException, InterruptedException {
-        final String lockPath = getUrLedgerLockZnode(getUrLockPath(zkLedgersRootPath), ledgerId);
-        ZkUtils.createFullPathOptimistic(zkc, lockPath, LOCK_DATA, zkAcls, CreateMode.EPHEMERAL);
-        return lockPath;
+            throws UnavailableException, InterruptedException {
+        try {
+            final String lockPath = getUrLedgerLockZnode(getUrLockPath(zkLedgersRootPath), ledgerId);
+            ZkUtils.createFullPathOptimistic(zkc, lockPath, LOCK_DATA, zkAcls, CreateMode.EPHEMERAL);
+            return lockPath;
+        } catch (KeeperException ke) {
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
+        }
     }
 
     @Override
@@ -824,7 +828,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             return false;
         } catch (KeeperException ke) {
             LOG.error("Error while initializing LostBookieRecoveryDelay", ke);
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -845,7 +849,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             }
         } catch (KeeperException ke) {
             LOG.error("Error while setting LostBookieRecoveryDelay ", ke);
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -860,7 +864,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             return Integer.parseInt(new String(data, UTF_8));
         } catch (KeeperException ke) {
             LOG.error("Error while getting LostBookieRecoveryDelay ", ke);
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -882,7 +886,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             zkc.addWatch(urLedgerPath, w, AddWatchMode.PERSISTENT_RECURSIVE);
         } catch (KeeperException ke) {
             LOG.error("Error while checking the state of underReplicated ledgers", ke);
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -907,7 +911,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             }
         } catch (KeeperException ke) {
             LOG.error("Error while checking the state of lostBookieRecoveryDelay", ke);
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -928,7 +932,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             // this is ok.
         } catch (KeeperException e) {
             LOG.error("Error while getting ReplicationWorkerId rereplicating Ledger", e);
-            throw new ReplicationException.UnavailableException(
+            throw ReplicationException.fromKeeperException(
                     "Error while getting ReplicationWorkerId rereplicating Ledger", e);
         } catch (InterruptedException e) {
             LOG.error("Got interrupted while getting ReplicationWorkerId rereplicating Ledger", e);
@@ -957,7 +961,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
                 zkc.create(checkAllLedgersCtimeZnode, checkAllLedgersFormatByteArray, zkAcls, CreateMode.PERSISTENT);
             }
         } catch (KeeperException ke) {
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -978,7 +982,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             LOG.warn("checkAllLedgersCtimeZnode is not yet available");
             return -1;
         } catch (KeeperException ke) {
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -1004,7 +1008,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
                         CreateMode.PERSISTENT);
             }
         } catch (KeeperException ke) {
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -1025,7 +1029,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             LOG.warn("placementPolicyCheckCtimeZnode is not yet available");
             return -1;
         } catch (KeeperException ke) {
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -1050,7 +1054,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
                 LOG.debug("setReplicasCheckCTime completed successfully");
             }
         } catch (KeeperException ke) {
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
@@ -1070,7 +1074,7 @@ public class ZkLedgerUnderreplicationManager implements LedgerUnderreplicationMa
             LOG.warn("replicasCheckCtimeZnode is not yet available");
             return -1;
         } catch (KeeperException ke) {
-            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+            throw ReplicationException.fromKeeperException("Error contacting zookeeper", ke);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommand.java
@@ -39,7 +39,6 @@ import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
 import org.apache.commons.lang.StringUtils;
-import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,7 +140,7 @@ public class ListUnderReplicatedCommand extends BookieCommand<ListUnderReplicate
             LedgerUnderreplicationManager underreplicationManager;
             try {
                 underreplicationManager = mFactory.newLedgerUnderreplicationManager();
-            } catch (KeeperException | ReplicationException.CompatibilityException e) {
+            } catch (ReplicationException e) {
                 throw new UncheckedExecutionException("Failed to new ledger underreplicated manager", e);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/QueryAutoRecoveryStatusCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/QueryAutoRecoveryStatusCommand.java
@@ -34,7 +34,6 @@ import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
-import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +98,7 @@ public class QueryAutoRecoveryStatusCommand
             List<LedgerRecoverInfo> ledgerList = new LinkedList<>();
             try {
                 underreplicationManager = mFactory.newLedgerUnderreplicationManager();
-            } catch (KeeperException | ReplicationException.CompatibilityException e) {
+            } catch (ReplicationException e) {
                 throw new UncheckedExecutionException("Failed to new ledger underreplicated manager", e);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ToggleCommand.java
@@ -32,7 +32,6 @@ import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
-import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,7 +112,7 @@ public class ToggleCommand extends BookieCommand<ToggleCommand.AutoRecoveryFlags
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new UncheckedExecutionException(e);
-            } catch (KeeperException | ReplicationException e) {
+            } catch (ReplicationException e) {
                 throw new UncheckedExecutionException(e);
             }
             return null;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/ForceAuditorChecksCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/ForceAuditorChecksCmdTest.java
@@ -25,7 +25,6 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
 import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.zookeeper.KeeperException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -62,7 +61,7 @@ public class ForceAuditorChecksCmdTest extends BookKeeperClusterTestCase {
                 urM.setCheckAllLedgersCTime(curTime);
                 urM.setPlacementPolicyCheckCTime(curTime);
                 urM.setReplicasCheckCTime(curTime);
-            } catch (InterruptedException | KeeperException | ReplicationException e) {
+            } catch (InterruptedException | ReplicationException e) {
                 throw new UncheckedExecutionException(e);
             }
             return null;
@@ -87,7 +86,7 @@ public class ForceAuditorChecksCmdTest extends BookKeeperClusterTestCase {
                 if (replicasCheckCTime > (curTime - (20 * 24 * 60 * 60 * 1000))) {
                     Assert.fail("The replicasCheckCTime should have been reset to atleast 20 days old");
                 }
-            } catch (InterruptedException | KeeperException | ReplicationException e) {
+            } catch (InterruptedException | ReplicationException e) {
                 throw new UncheckedExecutionException(e);
             }
             return null;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
@@ -81,7 +81,6 @@ import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.test.TestStatsProvider;
 import org.apache.bookkeeper.test.TestStatsProvider.TestOpStatsLogger;
 import org.apache.bookkeeper.test.TestStatsProvider.TestStatsLogger;
-import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -730,7 +729,7 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
             super(bookieIdentifier, conf, statsLogger);
         }
 
-        void checkAllLedgers() throws BKException, IOException, InterruptedException, KeeperException {
+        void checkAllLedgers() throws BKException, IOException, InterruptedException {
             super.checkAllLedgers();
             latchRef.get().countDown();
         }

--- a/metadata-drivers/etcd/src/main/java/org/apache/bookkeeper/metadata/etcd/EtcdLedgerManagerFactory.java
+++ b/metadata-drivers/etcd/src/main/java/org/apache/bookkeeper/metadata/etcd/EtcdLedgerManagerFactory.java
@@ -30,6 +30,7 @@ import org.apache.bookkeeper.meta.LedgerIdGenerator;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.zookeeper.KeeperException;
@@ -88,7 +89,7 @@ class EtcdLedgerManagerFactory implements LedgerManagerFactory {
 
     @Override
     public LedgerUnderreplicationManager newLedgerUnderreplicationManager()
-        throws KeeperException, InterruptedException, CompatibilityException {
+        throws ReplicationException.UnavailableException, InterruptedException, CompatibilityException {
         throw new UnsupportedOperationException();
     }
 

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/autorecovery/ListUnderReplicatedCommandTest.java
@@ -72,7 +72,7 @@ public class ListUnderReplicatedCommandTest extends BookieCommandTestBase {
 
     @Test
     public void testWithoutArgs()
-        throws InterruptedException, ReplicationException.CompatibilityException, KeeperException {
+        throws InterruptedException, ReplicationException {
         testCommand("");
         verify(factory, times(1)).newLedgerUnderreplicationManager();
         verify(underreplicationManager, times(1)).listLedgersToRereplicate(any());
@@ -82,7 +82,7 @@ public class ListUnderReplicatedCommandTest extends BookieCommandTestBase {
 
     @Test
     public void testMissingReplica()
-        throws InterruptedException, ReplicationException.CompatibilityException, KeeperException {
+        throws InterruptedException, ReplicationException {
         testCommand("-mr", "");
         verify(factory, times(1)).newLedgerUnderreplicationManager();
         verify(underreplicationManager, times(1)).listLedgersToRereplicate(any());
@@ -92,7 +92,7 @@ public class ListUnderReplicatedCommandTest extends BookieCommandTestBase {
 
     @Test
     public void testExcludingMissingReplica()
-        throws InterruptedException, ReplicationException.CompatibilityException, KeeperException {
+        throws InterruptedException, ReplicationException {
         testCommand("-emr", "");
         verify(factory, times(1)).newLedgerUnderreplicationManager();
         verify(underreplicationManager, times(1)).listLedgersToRereplicate(any());
@@ -102,7 +102,7 @@ public class ListUnderReplicatedCommandTest extends BookieCommandTestBase {
 
     @Test
     public void testPrintMissingReplica()
-        throws InterruptedException, ReplicationException.CompatibilityException, KeeperException {
+        throws InterruptedException, ReplicationException {
 
         ArrayList<String> list = new ArrayList<>();
         list.add("replica");


### PR DESCRIPTION
Descriptions of the changes in this PR:

Shut down Replication Worker and Auditor on non-recoverable ZK error

### Motivation

Some errors require one to re-create Zk client.
Currently BK and underlying components cannot do that transparently.
When running AutoRecovery as a separate service it does not seem to crash in such cases and keeps on running while unable to do anything useful and requires operator restarting the service manually.

One can see such log messages like 
 ```
ReplicationWorker] ERROR org.apache.bookkeeper.replication.ReplicationWorker - UnavailableException while replicating fragments
org.apache.bookkeeper.replication.ReplicationException$UnavailableException: Error contacting zookeeper
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager.getLedgerToRereplicate(ZkLedgerUnderreplicationManager.java:610) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.replication.ReplicationWorker.rereplicate(ReplicationWorker.java:264) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.replication.ReplicationWorker.run(ReplicationWorker.java:230) [com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.76.Final.jar:4.1.76.Final]
	at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss for /ledgers/underreplication/ledgers/0000/0001/0ebb
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:102) ~[com.datastax.oss-pulsar-zookeeper-2.7.2.1.1.33.jar:2.7.2.1.1.33]
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:54) ~[com.datastax.oss-pulsar-zookeeper-2.7.2.1.1.33.jar:2.7.2.1.1.33]
	at org.apache.zookeeper.ZooKeeper.getChildren(ZooKeeper.java:2589) ~[com.datastax.oss-pulsar-zookeeper-2.7.2.1.1.33.jar:2.7.2.1.1.33]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient.access$3701(ZooKeeperClient.java:70) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient$27.call(ZooKeeperClient.java:1251) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient$27.call(ZooKeeperClient.java:1245) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooWorker.syncCallWithRetries(ZooWorker.java:140) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient.getChildren(ZooKeeperClient.java:1245) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager$1.getChildren(ZkLedgerUnderreplicationManager.java:147) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.util.SubTreeCache.getChildren(SubTreeCache.java:118) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager.getLedgerToRereplicateFromHierarchy(ZkLedgerUnderreplicationManager.java:550) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager.getLedgerToRereplicateFromHierarchy(ZkLedgerUnderreplicationManager.java:562) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager.getLedgerToRereplicateFromHierarchy(ZkLedgerUnderreplicationManager.java:562) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager.getLedgerToRereplicateFromHierarchy(ZkLedgerUnderreplicationManager.java:562) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager.getLedgerToRereplicate(ZkLedgerUnderreplicationManager.java:603) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
```

```
2022-06-24T17:15:55,405 [ZkLedgerManagerScheduler-11-1] ERROR org.apache.bookkeeper.replication.Auditor - Underreplication manager unavailable running periodic check
org.apache.bookkeeper.replication.ReplicationException$UnavailableException: Error contacting zookeeper
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager.isLedgerReplicationEnabled(ZkLedgerUnderreplicationManager.java:731) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.replication.Auditor.lambda$checkAllLedgers$7(Auditor.java:1254) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.meta.AbstractZkLedgerManager$5.lambda$operationComplete$0(AbstractZkLedgerManager.java:573) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.76.Final.jar:4.1.76.Final]
	at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss for /ledgers/underreplication/disable
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:102) ~[com.datastax.oss-pulsar-zookeeper-2.7.2.1.1.33.jar:2.7.2.1.1.33]
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:54) ~[com.datastax.oss-pulsar-zookeeper-2.7.2.1.1.33.jar:2.7.2.1.1.33]
	at org.apache.zookeeper.ZooKeeper.exists(ZooKeeper.java:2021) ~[com.datastax.oss-pulsar-zookeeper-2.7.2.1.1.33.jar:2.7.2.1.1.33]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient.access$2301(ZooKeeperClient.java:70) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient$13.call(ZooKeeperClient.java:833) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient$13.call(ZooKeeperClient.java:827) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooWorker.syncCallWithRetries(ZooWorker.java:140) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient.exists(ZooKeeperClient.java:827) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.zookeeper.ZooKeeper.exists(ZooKeeper.java:2049) ~[com.datastax.oss-pulsar-zookeeper-2.7.2.1.1.33.jar:2.7.2.1.1.33]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient.access$2401(ZooKeeperClient.java:70) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient$14.call(ZooKeeperClient.java:854) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient$14.call(ZooKeeperClient.java:848) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooWorker.syncCallWithRetries(ZooWorker.java:140) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient.exists(ZooKeeperClient.java:848) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
	at org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager.isLedgerReplicationEnabled(ZkLedgerUnderreplicationManager.java:726) ~[com.datastax.oss-bookkeeper-server-4.14.5.1.0.0.jar:4.14.5.1.0.0]
```

and other similar

### Changes

Now Replication Worker and Auditor will shut down on such errors making their error state visible / letting k8s or service monitor restart them.

Added tests.

Removed KeeperException from some interfaces/implementations to prevent raw ZK exception sneaking through but there are other interfaces, see https://github.com/apache/bookkeeper/issues/3373