### PR TITLE
Switch back ordered executor to LinkedBlockingQueue

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.bookkeeper.common.collections.BlockingMpscQueue;
-import org.apache.bookkeeper.common.collections.GrowableArrayBlockingQueue;
 import org.apache.bookkeeper.common.util.affinity.CpuAffinity;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -305,7 +305,7 @@ public class OrderedExecutor implements ExecutorService {
             queue = new BlockingMpscQueue<>(maxTasksInQueue > 0 ? maxTasksInQueue : DEFAULT_MAX_ARRAY_QUEUE_SIZE);
         } else {
             // By default, use regular JDK LinkedBlockingQueue
-            queue = new GrowableArrayBlockingQueue<>();
+            queue = new LinkedBlockingQueue<>();
         }
         return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, queue, factory);
     }


### PR DESCRIPTION
### Motivation

In #3108, we have switched to use GrowableArrayBlockingQueue for the OrderedExecutor.

I've been doing some testing recently, with respect with throughput and latencies when there are many small requests being passed on. This was on newer machines and using Java 17, so my conclusion is that many things have changed since when I did add that class back in the day :). 

I've tested with `LinkedBlockingQueue`, `GrowableArrayBlockingQueue`, JCTools based queue and Cognizant disruptor based queue, in the context of the OrderedExecutor, running in a Pulsar broker and BK bookie.

I've actually lost the document with all the results :/, though the summary was that: 
 1. `LinkedBlockingQueue` had the best throughput and latency. Behavior was very stable
 2. `GrowableArrayBlockingQueue` had decent throughput (slightly lower than LBQ) and worse latency, a bit jumpy. 
 3. JCTools and Cognizant disruptor based blocking MP-SC queues all had much worse performance overall, and causing lot of variance in the throughput and latency.
 4. I tried to perform some improvements on `GrowableArrayBlockingQueue` aimed at reducing contention and avoid locking in few cases to assume a single consumer, though I wasn't able to achieve any better result there.

Result: I think we should stick the default LBQ.

cc/ @lhotari 