### PR TITLE
fix Flaky-test: testBookieShouldTurnWritableFromReadOnly

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -209,6 +209,11 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.File;
-import java.time.Duration;
 import java.util.Enumeration;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.Bookie;
@@ -134,7 +133,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         // waitForReadOnlyBookie adds another listener thread to observe the node status of bookie,
         // which may be out of sync with the triggering of node changes in EnsemblePlacementPolicy.
         // This sequence leads to flaky test. So change from watching zk to Awaitility.await().
-        Awaitility.await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             assertTrue("Bookie should be running and converted to readonly mode",
                     bookie.isRunning() && bookie.isReadOnly());
         });

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -154,7 +154,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         // waitForWritableBookie adds another listener thread to observe the node status of bookie,
         // which may be out of sync with the triggering of node changes in EnsemblePlacementPolicy.
         // This sequence leads to flaky test. So change from watching zk to Awaitility.await().
-        Awaitility.await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             assertTrue("Bookie should be running and converted back to writable mode", bookie.isRunning()
                     && !bookie.isReadOnly());
         });

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,7 @@
     <servlet-api.version>4.0.0</servlet-api.version>
     <rxjava.version>3.0.1</rxjava.version>
     <maven-failsafe-plugin.version>3.0.0-M6</maven-failsafe-plugin.version>
+    <awaitility.version>4.0.3</awaitility.version>
   </properties>
 
   <!-- dependency definitions -->
@@ -759,6 +760,18 @@
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
         <version>${jsoup.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${awaitility.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- benchmark dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -767,18 +767,6 @@
         <artifactId>jsoup</artifactId>
         <version>${jsoup.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>${awaitility.version}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
 
       <!-- benchmark dependencies -->
       <dependency>


### PR DESCRIPTION
### Motivation
Fixes issue #3422 

1.`waitForReadOnlyBookie` adds another `listener` thread to observe the node status of bookie, which may be out of sync with the triggering of node changes(`onClusterChanged`) in `EnsemblePlacementPolicy`.This `sequence` leads to flaky test. 

2.Expose bookie nodes in EnsemblePlacementPolicy to client.

3.Just change from watching zk to thread sleep.

We currently don't have any additional requirements for getting bookie nodes on the client side, so it's better to just use thread sleep here. 

### Changes
Change from `waitForReadOnlyBookie` and `waitForWritableBookie` to thread `sleep`.
3 seconds is enough for most.

