### PR TITLE
fix(sec): upgrade commons-codec to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <codahale.metrics.version>3.0.1</codahale.metrics.version>
     <commons-cli.version>1.2</commons-cli.version>
     <commons-collections4.version>4.1</commons-collections4.version>
-    <commons-codec.version>1.6</commons-codec.version>
+    <commons-codec.version>1.13</commons-codec.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-compress.version>1.21</commons-compress.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:

Upgrade commons-codec from 1.6 to 1.13 for vulnerability fix:
- [MPS-2022-11853](https://www.oscs1024.com/hd/MPS-2022-11853)