### PR TITLE
Upgrade log4j2 to 2.18.0

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -252,9 +252,9 @@ Apache Software License, Version 2.
 - lib/io.vertx-vertx-core-3.9.8.jar [15]
 - lib/io.vertx-vertx-web-3.9.8.jar [16]
 - lib/io.vertx-vertx-web-common-3.9.8.jar [16]
-- lib/org.apache.logging.log4j-log4j-api-2.17.2.jar [17]
-- lib/org.apache.logging.log4j-log4j-core-2.17.2.jar [17]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.2.jar [17]
+- lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [17]
 - lib/net.java.dev.jna-jna-5.12.1.jar [18]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-lang3-3.6.jar [20]
@@ -334,7 +334,7 @@ Apache Software License, Version 2.
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
 [15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8
 [16] Source available at https://github.com/vert-x3/vertx-web/tree/3.9.8
-[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.2
+[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.18.0
 [18] Source available at https://github.com/java-native-access/jna/tree/5.12.1
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -237,9 +237,9 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-classes-epoll-4.1.77.Final.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.77.Final-linux-x86_64.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.77.Final.jar [11]
-- lib/org.apache.logging.log4j-log4j-api-2.17.2.jar [16]
-- lib/org.apache.logging.log4j-log4j-core-2.17.2.jar [16]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.2.jar [16]
+- lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [16]
+- lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [16]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [16]
 - lib/net.java.dev.jna-jna-5.12.1.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [18]
 - lib/org.apache.commons-commons-lang3-3.6.jar [19]
@@ -301,7 +301,7 @@ Apache Software License, Version 2.
 [9] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=tag;h=375459
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.77.Final
-[16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.2
+[16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.18.0
 [17] Source available at https://github.com/java-native-access/jna/tree/5.12.1
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -252,9 +252,9 @@ Apache Software License, Version 2.
 - lib/io.vertx-vertx-core-3.9.8.jar [15]
 - lib/io.vertx-vertx-web-3.9.8.jar [16]
 - lib/io.vertx-vertx-web-common-3.9.8.jar [16]
-- lib/org.apache.logging.log4j-log4j-api-2.17.2.jar [17]
-- lib/org.apache.logging.log4j-log4j-core-2.17.2.jar [17]
-- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.17.2.jar [17]
+- lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [17]
+- lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [17]
 - lib/net.java.dev.jna-jna-5.12.1.jar [18]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-lang3-3.6.jar [20]
@@ -331,7 +331,7 @@ Apache Software License, Version 2.
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
 [15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8
 [16] Source available at https://github.com/vert-x3/vertx-web/tree/3.9.8
-[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.17.2
+[17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.18.0
 [18] Source available at https://github.com/java-native-access/jna/tree/5.12.1
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <junit5.version>5.8.2</junit5.version>
     <libthrift.version>0.14.2</libthrift.version>
     <lombok.version>1.18.22</lombok.version>
-    <log4j.version>2.17.2</log4j.version>
+    <log4j.version>2.18.0</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.12.4</mockito.version>
     <netty.version>4.1.77.Final</netty.version>


### PR DESCRIPTION
### Modification
Upgrade log4j2 from 2.17.2 to 2.18.0