### PR TITLE
[Issue 3389] Prioritize compaction of entry logs with the lowest amount of remaining usable data

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogMetadataMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogMetadataMap.java
@@ -59,6 +59,14 @@ public interface EntryLogMetadataMap extends Closeable {
     void forEach(BiConsumer<Long, EntryLogMetadata> action) throws EntryLogMetadataMapException;
 
     /**
+     * Performs the given action for the key.
+     *
+     * @param action
+     * @throws EntryLogMetadataMapException
+     */
+    void forKey(long entryLogId, BiConsumer<Long, EntryLogMetadata> action) throws EntryLogMetadataMapException;
+
+    /**
      * Removes entryLogMetadata record from the map.
      *
      * @param entryLogId

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -28,8 +28,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.io.IOException;
-import java.util.Comparator;
-import java.util.PriorityQueue;
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -545,12 +545,14 @@ public class GarbageCollectorThread extends SafeRunnable {
         int[] entryLogUsageBuckets = new int[numBuckets];
         int[] compactedBuckets = new int[numBuckets];
 
+        ArrayList<LinkedList<Long>> compactableBuckets = new ArrayList<>(numBuckets);
+        for (int i = 0; i < numBuckets; i++) {
+            compactableBuckets.add(new LinkedList<>());
+        }
+
         long start = System.currentTimeMillis();
         MutableLong end = new MutableLong(start);
         MutableLong timeDiff = new MutableLong(0);
-
-        PriorityQueue<EntryLogMetadata> pq = new PriorityQueue<>(Comparator
-                .comparingDouble(EntryLogMetadata::getUsage));
 
         entryLogMetaMap.forEach((entryLogId, meta) -> {
             int bucketIndex = calculateUsageIndex(numBuckets, meta.getUsage());
@@ -567,36 +569,50 @@ public class GarbageCollectorThread extends SafeRunnable {
                 return;
             }
 
-            pq.add(meta);
+            compactableBuckets.get(bucketIndex).add(meta.getEntryLogId());
         });
 
         LOG.info(
                 "Compaction: entry log usage buckets before compaction [10% 20% 30% 40% 50% 60% 70% 80% 90% 100%] = {}",
                 entryLogUsageBuckets);
 
-        while (!pq.isEmpty()) {
-            if (timeDiff.getValue() < maxTimeMillis) {
-                end.setValue(System.currentTimeMillis());
-                timeDiff.setValue(end.getValue() - start);
-            }
+        final int maxBucket = calculateUsageIndex(numBuckets, threshold);
+        stopCompaction:
+        for (int currBucket = 0; currBucket <= maxBucket; currBucket++) {
+            LinkedList<Long> entryLogIds = compactableBuckets.get(currBucket);
+            while (!entryLogIds.isEmpty()) {
+                if (timeDiff.getValue() < maxTimeMillis) {
+                    end.setValue(System.currentTimeMillis());
+                    timeDiff.setValue(end.getValue() - start);
+                }
 
-            if ((maxTimeMillis > 0 && timeDiff.getValue() >= maxTimeMillis) || !running) {
-                // We allow the usage limit calculation to continue so that we get an accurate
-                // report of where the usage was prior to running compaction.
-                break;
-            }
+                if ((maxTimeMillis > 0 && timeDiff.getValue() >= maxTimeMillis) || !running) {
+                    // We allow the usage limit calculation to continue so that we get an accurate
+                    // report of where the usage was prior to running compaction.
+                    break stopCompaction;
+                }
 
-            final EntryLogMetadata meta = pq.remove();
-            int bucketIndex = calculateUsageIndex(numBuckets, meta.getUsage());
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Compacting entry log {} with usage {} below threshold {}",
-                        meta.getEntryLogId(), meta.getUsage(), threshold);
-            }
+                final int bucketIndex = currBucket;
+                final long logId = entryLogIds.remove();
 
-            long priorRemainingSize = meta.getRemainingSize();
-            compactEntryLog(meta);
-            gcStats.getReclaimedSpaceViaCompaction().add(meta.getTotalSize() - priorRemainingSize);
-            compactedBuckets[bucketIndex]++;
+                entryLogMetaMap.forKey(logId, (entryLogId, meta) -> {
+                    if (meta == null) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Metadata for entry log {} already deleted", logId);
+                        }
+                        return;
+                    }
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Compacting entry log {} with usage {} below threshold {}",
+                                meta.getEntryLogId(), meta.getUsage(), threshold);
+                    }
+
+                    long priorRemainingSize = meta.getRemainingSize();
+                    compactEntryLog(meta);
+                    gcStats.getReclaimedSpaceViaCompaction().add(meta.getTotalSize() - priorRemainingSize);
+                    compactedBuckets[bucketIndex]++;
+                });
+            }
         }
 
         if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -549,8 +549,8 @@ public class GarbageCollectorThread extends SafeRunnable {
         MutableLong end = new MutableLong(start);
         MutableLong timeDiff = new MutableLong(0);
 
-        PriorityQueue<EntryLogMetadata> pq = new PriorityQueue<>(entryLogMetaMap.size() / 10,
-                Comparator.comparingDouble(EntryLogMetadata::getUsage));
+        PriorityQueue<EntryLogMetadata> pq = new PriorityQueue<>(Comparator
+                .comparingDouble(EntryLogMetadata::getUsage));
 
         entryLogMetaMap.forEach((entryLogId, meta) -> {
             int bucketIndex = calculateUsageIndex(numBuckets, meta.getUsage());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InMemoryEntryLogMetadataMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InMemoryEntryLogMetadataMap.java
@@ -48,6 +48,12 @@ public class InMemoryEntryLogMetadataMap implements EntryLogMetadataMap {
     }
 
     @Override
+    public void forKey(long entryLogId, BiConsumer<Long, EntryLogMetadata> action)
+            throws BookieException.EntryLogMetadataMapException {
+        action.accept(entryLogId, entryLogMetaMap.get(entryLogId));
+    }
+
+    @Override
     public void remove(long entryLogId) {
         entryLogMetaMap.remove(entryLogId);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/PersistentEntryLogMetadataMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/PersistentEntryLogMetadataMapTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.List;
 
+import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.junit.Rule;
@@ -77,6 +78,19 @@ public class PersistentEntryLogMetadataMapTest {
             assertEquals(metadatas.get(logId.intValue() - 1).getTotalSize(), metadata.getTotalSize());
             for (int i = 0; i < logId.intValue(); i++) {
                 assertTrue(metadata.containsLedger(i));
+            }
+        });
+
+        metadatas.forEach(meta -> {
+            long logId = meta.getEntryLogId();
+            try {
+                entryMetadataMap.forKey(logId, (entryLogId, persistedMeta) -> {
+                    assertEquals(meta.getEntryLogId(), persistedMeta.getEntryLogId());
+                    assertEquals(meta.getTotalSize(), persistedMeta.getTotalSize());
+                    assertEquals(logId, (long) entryLogId);
+                });
+            } catch (BookieException.EntryLogMetadataMapException e) {
+                throw new RuntimeException(e);
             }
         });
 


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

Prioritize compaction to free up more space faster.

### Changes

doCompactEntryLogs() iterates over entry logs in whatever natural order they happen to be, picks the first with usage below thresholds and starts compacting.

Added a Priority Queue of entry logs to pick ones with the most compactable space first; it also helps when the time for compaction is limited (via majorCompactionMaxTimeMillis / minorCompactionMaxTimeMillis), instead of spending time on rewriting files with more data we'll pick the files with the least amount of data first.

Master Issue: #3389 

