### PR TITLE
[doc]Fixed incorrect checkstyle configuration prompts

### DIFF
--- a/site3/website/src/pages/community/contributing.md
+++ b/site3/website/src/pages/community/contributing.md
@@ -108,10 +108,8 @@ IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
     1. Select "Use a local Checkstyle file", and point it to
       "buildtools/src/main/resources/bookkeeper/checkstyle.xml" within
       your repository.
-    1. Check the box for "Store relative to project location", and click
-      "Next".
-    1. Configure the "checkstyle.suppressions.file" property value to
-      "suppressions.xml", and click "Next", then "Finish".
+    1. Check the box for "Store relative to project location".
+    1. Click Next -> Next -> Finish.
 1. Select "BookKeeper" as the only active configuration file, and click "Apply" and
    "OK".
 1. Checkstyle will now give warnings in the editor for any Checkstyle


### PR DESCRIPTION
### Motivation

The property name of `checkstyle suppressions` already changed in the PR https://github.com/apache/bookkeeper/pull/2817/files#diff-f295bca9ef0353572bbaeaeaa17061f524e9236ac46763c836ed779dee99935e, but web site still recommends the old

<img width="855" alt="截屏2022-10-25 10 36 05" src="https://user-images.githubusercontent.com/25195800/197669021-6c6e0a59-3ee3-4800-bb32-b83cd091cba1.png">





<img width="1354" alt="截屏2022-10-25 10 33 46" src="https://user-images.githubusercontent.com/25195800/197668603-d1faac1e-393b-4328-9eb8-039b9c2346e9.png">

### Changes

Since this configuration has a default setting, change the doc-line to "Click Next -> Finish".
