### PR TITLE
Check if channel closed before processing read request

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -61,6 +61,12 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Received new read request: {}", request);
         }
+        if (!channel.isOpen()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Dropping read request for closed channel: {}", channel);
+            }
+            return;
+        }
         int errorCode = BookieProtocol.EOK;
         long startTimeNanos = MathUtils.nowInNano();
         ByteBuf data = null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -65,6 +65,7 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Dropping read request for closed channel: {}", channel);
             }
+            requestProcessor.onReadRequestFinish();
             return;
         }
         int errorCode = BookieProtocol.EOK;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -249,6 +249,12 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
     public void safeRun() {
         requestProcessor.getRequestStats().getReadEntrySchedulingDelayStats().registerSuccessfulEvent(
             MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+        if (!channel.isOpen()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Dropping read request for closed channel: {}", channel);
+            }
+            return;
+        }
 
         if (!isVersionCompatible()) {
             ReadResponse readResponse = ReadResponse.newBuilder()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -253,6 +253,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Dropping read request for closed channel: {}", channel);
             }
+            requestProcessor.onReadRequestFinish();
             return;
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ForceLedgerProcessorV3Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ForceLedgerProcessorV3Test.java
@@ -72,6 +72,7 @@ public class ForceLedgerProcessorV3Test {
                 .build())
             .build();
         channel = mock(Channel.class);
+        when(channel.isOpen()).thenReturn(true);
         bookie = mock(Bookie.class);
         requestProcessor = mock(BookieRequestProcessor.class);
         when(requestProcessor.getBookie()).thenReturn(bookie);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3Test.java
@@ -83,6 +83,7 @@ public class LongPollReadEntryProcessorV3Test {
             .build();
 
         Channel channel = mock(Channel.class);
+        when(channel.isOpen()).thenReturn(true);
         Bookie bookie = mock(Bookie.class);
 
         BookieRequestProcessor requestProcessor = mock(BookieRequestProcessor.class);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
@@ -59,6 +59,7 @@ public class ReadEntryProcessorTest {
     @Before
     public void setup() throws IOException, BookieException {
         channel = mock(Channel.class);
+        when(channel.isOpen()).thenReturn(true);
         bookie = mock(Bookie.class);
         requestProcessor = mock(BookieRequestProcessor.class);
         when(requestProcessor.getBookie()).thenReturn(bookie);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
@@ -66,6 +66,7 @@ public class WriteEntryProcessorTest {
             new byte[0],
             Unpooled.wrappedBuffer("test-entry-data".getBytes(UTF_8)));
         channel = mock(Channel.class);
+        when(channel.isOpen()).thenReturn(true);
         bookie = mock(Bookie.class);
         requestProcessor = mock(BookieRequestProcessor.class);
         when(requestProcessor.getBookie()).thenReturn(bookie);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3Test.java
@@ -77,6 +77,7 @@ public class WriteEntryProcessorV3Test {
                 .build())
             .build();
         channel = mock(Channel.class);
+        when(channel.isOpen()).thenReturn(true);
         bookie = mock(Bookie.class);
         requestProcessor = mock(BookieRequestProcessor.class);
         when(requestProcessor.getBookie()).thenReturn(bookie);


### PR DESCRIPTION
### Motivation

When a client disconnects from a bookie server, there is a chance that there are pending read requests in the `BookieRequestProcessor`'s queue. Since these are read operations cannot succeed, there is no reason to attempt them.

The primary motivation is to prevent unnecessary reads to the disk as well as decrease the memory utilization associated with unnecessary reads. Additionally, reads are currently performed as blocking calls on the `BookieRequestProcessor` processing thread pool, so failing fast can increase the processing speed of the thread pool. See:

https://github.com/apache/bookkeeper/blob/a65e888b25eb966921ff39032e04f367a553d634/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java#L57-L58

Note: we cannot add this logic for writes because those can be "recovered" when the client reconnects.

### Changes

* Only process a read request if the channel is open.

### Alternative Designs

If we are concerned about the cost of reading the volatile variable from the channel, we could possibly speed up the logic by only running the check if the operation has been enqueued for over some threshold, like 100 millis.