### PR TITLE
fix(sec): upgrade org.bouncycastle:bcprov-ext-jdk15on to 1.69

### DIFF
--- a/tests/backward-compat/bc-non-fips/pom.xml
+++ b/tests/backward-compat/bc-non-fips/pom.xml
@@ -14,8 +14,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
@@ -29,7 +28,7 @@
   <packaging>jar</packaging>
   <name>Apache BookKeeper :: Tests :: Backward Compatibility :: Test Bouncy Castle Provider load non FIPS version</name>
   <properties>
-    <bc-non-fips.version>1.68</bc-non-fips.version>
+    <bc-non-fips.version>1.69</bc-non-fips.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.bouncycastle:bcprov-ext-jdk15on 1.68
- [MPS-2022-54308](https://www.oscs1024.com/hd/MPS-2022-54308)


### What did I do？
Upgrade org.bouncycastle:bcprov-ext-jdk15on from 1.68 to 1.69 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS