### PR TITLE
Issue #3498  Fix bookkeeper command path in decommission doc

### DIFF
--- a/site3/website/docs/admin/decomission.md
+++ b/site3/website/docs/admin/decomission.md
@@ -37,6 +37,6 @@ or
 Last step to verify is you could run this command to check if the bookie you decommissioned doesn’t show up in list bookies:
 
 ```bash
-./bookkeeper shell listbookies -rw -h
-./bookkeeper shell listbookies -ro -h
+$ bin/bookkeeper shell listbookies -rw -h
+$ bin/bookkeeper shell listbookies -ro -h
 ```


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

The bookkeeper command path is wrong in the demo of [decommission doc](https://bookkeeper.apache.org/docs/admin/decomission/).
<img width="1259" alt="image" src="https://user-images.githubusercontent.com/93108425/191873762-8f45645f-bb65-431a-90d0-c03f0efea084.png">


### Changes

Update the command path.

Fix #3498 


