### PR TITLE
fix close ledgerAuditorManager repeatedly

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorElector.java
@@ -231,16 +231,11 @@ public class AuditorElector {
      * Shutting down AuditorElector.
      */
     public void shutdown() throws InterruptedException {
-        try {
-            ledgerAuditorManager.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
         synchronized (this) {
             if (executor.isShutdown()) {
                 return;
             }
+            // close auditor manager
             submitShutdownTask();
             executor.shutdown();
         }


### PR DESCRIPTION
### Motivation
this introduced in #2842, the `ledgerAuditorManager` will be close repeatedly.

```java
    private void submitShutdownTask() {
        executor.submit(new Runnable() {
                @Override
                public void run() {
                    if (!running.compareAndSet(true, false)) {
                        return;
                    }

                    try {
                        ledgerAuditorManager.close();   <- here has already closed LAM.
                    } catch (InterruptedException ie) {
                        Thread.currentThread().interrupt();
                        LOG.warn("InterruptedException while closing ledger auditor manager", ie);
                    } catch (Exception ke) {
                        LOG.error("Exception while closing ledger auditor manager", ke);
                    }
                }
            });
    }
```
