### PR TITLE
Upgrade junit-jupiter-api version to 5.9.0-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <jna.version>5.12.1</jna.version>
     <junit.version>4.12</junit.version>
     <!-- required by zookeeper test utilities imported from ZooKeeper -->
-    <junit5.version>5.8.2</junit5.version>
+    <junit5.version>5.9.0-RC1</junit5.version>
     <libthrift.version>0.14.2</libthrift.version>
     <lombok.version>1.18.22</lombok.version>
     <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
### Motivation

In CVE check, it found the following CVEs
```
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error: 
Error:  junit-jupiter-engine-5.8.2.jar: CVE-2022-31514(9.3)
Error:  junit-platform-engine-1.8.2.jar: CVE-2022-315[14](https://github.com/apache/bookkeeper/runs/7424764745?check_suite_focus=true#step:6:15)(9.3)
```
https://github.com/apache/bookkeeper/runs/7424764745?check_suite_focus=true

### Modification
Upgrade `junit-jupiter-api` version from `5.8.2` to `5.9.0-RC1`