### PR TITLE
stage 10: bugfix indexDirs for ConvertToInterleavedStorageCommand

### DIFF
--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToInterleavedStorageCommandTest.java
@@ -56,8 +56,9 @@ public class ConvertToInterleavedStorageCommandTest extends BookieCommandTestBas
     private LedgerCache interleavedLedgerCache;
 
 
+    // create multi ledger dirs and multi index dirs
     public ConvertToInterleavedStorageCommandTest() {
-        super(3, 0);
+        super(3, 3);
     }
 
     @Override


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

planning for index dir: [mail talking](https://lists.apache.org/thread/r657jf55khl59bbqltj2s95107lbkr0w)
stage 10 (the last one): 
1)  bugfix indexDirs for ConvertToInterleavedStorageCommand:
init index's LedgerDirsManager use conf.getIndexDirs but old code use conf.getLedgerDirs

the condition that the bug triggers:
    1)  when conf.getIndexDirs is different from conf.getLedgerDirs

### Changes

1.  bugfix indexDirs for ConvertToInterleavedStorageCommand
2. update index's testcase for ConvertToInterleavedStorageCommand( set multi different ledger and index dirs)