### PR TITLE
Bump vertx version from 3.9.8 to 4.3.2

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -247,11 +247,11 @@ Apache Software License, Version 2.
 - lib/io.prometheus-simpleclient_tracer_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_tracer_otel-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar [12]
-- lib/io.vertx-vertx-auth-common-3.9.8.jar [13]
-- lib/io.vertx-vertx-bridge-common-3.9.8.jar [14]
-- lib/io.vertx-vertx-core-3.9.8.jar [15]
-- lib/io.vertx-vertx-web-3.9.8.jar [16]
-- lib/io.vertx-vertx-web-common-3.9.8.jar [16]
+- lib/io.vertx-vertx-auth-common-4.3.2.jar [13]
+- lib/io.vertx-vertx-bridge-common-4.3.2.jar [14]
+- lib/io.vertx-vertx-core-4.3.2.jar [15]
+- lib/io.vertx-vertx-web-4.3.2.jar [16]
+- lib/io.vertx-vertx-web-common-4.3.2.jar [16]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [17]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [17]
 - lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [17]
@@ -330,10 +330,10 @@ Apache Software License, Version 2.
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.77.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
-[13] Source available at https://github.com/vert-x3/vertx-auth/tree/3.9.8
-[14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
-[15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8
-[16] Source available at https://github.com/vert-x3/vertx-web/tree/3.9.8
+[13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
+[14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
+[15] Source available at https://github.com/eclipse/vert.x/tree/4.3.2
+[16] Source available at https://github.com/vert-x3/vertx-web/tree/4.3.2
 [17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.18.0
 [18] Source available at https://github.com/java-native-access/jna/tree/5.12.1
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -247,11 +247,11 @@ Apache Software License, Version 2.
 - lib/io.prometheus-simpleclient_tracer_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_tracer_otel-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar [12]
-- lib/io.vertx-vertx-auth-common-3.9.8.jar [13]
-- lib/io.vertx-vertx-bridge-common-3.9.8.jar [14]
-- lib/io.vertx-vertx-core-3.9.8.jar [15]
-- lib/io.vertx-vertx-web-3.9.8.jar [16]
-- lib/io.vertx-vertx-web-common-3.9.8.jar [16]
+- lib/io.vertx-vertx-auth-common-4.3.2.jar [13]
+- lib/io.vertx-vertx-bridge-common-4.3.2.jar [14]
+- lib/io.vertx-vertx-core-4.3.2.jar [15]
+- lib/io.vertx-vertx-web-4.3.2.jar [16]
+- lib/io.vertx-vertx-web-common-4.3.2.jar [16]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [17]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [17]
 - lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [17]
@@ -327,10 +327,10 @@ Apache Software License, Version 2.
 [10] Source available at http://svn.apache.org/viewvc/commons/proper/logging/tags/commons-logging-1.1.1/
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.77.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
-[13] Source available at https://github.com/vert-x3/vertx-auth/tree/3.9.8
-[14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/3.9.8
-[15] Source available at https://github.com/eclipse/vert.x/tree/3.9.8
-[16] Source available at https://github.com/vert-x3/vertx-web/tree/3.9.8
+[13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
+[14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
+[15] Source available at https://github.com/eclipse/vert.x/tree/4.3.2
+[16] Source available at https://github.com/vert-x3/vertx-web/tree/4.3.2
 [17] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.18.0
 [18] Source available at https://github.com/java-native-access/jna/tree/5.12.1
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad

--- a/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxAbstractHandler.java
+++ b/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxAbstractHandler.java
@@ -21,6 +21,7 @@
 package org.apache.bookkeeper.http.vertx;
 
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
@@ -47,7 +48,7 @@ public abstract class VertxAbstractHandler implements Handler<RoutingContext> {
         HttpServiceRequest request = new HttpServiceRequest()
             .setMethod(convertMethod(httpRequest))
             .setParams(convertParams(httpRequest))
-            .setBody(context.getBodyAsString());
+            .setBody(context.body().asString());
         HttpServiceResponse response = null;
         try {
             response = httpEndpointService.handle(request);
@@ -77,15 +78,14 @@ public abstract class VertxAbstractHandler implements Handler<RoutingContext> {
      * can be recognized by HttpServer.
      */
     HttpServer.Method convertMethod(HttpServerRequest request) {
-        switch (request.method()) {
-            case POST:
-                return HttpServer.Method.POST;
-            case DELETE:
-                return HttpServer.Method.DELETE;
-            case PUT:
-                return HttpServer.Method.PUT;
-            default:
-                return HttpServer.Method.GET;
+        HttpMethod method = request.method();
+        if (HttpMethod.POST.equals(method)) {
+            return HttpServer.Method.POST;
+        } else if (HttpMethod.DELETE.equals(method)) {
+            return HttpServer.Method.DELETE;
+        } else if (HttpMethod.PUT.equals(method)) {
+            return HttpServer.Method.PUT;
         }
+        return HttpServer.Method.GET;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
     <spotbugs-annotations.version>4.6.0</spotbugs-annotations.version>
     <javax-annotations-api.version>1.3.2</javax-annotations-api.version>
     <testcontainers.version>1.15.1</testcontainers.version>
-    <vertx.version>3.9.8</vertx.version>
+    <vertx.version>4.3.2</vertx.version>
     <zookeeper.version>3.8.0</zookeeper.version>
     <snappy.version>1.1.7.7</snappy.version>
     <jctools.version>2.1.2</jctools.version>

--- a/site3/website/src/pages/release-notes.md
+++ b/site3/website/src/pages/release-notes.md
@@ -231,7 +231,7 @@ The technical details of this release are summarized below.
       - [optional in maven](https://github.com/inferred/FreeBuilder#maven)
       - [compileOnly in gradle](https://github.com/inferred/FreeBuilder#gradle)
 
-- [https://github.com/apache/bookkeeper/pull/2693] Upgrade vertx to 3.9.8, addresses CVE-2018-12541
+- [https://github.com/apache/bookkeeper/pull/2693] Upgrade vertx to 4.3.2, addresses CVE-2018-12541
 
   The current vertx version is 3.5.3 which has a vulnerability, CVE-2018-12541 .
 


### PR DESCRIPTION
### Motivation
Vertx has several broken api changes. It raised error when embedded  bookkeeper with vertx application

### Changes
- Bump vertx version from 3.9.8 to 4.3.2
- Adapt vertx broken API changes