### PR TITLE
Migrate Dockerfile from centos to ubuntu

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,10 +17,12 @@
 # under the License.
 #
 
-FROM centos:7
+FROM ubuntu:22.10
 MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
 
-ARG BK_VERSION=4.12.1
+ARG TARGETARCH
+
+ARG BK_VERSION=4.15.1
 ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
 ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
 
@@ -29,12 +31,19 @@ ENV BOOKIE_HTTP_PORT=8080
 EXPOSE $BOOKIE_PORT $BOOKIE_HTTP_PORT
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/java-11
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-$TARGETARCH
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Download Apache Bookkeeper, untar and clean up
 RUN set -x \
     && adduser "${BK_USER}" \
-    && yum install -y java-11-openjdk-devel wget bash python3 sudo\
+    && apt-get update \
+    && apt-get install -y openjdk-17-jdk \
+    && apt-get install -y python3 pip \
+    && ln -s /usr/bin/python3 /usr/bin/python \
+    && apt-get install -y gcc g++ \
+    && apt-get install -y wget sudo \
+    && apt-get clean all \
     && mkdir -pv /opt \
     && cd /opt \
     && wget -q "${DISTRO_URL}" \
@@ -47,14 +56,7 @@ RUN set -x \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
     && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
-    # install zookeeper shell
-    && wget -q https://bootstrap.pypa.io/pip/2.7/get-pip.py \
-    && python --version \
-    && python get-pip.py \
     && pip install zk-shell \
-    && rm -rf get-pip.py \
-    && yum remove -y wget \
-    && yum clean all \
     && ls /usr/lib/jvm
 
 WORKDIR /opt/bookkeeper

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/java-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 
@@ -38,7 +37,6 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/java-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 
@@ -48,7 +46,6 @@ services:
     links:
       - zookeeper
     environment:
-      - JAVA_HOME=/usr/lib/jvm/java-11
       - BK_zkServers=zookeeper:2181
       - BK_zkLedgersRootPath=/ledgers
 


### PR DESCRIPTION
### Motivation
centos is not maintained anymore, switch to ubuntu

### Changes
- migrate from centos to ubuntu
- use python3 instead of python2
- Bump bookkeeper version from 4.12.1 to latest 4.15.1