### PR TITLE
unified latency metric unit

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/stats/BroadCastStatsLogger.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/stats/BroadCastStatsLogger.java
@@ -127,9 +127,16 @@ public class BroadCastStatsLogger {
                 }
 
                 @Override
-                public void add(long l) {
-                    firstCounter.add(l);
-                    secondCounter.add(l);
+                public void addCount(long l) {
+                    firstCounter.addCount(l);
+                    secondCounter.addCount(l);
+                }
+
+                @Override
+                public void addLatency(long eventLatency, TimeUnit unit) {
+                    long valueMillis = unit.toMicros(eventLatency) / 1000;
+                    firstCounter.addCount(valueMillis);
+                    secondCounter.addCount(valueMillis);
                 }
 
                 @Override

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/stats/BroadCastStatsLogger.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/stats/BroadCastStatsLogger.java
@@ -134,7 +134,7 @@ public class BroadCastStatsLogger {
 
                 @Override
                 public void addLatency(long eventLatency, TimeUnit unit) {
-                    long valueMillis = unit.toMicros(eventLatency) / 1000;
+                    long valueMillis = unit.toMillis(eventLatency);
                     firstCounter.addCount(valueMillis);
                     secondCounter.addCount(valueMillis);
                 }

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
@@ -60,8 +60,14 @@ public class TestStatsProvider implements StatsProvider {
         }
 
         @Override
-        public void add(long delta) {
+        public void addCount(long delta) {
             updateMax(val.addAndGet(delta));
+        }
+
+        @Override
+        public void addLatency(long eventLatency, TimeUnit unit) {
+            long valueMillis = unit.toMicros(eventLatency) / 1000;
+            updateMax(val.addAndGet(valueMillis));
         }
 
         @Override

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
@@ -66,7 +66,7 @@ public class TestStatsProvider implements StatsProvider {
 
         @Override
         public void addLatency(long eventLatency, TimeUnit unit) {
-            long valueMillis = unit.toMicros(eventLatency) / 1000;
+            long valueMillis = unit.toMillis(eventLatency);
             updateMax(val.addAndGet(valueMillis));
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -931,7 +931,7 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
         long ledgerId = handle.getLedgerId();
         long entryId = handle.addEntry(entry);
 
-        bookieStats.getWriteBytes().add(entry.readableBytes());
+        bookieStats.getWriteBytes().addCount(entry.readableBytes());
 
         // journal `addEntry` should happen after the entry is added to ledger storage.
         // otherwise the journal entry can potentially be rolled before the ledger is created in ledger storage.
@@ -1110,7 +1110,7 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
             }
             ByteBuf entry = handle.readEntry(entryId);
             entrySize = entry.readableBytes();
-            bookieStats.getReadBytes().add(entrySize);
+            bookieStats.getReadBytes().addCount(entrySize);
             success = true;
             return entry;
         } finally {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTable.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTable.java
@@ -258,7 +258,7 @@ public class EntryMemTable implements AutoCloseable{
                             }
                         }
                     }
-                    memTableStats.getFlushBytesCounter().add(size);
+                    memTableStats.getFlushBytesCounter().addCount(size);
                     clearSnapshot(keyValues);
                 }
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTableWithParallelFlusher.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryMemTableWithParallelFlusher.java
@@ -139,7 +139,7 @@ class EntryMemTableWithParallelFlusher extends EntryMemTable {
                         throw new IOException("Failed to complete the flushSnapshotByParallelizing",
                                 exceptionWhileFlushingParallelly.get());
                     }
-                    memTableStats.getFlushBytesCounter().add(flushedSize.get());
+                    memTableStats.getFlushBytesCounter().addCount(flushedSize.get());
                     clearSnapshot(keyValues);
                 }
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -489,7 +489,7 @@ public class GarbageCollectorThread extends SafeRunnable {
                     // We can remove this entry log file now.
                     LOG.info("Deleting entryLogId {} as it has no active ledgers!", entryLogId);
                     removeEntryLog(entryLogId);
-                    gcStats.getReclaimedSpaceViaDeletes().add(meta.getTotalSize());
+                    gcStats.getReclaimedSpaceViaDeletes().addCount(meta.getTotalSize());
                 } else if (modified) {
                     // update entryLogMetaMap only when the meta modified.
                     entryLogMetaMap.put(meta.getEntryLogId(), meta);
@@ -607,7 +607,7 @@ public class GarbageCollectorThread extends SafeRunnable {
 
                     long priorRemainingSize = meta.getRemainingSize();
                     compactEntryLog(meta);
-                    gcStats.getReclaimedSpaceViaCompaction().add(meta.getTotalSize() - priorRemainingSize);
+                    gcStats.getReclaimedSpaceViaCompaction().addCount(meta.getTotalSize() - priorRemainingSize);
                     compactedBuckets[bucketIndex]++;
                 });
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -346,7 +346,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
             journalAddEntryStats.registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueTime), TimeUnit.NANOSECONDS);
             cb.writeComplete(0, ledgerId, entryId, null, ctx);
             recycle();
