### PR TITLE
Fix configuration cannot be leave unset in bk_server.conf

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -174,7 +174,8 @@ public class DbLedgerStorage implements LedgerStorage {
 
         long perDirectoryWriteCacheSize = writeCacheMaxSize / numberOfDirs;
         long perDirectoryReadCacheSize = readCacheMaxSize / numberOfDirs;
-        int readAheadCacheBatchSize = conf.getInt(READ_AHEAD_CACHE_BATCH_SIZE, DEFAULT_READ_AHEAD_CACHE_BATCH_SIZE);
+        int readAheadCacheBatchSize = getIntVariableOrDefault(conf, READ_AHEAD_CACHE_BATCH_SIZE,
+                DEFAULT_READ_AHEAD_CACHE_BATCH_SIZE);
 
         gcExecutor = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("GarbageCollector"));
 
@@ -524,6 +525,19 @@ public class DbLedgerStorage implements LedgerStorage {
     public List<GarbageCollectionStatus> getGarbageCollectionStatus() {
         return ledgerStorageList.stream()
             .map(single -> single.getGarbageCollectionStatus().get(0)).collect(Collectors.toList());
+    }
+
+    static int getIntVariableOrDefault(ServerConfiguration conf, String keyName, int defaultValue) {
+        Object obj = conf.getProperty(keyName);
+        if (obj instanceof Number) {
+            return ((Number) obj).intValue();
+        } else if (obj == null) {
+            return defaultValue;
+        } else if (StringUtils.isEmpty(conf.getString(keyName))) {
+            return defaultValue;
+        } else {
+            return conf.getInt(keyName);
+        }
     }
 
     static long getLongVariableOrDefault(ServerConfiguration conf, String keyName, long defaultValue) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -178,7 +178,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         // Do not attempt to perform read-ahead more than half the total size of the cache
         maxReadAheadBytesSize = readCacheMaxSize / 2;
 
-        long maxThrottleTimeMillis = conf.getLong(DbLedgerStorage.MAX_THROTTLE_TIME_MILLIS,
+        long maxThrottleTimeMillis =
+                DbLedgerStorage.getLongVariableOrDefault(conf, DbLedgerStorage.MAX_THROTTLE_TIME_MILLIS,
                 DEFAULT_MAX_THROTTLE_TIME_MILLIS);
         maxThrottleTimeNanos = TimeUnit.MILLISECONDS.toNanos(maxThrottleTimeMillis);
 


### PR DESCRIPTION
### Motivation
We cannot leave  `dbStorage_readAheadCacheBatchSize` `dbStorage_maxThrottleTimeMs` unset like  `dbStorage_writeCacheMaxSizeMb`


### Changes
If configuration is not set in bk_server.conf, default value will be used.

