### PR TITLE
Useing Awaitility for asynchroneous testing.

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -209,6 +209,10 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>  
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
     <forkCount.variable>1</forkCount.variable>
     <servlet-api.version>4.0.0</servlet-api.version>
     <rxjava.version>3.0.1</rxjava.version>
+    <awaitility.version>4.2.0</awaitility.version>  
     <maven-failsafe-plugin.version>3.0.0-M6</maven-failsafe-plugin.version>
   </properties>
 
@@ -837,6 +838,12 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Descriptions of the changes in this PR:

Using Thread.sleep in a test is just generally a bad idea. It creates brittle tests that can fail unpredictably depending on environment ("Passes on my machine!") or load. So I used  Awaitility for asynchroneous testing.

Such as:https://github.com/apache/bookkeeper/runs/7219059790?check_suite_focus=true
(He may not be a perfect guarantee, but it can improve the stability ratio.)

### Motivation

Using `Thread.sleep` in a test is generally a bad idea. It creates brittle tests that can fail unpredictably depending on the environment ("Passes on my machine!") or load

### Changes
Useing `Awaitility` for asynchronous testing.
Useing `Awaitility` test `AutoRecoveryMainTest`
