### PR TITLE
Add option to clean up test ledger after simpletest.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
@@ -101,8 +101,9 @@ public class SimpleTestCommand extends ClientCommand<Flags> {
                     lastReport = System.nanoTime();
                 }
             }
-            LOG.info("{} entries written to ledger {}, cleaning up the ledger", flags.numEntries, wh.getId());
+            LOG.info("{} entries written to ledger {}", flags.numEntries, wh.getId());
             if (flags.cleanup) {
+                LOG.info("Cleaning up the ledger {}", wh.getId());
                 result(bk.newDeleteLedgerOp().withLedgerId(wh.getId()).execute());
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommand.java
@@ -23,9 +23,7 @@ import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import com.beust.jcommander.Parameter;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -92,7 +90,7 @@ public class SimpleTestCommand extends ClientCommand<Flags> {
             .withCustomMetadata(ImmutableMap.of("Bookie", NAME.getBytes(StandardCharsets.UTF_8)))
             .withPassword(new byte[0])
             .execute())) {
-            
+
             LOG.info("Ledger ID: {}", wh.getId());
             long lastReport = System.nanoTime();
             for (int i = 0; i < flags.numEntries; i++) {

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommandTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.bookkeeper.tools.cli.commands.client;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -34,8 +33,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
-
-import com.google.common.collect.ImmutableMap;
 import org.apache.bookkeeper.client.api.CreateBuilder;
 import org.apache.bookkeeper.client.api.DeleteBuilder;
 import org.apache.bookkeeper.client.api.DigestType;
@@ -56,7 +53,7 @@ public class SimpleTestCommandTest extends ClientCommandTestBase {
             "-e", "5",
             "-w", "3",
             "-a", "3",
-            "-n", "10", 
+            "-n", "10",
             "-c");
     }
 
@@ -100,12 +97,13 @@ public class SimpleTestCommandTest extends ClientCommandTestBase {
         verify(createBuilder, times(1)).withWriteQuorumSize(eq(3));
         verify(createBuilder, times(1)).withAckQuorumSize(eq(3));
         verify(createBuilder, times(1)).withCustomMetadata(mapArgumentCaptor.capture());
-        assertTrue(Arrays.equals((byte[])mapArgumentCaptor.getValue().get("Bookie"), "simpletest".getBytes(StandardCharsets.UTF_8)));
+        assertTrue(Arrays.equals((byte[]) mapArgumentCaptor.getValue().get("Bookie"),
+                "simpletest".getBytes(StandardCharsets.UTF_8)));
         verify(createBuilder, times(1)).withDigestType(eq(DigestType.CRC32C));
         verify(createBuilder, times(1)).withPassword(eq(new byte[0]));
         verify(createBuilder, times(1)).execute();
 
-        verify(deleteBuilder, times(1)).withLedgerId(eq(0l));
+        verify(deleteBuilder, times(1)).withLedgerId(eq(0L));
         verify(deleteBuilder, times(1)).execute();
 
         // verify appends

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/client/SimpleTestCommandTest.java
@@ -18,21 +18,32 @@
  */
 package org.apache.bookkeeper.tools.cli.commands.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.collect.ImmutableMap;
 import org.apache.bookkeeper.client.api.CreateBuilder;
+import org.apache.bookkeeper.client.api.DeleteBuilder;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.client.api.WriteHandle;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.tools.cli.helpers.ClientCommandTestBase;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Unit test of {@link SimpleTestCommand}.
@@ -45,7 +56,8 @@ public class SimpleTestCommandTest extends ClientCommandTestBase {
             "-e", "5",
             "-w", "3",
             "-a", "3",
-            "-n", "10");
+            "-n", "10", 
+            "-c");
     }
 
     @Test
@@ -54,33 +66,47 @@ public class SimpleTestCommandTest extends ClientCommandTestBase {
             "--ensemble-size", "5",
             "--write-quorum-size", "3",
             "--ack-quorum-size", "3",
-            "--num-entries", "10");
+            "--num-entries", "10",
+            "-c");
     }
 
+    @SuppressWarnings("unchecked")
     public void testCommand(String... args) throws Exception {
         WriteHandle wh = mock(WriteHandle.class);
         AtomicLong counter = new AtomicLong(0L);
         when(wh.append(any(byte[].class))).thenReturn(counter.get());
         CreateBuilder createBuilder = mock(CreateBuilder.class);
-        when(createBuilder.execute())
-            .thenReturn(FutureUtils.value(wh));
+        when(createBuilder.execute()).thenReturn(FutureUtils.value(wh));
         when(createBuilder.withEnsembleSize(anyInt())).thenReturn(createBuilder);
+        when(createBuilder.withCustomMetadata(any())).thenReturn(createBuilder);
         when(createBuilder.withWriteQuorumSize(anyInt())).thenReturn(createBuilder);
         when(createBuilder.withAckQuorumSize(anyInt())).thenReturn(createBuilder);
         when(createBuilder.withDigestType(any(DigestType.class))).thenReturn(createBuilder);
         when(createBuilder.withPassword(any(byte[].class))).thenReturn(createBuilder);
+        when(createBuilder.execute()).thenReturn(CompletableFuture.completedFuture(wh));
         when(mockBk.newCreateLedgerOp()).thenReturn(createBuilder);
+
+        DeleteBuilder deleteBuilder = mock(DeleteBuilder.class);
+        when(deleteBuilder.withLedgerId(anyLong())).thenReturn(deleteBuilder);
+        when(deleteBuilder.execute()).thenReturn(CompletableFuture.completedFuture(null));
+        when(mockBk.newDeleteLedgerOp()).thenReturn(deleteBuilder);
 
         SimpleTestCommand cmd = new SimpleTestCommand();
         cmd.apply(bkFlags, args);
 
         // verify create builder
+        ArgumentCaptor<Map> mapArgumentCaptor = ArgumentCaptor.forClass(Map.class);
         verify(createBuilder, times(1)).withEnsembleSize(eq(5));
         verify(createBuilder, times(1)).withWriteQuorumSize(eq(3));
         verify(createBuilder, times(1)).withAckQuorumSize(eq(3));
+        verify(createBuilder, times(1)).withCustomMetadata(mapArgumentCaptor.capture());
+        assertTrue(Arrays.equals((byte[])mapArgumentCaptor.getValue().get("Bookie"), "simpletest".getBytes(StandardCharsets.UTF_8)));
         verify(createBuilder, times(1)).withDigestType(eq(DigestType.CRC32C));
         verify(createBuilder, times(1)).withPassword(eq(new byte[0]));
         verify(createBuilder, times(1)).execute();
+
+        verify(deleteBuilder, times(1)).withLedgerId(eq(0l));
+        verify(deleteBuilder, times(1)).execute();
 
         // verify appends
         verify(wh, times(10)).append(eq(new byte[100]));


### PR DESCRIPTION
### Motivation
resolves: https://github.com/apache/bookkeeper/issues/3473

### Changes
Add option to clean up test ledger after simpletest.
Also add metadata for ledger created by simpletest so we have more confidence when clean them up manually.
