### PR TITLE
Add .asf.yaml for configuring the project

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,96 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+github:
+  description: "Apache BookKeeper - a scalable, fault tolerant and low latency storage service optimized for append-only workloads"
+  homepage: https://bookkeeper.apache.org/
+  labels:
+    - bookkeeper
+    - big-data
+  features:
+    # Enable wiki for documentation
+    wiki: false
+    # Enable issues management
+    issues: true
+    # Enable projects for project management boards
+    projects: true
+  enabled_merge_buttons:
+    # enable squash button:
+    squash:  true
+    # disable merge button:
+    merge:   false
+    # disable rebase button:
+    rebase:  false
+  protected_branches:
+    master:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # Contexts are the names of checks that must pass.
+        # See ./github/workflows/README.md for more documentation on this list.
+        contexts:
+          - PR Validation
+          - Backward compatibility tests
+          - Bookie Tests
+          - Build with macos on JDK 11
+          - Build with windows on JDK 11
+          - Client Tests
+          - Compatibility Check Java11
+          - Compatibility Check Java17
+          - Compatibility Check Java8
+          - Integration Tests
+          - Remaining Tests
+          - Replication Tests
+          - StreamStorage Tests
+          - TLS Tests
+
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        required_approving_review_count: 1
+
+      # squash or rebase must be allowed in the repo for this setting to be set to true.
+      required_linear_history: true
+
+      required_signatures: false
+
+    # The following branch protections only ensure that force pushes are not allowed
+    branch-4.0: {}
+    branch-4.1: {}
+    branch-4.2: {}
+    branch-4.3: {}
+    branch-4.4: {}
+    branch-4.5: {}
+    branch-4.6: {}
+    branch-4.7: {}
+    branch-4.8: {}
+    branch-4.9: {}
+    branch-4.10: {}
+    branch-4.11: {}
+    branch-4.12: {}
+    branch-4.13: {}
+    branch-4.14: {}
+    branch-4.15: {}
+
+notifications:
+  commits:      commits@bookkeeper.apache.org
+  issues:       commits@bookkeeper.apache.org
+  pullrequests: commits@bookkeeper.apache.org
+  discussions:  dev@bookkeeper.apache.org
+  jira_options: link label

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,60 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+## GitHub Workflows
+
+This directory contains all BookKeeper CI checks.
+
+### Required Workflows
+
+When adding new CI workflows, please update the [.asf.yaml](../../.asf.yaml) if the workflow is required to pass before
+a PR can be merged. Instructions on how to update the file are below.
+
+This project uses the [.asf.yaml](../../.asf.yaml) to configure which workflows are required to pass before a PR can
+be merged. In the `.asf.yaml`, the required contexts are defined in the `github.protected_branches.*.required_status_checks.contexts.[]`
+where * is any key in the `protected_branches` map.
+
+You can view the currently required status checks by running the following command:
+
+```shell
+curl -s -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/apache/bookkeeper/branches/master | \
+jq .protection
+```
+
+These contexts get their names in one of two ways depending on how the workflow file is written in this directory. The
+following command will print out the names of each file and the associated with the check. If the `name` field is `null`,
+the context will be named by the `id`.
+
+```shell
+for f in .github/workflows/*.yaml; \
+do FILE=$f yq eval -o j '.jobs | to_entries | {"file": env(FILE),"id":.[].key, "name":.[].value.name}' $f; \
+done
+```
+
+Duplicate names are allowed, and all checks with the same name will be treated the same (required or not required).
+
+When working on workflow changes, one way to find out the names of the status checks is to retrieve the names
+from the PR build run. The "check-runs" can be found by commit id. Here's an example:
+
+```shell
+curl -s "https://api.github.com/repos/apache/bookkeeper/commits/$(git rev-parse HEAD)/check-runs" | \
+  jq -r '.check_runs | .[] | .name' |sort
+```


### PR DESCRIPTION
---

*Motivation*

Same as Pulsar, Pulsar is using [.asf.yaml](https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection) to configure the project,
like the branch protection.
Add .asf.yaml for configuring the PR required CI.

