### PR TITLE
Bump jackson version to 2.13.4

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.2.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.2.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.2.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.2.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.2.2.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <hadoop.version>3.2.4</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
-    <jackson.version>2.13.2.20220328</jackson.version>
+    <jackson.version>2.13.4</jackson.version>
     <jcommander.version>1.82</jcommander.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jmh.version>1.19</jmh.version>


### PR DESCRIPTION
### Motivation
Bump jackson version to 2.13.4 to solve CVE-2022-42004