-            callbackTime.add(MathUtils.elapsedNanos(startTime));
+            callbackTime.addLatency(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
         }
 
         private final Handle<QueueEntry> recyclerHandle;
@@ -515,7 +515,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
             while (running) {
                 ForceWriteRequest req = null;
                 try {
-                    forceWriteThreadTime.add(MathUtils.elapsedNanos(busyStartTime));
+                    forceWriteThreadTime.addLatency(MathUtils.elapsedNanos(busyStartTime), TimeUnit.NANOSECONDS);
                     req = forceWriteRequests.take();
                     busyStartTime = System.nanoTime();
                     // Force write the file and then notify the write completions
@@ -1081,7 +1081,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     }
 
                     if (numEntriesToFlush == 0) {
-                        journalTime.add(MathUtils.elapsedNanos(busyStartTime));
+                        journalTime.addLatency(MathUtils.elapsedNanos(busyStartTime), TimeUnit.NANOSECONDS);
                         qe = queue.take();
                         dequeueStartTime = MathUtils.nowInNano();
                         busyStartTime = dequeueStartTime;
@@ -1230,7 +1230,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     qe.entry.release();
                 } else if (qe.entryId != BookieImpl.METAENTRY_ID_FORCE_LEDGER) {
                     int entrySize = qe.entry.readableBytes();
-                    journalStats.getJournalWriteBytes().add(entrySize);
+                    journalStats.getJournalWriteBytes().addCount(entrySize);
 
                     batchSize += (4 + entrySize);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -111,7 +111,7 @@ class SyncThread implements Checkpointer {
                 log.error("Exception in SyncThread", t);
                 dirsListener.fatalError();
             } finally {
-                syncExecutorTime.add(MathUtils.elapsedNanos(startTime));
+                syncExecutorTime.addLatency(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
             }
         });
     }
@@ -124,7 +124,7 @@ class SyncThread implements Checkpointer {
             } catch (Throwable t) {
                 log.error("Exception flushing ledgers ", t);
             } finally {
-                syncExecutorTime.add(MathUtils.elapsedNanos(startTime));
+                syncExecutorTime.addLatency(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
             }
         });
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -212,7 +212,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             ThreadRegistry.register(dbStoragerExecutorName, 0);
             // ensure the metric gets registered on start-up as this thread only executes
             // when the write cache is full which may not happen or not for a long time
-            flushExecutorTime.add(0);
+            flushExecutorTime.addLatency(0, TimeUnit.NANOSECONDS);
         });
 
         ledgerDirsManager.addLedgerDirsListener(getLedgerDirsListener());
@@ -463,7 +463,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                         } catch (IOException e) {
                             log.error("Error during flush", e);
                         } finally {
-                            flushExecutorTime.add(MathUtils.elapsedNanos(startTime));
+                            flushExecutorTime.addLatency(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
                         }
                     });
             }
