### PR TITLE
Backport BookieBackpressureForV2Test to branch-4.14

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java
@@ -31,6 +31,6 @@ public class BookieBackpressureForV2Test extends BookieBackpressureTest {
         super.setUp();
         baseClientConf.setUseV2WireProtocol(true);
         // the backpressure will bloc the read response, disable it to let it use backpressure mechanism
-        confByIndex(0).setReadWorkerThreadsThrottlingEnabled(false);
+        bsConfs.get(0).setReadWorkerThreadsThrottlingEnabled(false);
     }
 }


### PR DESCRIPTION
### Motivation

branch-4.14 fails to compile with this error message:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project bookkeeper-server: Compilation failure
[ERROR] /home/lari/workspace-pulsar/bookkeeper/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieBackpressureForV2Test.java:[34,9] cannot find symbol
[ERROR]   symbol:   method confByIndex(int)
[ERROR]   location: class org.apache.bookkeeper.proto.BookieBackpressureForV2Test
```

### Changes

- cherry-picking #3324 requires back porting BookieBackpressureForV2Test to branch-4.14 . Replace `confByIndex(0)` with `bsConfs.get(0)`.