### PR TITLE
[Branch-4.14] Fix TLS test stat npe

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -895,7 +895,8 @@ public class TestTLS extends BookKeeperClusterTestCase {
                     .append("bookie_")
                     .append(bookie.getBookieId().toString()
                     .replace('.', '_')
-                    .replace('-', '_'))
+                    .replace('-', '_')
+                    .replace(":", "_"))
                     .append(".");
 
             // check stats on TLS enabled client
@@ -996,7 +997,8 @@ public class TestTLS extends BookKeeperClusterTestCase {
                 .append("bookie_")
                 .append(bookie.getBookieId().toString()
                         .replace('.', '_')
-                        .replace('-', '_'))
+                        .replace('-', '_')
+                        .replace(":", "_"))
                 .append(".");
 
         assertEquals("TLS handshake failure expected", 1,


### PR DESCRIPTION
Patch for #3557

Descriptions of the changes in this PR:

The stat is `per_channel_bookie_client.bookie_127_0_0_1_60541.FAILED_TLS_HANDSHAKE_COUNTER`
The input is: `per_channel_bookie_client.bookie_127_0_0_1:60541.FAILED_TLS_HANDSHAKE_COUNTER`

The input `127_0_0_1:60541`, the `:` should be replaced by `_`

The same logic at master branch.
https://github.com/apache/bookkeeper/blob/255416a8552f34e5fd50231bbeed77e0945b63e3/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestUtils.java#L47-L49


