### PR TITLE
 SortedLedgerStorage supports multiple dirs

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -120,6 +120,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     private OpStatsLogger getEntryStats;
     private OpStatsLogger pageScanStats;
     private Counter retryCounter;
+    private StateManager stateManager;
 
     public InterleavedLedgerStorage() {
         activeLedgers = new SnapshotMap<>();
@@ -161,7 +162,13 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     }
 
     @Override
-    public void setStateManager(StateManager stateManager) {}
+    public void setStateManager(StateManager stateManager) {
+        this.stateManager = stateManager;
+    }
+
+    public StateManager getStateManager() {
+        return stateManager;
+    }
 
     @Override
     public void setCheckpointSource(CheckpointSource checkpointSource) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -21,6 +21,7 @@
 
 package org.apache.bookkeeper.bookie;
 
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.RateLimiter;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -217,8 +218,8 @@ public interface LedgerStorage {
     ByteBuf getExplicitLac(long ledgerId) throws IOException, BookieException;
 
     // for testability
-    default LedgerStorage getUnderlyingLedgerStorage() {
-        return this;
+    default <E> List<E> getUnderlyingLedgerStorage() {
+        return Lists.newArrayList((E)this);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -217,9 +217,9 @@ public interface LedgerStorage {
 
     ByteBuf getExplicitLac(long ledgerId) throws IOException, BookieException;
 
-    // for testability
-    default <E> List<E> getUnderlyingLedgerStorage() {
-        return Lists.newArrayList((E)this);
+    // for InterleavedLedgerStorage's testability
+    default List<InterleavedLedgerStorage> getUnderlyingInterleavedLedgerStorage() {
+        return Lists.newArrayList((InterleavedLedgerStorage) this);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -439,7 +439,7 @@ public class SortedLedgerStorage
     }
 
     @Override
-    public List<InterleavedLedgerStorage> getUnderlyingLedgerStorage() {
+    public List<InterleavedLedgerStorage> getUnderlyingInterleavedLedgerStorage() {
         return interleavedLedgerStorageList;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/DefaultEntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/DefaultEntryLogTest.java
@@ -309,7 +309,7 @@ public class DefaultEntryLogTest {
         BookieImpl bookie = new TestBookieImpl(conf);
         DefaultEntryLogger entryLogger = new DefaultEntryLogger(conf,
                 bookie.getLedgerDirsManager());
-        List<InterleavedLedgerStorage> ils = bookie.ledgerStorage.getUnderlyingLedgerStorage();
+        List<InterleavedLedgerStorage> ils = bookie.ledgerStorage.getUnderlyingInterleavedLedgerStorage();
         InterleavedLedgerStorage ledgerStorage = ils.get(0);
         ledgerStorage.entryLogger = entryLogger;
         // Create ledgers

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/DefaultEntryLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/DefaultEntryLogTest.java
@@ -309,8 +309,8 @@ public class DefaultEntryLogTest {
         BookieImpl bookie = new TestBookieImpl(conf);
         DefaultEntryLogger entryLogger = new DefaultEntryLogger(conf,
                 bookie.getLedgerDirsManager());
-        InterleavedLedgerStorage ledgerStorage =
-                ((InterleavedLedgerStorage) bookie.ledgerStorage.getUnderlyingLedgerStorage());
+        List<InterleavedLedgerStorage> ils = bookie.ledgerStorage.getUnderlyingLedgerStorage();
+        InterleavedLedgerStorage ledgerStorage = ils.get(0);
         ledgerStorage.entryLogger = entryLogger;
         // Create ledgers
         ledgerStorage.setMasterKey(1, "key".getBytes());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -88,7 +88,7 @@ public class LedgerCacheTest {
         bookie = new TestBookieImpl(conf);
 
         activeLedgers = new SnapshotMap<Long, Boolean>();
-        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingLedgerStorage();
+        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingInterleavedLedgerStorage();
         ledgerCache = ils.get(0).ledgerCache;
     }
 
@@ -116,7 +116,7 @@ public class LedgerCacheTest {
         if (ledgerCache != null) {
             ledgerCache.close();
         }
-        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingLedgerStorage();
+        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingInterleavedLedgerStorage();
         ledgerCache = ils.get(0).ledgerCache = new LedgerCacheImpl(conf, activeLedgers, bookie.getIndexDirsManager());
         flushThread = new Thread() {
                 public void run() {
@@ -275,7 +275,7 @@ public class LedgerCacheTest {
         conf.setLedgerDirNames(new String[] { ledgerDir1.getAbsolutePath(), ledgerDir2.getAbsolutePath() });
 
         BookieImpl bookie = new TestBookieImpl(conf);
-        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingLedgerStorage();
+        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingInterleavedLedgerStorage();
         InterleavedLedgerStorage ledgerStorage = ils.get(0);
         LedgerCacheImpl ledgerCache = (LedgerCacheImpl) ledgerStorage.ledgerCache;
         // Create ledger index file

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -88,7 +88,8 @@ public class LedgerCacheTest {
         bookie = new TestBookieImpl(conf);
 
         activeLedgers = new SnapshotMap<Long, Boolean>();
-        ledgerCache = ((InterleavedLedgerStorage) bookie.getLedgerStorage().getUnderlyingLedgerStorage()).ledgerCache;
+        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingLedgerStorage();
+        ledgerCache = ils.get(0).ledgerCache;
     }
 
     @After
@@ -115,8 +116,8 @@ public class LedgerCacheTest {
         if (ledgerCache != null) {
             ledgerCache.close();
         }
-        ledgerCache = ((InterleavedLedgerStorage) bookie.getLedgerStorage().getUnderlyingLedgerStorage())
-            .ledgerCache = new LedgerCacheImpl(conf, activeLedgers, bookie.getIndexDirsManager());
+        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingLedgerStorage();
+        ledgerCache = ils.get(0).ledgerCache = new LedgerCacheImpl(conf, activeLedgers, bookie.getIndexDirsManager());
         flushThread = new Thread() {
                 public void run() {
                     while (true) {
@@ -274,8 +275,8 @@ public class LedgerCacheTest {
         conf.setLedgerDirNames(new String[] { ledgerDir1.getAbsolutePath(), ledgerDir2.getAbsolutePath() });
 
         BookieImpl bookie = new TestBookieImpl(conf);
-        InterleavedLedgerStorage ledgerStorage =
-            ((InterleavedLedgerStorage) bookie.getLedgerStorage().getUnderlyingLedgerStorage());
+        List<InterleavedLedgerStorage> ils = bookie.getLedgerStorage().getUnderlyingLedgerStorage();
+        InterleavedLedgerStorage ledgerStorage = ils.get(0);
         LedgerCacheImpl ledgerCache = (LedgerCacheImpl) ledgerStorage.ledgerCache;
         // Create ledger index file
         ledgerStorage.setMasterKey(1, "key".getBytes());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -706,15 +706,16 @@ public class LedgerCacheTest {
         public void onSizeLimitReached(final CheckpointSource.Checkpoint cp) throws IOException {
             LOG.info("Reached size {}", cp);
             // use synchronous way
-            try {
-                LOG.info("Started flushing mem table.");
-                memTable.flush(FlushTestSortedLedgerStorage.this);
-            } catch (IOException e) {
-                getStateManager().doTransitionToReadOnlyMode();
-                LOG.error("Exception thrown while flushing skip list cache.", e);
-         }
-         }
-
+            for (InterleavedLedgerStorage s : this.interleavedLedgerStorageList) {
+                try {
+                    LOG.info("Started flushing mem table.");
+                    memTable.flush(FlushTestSortedLedgerStorage.this);
+                } catch (IOException e) {
+                    s.getStateManager().transitionToReadOnlyMode();
+                    LOG.error("Exception thrown while flushing skip list cache.", e);
+                }
+            }
+        }
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/MockLedgerStorage.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/MockLedgerStorage.java
@@ -261,8 +261,8 @@ public class MockLedgerStorage implements CompactableLedgerStorage {
     }
 
     @Override
-    public List<InterleavedLedgerStorage> getUnderlyingLedgerStorage() {
-        return CompactableLedgerStorage.super.getUnderlyingLedgerStorage();
+    public List<InterleavedLedgerStorage> getUnderlyingInterleavedLedgerStorage() {
+        return CompactableLedgerStorage.super.getUnderlyingInterleavedLedgerStorage();
     }
 
     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/MockLedgerStorage.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/MockLedgerStorage.java
@@ -261,7 +261,7 @@ public class MockLedgerStorage implements CompactableLedgerStorage {
     }
 
     @Override
-    public LedgerStorage getUnderlyingLedgerStorage() {
+    public List<InterleavedLedgerStorage> getUnderlyingLedgerStorage() {
         return CompactableLedgerStorage.super.getUnderlyingLedgerStorage();
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SlowSortedLedgerStorage.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SlowSortedLedgerStorage.java
@@ -27,10 +27,10 @@ package org.apache.bookkeeper.bookie;
 public class SlowSortedLedgerStorage extends SortedLedgerStorage {
 
     public SlowSortedLedgerStorage() {
-        this(new SlowInterleavedLedgerStorage());
+        this(SlowInterleavedLedgerStorage.class.getName());
     }
 
-    SlowSortedLedgerStorage(InterleavedLedgerStorage ils) {
-        super(ils);
+    SlowSortedLedgerStorage(String interleavedLedgerStorageClazz) {
+        super(interleavedLedgerStorageClazz);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageCheckpointTest.java
@@ -224,7 +224,7 @@ public class SortedLedgerStorageCheckpointTest extends LedgerStorageTestBase {
         });
 
         // simulate entry log is rotated (due to compaction)
-        List<DefaultEntryLogger> eloggers = storage.getEntryLogger();
+        List<DefaultEntryLogger> eloggers = storage.getDefaultEntryLoggers();
         for (DefaultEntryLogger elogger : eloggers) {
             EntryLogManagerForSingleEntryLog entryLogManager =
                     (EntryLogManagerForSingleEntryLog) elogger.getEntryLogManager();


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

planning for multiple dirs: [mail talking](https://lists.apache.org/thread/njw4yhdgv9db64notq5o3hc0k8bbpl8v)
stage 1 : 
1)  SortedLedgerStorage supports multiple dirs

the condition that the bug triggers:
    1)  conf.getLedgerDirs are multiple dirs
    2)  ledgerStorageClass=org.apache.bookkeeper.bookie.SortedLedgerStorage

### Changes

1.  SortedLedgerStorage supports multiple dirs