### PR TITLE
Support  reading entry fail-fast on unavailable bookie

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -294,7 +294,8 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
             for (int i = 0; i < writeSet.size(); i++) {
                 BookieId to = ensemble.get(writeSet.get(i));
                 if (clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
-                    continue;
+                    int rc = BKException.Code.BookieHandleNotAvailableException;
+                    logErrorAndReattemptRead(writeSet.get(i), to, "Error: " + BKException.getMessage(rc), rc);
                 }
                 try {
                     sendReadTo(writeSet.get(i), to, this);
@@ -410,7 +411,8 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
             try {
                 BookieId to = ensemble.get(bookieIndex);
                 if (clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
-                    return null;
+                    int rc = BKException.Code.BookieHandleNotAvailableException;
+                    logErrorAndReattemptRead(bookieIndex, to, "Error: " + BKException.getMessage(rc), rc);
                 }
                 sendReadTo(bookieIndex, to, this);
                 sentToHosts.add(to);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -293,7 +293,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
         void read() {
             for (int i = 0; i < writeSet.size(); i++) {
                 BookieId to = ensemble.get(writeSet.get(i));
-                if (!clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
+                if (clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
                     continue;
                 }
                 try {
@@ -409,7 +409,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
 
             try {
                 BookieId to = ensemble.get(bookieIndex);
-                if (!clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
+                if (clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
                     return null;
                 }
                 sendReadTo(bookieIndex, to, this);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -293,6 +293,9 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
         void read() {
             for (int i = 0; i < writeSet.size(); i++) {
                 BookieId to = ensemble.get(writeSet.get(i));
+                if(!clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
+                    continue;
+                }
                 try {
                     sendReadTo(writeSet.get(i), to, this);
                 } catch (InterruptedException ie) {
@@ -406,6 +409,9 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
 
             try {
                 BookieId to = ensemble.get(bookieIndex);
+                if(!clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
+                    return null;
+                }
                 sendReadTo(bookieIndex, to, this);
                 sentToHosts.add(to);
                 sentReplicas.set(replica);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -293,7 +293,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
         void read() {
             for (int i = 0; i < writeSet.size(); i++) {
                 BookieId to = ensemble.get(writeSet.get(i));
-                if(!clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
+                if (!clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
                     continue;
                 }
                 try {
@@ -409,7 +409,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
 
             try {
                 BookieId to = ensemble.get(bookieIndex);
-                if(!clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
+                if (!clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
                     return null;
                 }
                 sendReadTo(bookieIndex, to, this);


### PR DESCRIPTION

### Motivation
During autoRecovery, there were so many  `Bookie handle is not available` errors,  it was because replicateWorker would tried to read entry  from bookie even if it's already offlined.

We should skip those replica  located at unavailable bookie  when reading entry. 
```
INFO  org.apache.bookkeeper.client.PendingReadOp - Error: Bookie handle is not available while reading L61530597 E0 from bookie: x.x.x.x:3181
```

### Changes

Before `sendReadTo`  sending request to bookie, we judged if bookie is available or not. 