### PR TITLE
bugfix for project's .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,7 +63,7 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         require_code_owner_reviews: true
-        required_approving_review_count: 1
+        required_approving_review_count: 2
 
       # squash or rebase must be allowed in the repo for this setting to be set to true.
       required_linear_history: true

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,7 +44,7 @@ following command will print out the names of each file and the associated with 
 the context will be named by the `id`.
 
 ```shell
-for f in .github/workflows/*.yaml; \
+for f in .github/workflows/*.yaml .github/workflows/*.yml; \
 do FILE=$f yq eval -o j '.jobs | to_entries | {"file": env(FILE),"id":.[].key, "name":.[].value.name}' $f; \
 done
 ```

--- a/.github/workflows/backward-compat-tests.yml
+++ b/.github/workflows/backward-compat-tests.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   test:
-
+    name: Backward compatibility tests
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   test:
-
+    name: Bookie Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   bot:
+    name: Bot tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   test:
-
+    name: Client Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   check:
-
+    name: Compatibility Check Java11
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/compatibility-check-java17.yml
+++ b/.github/workflows/compatibility-check-java17.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   check:
-
+    name: Compatibility Check Java17
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   check:
-
+    name: Compatibility Check Java8
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/dead-link-checker.yaml
+++ b/.github/workflows/dead-link-checker.yaml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   check-dead-links:
+    name: Dead link checker
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   test:
-
+    name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   test:
+    name: Build with macos on JDK 11
     runs-on: macos-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/owasp-dep-check.yml
+++ b/.github/workflows/owasp-dep-check.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   check:
-
+    name: OWASP Dependency Check
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   check:
-
+    name: PR Validation
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   test:
-
+    name: Remaining Tests
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   test:
-
+    name: Replication Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   test:
-
+    name: StreamStorage Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   test:
-
+    name: TLS Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   test:
+    name: Build with windows on JDK 11
     runs-on: windows-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

using [.asf.yaml](https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection) to configure the project,
but there 's some config bugfix for project's .asf.yaml
the name of workflow's jobs is not set, so #3439 causes contexts can't match check's jobs



this picture is the other new add pr's running result: the other pr's workflow run abnormally
<img width="923" alt="image" src="https://user-images.githubusercontent.com/42990025/185718866-b7054dd7-502f-4371-8906-c43f8b1b166b.png">





this picture is current running result: current pr is running normally because the job name is added in yaml file
<img width="954" alt="image" src="https://user-images.githubusercontent.com/42990025/185718710-ec41584e-4871-40cc-9ed6-655caa7ff021.png">
 
### Changes

1.  add the name for checks
2. change required_approving_review_count to 2 person
3. update README.md for workflows