### PR TITLE
Bump snakeyaml from 1.31 to 1.32 to solve CVE-2022-38752

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <rocksdb.version>6.29.4.1</rocksdb.version>
     <shrinkwrap.version>3.0.1</shrinkwrap.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <snakeyaml.version>1.31</snakeyaml.version>
+    <snakeyaml.version>1.32</snakeyaml.version>
     <spotbugs-annotations.version>4.6.0</spotbugs-annotations.version>
     <javax-annotations-api.version>1.3.2</javax-annotations-api.version>
     <testcontainers.version>1.15.1</testcontainers.version>


### PR DESCRIPTION
Bump snakeyaml from 1.31 to 1.32 to solve CVE-2022-38752

### Motivation

1.32 had this resolved https://www.cvedetails.com/cve/CVE-2022-38752


