### PR TITLE
LedgerHandle: do not complete metadata operation on the ZookKeeper/Metadata callback thread

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -280,7 +280,7 @@ class LedgerCreateOp {
                 }
             });
         } else {
-            cb.createComplete(rc, lh, ctx);
+            cb.createComplete(rc, null, ctx);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -46,6 +46,7 @@ import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -271,7 +272,12 @@ class LedgerCreateOp {
         } else {
             createOpLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
         }
-        cb.createComplete(rc, lh, ctx);
+        lh.executeOrdered(new SafeRunnable() {
+                              @Override
+                              public void safeRun() {
+                                  cb.createComplete(rc, lh, ctx);
+                              }
+        });
     }
 
     public static class CreateBuilderImpl implements CreateBuilder {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -272,12 +272,16 @@ class LedgerCreateOp {
         } else {
             createOpLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
         }
-        lh.executeOrdered(new SafeRunnable() {
-                              @Override
-                              public void safeRun() {
-                                  cb.createComplete(rc, lh, ctx);
-                              }
-        });
+        if (lh != null) { // lh is null in case of errors
+            lh.executeOrdered(new SafeRunnable() {
+                @Override
+                public void safeRun() {
+                    cb.createComplete(rc, lh, ctx);
+                }
+            });
+        } else {
+            cb.createComplete(rc, lh, ctx);
+        }
     }
 
     public static class CreateBuilderImpl implements CreateBuilder {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -538,7 +538,7 @@ public class LedgerHandle implements WriteHandle {
      * @param rc
      */
     void doAsyncCloseInternal(final CloseCallback cb, final Object ctx, final int rc) {
-        clientCtx.getMainWorkerPool().executeOrdered(ledgerId, new SafeRunnable() {
+        executeOrdered(new SafeRunnable() {
             @Override
             public void safeRun() {
                 final HandleState prevHandleState;
@@ -895,7 +895,7 @@ public class LedgerHandle implements WriteHandle {
 
             if (isHandleWritable()) {
                 // Ledger handle in read/write mode: submit to OSE for ordered execution.
-                clientCtx.getMainWorkerPool().executeOrdered(ledgerId, op);
+                executeOrdered(op);
             } else {
                 // Read-only ledger handle: bypass OSE and execute read directly in client thread.
                 // This avoids a context-switch to OSE thread and thus reduces latency.
@@ -1158,7 +1158,7 @@ public class LedgerHandle implements WriteHandle {
         if (wasClosed) {
             // make sure the callback is triggered in main worker pool
             try {
-                clientCtx.getMainWorkerPool().executeOrdered(ledgerId, new SafeRunnable() {
+                executeOrdered(new SafeRunnable() {
                     @Override
                     public void safeRun() {
                         LOG.warn("Force() attempted on a closed ledger: {}", ledgerId);
@@ -1178,7 +1178,7 @@ public class LedgerHandle implements WriteHandle {
 
         // early exit: no write has been issued yet
         if (pendingAddsSequenceHead == INVALID_ENTRY_ID) {
-            clientCtx.getMainWorkerPool().executeOrdered(ledgerId, new SafeRunnable() {
+            executeOrdered(new SafeRunnable() {
                     @Override
                     public void safeRun() {
                         FutureUtils.complete(result, null);
@@ -1193,7 +1193,7 @@ public class LedgerHandle implements WriteHandle {
         }
 
         try {
-            clientCtx.getMainWorkerPool().executeOrdered(ledgerId, op);
+            executeOrdered(op);
         } catch (RejectedExecutionException e) {
             result.completeExceptionally(new BKException.BKInterruptedException());
         }
@@ -1326,7 +1326,7 @@ public class LedgerHandle implements WriteHandle {
         if (wasClosed) {
             // make sure the callback is triggered in main worker pool
             try {
-                clientCtx.getMainWorkerPool().executeOrdered(ledgerId, new SafeRunnable() {
+                executeOrdered(new SafeRunnable() {
                     @Override
                     public void safeRun() {
                         LOG.warn("Attempt to add to closed ledger: {}", ledgerId);
@@ -1361,7 +1361,7 @@ public class LedgerHandle implements WriteHandle {
         }
 
         try {
-            clientCtx.getMainWorkerPool().executeOrdered(ledgerId, op);
+            executeOrdered(op);
         } catch (RejectedExecutionException e) {
             op.cb.addCompleteWithLatency(
                     BookKeeper.getReturnRc(clientCtx.getBookieClient(), BKException.Code.InterruptedException),
@@ -2083,4 +2083,14 @@ public class LedgerHandle implements WriteHandle {
             return distributionSchedule.getWriteSet(entryId);
         }
     }
+
+    /**
+     * Execute the callback in the thread pinned to the ledger.
+     * @param runnable
+     * @throws RejectedExecutionException
+     */
+    void executeOrdered(SafeRunnable runnable) throws RejectedExecutionException {
+        clientCtx.getMainWorkerPool().executeOrdered(ledgerId, runnable);
+    }
+
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -2089,7 +2089,7 @@ public class LedgerHandle implements WriteHandle {
      * @param runnable
      * @throws RejectedExecutionException
      */
-    void executeOrdered(SafeRunnable runnable) throws RejectedExecutionException {
+    void executeOrdered(org.apache.bookkeeper.common.util.SafeRunnable runnable) throws RejectedExecutionException {
         clientCtx.getMainWorkerPool().executeOrdered(ledgerId, runnable);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -254,7 +254,7 @@ class LedgerOpenOp {
                 }
             });
         } else {
-            cb.openComplete(rc, lh, ctx);
+            cb.openComplete(rc, null, ctx);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -245,12 +245,17 @@ class LedgerOpenOp {
         } else {
             openOpLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
         }
-        lh.executeOrdered(new SafeRunnable() {
-            @Override
-            public void safeRun() {
-                cb.openComplete(rc, lh, ctx);
-            }
-        });
+
+        if (lh != null) { // lh is null in case of errors
+            lh.executeOrdered(new SafeRunnable() {
+                @Override
+                public void safeRun() {
+                    cb.openComplete(rc, lh, ctx);
+                }
+            });
+        } else {
+            cb.openComplete(rc, lh, ctx);
+        }
     }
 
     static final class OpenBuilderImpl extends OpenBuilderBase {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -39,6 +39,7 @@ import org.apache.bookkeeper.client.impl.OpenBuilderBase;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.OrderedGenericCallback;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -244,7 +245,12 @@ class LedgerOpenOp {
         } else {
             openOpLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
         }
-        cb.openComplete(rc, lh, ctx);
+        lh.executeOrdered(new SafeRunnable() {
+            @Override
+            public void safeRun() {
+                cb.openComplete(rc, lh, ctx);
+            }
+        });
     }
 
     static final class OpenBuilderImpl extends OpenBuilderBase {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -732,7 +732,7 @@ public class BookieWriteLedgerTest extends
                         .withDigestType(org.apache.bookkeeper.client.api.DigestType.CRC32)
                         .withPassword(ledgerPassword).makeAdv().withLedgerId(ledgerId)
                         .execute()
-                        .thenApply(writer -> { // Add entries to ledger when created
+                        .thenCompose(writer -> { // Add entries to ledger when created
                                 LOG.info("Writing stream of {} entries to {}",
                                          numEntriesToWrite, ledgerId);
                                 List<ByteBuf> entries = rng.ints(numEntriesToWrite, 0, maxInt)
@@ -751,8 +751,8 @@ public class BookieWriteLedgerTest extends
                                              ledgerId, entryId, entry.slice().readInt());
                                     lastRequest = writer.writeAsync(entryId, entry);
                                 }
-                                lastRequest.join();
-                                return Pair.of(writer, entries);
+                                return lastRequest
+                                        .thenApply(___ -> Pair.of(writer, entries));
                             });
                 })
             .parallel().map(CompletableFuture::join) // wait for all creations and adds in parallel

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeper.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeper.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.client.api.OpenBuilder;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.OpenBuilderBase;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,9 +106,14 @@ public class MockBookKeeper extends BookKeeper {
                     log.info("Creating ledger {}", id);
                     MockLedgerHandle lh = new MockLedgerHandle(MockBookKeeper.this, id, digestType, passwd);
                     ledgers.put(id, lh);
-                    cb.createComplete(0, lh, ctx);
+                    lh.executeOrdered(new SafeRunnable() {
+                        @Override
+                        public void safeRun() {
+                            cb.createComplete(0, lh, ctx);
+                        }
+                    });
                 } catch (Throwable t) {
-                    t.printStackTrace();
+                    log.error("Error", t);
                 }
             }
         });
@@ -162,7 +168,12 @@ public class MockBookKeeper extends BookKeeper {
         } else if (!Arrays.equals(lh.passwd, passwd)) {
             cb.openComplete(BKException.Code.UnauthorizedAccessException, null, ctx);
         } else {
-            cb.openComplete(0, lh, ctx);
+            lh.executeOrdered(new SafeRunnable() {
+                                  @Override
+                                  public void safeRun() {
+                                      cb.openComplete(0, lh, ctx);
+                                  }
+                              });
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -42,7 +42,6 @@ import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -91,7 +91,7 @@ public class MockLedgerHandle extends LedgerHandle {
     }
 
     @Override
-    void executeOrdered(SafeRunnable runnable) throws RejectedExecutionException {
+    void executeOrdered(org.apache.bookkeeper.common.util.SafeRunnable runnable) throws RejectedExecutionException {
         bk.executor.execute(runnable);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -42,6 +42,7 @@ import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;
@@ -87,6 +88,11 @@ public class MockLedgerHandle extends LedgerHandle {
             cb.closeComplete(0, this, ctx);
         }
 
+    }
+
+    @Override
+    void executeOrdered(SafeRunnable runnable) throws RejectedExecutionException {
+        bk.executor.execute(runnable);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

We are currently completing the creation and opening (also with recovery) of the LedgerHandle in the main ZookKeeper (or metadata driver) callback thread.

This leads to unpredictable code to be executed on that thread:
- possible deadlocks (that cannot be prevented fully from BK code)
- execute heavy weight operations, like opening BK connections

This is a good example of a something that tries to open a connection to a bookie because the application executes a "read" after a "openLedger" operation.

```
at org.apache.bookkeeper.proto.PerChannelBookieClient.connect(PerChannelBookieClient.java:532)
	at org.apache.bookkeeper.proto.PerChannelBookieClient.connectIfNeededAndDoOp(PerChannelBookieClient.java:658)
	at org.apache.bookkeeper.proto.DefaultPerChannelBookieClientPool.initialize(DefaultPerChannelBookieClientPool.java:92)
	at org.apache.bookkeeper.proto.BookieClientImpl.lookupClient(BookieClientImpl.java:217)
	at org.apache.bookkeeper.proto.BookieClientImpl.isWritable(BookieClientImpl.java:170)
	at org.apache.bookkeeper.client.LedgerHandle.isWriteSetWritable(LedgerHandle.java:1227)
	at org.apache.bookkeeper.client.LedgerHandle.waitForWritable(LedgerHandle.java:1249)
	at org.apache.bookkeeper.client.LedgerHandle.readEntriesInternalAsync(LedgerHandle.java:883)
	at org.apache.bookkeeper.client.LedgerHandle.asyncReadEntriesInternal(LedgerHandle.java:800)
	at org.apache.bookkeeper.client.LedgerHandle.asyncReadEntries(LedgerHandle.java:694)
	at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage$Functions.getLedgerEntry(BookkeeperSchemaStorage.java:646)
	at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.lambda$readSchemaEntry$33(BookkeeperSchemaStorage.java:524)
	at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage$$Lambda$820/0x00000008007e5840.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(java.base@11.0.15.0.1/CompletableFuture.java:1072)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.15.0.1/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.15.0.1/CompletableFuture.java:2073)
	at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.lambda$openLedger$40(BookkeeperSchemaStorage.java:601)
	at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage$$Lambda$819/0x00000008007e5440.openComplete(Unknown Source)
	at org.apache.bookkeeper.client.LedgerOpenOp.openComplete(LedgerOpenOp.java:248)
	at org.apache.bookkeeper.client.LedgerOpenOp.openWithMetadata(LedgerOpenOp.java:201)
	at org.apache.bookkeeper.client.LedgerOpenOp.lambda$initiate$0(LedgerOpenOp.java:119)
	at org.apache.bookkeeper.client.LedgerOpenOp$$Lambda$621/0x0000000800715040.accept(Unknown Source)
```

The full story is here, but this patch does not focus on the BookieAddressResolver blocking calls to the metadata storage. The scope is this patch is to prevent application from running code on the metadata store main thread.
https://github.com/apache/pulsar/issues/17913

It is unfortunate that CompletableFuture doesn't allow you to have full control on the thread which will execute the completion tasks

 

### Changes

(Describe: what changes you have made)

Master Issue: #<master-issue-number>

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
