### PR TITLE
Make BookieFileChannel interface public

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieFileChannel.java
@@ -28,7 +28,7 @@ import java.nio.channels.FileChannel;
  * A FileChannel for the JournalChannel read and write, we can use this interface to extend the FileChannel
  * which we use in the JournalChannel.
  */
-interface BookieFileChannel {
+public interface BookieFileChannel {
 
     /**
      * An interface for get the FileChannel from the provider.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
@@ -29,7 +29,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 
-class DefaultFileChannel implements BookieFileChannel {
+public class DefaultFileChannel implements BookieFileChannel {
     private final File file;
     private RandomAccessFile randomAccessFile;
     private final ServerConfiguration configuration;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultFileChannel.java
@@ -29,6 +29,10 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 
+/**
+ * Default FileChannel for bookie to read and write.
+ *
+ */
 public class DefaultFileChannel implements BookieFileChannel {
     private final File file;
     private RandomAccessFile randomAccessFile;


### PR DESCRIPTION
### Motivation
The `BookieFileChannel` is package public, and can't be implemented out of the `org.apache.bookkeeper.bookie` package.
We should make it public

### Modification
Make `BookieFileChannel` and `DefaultFileChannel` public