### PR TITLE
upgrade hadoop version to 3.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <grpc.version>1.47.0</grpc.version>
     <guava.version>31.0.1-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
-    <hadoop.version>2.10.0</hadoop.version>
+    <hadoop.version>3.2.4</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
     <jackson.version>2.13.2.20220328</jackson.version>


### PR DESCRIPTION
### Modification
Upgrade the hadoop version to 3.2.4 to fix [CVE-2022-25168](https://www.cve.org/CVERecord?id=CVE-2022-25168)