### PR TITLE
Skipping placementPolicyCheck when ledger replication disabled

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -878,6 +878,11 @@ public class Auditor implements AutoCloseable {
                 @Override
                 public void run() {
                     try {
+                        if (!ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {
+                            LOG.info("Ledger replication disabled, skipping placementPolicyCheck");
+                            return;
+                        }
+
                         Stopwatch stopwatch = Stopwatch.createStarted();
                         LOG.info("Starting PlacementPolicyCheck");
                         placementPolicyCheck();
@@ -953,6 +958,8 @@ public class Auditor implements AutoCloseable {
                                 numOfLedgersFoundInPlacementPolicyCheckValue,
                                 numOfLedgersFoundSoftlyAdheringInPlacementPolicyCheckValue,
                                 numOfURLedgersElapsedRecoveryGracePeriodValue, e);
+                    } catch (ReplicationException.UnavailableException ue) {
+                        LOG.error("Underreplication manager unavailable running periodic check", ue);
                     }
                 }
             }), initialDelay, interval, TimeUnit.SECONDS);


### PR DESCRIPTION
### Motivation

When `placementPolicyCheck` is enabled and then `bookkeeper shell autorecovery -disable` is executed, `placementPolicyCheck` will detect ledgers that do not satisfy `placementPolicy` and write to zookeeper, but `ReplicationWorker` no longer obtains ledgers from zookeeper for replication work because autorecovery is disabled, which results in a large number of temporary nodes on zookeeper , when there are more ledgers that do not satisfy placementPolicy, the problem will get worse.

The method of `ReplicationWorker` to get ledger:
```java
private boolean rereplicate() throws InterruptedException, BKException,
            UnavailableException {
        long ledgerIdToReplicate = underreplicationManager
                .getLedgerToRereplicate();
       
       ...
```

So we should also disable `placementPolicyCheck`.