### PR TITLE
fix Flaky-test: BookieZKExpireTest.testBookieServerZKSessionExpireBehaviour

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataBookieDriver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataBookieDriver.java
@@ -57,7 +57,8 @@ public class ZKMetadataBookieDriver
             statsLogger.scope(BOOKIE_SCOPE),
             new BoundExponentialBackoffRetryPolicy(conf.getZkRetryBackoffStartMs(),
                         conf.getZkRetryBackoffMaxMs(), conf.getZkRetryBackoffMaxRetries()),
-            Optional.empty());
+            Optional.empty(),
+            false);
         this.serverConf = conf;
         this.statsLogger = statsLogger;
         return this;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataClientDriver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataClientDriver.java
@@ -67,7 +67,8 @@ public class ZKMetadataClientDriver
                 conf.getZkTimeout(),
                 conf.getZkTimeout(),
                 conf.getZkRetryBackoffMaxRetries()),
-            optionalCtx);
+            optionalCtx,
+            true);
         this.statsLogger = statsLogger;
         this.clientConf = conf;
         this.scheduler = scheduler;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBase.java
@@ -165,7 +165,8 @@ public class ZKMetadataDriverBase implements AutoCloseable {
     protected void initialize(AbstractConfiguration<?> conf,
                               StatsLogger statsLogger,
                               RetryPolicy zkRetryPolicy,
-                              Optional<Object> optionalCtx) throws MetadataException {
+                              Optional<Object> optionalCtx,
+                              boolean zkRetryExpired) throws MetadataException {
         this.conf = conf;
         this.acls = ZkUtils.getACLs(conf);
 
@@ -213,6 +214,7 @@ public class ZKMetadataDriverBase implements AutoCloseable {
                     .operationRetryPolicy(zkRetryPolicy)
                     .requestRateLimit(conf.getZkRequestRateLimit())
                     .statsLogger(statsLogger)
+                    .retryExpired(zkRetryExpired)
                     .build();
 
                 if (null == zk.exists(bookieReadonlyRegistrationPath, false)) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -145,6 +145,7 @@ public class LocalBookKeeper implements AutoCloseable {
         try (ZooKeeperClient zkc = ZooKeeperClient.newBuilder()
                     .connectString(zkHost + ":" + zkPort)
                     .sessionTimeoutMs(zkSessionTimeOut)
+                    .retryExpired(false)
                     .build()) {
             String zkLedgersRootPath = ZKMetadataDriverBase.resolveZkLedgersRootPath(baseConf);
             ZkUtils.createFullPathOptimistic(zkc, zkLedgersRootPath, new byte[0], Ids.OPEN_ACL_UNSAFE,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -883,7 +883,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
             super(connectString, sessionTimeoutMs, watcher,
                     new BoundExponentialBackoffRetryPolicy(sessionTimeoutMs, sessionTimeoutMs, Integer.MAX_VALUE),
                     new BoundExponentialBackoffRetryPolicy(sessionTimeoutMs, sessionTimeoutMs, 3),
-                    NullStatsLogger.INSTANCE, 1, 0, false);
+                    NullStatsLogger.INSTANCE, 1, 0, false, true);
             this.connectString = connectString;
             this.sessionTimeoutMs = sessionTimeoutMs;
             this.watcherManager = watcher;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBaseTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/zk/ZKMetadataDriverBaseTest.java
@@ -69,7 +69,7 @@ public class ZKMetadataDriverBaseTest extends ZKMetadataDriverTestBase {
     @Test
     public void testInitialize() throws Exception {
         driver.initialize(
-            conf, NullStatsLogger.INSTANCE, retryPolicy, Optional.empty());
+            conf, NullStatsLogger.INSTANCE, retryPolicy, Optional.empty(), false);
 
         assertEquals(
             "/path/to/ledgers",
@@ -97,7 +97,7 @@ public class ZKMetadataDriverBaseTest extends ZKMetadataDriverTestBase {
         ZooKeeperClient anotherZk = mock(ZooKeeperClient.class);
 
         driver.initialize(
-            conf, NullStatsLogger.INSTANCE, retryPolicy, Optional.of(anotherZk));
+            conf, NullStatsLogger.INSTANCE, retryPolicy, Optional.of(anotherZk), false);
 
         assertEquals(
             "/ledgers",
@@ -123,7 +123,7 @@ public class ZKMetadataDriverBaseTest extends ZKMetadataDriverTestBase {
     @Test
     public void testGetLedgerManagerFactory() throws Exception {
         driver.initialize(
-            conf, NullStatsLogger.INSTANCE, retryPolicy, Optional.empty());
+            conf, NullStatsLogger.INSTANCE, retryPolicy, Optional.empty(), false);
 
         mockStatic(AbstractZkLedgerManagerFactory.class);
         LedgerManagerFactory factory = mock(LedgerManagerFactory.class);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -940,7 +940,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
             super(connectString, sessionTimeoutMs, watcher,
                     new BoundExponentialBackoffRetryPolicy(sessionTimeoutMs, sessionTimeoutMs, Integer.MAX_VALUE),
                     new BoundExponentialBackoffRetryPolicy(sessionTimeoutMs, sessionTimeoutMs, 0),
-                    NullStatsLogger.INSTANCE, 1, 0, false);
+                    NullStatsLogger.INSTANCE, 1, 0, false, true);
             this.connectString = connectString;
             this.sessionTimeoutMs = sessionTimeoutMs;
             this.watcherManager = watcher;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
@@ -69,7 +69,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             Thread[] threads = new Thread[threadCount * 2];
             threadCount = Thread.enumerate(threads);
             for (int i = 0; i < threadCount; i++) {
-                if (threads[i].getName().indexOf("SendThread") != -1) {
+                if (threads[i].getName().contains("SendThread")) {
                     threadset.add(threads[i]);
                 }
             }
@@ -93,7 +93,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             threads = new Thread[threadCount * 2];
             threadCount = Thread.enumerate(threads);
             for (int i = 0; i < threadCount; i++) {
-                if (threads[i].getName().indexOf("SendThread") != -1
+                if (threads[i].getName().contains("SendThread")
                         && !threadset.contains(threads[i])) {
                     sendthread = threads[i];
                     break;
@@ -113,7 +113,9 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             assertTrue("Bookie Server should not shutdown on zk timeout", server.isRunning());
         } finally {
             System.clearProperty("zookeeper.request.timeout");
-            server.shutdown();
+            if (server != null) {
+                server.shutdown();
+            }
         }
     }
 
@@ -139,7 +141,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             Thread[] threads = new Thread[threadCount * 2];
             threadCount = Thread.enumerate(threads);
             for (int i = 0; i < threadCount; i++) {
-                if (threads[i].getName().indexOf("SendThread") != -1) {
+                if (threads[i].getName().contains("SendThread")) {
                     threadset.add(threads[i]);
                 }
             }
@@ -163,7 +165,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             threads = new Thread[threadCount * 2];
             threadCount = Thread.enumerate(threads);
             for (int i = 0; i < threadCount; i++) {
-                if (threads[i].getName().indexOf("SendThread") != -1
+                if (threads[i].getName().contains("SendThread")
                         && !threadset.contains(threads[i])) {
                     sendthread = threads[i];
                     break;
@@ -177,13 +179,15 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             log.info("Resuming threads");
             sendthread.resume();
 
-            // allow watcher thread to run
-            Thread.sleep(3000);
+            // allow client.waitForConnection() timeout
+            Thread.sleep(10000);
             assertFalse("Bookie should shutdown on losing zk session", server.isBookieRunning());
             assertFalse("Bookie Server should shutdown on losing zk session", server.isRunning());
         } finally {
             System.clearProperty("zookeeper.request.timeout");
-            server.shutdown();
+            if (server != null) {
+                server.shutdown();
+            }
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestZooKeeperClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/zookeeper/TestZooKeeperClient.java
@@ -141,7 +141,7 @@ public abstract class TestZooKeeperClient extends TestCase {
             super(connectString, sessionTimeoutMs, watcher,
                     new BoundExponentialBackoffRetryPolicy(sessionTimeoutMs, sessionTimeoutMs, Integer.MAX_VALUE),
                     operationRetryPolicy,
-                    NullStatsLogger.INSTANCE, 1, 0, false);
+                    NullStatsLogger.INSTANCE, 1, 0, false, true);
         }
 
         @Override


### PR DESCRIPTION
### Motivation

fix Flaky-test: `BookieZKExpireTest.testBookieServerZKSessionExpireBehaviour` by disable retry session expired.

issue #3206  was fixed by PR #3415, but it still introduced another flaky test: `BookieZKExpireTest.testBookieServerZKSessionExpireBehaviour`

According to the investigation, the reason is: 
`ZookeeperClient` still creates a new `zookeeper` instance when the old zookeeper client session time out.

Due to the asynchronous execution of two threads executing bookie temporary node re-registration and zk instance re-creation, the test program sometimes succeeds and sometimes fails.

1. When the temporary node re-registration is performed before the zk re-instantiation, the temporary node creation will use the old zk instance, which will cause a session timeout error, the bookie service will be shutdown, and the test will be successful;
 
2. When the zk re-instantiation precedes the re-registration of the temporary node, the temporary node creation will use the new re-instantiated zk instance, then the temporary node will be successfully created, the bookie service is running normally, and the test fails.

```java
        try {
            connectExecutor.submit(clientCreator);
        } catch (RejectedExecutionException ree) {
            if (!closed.get()) {
                logger.error("ZooKeeper reconnect task is rejected : ", ree);
            }
        } catch (Exception t) {
            logger.error("Failed to submit zookeeper reconnect task due to runtime exception : ", t);
        }
```

### Changes
Add a `retryExpired` flag to indicate whether to run the zk instance and retry to create a new instance after the session times out.
Set this flag to false for `ZKMetadataBookieDriver`;
Other ZookeeperClient and normal ZookeeperClient applications will generate the default value true or set to true, which is consistent with the original behavior.

### Test the behavior of this PR:
**Before this PR:**
Executed the test 10 times, all failed.
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/35599757/180596967-9f3f4300-6ba6-4989-b35e-a275a955d139.png">

**After this PR:**
Executed the test 10 times, all successful.
<img width="894" alt="image" src="https://user-images.githubusercontent.com/35599757/180597032-01318ed6-e498-4ba4-8bd7-fb081ed8245a.png">

