### PR TITLE
[website] Remove alert for non mantained releases

### DIFF
--- a/site3/website/src/theme/DocVersionBanner/index.js
+++ b/site3/website/src/theme/DocVersionBanner/index.js
@@ -1,0 +1,3 @@
+export default function DocVersionBanner() {
+  return null
+}


### PR DESCRIPTION
### Motivation

For the non latest releases in the website there's alert that says
"This is documentation for Apache BookKeeper 4.14.5, which is no longer actively maintained."

This is not true

### Changes

* Overridden the DocVersionBanner component to be always null as suggested in the Docusaurus doc https://github.com/facebook/docusaurus/issues/3013

Note that we could add the banner only for the non mantained releases but currently we don't distinct them in the codebase. This would be a useful improvement for the future 
