### PR TITLE
fix Flaky-test: testBookieContinueWritingIfMultipleLedgersPresent

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileInfo.java
@@ -549,6 +549,7 @@ class FileInfo extends Watchable<LastAddConfirmedUpdateNotification> {
         }
         fc = new RandomAccessFile(newFile, mode).getChannel();
         lf = newFile;
+        deleted = false;
     }
 
     public synchronized byte[] getMasterKey() throws IOException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -248,6 +248,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         ServerConfiguration newConf = newServerConfiguration(
                 PortManager.nextFreePort(),
                 ledgerDirs[0], ledgerDirs);
+        newConf.setDiskCheckInterval(Integer.MAX_VALUE);
         startAndAddBookie(newConf);
     }
 


### PR DESCRIPTION
### Motivation

Fixes issue #2665 

When the disk is full, `InterleavedLedgerStorage` creates a new entryLog and index file, copies and moves the old index (newFile) `FileInfo` to the new directory, and finally deletes the old index file.

The old file of `FileInfo` was `deleted`, but it was copied and moved a newFile to the new directory. Therefore, the delete status flag should be restored. If it is not set to false,`checkOpen` will throw `FileInfoDeletedException` when judging the fence status of `ledgerHandle` when adding an entry, causing the writing to fail. When the client changes the `ensemble`, it throws an exception because the test has only two bookie nodes and cannot satisfy the two writeSet: `Not enough non-faulty bookies available`.
```java
    public synchronized boolean isFenced() throws IOException {
        checkOpen(false);
        return (stateBits & STATE_FENCED_BIT) == STATE_FENCED_BIT;
    }

    private synchronized void checkOpen(boolean create, boolean openBeforeClose)
            throws IOException {
        if (deleted) {
            throw new FileInfoDeletedException();
        }
      .....
    }
``` 

### Changes
When `FileInfo` moves to a new directory by `moveToNewLocation`,delete the old index file and restore the `delete` flag, because the new index file is ready.


Set the disk check interval to the `Integer.MAX_VALUE`, which is stable 
`assertEquals("writable dirs should have one dir", 1, ledgerDirsManager
                .getWritableLedgerDirs().size());`
Because once the test thrashes, the disk check thread will restore the full disk to a writable state.
```java
newConf.setDiskCheckInterval(Integer.MAX_VALUE);
```

