### PR TITLE
<Issue #3537>[website]Declare the bookkeeper shell queryautorecoverystatus command on the web site

### DIFF
--- a/site3/website/docs/reference/cli.md
+++ b/site3/website/docs/reference/cli.md
@@ -98,6 +98,19 @@ $ bin/bookkeeper help
 
 
 
+### queryautorecoverystatus {#bookkeeper-shell-queryautorecoverystatus}
+
+Query the autorecovery status
+
+##### Usage
+
+```shell
+$ bin/bookkeeper shell queryautorecoverystatus
+```
+
+| Flag           | Description |
+|----------------| ----------- |
+| -v,--verbose   | List recovering detailed ledger info | 
 
 ### autorecovery {#bookkeeper-shell-autorecovery}
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation
The [bookkeeper shell queryautorecoverystatus](https://github.com/apache/bookkeeper/blob/b13dd20f0a905c615daef2e1ddcfa0e0979d1a07/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java#L1361) command is not publicly listed on the site

### Changes

Declare the bookkeeper shell queryautorecoverystatuscommand on the web site

Master Issue: #3536