### PR TITLE
Reduce unnecessary loop in removeIf if map is empty

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -531,7 +531,7 @@ public class ConcurrentLongHashMap<V> {
             try {
                 // Go through all the buckets for this section
                 int capacity = this.capacity;
-                for (int bucket = 0; bucket < capacity; bucket++) {
+                for (int bucket = 0; size > 0 && bucket < capacity; bucket++) {
                     long storedKey = keys[bucket];
                     V storedValue = values[bucket];
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
@@ -681,7 +681,7 @@ public class ConcurrentLongLongHashMap {
             int removedCount = 0;
             try {
                 // Go through all the buckets for this section
-                for (int bucket = 0; bucket < table.length; bucket += 2) {
+                for (int bucket = 0; size > 0 && bucket < table.length; bucket += 2) {
                     long storedKey = table[bucket];
 
                     if (storedKey != DeletedKey && storedKey != EmptyKey) {
@@ -719,7 +719,7 @@ public class ConcurrentLongLongHashMap {
             int removedCount = 0;
             try {
                 // Go through all the buckets for this section
-                for (int bucket = 0; bucket < table.length; bucket += 2) {
+                for (int bucket = 0; size > 0 && bucket < table.length; bucket += 2) {
                     long storedKey = table[bucket];
                     long storedValue = table[bucket + 1];
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
@@ -526,7 +526,7 @@ public class ConcurrentOpenHashMap<K, V> {
             int removedCount = 0;
             try {
                 // Go through all the buckets for this section
-                for (int bucket = 0; bucket < table.length; bucket += 2) {
+                for (int bucket = 0; size > 0 && bucket < table.length; bucket += 2) {
                     K storedKey = (K) table[bucket];
                     V storedValue = (V) table[bucket + 1];
 


### PR DESCRIPTION
### Motivation

After unload all bundles of a heavy pulsar broker, cpu usage is still above 50%, here is a cpu profile and a heapdump
<img width="1665" alt="image" src="https://user-images.githubusercontent.com/5058708/193253189-1cfd66d4-11ab-4850-9768-eeb113ba0ce1.png">
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5058708/193262269-d68f5268-f256-4fc7-9f0d-a2c6321ee2c6.png">

- [28726.html.zip](https://github.com/apache/bookkeeper/files/9683416/28726.html.zip)

It looks like there's a schedule task executing `BookieClientImpl#monitorPendingOperations`.

Most of `completionObjects` in `PerChannelBookieClient` are empty.

IMO, it's worth to check whether a section is empty or not in loop predication.

### Changes

Add `size > 0` into `Section#removeIf` loop predication.
