### PR TITLE
WriteLacResponse should be processed in the same thread as other requ…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -683,7 +683,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         // writeLac is mostly like addEntry hence uses addEntryTimeout
         completionObjects.put(completionKey,
                               new WriteLacCompletion(completionKey, cb,
-                                                     ctx, lac));
+                                                     ctx, ledgerId));
 
         // Build the request
         BKPacketHeader.Builder headerBuilder = BKPacketHeader.newBuilder()


### PR DESCRIPTION
…ests for same ledgerId

In PCBC code, the WriteLacCompletion object uses LAC as the key for selecting the thread in which the response
will be processed. However, according to bookkeeper code guarantees, the thread should be decided based on hash of ledgerId.