@@ -570,14 +570,16 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 throw new NoEntryException(ledgerId, entryId);
             }
         } finally {
-            dbLedgerStorageStats.getReadFromLocationIndexTime().add(MathUtils.elapsedNanos(locationIndexStartNano));
+            dbLedgerStorageStats.getReadFromLocationIndexTime().addLatency(
+                    MathUtils.elapsedNanos(locationIndexStartNano), TimeUnit.NANOSECONDS);
         }
 
         long readEntryStartNano = MathUtils.nowInNano();
         try {
             entry = entryLogger.readEntry(ledgerId, entryId, entryLocation);
         } finally {
-            dbLedgerStorageStats.getReadFromEntryLogTime().add(MathUtils.elapsedNanos(readEntryStartNano));
+            dbLedgerStorageStats.getReadFromEntryLogTime().addLatency(
+                    MathUtils.elapsedNanos(readEntryStartNano), TimeUnit.NANOSECONDS);
         }
 
         readCache.put(ledgerId, entryId, entry);
@@ -634,7 +636,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         } finally {
             dbLedgerStorageStats.getReadAheadBatchCountStats().registerSuccessfulValue(count);
             dbLedgerStorageStats.getReadAheadBatchSizeStats().registerSuccessfulValue(size);
-            dbLedgerStorageStats.getReadAheadTime().add(MathUtils.elapsedNanos(readAheadStartNano));
+            dbLedgerStorageStats.getReadAheadTime().addLatency(
+                    MathUtils.elapsedNanos(readAheadStartNano), TimeUnit.NANOSECONDS);
         }
     }
 
@@ -689,11 +692,13 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         }
 
         long entryLocation = entryLocationIndex.getLocation(ledgerId, lastEntryId);
-        dbLedgerStorageStats.getReadFromLocationIndexTime().add(MathUtils.elapsedNanos(locationIndexStartNano));
+        dbLedgerStorageStats.getReadFromLocationIndexTime().addLatency(
+                MathUtils.elapsedNanos(locationIndexStartNano), TimeUnit.NANOSECONDS);
 
         long readEntryStartNano = MathUtils.nowInNano();
         ByteBuf content = entryLogger.readEntry(ledgerId, lastEntryId, entryLocation);
-        dbLedgerStorageStats.getReadFromEntryLogTime().add(MathUtils.elapsedNanos(readEntryStartNano));
+        dbLedgerStorageStats.getReadFromEntryLogTime().addLatency(
+                MathUtils.elapsedNanos(readEntryStartNano), TimeUnit.NANOSECONDS);
         return content;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/service/ScrubberService.java
