### PR TITLE
Adapt thread number automatically

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -43,6 +43,7 @@ import org.apache.bookkeeper.discover.ZKRegistrationManager;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
+import org.apache.bookkeeper.util.ThreadNumUtils;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 
@@ -1942,7 +1943,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return the number of threads that handle write requests.
      */
     public int getNumAddWorkerThreads() {
-        return getInt(NUM_ADD_WORKER_THREADS, 1);
+        return getInt(NUM_ADD_WORKER_THREADS, ThreadNumUtils.adaptThreadNum());
     }
 
     /**
@@ -1989,7 +1990,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return
      */
     public int getNumHighPriorityWorkerThreads() {
-        return getInt(NUM_HIGH_PRIORITY_WORKER_THREADS, 8);
+        return getInt(NUM_HIGH_PRIORITY_WORKER_THREADS, ThreadNumUtils.adaptThreadNum());
     }
 
     /**
@@ -2032,7 +2033,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * Get the number of threads that should handle read requests.
      */
     public int getNumReadWorkerThreads() {
-        return getInt(NUM_READ_WORKER_THREADS, 8);
+        return getInt(NUM_READ_WORKER_THREADS, ThreadNumUtils.adaptThreadNum());
     }
 
     /**
@@ -2157,7 +2158,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return the number of threads that handle journal callbacks.
      */
     public int getNumJournalCallbackThreads() {
-        return getInt(NUM_JOURNAL_CALLBACK_THREADS, 1);
+        return getInt(NUM_JOURNAL_CALLBACK_THREADS, ThreadNumUtils.adaptThreadNum());
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ThreadNumUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ThreadNumUtils.java
@@ -1,0 +1,49 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.util;
+
+/**
+ * Adapt thread number automatically.
+ */
+public class ThreadNumUtils {
+
+    public final static int DEFAULT_MIN_THREAD_NUM = 8;
+    public final static int DEFAULT_MAX_THREAD_NUM = 64;
+
+    public static int adaptThreadNum() {
+        int processorSize = Runtime.getRuntime().availableProcessors();
+        return adaptThreadNum(DEFAULT_MIN_THREAD_NUM, DEFAULT_MAX_THREAD_NUM, processorSize);
+    }
+
+    public static int adaptThreadNum(int min, int max) {
+        int processorSize = Runtime.getRuntime().availableProcessors();
+        return adaptThreadNum(min, max, processorSize);
+    }
+
+    public static int adaptThreadNum(int min, int max, int processorSize) {
+        if (min <= 0 || min > max) {
+            throw new IllegalArgumentException(
+                    String.format("min [%d] number should be positive and smaller than max [%d]", min, max));
+        }
+        return Math.min(Math.max(min, processorSize), max);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/ThreadNumUtilsTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/ThreadNumUtilsTest.java
@@ -1,0 +1,48 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ThreadNumUtilsTest {
+
+    @Test
+    public void testAdaptThreadNum() {
+
+        int pSize = Runtime.getRuntime().availableProcessors();
+
+        if (pSize >= ThreadNumUtils.DEFAULT_MIN_THREAD_NUM && pSize <= ThreadNumUtils.DEFAULT_MAX_THREAD_NUM) {
+            Assert.assertEquals(pSize, ThreadNumUtils.adaptThreadNum());
+        }
+        Assert.assertEquals(pSize, ThreadNumUtils.adaptThreadNum());
+        Assert.assertEquals(pSize, ThreadNumUtils.adaptThreadNum(1, 1000));
+        Assert.assertEquals(1, ThreadNumUtils.adaptThreadNum(1, 1));
+        Assert.assertEquals(6, ThreadNumUtils.adaptThreadNum(4, 8, 6));
+
+        try {
+            ThreadNumUtils.adaptThreadNum(0, 1);
+        } catch (IllegalArgumentException ex) {
+            Assert.assertNotNull(ex);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>

Descriptions of the changes in this PR:



### Motivation

In actual production scenarios, the default configuration of the number of read and write threads provided by Bookie is relatively small, and we generally need to configure the number of read and write threads in the configuration file. In fact, for machines with different CPU cores, we can adopt a certain default strategy to automatically adapt the number of threads for reading and writing.

### Changes

 
- Add `ThreadNumUtils` func
- Add test case for this change

