### PR TITLE
Fix flaky-test testWriteSetWriteableCheck

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
@@ -323,6 +323,10 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
             // b2 or b3 is no more writeable
             int slowBookieIndex = writeSet.get(ThreadLocalRandom.current().nextInt(writeSet.size()));
             List<BookieId> curEns = lh.getCurrentEnsemble();
+
+            // Trigger connection to the bookie service first
+            bkc.getBookieInfo().get(curEns.get(slowBookieIndex));
+            // then mock channel is not writable
             setTargetChannelState(bkc, curEns.get(slowBookieIndex), 0, false);
 
             boolean isWriteable = lh.waitForWritable(writeSet, 0, 1000);


### PR DESCRIPTION
### Motivation
 `testWriteSetWriteableCheck` always failed. After investigation, it is found that `isWritable=false` is set when the simulated channel is not writable, but the unit test cannot fully perceive the channel establishment, because the channel is completely established asynchronously. The isWritable state of false is changed to true again.

you can see the following logs:
![image](https://user-images.githubusercontent.com/35599757/196625314-0ea5a305-9564-4738-8055-20baa6a5c5a2.png)

The smallest change is that we can ensure that the channel is established before changing the channel state, such as executing `bkc.getBookieInfo()`, and then `setTargetChannelState`
