### PR TITLE
Consolidate Netty channel flushes to mitigate syscall overhead

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -50,6 +50,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
@@ -328,6 +329,8 @@ class BookieNettyServer {
                     BookieSideConnectionPeerContextHandler contextHandler =
                         new BookieSideConnectionPeerContextHandler();
                     ChannelPipeline pipeline = ch.pipeline();
+
+                    pipeline.addLast("consolidation", new FlushConsolidationHandler(1024, true));
 
                     // For ByteBufList, skip the usual LengthFieldPrepender and have the encoder itself to add it
                     pipeline.addLast("bytebufList", ByteBufList.ENCODER_WITH_SIZE);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -54,6 +54,7 @@ import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
@@ -582,7 +583,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline pipeline = ch.pipeline();
-
+                pipeline.addLast("consolidation", new FlushConsolidationHandler(1024, true));
                 pipeline.addLast("bytebufList", ByteBufList.ENCODER_WITH_SIZE);
                 pipeline.addLast("lengthbasedframedecoder",
                         new LengthFieldBasedFrameDecoder(maxFrameSize, 0, 4, 0, 4));


### PR DESCRIPTION
### Motivation

When we are writing/reading a lot of small entries, one of the main bottleneck in BK client/server becomes the CPU usage. A big part of it is caused by the syscall overhead when writing to the socket. 

The reason is that we have many independent (and small) operations happening on the connection and each time we call `writeAndFlush()` on each of them, causing many `write()` calls on the socket.

Netty has a mechanism to consolidate the flushes on the channel and it improves the handling of many small entries.