### PR TITLE
upgrade netty version to 4.1.79.Final released

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <log4j.version>2.17.2</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.12.4</mockito.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.79.Final</netty.version>
     <netty-boringssl.version>2.0.52.Final</netty-boringssl.version>
     <ostrich.version>9.1.3</ostrich.version>
     <powermock.version>2.0.9</powermock.version>


### PR DESCRIPTION
## Motivation
fix some netty bugs for: 
https://github.com/netty/netty/pull/12370
https://github.com/netty/netty/pull/12490
### changeLog:
https://netty.io/news/2022/06/14/4-1-78-Final.html
https://netty.io/news/2022/07/11/4-1-79-Final.html

## Modifications
Upgrade Netty from 4.1.77.Final to 4.1.79.Final
