### PR TITLE
Confirm content and update .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,7 +63,7 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         require_code_owner_reviews: true
-        required_approving_review_count: 2
+        required_approving_review_count: 1
 
       # squash or rebase must be allowed in the repo for this setting to be set to true.
       required_linear_history: true


### PR DESCRIPTION
### Motivation
Now Bookkeeper is using [.asf.yaml](https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection) to configure the project,
.asf.yaml details are determined

1)  Whether checks are enough,
     now these checks are required:
     ```
        contexts:
          - PR Validation
          - Backward compatibility tests
          - Bookie Tests
          - Build with macos on JDK 11
          - Build with windows on JDK 11
          - Client Tests
          - Compatibility Check Java11
          - Compatibility Check Java17
          - Compatibility Check Java8
          - Integration Tests
          - Remaining Tests
          - Replication Tests
          - StreamStorage Tests
          - TLS Tests
     ```
     Do we need to add others, such as: OWASP Dependency Check?
<img width="792" alt="image" src="https://user-images.githubusercontent.com/42990025/185770497-bf26b3ae-d2c5-4e18-a39a-f3d105d444b8.png">

2) required_approving_review_count: 
     2.1) is there a need for a limit
     2.2) or is the value more reasonable, 1 or 2?

### Mail talking Result
mail talking url: https://lists.apache.org/thread/o75xogn8r7zylqlwnno84dsm9nqoh5rs
**this picture is the first question's conclusion**
- the current required check is sufficient, no need to add another

<img width="671" alt="image" src="https://user-images.githubusercontent.com/42990025/186059053-84b4418f-d06f-4081-91e7-9f008d46f662.png">


**this picture is the second question's conclusion**
- If a committer sends a patch it is required only one more approval and not two

<img width="597" alt="image" src="https://user-images.githubusercontent.com/42990025/186058925-a6e6e6e7-face-4a4f-9fdf-0f1336026618.png">


### Changes
1) contexts in .asf.yaml no need to update
2) required_approving_review_count: from 2 back to 1
