### PR TITLE
Bump jcommander from 1.78 to 1.82

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -269,7 +269,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-util-9.4.48.v20220622.jar [22]
 - lib/org.eclipse.jetty-jetty-util-ajax-9.4.48.v20220622.jar [22]
 - lib/org.rocksdb-rocksdbjni-6.29.4.1.jar [23]
-- lib/com.beust-jcommander-1.78.jar [24]
+- lib/com.beust-jcommander-1.82.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
@@ -341,7 +341,7 @@ Apache Software License, Version 2.
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.48.v20220622
 [23] Source available at https://github.com/facebook/rocksdb/tree/v6.22.1
-[24] Source available at https://github.com/cbeust/jcommander/tree/1.78
+[24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [28] Source available at https://github.com/googleapis/googleapis

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -246,7 +246,7 @@ Apache Software License, Version 2.
 - lib/org.apache.zookeeper-zookeeper-3.8.0.jar [20]
 - lib/org.apache.zookeeper-zookeeper-jute-3.8.0.jar [20]
 - lib/org.apache.zookeeper-zookeeper-3.8.0-tests.jar [20]
-- lib/com.beust-jcommander-1.78.jar [23]
+- lib/com.beust-jcommander-1.82.jar [23]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
 - lib/com.google.api.grpc-proto-google-common-protos-2.0.1.jar [27]
 - lib/com.google.code.gson-gson-2.9.0.jar [28]
@@ -306,7 +306,7 @@ Apache Software License, Version 2.
 [18] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-collections.git;a=tag;h=a3a5ad
 [19] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [20] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
-[23] Source available at https://github.com/cbeust/jcommander/tree/1.78
+[23] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [27] Source available at https://github.com/googleapis/googleapis
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.9.0

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -269,7 +269,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-util-9.4.48.v20220622.jar [22]
 - lib/org.eclipse.jetty-jetty-util-ajax-9.4.48.v20220622.jar [22]
 - lib/org.rocksdb-rocksdbjni-6.29.4.1.jar [23]
-- lib/com.beust-jcommander-1.78.jar [24]
+- lib/com.beust-jcommander-1.82.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
@@ -338,7 +338,7 @@ Apache Software License, Version 2.
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.48.v20220622
 [23] Source available at https://github.com/facebook/rocksdb/tree/v6.16.4
-[24] Source available at https://github.com/cbeust/jcommander/tree/1.78
+[24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
 [28] Source available at https://github.com/googleapis/googleapis

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -127,7 +127,7 @@ Permission to use, copy, modify and distribute UnixCrypt
 for non-commercial or commercial purposes and without fee is
 granted provided that the copyright notice appears in all copies.
 ------------------------------------------------------------------------------------
-- lib/com.beust-jcommander-1.78.jar
+- lib/com.beust-jcommander-1.82.jar
 
 Copyright 2010 Cedric Beust cedric@beust.com
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -49,7 +49,7 @@ License for the specific language governing permissions and limitations
 under the License.
 
 ------------------------------------------------------------------------------------
-- lib/com.beust-jcommander-1.78.jar
+- lib/com.beust-jcommander-1.82.jar
 
 Copyright 2010 Cedric Beust cedric@beust.com
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -109,7 +109,7 @@ Permission to use, copy, modify and distribute UnixCrypt
 for non-commercial or commercial purposes and without fee is
 granted provided that the copyright notice appears in all copies.
 ------------------------------------------------------------------------------------
-- lib/com.beust-jcommander-1.78.jar
+- lib/com.beust-jcommander-1.82.jar
 
 Copyright 2010 Cedric Beust cedric@beust.com
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
     <jackson.version>2.13.2.20220328</jackson.version>
-    <jcommander.version>1.78</jcommander.version>
+    <jcommander.version>1.82</jcommander.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jmh.version>1.19</jmh.version>
     <jmock.version>2.8.2</jmock.version>


### PR DESCRIPTION
### Motivation
That's a regular update, `jcommander` 1.78 was released in 2019.

### Modifications
Bump jcommander version from 1.78 to 1.82