### PR TITLE
Issue 3567: Upgrade rocksdb version to avoid checksum mismatch error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <protoc3.version>3.19.2</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
-    <rocksdb.version>6.29.4.1</rocksdb.version>
+    <rocksdb.version>7.4.5</rocksdb.version>
     <shrinkwrap.version>3.0.1</shrinkwrap.version>
     <slf4j.version>1.7.32</slf4j.version>
     <snakeyaml.version>1.32</snakeyaml.version>


### PR DESCRIPTION
### Motivation
Rocksdb instance throws Checksum Mismatch exception frequently in high workload(2000MB/s with 3 bookies and 3 replica) with directio mode.
I checked the release history of rocksdb and found that checksum mismatch bug maybe fixed after 7.4.0. The fix is followed
* Fixed a bug in `WriteBatchInternal::Append()` where WAL termination point in write batch was not considered and the function appends an incorrect number of checksums.

### Changes

Upgrade rocksdb version to 7.4.5 to avoid checksum mismatch error
After rocksdb upgraded to 7.4.5. Checksum mismatch error no longer appears

Master Issue: #3567