@@ -105,7 +105,7 @@ public class ScrubberService extends ServerLifecycleComponent {
         try {
             List<LedgerStorage.DetectedInconsistency> errors = ledgerStorage.localConsistencyCheck(scrubRateLimiter);
             if (errors.size() > 0) {
-                errorCounter.add(errors.size());
+                errorCounter.addCount(errors.size());
                 LOG.error("Found inconsistency during localConsistencyCheck:");
                 for (LedgerStorage.DetectedInconsistency error : errors) {
                     LOG.error("Ledger {}, entry {}: ", error.getLedgerId(), error.getEntryId(), error.getException());

--- a/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/Counter.java
+++ b/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/Counter.java
@@ -16,6 +16,8 @@
  */
 package org.apache.bookkeeper.stats;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Simple stats that require only increment and decrement
  * functions on a Long. Metrics like the number of topics, persist queue size
@@ -41,7 +43,15 @@ public interface Counter {
      * Add delta to the value associated with this stat.
      * @param delta
      */
-    void add(long delta);
+    void addCount(long delta);
+
+    /**
+     * An operation succeeded with the given eventLatency. Update
+     * stats to reflect the same
+     * @param eventLatency The event latency
+     * @param unit
+     */
+    void addLatency(long eventLatency, TimeUnit unit);
 
     /**
      * Get the value associated with this stat.

--- a/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/NullStatsLogger.java
+++ b/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/NullStatsLogger.java
@@ -88,7 +88,12 @@ public class NullStatsLogger implements StatsLogger {
         }
 
         @Override
-        public void add(long delta) {
+        public void addCount(long delta) {
+            // nop
+        }
+
+        @Override
+        public void addLatency(long eventLatency, TimeUnit unit) {
             // nop
         }
 

--- a/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleStatsLogger.java
@@ -25,6 +25,8 @@ import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A {@link StatsLogger} implemented based on <i>Codahale</i> metrics library.
  */
@@ -70,8 +72,14 @@ public class CodahaleStatsLogger implements StatsLogger {
             }
 
             @Override
-            public void add(long delta) {
+            public void addCount(long delta) {
                 c.inc(delta);
+            }
+
+            @Override
+            public void addLatency(long eventLatency, TimeUnit unit) {
+                long valueMillis = unit.toMicros(eventLatency) / 1000;
+                c.inc(valueMillis);
             }
         };
     }

--- a/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleStatsLogger.java
@@ -20,12 +20,11 @@ import static com.codahale.metrics.MetricRegistry.name;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link StatsLogger} implemented based on <i>Codahale</i> metrics library.

--- a/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/CodahaleStatsLogger.java
@@ -77,7 +77,7 @@ public class CodahaleStatsLogger implements StatsLogger {
 
             @Override
             public void addLatency(long eventLatency, TimeUnit unit) {
-                long valueMillis = unit.toMicros(eventLatency) / 1000;
+                long valueMillis = unit.toMillis(eventLatency);
                 c.inc(valueMillis);
             }
         };

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/LongAdderCounter.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/LongAdderCounter.java
@@ -60,7 +60,7 @@ public class LongAdderCounter implements Counter {
     }
 
     /**
-     * When counter is used to count time,
+     * When counter is used to count time.
      * consistent with the {@link DataSketchesOpStatsLogger#registerSuccessfulEvent(long, TimeUnit)} 's logic
      * */
     @Override

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/LongAdderCounter.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/LongAdderCounter.java
@@ -60,8 +60,8 @@ public class LongAdderCounter implements Counter {
     }
 
     /**
-     * When counter is used to count time, consistent with
-     * the {@link DataSketchesOpStatsLogger#registerSuccessfulEvent(long, TimeUnit)} 's logic
+     * When counter is used to count time,
+     * consistent with the {@link DataSketchesOpStatsLogger#registerSuccessfulEvent(long, TimeUnit)} 's logic
      * */
     @Override
     public void addLatency(long eventLatency, TimeUnit unit) {

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/LongAdderCounter.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/LongAdderCounter.java
@@ -65,7 +65,7 @@ public class LongAdderCounter implements Counter {
      * */
     @Override
     public void addLatency(long eventLatency, TimeUnit unit) {
-        long valueMillis = unit.toMicros(eventLatency) / 1000;
+        long valueMillis = unit.toMillis(eventLatency);
         counter.add(valueMillis);
     }
 

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/LongAdderCounter.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/LongAdderCounter.java
@@ -17,6 +17,7 @@
 package org.apache.bookkeeper.stats.prometheus;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.bookkeeper.stats.Counter;
 
@@ -54,8 +55,18 @@ public class LongAdderCounter implements Counter {
     }
 
     @Override
-    public void add(long delta) {
+    public void addCount(long delta) {
         counter.add(delta);
+    }
+
+    /**
+     * When counter is used to count time, consistent with
+     * the {@link DataSketchesOpStatsLogger#registerSuccessfulEvent(long, TimeUnit)} 's logic
+     * */
+    @Override
+    public void addLatency(long eventLatency, TimeUnit unit) {
+        long valueMillis = unit.toMicros(eventLatency) / 1000;
+        counter.add(valueMillis);
     }
 
     @Override

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedLongAdderCounter.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedLongAdderCounter.java
@@ -18,6 +18,8 @@ package org.apache.bookkeeper.stats.prometheus;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.ThreadRegistry;
 
@@ -65,8 +67,13 @@ public class ThreadScopedLongAdderCounter implements Counter {
     }
 
     @Override
-    public void add(long delta) {
-        getCounter().add(delta);
+    public void addCount(long delta) {
+        getCounter().addCount(delta);
+    }
+
+    @Override
+    public void addLatency(long eventLatency, TimeUnit unit) {
+        getCounter().addLatency(eventLatency, unit);
     }
 
     @Override

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedLongAdderCounter.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedLongAdderCounter.java
@@ -19,7 +19,6 @@ package org.apache.bookkeeper.stats.prometheus;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.ThreadRegistry;
 

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -25,6 +25,8 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
 import lombok.Cleanup;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -98,7 +100,16 @@ public class TestPrometheusMetricsProvider {
         assertEquals(1L, counter.get().longValue());
         counter.dec();
         assertEquals(0L, counter.get().longValue());
-        counter.add(3);
+        counter.addCount(3);
+        assertEquals(3L, counter.get().longValue());
+    }
+
+    @Test
+    public void testCounter2() {
+        LongAdderCounter counter = new LongAdderCounter(Collections.emptyMap());
+        long value = counter.get();
+        assertEquals(0L, value);
+        counter.addLatency(3 * 1000 * 1000L, TimeUnit.NANOSECONDS);
         assertEquals(3L, counter.get().longValue());
     }
 

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.util.Collections;

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -20,13 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Cleanup;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.StatsLogger;

--- a/stream/distributedlog/common/src/main/java/org/apache/distributedlog/common/stats/BroadCastStatsLogger.java
+++ b/stream/distributedlog/common/src/main/java/org/apache/distributedlog/common/stats/BroadCastStatsLogger.java
@@ -127,9 +127,16 @@ public class BroadCastStatsLogger {
                 }
 
                 @Override
-                public void add(long l) {
-                    firstCounter.add(l);
-                    secondCounter.add(l);
+                public void addCount(long l) {
+                    firstCounter.addCount(l);
+                    secondCounter.addCount(l);
+                }
+
+                @Override
+                public void addLatency(long eventLatency, TimeUnit unit) {
+                    long valueMillis = unit.toMicros(eventLatency) / 1000;
+                    firstCounter.addCount(valueMillis);
+                    secondCounter.addCount(valueMillis);
                 }
 
                 @Override

--- a/stream/distributedlog/common/src/main/java/org/apache/distributedlog/common/stats/BroadCastStatsLogger.java
+++ b/stream/distributedlog/common/src/main/java/org/apache/distributedlog/common/stats/BroadCastStatsLogger.java
@@ -134,7 +134,7 @@ public class BroadCastStatsLogger {
 
                 @Override
                 public void addLatency(long eventLatency, TimeUnit unit) {
-                    long valueMillis = unit.toMicros(eventLatency) / 1000;
+                    long valueMillis = unit.toMillis(eventLatency);
                     firstCounter.addCount(valueMillis);
                     secondCounter.addCount(valueMillis);
                 }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogWriter.java
@@ -367,7 +367,7 @@ class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWriter {
                             FutureUtils.complete(rollingFuture, writer);
                         }
                         rollingFuture = null;
-                        pendingRequestDispatch.add(pendingRequests.size());
+                        pendingRequestDispatch.addCount(pendingRequests.size());
                         pendingRequests = null;
                     }
                 } catch (IOException ioe) {
@@ -395,7 +395,7 @@ class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWriter {
             rollingFuture = null;
         }
 
-        pendingRequestDispatch.add(pendingRequestsSnapshot.size());
+        pendingRequestDispatch.addCount(pendingRequestsSnapshot.size());
 
         // After erroring out the writer above, no more requests
         // will be enqueued to pendingRequests


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

The latency of the OpStatsLogger.registerSuccessfulEvent calculation is to convert the time to milliseconds
<img width="855" alt="image" src="https://user-images.githubusercontent.com/42990025/191929953-bdac2d25-3fbe-4697-b3e9-f4942ed7c074.png">
but Counter.add nothing to do

so when using Counter for latency statistics, the time unit and OpStatsLogger are not unified, which is easy to be misleading.
then we unified latency metric unit 

### Changes

1.  change name : Counter.add -->  Counter.addCount
2. add new method Counter.addLatency to count the time and convert the time to milliseconds

then how to use counter correctly:
1. when using Counter for latency metric, call Counter.addLatency
2. when using Counter for count metric, call Counter.addCount