### PR TITLE
Include BK error code in default case for BKException#getMessage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
@@ -173,8 +173,10 @@ public class BKException extends Exception {
             return "Failed to serialize metadata";
         case Code.DataUnknownException:
             return "Ledger in limbo";
+        case Code.UnexpectedConditionException:
+            return "Unexpected condition";
         default:
-            return "Unexpected condition: " + code;
+            return "Unknown code: " + code;
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/BKException.java
@@ -174,7 +174,7 @@ public class BKException extends Exception {
         case Code.DataUnknownException:
             return "Ledger in limbo";
         default:
-            return "Unexpected condition";
+            return "Unexpected condition: " + code;
         }
     }
 


### PR DESCRIPTION
### Motivation

When a client gets an exception code from the server that is unexpected, it's hard to debug because the logs hide the error code. It'd be helpful to see the error code in those cases.

### Changes

* Make `Unexpected condition` its own case with the error code in the `BKException#getMessage` method.
* Add new default called `Unknown code: <code>`
