### PR TITLE
Add powermock global configuration

### DIFF
--- a/bookkeeper-server/src/test/resources/org/powermock/extensions/configuration.properties
+++ b/bookkeeper-server/src/test/resources/org/powermock/extensions/configuration.properties
@@ -1,0 +1,1 @@
+powermock.global-ignore=javax.management.*

--- a/bookkeeper-server/src/test/resources/org/powermock/extensions/configuration.properties
+++ b/bookkeeper-server/src/test/resources/org/powermock/extensions/configuration.properties
@@ -1,1 +1,22 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
 powermock.global-ignore=javax.management.*


### PR DESCRIPTION
### Motivation

Fix https://github.com/apache/bookkeeper/issues/3115 

When I try to run some test classes, there will occur an error message like the above issue cause `javax/management/MBeanServer` is a system class and javassist's classloader cannot load it. we can add powermock global configuration to ignore this error message.

The powermock's instruction is here: https://github.com/powermock/powermock/wiki/PowerMock-Configuration

### Changes

Add `org/powermock/extensions/configuration.properties`.