### PR TITLE
Flush time started moved to after lock

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -719,10 +719,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             return;
         }
 
-        long startTime = MathUtils.nowInNano();
 
         // Only a single flush operation can happen at a time
         flushMutex.lock();
+        long startTime = MathUtils.nowInNano();
         try {
             if (writeCache.isEmpty()) {
                 return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -719,10 +719,17 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             return;
         }
 
-
         // Only a single flush operation can happen at a time
         flushMutex.lock();
-        long startTime = MathUtils.nowInNano();
+        long startTime = -1;
+        try {
+            startTime = MathUtils.nowInNano();
+        } catch (Throwable e) {
+            // Fix spotbugs warning. Should never happen
+            flushMutex.unlock();
+            throw new IOException(e);
+        }
+
         try {
             if (writeCache.isEmpty()) {
                 return;


### PR DESCRIPTION
### Motivation

In BP-44(Ledger storage metrics enhancement), ledger flush start time is moved to after lock to avoid 200% time
  utilization calculations.
However, 200% time utilization still happens in my test. After reading the source code, I found that this part was rolled back by #3160. 
If I understand correctly, this change is not as expected

### Changes

Flush start time is moved to after lock again.


