### PR TITLE
add log's dependency for bookkeeper-dist-server

### DIFF
--- a/bookkeeper-dist/server/pom.xml
+++ b/bookkeeper-dist/server/pom.xml
@@ -71,12 +71,6 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <version>${log4j.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>${log4j.version}</version>
     </dependency>

--- a/bookkeeper-dist/server/pom.xml
+++ b/bookkeeper-dist/server/pom.xml
@@ -31,7 +31,80 @@
   <packaging>jar</packaging>
   <name>Apache BookKeeper :: Dist (Server)</name>
 
+  <properties>
+    <disruptor.version>3.4.0</disruptor.version>
+  </properties>
+
   <dependencies>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-web</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_log4j2</artifactId>
+      <version>${prometheus.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>${disruptor.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -314,6 +314,14 @@ Apache Software License, Version 2.
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.7.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
+- lib/com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.13.2.jar [52]
+- lib/com.lmax-disruptor-3.4.0.jar [53]
+- lib/io.prometheus-simpleclient_log4j2-0.15.0.jar [54]
+- lib/org.apache.logging.log4j-log4j-1.2-api-2.18.0.jar [55]
+- lib/org.apache.logging.log4j-log4j-web-2.18.0.jar [56]
+- lib/org.slf4j-jcl-over-slf4j-1.7.32.jar [57]
+- lib/org.slf4j-jul-to-slf4j-1.7.32.jar [58]
+- lib/org.yaml-snakeyaml-1.30.jar [59]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -321,7 +321,7 @@ Apache Software License, Version 2.
 - lib/org.apache.logging.log4j-log4j-web-2.18.0.jar [56]
 - lib/org.slf4j-jcl-over-slf4j-1.7.32.jar [57]
 - lib/org.slf4j-jul-to-slf4j-1.7.32.jar [58]
-- lib/org.yaml-snakeyaml-1.30.jar [59]
+- lib/org.yaml-snakeyaml-1.32.jar [59]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -317,11 +317,10 @@ Apache Software License, Version 2.
 - lib/com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.13.2.jar [52]
 - lib/com.lmax-disruptor-3.4.0.jar [53]
 - lib/io.prometheus-simpleclient_log4j2-0.15.0.jar [54]
-- lib/org.apache.logging.log4j-log4j-1.2-api-2.18.0.jar [55]
-- lib/org.apache.logging.log4j-log4j-web-2.18.0.jar [56]
-- lib/org.slf4j-jcl-over-slf4j-1.7.32.jar [57]
-- lib/org.slf4j-jul-to-slf4j-1.7.32.jar [58]
-- lib/org.yaml-snakeyaml-1.32.jar [59]
+- lib/org.apache.logging.log4j-log4j-web-2.18.0.jar [55]
+- lib/org.slf4j-jcl-over-slf4j-1.7.32.jar [56]
+- lib/org.slf4j-jul-to-slf4j-1.7.32.jar [57]
+- lib/org.yaml-snakeyaml-1.32.jar [58]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

like pulsar's distribution/server
add log's dependency in bookkeeper-dist/server 

### Changes

1.  add log's dependency in bookkeeper-dist/server/pom.xml
2. then auto add log's dependency to bookkeeper-server-*.*.*-SNAPSHOT-bin.tar.gz