### PR TITLE
Simplified No network topology script is found default log stack output

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -270,8 +270,8 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                 }
             } catch (RuntimeException re) {
                 if (!conf.getEnforceMinNumRacksPerWriteQuorum()) {
-                    LOG.warn("Failed to initialize DNS Resolver {}, used default subnet resolver ",
-                            dnsResolverName, re);
+                    LOG.warn("Failed to initialize DNS Resolver {}, used default subnet resolver because {}",
+                            dnsResolverName, re.getMessage());
                     dnsResolver = new DefaultResolver(this::getDefaultRack);
                     dnsResolver.setBookieAddressResolver(bookieAddressResolver);
                 } else {


### PR DESCRIPTION
### Motivation
The default `dnsResolver` of `RackawareEnsemblePlacementPolicyImpl` is initialized as `ScriptBasedMapping`. Since the script is missing by default, detailed stack information will be printed, but the code will fall back to `DefaultResolver` by default, so only simple exception information needs to be printed.
![image](https://user-images.githubusercontent.com/35599757/191254546-54395f24-5e64-4d89-9bcd-61eb9308c91e.png)
