### PR TITLE
Migrate centos7 to ubuntu 22.10, reduce image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,10 @@ RUN set -x \
     && apt-get install -y --no-install-recommends python3 pip \
     && ln -s /usr/bin/python3 /usr/bin/python \
     && apt-get install -y --no-install-recommends gpg gpg-agent wget sudo \
-    && apt-get clean all \
+    && apt-get -y --purge autoremove \
+     && apt-get autoclean \
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
     && mkdir -pv /opt \
     && cd /opt \
     && wget -q "${DISTRO_URL}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN set -x \
     && apt-get install -y --no-install-recommends openjdk-17-jdk \
     && apt-get install -y --no-install-recommends python3 pip \
     && ln -s /usr/bin/python3 /usr/bin/python \
-    && apt-get install -y --no-install-recommends gpg wget sudo \
+    && apt-get install -y --no-install-recommends gpg gpg-agent wget sudo \
     && apt-get clean all \
     && mkdir -pv /opt \
     && cd /opt \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,11 +38,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN set -x \
     && adduser "${BK_USER}" \
     && apt-get update \
-    && apt-get install -y openjdk-17-jdk \
-    && apt-get install -y python3 pip \
+    && apt-get install -y --no-install-recommends openjdk-17-jdk \
+    && apt-get install -y --no-install-recommends python3 pip \
     && ln -s /usr/bin/python3 /usr/bin/python \
-    && apt-get install -y gcc g++ \
-    && apt-get install -y wget sudo \
+    && apt-get install -y --no-install-recommends gpg wget sudo \
     && apt-get clean all \
     && mkdir -pv /opt \
     && cd /opt \
@@ -56,8 +55,7 @@ RUN set -x \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
     && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
-    && pip install zk-shell \
-    && ls /usr/lib/jvm
+    && pip install zk-shell
 
 WORKDIR /opt/bookkeeper
 

--- a/tests/docker-images/statestore-image/Dockerfile
+++ b/tests/docker-images/statestore-image/Dockerfile
@@ -17,7 +17,11 @@
 # under the License.
 #
 
-FROM centos:7
+FROM ubuntu:22.10
+MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
+
+ARG TARGETARCH
+
 #ENV OPTS="$OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
 ENV BOOKIE_PORT=3181
 ENV BOOKIE_HTTP_PORT=8080
@@ -25,19 +29,21 @@ ENV BOOKIE_GRPC_PORT=4181
 EXPOSE ${BOOKIE_PORT} ${BOOKIE_HTTP_PORT} ${BOOKIE_GRPC_PORT}
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
-ENV JAVA_HOME=/usr/lib/jvm/java-11
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-$TARGETARCH
+ENV DEBIAN_FRONTEND=noninteractive
 
 
 RUN set -x \
     && adduser "${BK_USER}" \
-    && yum install -y java-11-openjdk-devel wget bash python-pip python-devel sudo netcat gcc gcc-c++ \
-    && wget -q https://bootstrap.pypa.io/pip/2.7/get-pip.py \
-    && python get-pip.py \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends openjdk-17-jdk \
+    && apt-get install -y --no-install-recommends python3 pip \
+    && ln -s /usr/bin/python3 /usr/bin/python \
+    && apt-get install -y --no-install-recommends gpg gpg-agent wget sudo \
+    && apt-get clean all \
     && pip install zk-shell \
-    && rm -rf get-pip.py \
     && mkdir -pv /opt \
-    && cd /opt \
-    && yum clean all
+    && cd /opt
 
 WORKDIR /opt/bookkeeper
 RUN mkdir /opt/bookkeeper/lib

--- a/tests/docker-images/statestore-image/Dockerfile
+++ b/tests/docker-images/statestore-image/Dockerfile
@@ -40,7 +40,10 @@ RUN set -x \
     && apt-get install -y --no-install-recommends python3 pip \
     && ln -s /usr/bin/python3 /usr/bin/python \
     && apt-get install -y --no-install-recommends gpg gpg-agent wget sudo \
-    && apt-get clean all \
+     && apt-get -y --purge autoremove \
+     && apt-get autoclean \
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
     && pip install zk-shell \
     && mkdir -pv /opt \
     && cd /opt


### PR DESCRIPTION
### Changes
- migrate statestore image from centos7 to ubuntu
- use `--no-install-recommends` to reduce image size
- elminate `gcc`、`gcc-c++` in image

Thanks for @lhotari 