### PR TITLE
PendingReadOP supports fail-fast read 

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -572,12 +572,6 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
     }
 
     void sendReadTo(int bookieIndex, BookieId to, LedgerEntryRequest entry) throws InterruptedException {
-        if (clientCtx.getBookieWatcher().isBookieUnavailable(to)) {
-            readEntryComplete(BKException.Code.BookieHandleNotAvailableException,
-                    lh.ledgerId, entry.eId, null, new ReadContext(bookieIndex, to, entry));
-            return;
-        }
-
         if (lh.throttler != null) {
             lh.throttler.acquire();
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -213,7 +213,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
                             lh.ledgerId, eId, host);
                 }
             } else {
-                if(!clientCtx.getBookieWatcher().isBookieUnavailable(host)) {
+                if (!clientCtx.getBookieWatcher().isBookieUnavailable(host)) {
                     LOG.info("{} while reading L{} E{} from bookie: {}",
                             errMsg, lh.ledgerId, eId, host);
                 }


### PR DESCRIPTION
### Motivation
During autoRecovery, there were so many  `Bookie handle is not available` errors,  it was because replicateWorker would tried to read entry  from bookie even if it's already offline.

We could just skip sending read request to the unavailable bookie.
```
2022-10-03 18:34:01.305 [BookKeeperClientWorker-OrderedExecutor-39-0] ERROR org.apache.bookkeeper.proto.PerChannelBookieClient - Cannot connect to x.x.x.x:3181 as endpoint resolution failed (probably bookie is down) err org.apache.bookkeeper.proto.BookieAddressResolver$BookieIdNotResolvedException: Cannot resolve bookieId x.x.x.x:3181, bookie does not exist or it is not running

INFO  org.apache.bookkeeper.client.PendingReadOp - Error: Bookie handle is not available while reading L61530597 E0 from bookie: x.x.x.x:3181
```

### Changes

Before `sendReadTo`  sending request to bookie, we judged if bookie is available or not. 