### PR TITLE
Skip replicasCheck when replication disabled

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -1004,6 +1004,10 @@ public class Auditor implements AutoCloseable {
             @Override
             public void run() {
                 try {
+                    if (!ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {
+                        LOG.info("Ledger replication disabled, skipping replicasCheck task.");
+                        return;
+                    }
                     Stopwatch stopwatch = Stopwatch.createStarted();
                     LOG.info("Starting ReplicasCheck");
                     replicasCheck();
@@ -1059,6 +1063,8 @@ public class Auditor implements AutoCloseable {
                         numLedgersHavingLessThanWQReplicasOfAnEntryGuageValue
                                 .set(numLedgersFoundHavingLessThanWQReplicasOfAnEntryValue);
                     }
+                } catch (ReplicationException.UnavailableException ue) {
+                    LOG.error("Underreplication manager unavailable running periodic check", ue);
                 }
             }
         }), initialDelay, interval, TimeUnit.SECONDS);


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation
When disabled replication by the BookKeeper shell, the `replicasCheckTask` doesn't check the `replication disabled` flag and keeps checking the ledger replicas, which will lead to more disk IO.

### Changes
Check the `replication disabled` flag before running `replicasCheckTask`

(Describe: what changes you have made)

