### PR TITLE
Add RegistrationSessionExpiredPolicy for session expired event

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -119,6 +119,12 @@ public class BookieStateManager implements StateManager {
         this.rm = rm;
         if (this.rm != null) {
             rm.addRegistrationListener(() -> {
+                LOG.info("Received registration expired event");
+                if (conf.getRegistrationSessionExpiredPolicy() == RegistrationSessionExpiredPolicy.shutdown) {
+                    LOG.warn("The session with registration service was lost. Shutting down.");
+                    shutdownHandler.shutdown(ExitCode.BOOKIE_EXCEPTION);
+                    return;
+                }
                 log.info("Trying to re-register the bookie");
                 forceToUnregistered();
                 // schedule a re-register operation

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/RegistrationSessionExpiredPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/RegistrationSessionExpiredPolicy.java
@@ -1,0 +1,30 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.bookie;
+
+/**
+ * Enum with different policies do apply when bookies are loosing session with registration service.
+ */
+public enum RegistrationSessionExpiredPolicy {
+    reconnect,
+    shutdown,
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.FileChannelProvider;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.bookie.LedgerStorage;
+import org.apache.bookkeeper.bookie.RegistrationSessionExpiredPolicy;
 import org.apache.bookkeeper.bookie.SortedLedgerStorage;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 import org.apache.bookkeeper.common.conf.ConfigDef;
@@ -284,6 +285,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
 
     // Registration
     protected static final String REGISTRATION_MANAGER_CLASS = "registrationManagerClass";
+    protected static final String REGISTRATION_SESSION_EXPIRED_POLICY = "registrationSessionExpiredPolicy";
 
     // Stats
     protected static final String ENABLE_TASK_EXECUTION_STATS = "enableTaskExecutionStats";
@@ -3792,6 +3794,27 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
         return ReflectionUtils.getClass(this, REGISTRATION_MANAGER_CLASS,
                 ZKRegistrationManager.class, RegistrationManager.class,
                 DEFAULT_LOADER);
+    }
+
+    /**
+     * Set Registration session expired connection reconnect policy.
+     *
+     * @param sessionExpiredPolicy
+     * @return server configuration.
+     */
+    public ServerConfiguration setRegistrationSessionExpiredPolicy(RegistrationSessionExpiredPolicy sessionExpiredPolicy) {
+        setProperty(REGISTRATION_SESSION_EXPIRED_POLICY, sessionExpiredPolicy.toString());
+        return this;
+    }
+
+    /**
+     * Get Registration session expired connection reconnect policy.
+     *
+     * @return session expired connection reconnect policy
+     */
+    public RegistrationSessionExpiredPolicy getRegistrationSessionExpiredPolicy() {
+        return RegistrationSessionExpiredPolicy.valueOf(
+                getString(REGISTRATION_SESSION_EXPIRED_POLICY, RegistrationSessionExpiredPolicy.reconnect.toString()));
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -3802,7 +3802,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @param sessionExpiredPolicy
      * @return server configuration.
      */
-    public ServerConfiguration setRegistrationSessionExpiredPolicy(RegistrationSessionExpiredPolicy sessionExpiredPolicy) {
+    public ServerConfiguration setRegistrationSessionExpiredPolicy(
+            RegistrationSessionExpiredPolicy sessionExpiredPolicy) {
         setProperty(REGISTRATION_SESSION_EXPIRED_POLICY, sessionExpiredPolicy.toString());
         return this;
     }


### PR DESCRIPTION
### Motivation
The status of the Bookie service, including `writable` and `read-only`, needs to be registered with the `Registration` service.
At present, most of the time we use `zookeeper` as the `Registration` service, where `BookieStateManager` is mainly responsible for managing these state switches, including the  `re-registration` logic after processing the `session expired event`.
`BookieStateManager` uses `ZKRegistrationManager` to register the state, where `zk` in `ZKRegistrationManager` is a subclass of `Zookeeper` to implement `ZooKeeperClient`. When `session expired` occurs,`ZooKeeperClient` will re-instantiate a new `Zookeeper` for `zk`.
If the new `zk` is successfully constructed, the `BookieStateManager` will re-register the bookie state with zookeeper server.

Here we have a problem, from the existing unit tests and the actual show, we seem to want the bookie to be closed when the session expired occurs, because we can't prove whether the bookie can be in the correct working state just by reinitializing a new zk, refer to comments on the following issue: https://github.com/apache/bookkeeper/issues/3250#issuecomment-1190996890

Like pulsar, we can provide session expired poilicy to choose whether it should continue to reconnect.

### Changes
Add `RegistrationSessionExpiredPolicy` and server-side configuration items: `registrationSessionExpiredPolicy`
Contains two optional values:  `reconnect, shutdown`

To stay consistent with the existing logic, this PR will set the policy to `reconnect`.

If we want to solve the problem mentioned in #3418 , we can modify the policy to shutdown here at #3418.
