### PR TITLE
Add missed call to onReadRequestFinish() when read request rejected

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -539,6 +539,7 @@ public class BookieRequestProcessor implements RequestProcessor {
                     .setReadResponse(readResponse);
                 BookkeeperProtocol.Response resp = response.build();
                 read.sendResponse(readResponse.getStatus(), resp, requestStats.getReadRequestStats());
+                onReadRequestFinish();
             }
         }
     }
@@ -676,6 +677,7 @@ public class BookieRequestProcessor implements RequestProcessor {
                     BookieProtocol.ETOOMANYREQUESTS,
                     ResponseBuilder.buildErrorResponse(BookieProtocol.ETOOMANYREQUESTS, r),
                     requestStats.getReadRequestStats());
+                onReadRequestFinish();
             }
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/apache/bookkeeper/issues/2945

### Motivation

When a read request is rejected due to the limit on the number of reads that can be enqueued, we need to decrement the metric for `bookkeeper_server_READ_ENTRY_IN_PROGRESS` and release the `readsSemaphore`, if it is not null.

### Changes

* Call `onReadRequestFinish()` for failures in the V2 and V3 request processing logic.

### Observation
It looks like the V2 responses for this kind of failure are not throttled, even when `throttleReadResponses` is true. We could call `read.sendReadReqResponse(` to enable this throttling. I didn't change it here because there might be a reason we're not throttling these small responses.
