### PR TITLE
Fix group ForceWrite not take effect with forceWriteMarkerSent in while loop of ForceWriteThread

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -511,9 +511,9 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
             boolean shouldForceWrite = true;
             int numReqInLastForceWrite = 0;
             long busyStartTime = System.nanoTime();
+            boolean forceWriteMarkerSent = false;
             while (running) {
                 ForceWriteRequest req = null;
-                boolean forceWriteMarkerSent = false;
                 try {
                     forceWriteThreadTime.add(MathUtils.elapsedNanos(busyStartTime));
                     req = forceWriteRequests.take();


### PR DESCRIPTION
Fix group ForceWrite not take effect with forceWriteMarkerSent in while loop of ForceWriteThread

### Motivation
Bookkeeper 4.15 has performance issue. There are too many journal sync.
Then I found in ForceWriteThread, forceWriteMarkerSent is reset to false for every loop, and this can cause shouldForceWrite=true and trigger journal sync. This new logic is bringed by https://github.com/apache/bookkeeper/pull/2962

### Changes
move forceWriteMarkerSent=false out of while loop.

