### PR TITLE
LedgerOpenOp: Do not call blocking close() in the callback

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.AsyncCallback.OpenCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadLastConfirmedCallback;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -48,7 +47,6 @@ import org.slf4j.LoggerFactory;
  * Encapsulates the ledger open operation.
  *
  */
-@Slf4j
 class LedgerOpenOp {
     static final Logger LOG = LoggerFactory.getLogger(LedgerOpenOp.class);
 
@@ -206,7 +204,7 @@ class LedgerOpenOp {
                     } else if (rc == BKException.Code.UnauthorizedAccessException) {
                         closeLedgerHandleAsync().whenComplete((r, ex) -> {
                             if (ex != null) {
-                                log.error("Ledger {} close failed", ledgerId, ex);
+                                LOG.error("Ledger {} close failed", ledgerId, ex);
                             }
                             openComplete(BKException.Code.UnauthorizedAccessException, null);
                         });
@@ -227,7 +225,7 @@ class LedgerOpenOp {
                     if (rc != BKException.Code.OK) {
                         closeLedgerHandleAsync().whenComplete((r, ex) -> {
                             if (ex != null) {
-                                log.error("Ledger {} close failed", ledgerId, ex);
+                                LOG.error("Ledger {} close failed", ledgerId, ex);
                             }
                             openComplete(bk.getReturnRc(BKException.Code.ReadException), null);
                         });


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

https://github.com/apache/bookkeeper/pull/2794 introduced blocking call in the callback.
I can't tell if it contributes to https://github.com/apache/bookkeeper/issues/3466 but it will lead to slow processing main worker pool under the conditions described in the issue (network retries, Zk session reconnects etc) 

### Changes

Use async close.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
